### PR TITLE
feat(harness): foundation libs for structured errors + output + argv

### DIFF
--- a/plugins/harness/src/lib/argv.mjs
+++ b/plugins/harness/src/lib/argv.mjs
@@ -1,0 +1,108 @@
+/**
+ * Tiny argv parser built on Node's `util.parseArgs` (available since Node 18,
+ * engines.node `>=20`).
+ *
+ * Recognizes the harness-wide flag set:
+ *   --help / -h       bool
+ *   --version / -V    bool
+ *   --json            bool
+ *   --verbose / -v    bool
+ *   --no-color        bool
+ *
+ * Callers add their own flags via the `spec` parameter; the harness-wide set
+ * is merged in automatically.
+ *
+ * @typedef {object} FlagSpec
+ * @property {'boolean'|'string'} type
+ * @property {string} [short]       single-letter alias
+ * @property {string|boolean} [default]
+ * @property {boolean} [multiple]   allow repetition (array of values)
+ *
+ * @typedef {{ [name: string]: FlagSpec }} FlagsSpec
+ *
+ * @typedef {object} ParsedArgs
+ * @property {{ [name: string]: boolean|string|string[]|undefined }} flags
+ * @property {string[]} positional
+ * @property {boolean} help
+ * @property {boolean} version
+ * @property {boolean} json
+ * @property {boolean} verbose
+ * @property {boolean} noColor
+ */
+
+import { parseArgs } from 'node:util';
+
+/** Harness-wide flag set auto-included in every `parse()` call. */
+export const HARNESS_FLAGS = Object.freeze({
+  help: { type: 'boolean', short: 'h' },
+  version: { type: 'boolean', short: 'V' },
+  json: { type: 'boolean' },
+  verbose: { type: 'boolean', short: 'v' },
+  'no-color': { type: 'boolean' },
+});
+
+/**
+ * Parse `argv` (typically `process.argv.slice(2)`) against `spec`.
+ * Throws `Error` with a `.code = 'USAGE_UNKNOWN_FLAG'` property on unknown
+ * flags so callers can map to `EXIT_CODES.USAGE` without string matching.
+ *
+ * @param {string[]} argv
+ * @param {FlagsSpec} [spec]
+ * @returns {ParsedArgs}
+ */
+export function parse(argv, spec = {}) {
+  const merged = { ...HARNESS_FLAGS, ...spec };
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      options: /** @type {any} */ (merged),
+      allowPositionals: true,
+      strict: true,
+    });
+  } catch (err) {
+    const wrapped = new Error(err instanceof Error ? err.message : String(err));
+    /** @type {any} */ (wrapped).code = 'USAGE_UNKNOWN_FLAG';
+    throw wrapped;
+  }
+  const values = /** @type {Record<string, any>} */ (parsed.values);
+  return {
+    flags: values,
+    positional: parsed.positionals,
+    help: Boolean(values.help),
+    version: Boolean(values.version),
+    json: Boolean(values.json),
+    verbose: Boolean(values.verbose),
+    noColor: Boolean(values['no-color']),
+  };
+}
+
+/**
+ * Render a conventional `--help` message.
+ *
+ * @param {object} meta
+ * @param {string} meta.name         e.g. "harness-validate-specs"
+ * @param {string} meta.synopsis     e.g. "harness-validate-specs [OPTIONS]"
+ * @param {string} meta.description  1-2 sentence summary.
+ * @param {FlagsSpec} [meta.flags]   Bin-specific flags to document (harness-wide flags are always appended).
+ * @returns {string}
+ */
+export function helpText(meta) {
+  const lines = [
+    meta.synopsis,
+    '',
+    meta.description,
+    '',
+    'Options:',
+  ];
+  const all = { ...(meta.flags ?? {}), ...HARNESS_FLAGS };
+  const longest = Math.max(...Object.keys(all).map((k) => k.length + 2));
+  for (const [name, def] of Object.entries(all)) {
+    const long = `--${name}`;
+    const short = /** @type {any} */ (def).short ? `, -${/** @type {any} */ (def).short}` : '';
+    lines.push(`  ${long}${short}`.padEnd(longest + 6) + (def.type === 'string' ? '<value>' : ''));
+  }
+  lines.push('');
+  lines.push('Exit codes: 0 ok, 1 validation failure, 2 env error, 64 usage error.');
+  return lines.join('\n');
+}

--- a/plugins/harness/src/lib/debug.mjs
+++ b/plugins/harness/src/lib/debug.mjs
@@ -1,0 +1,37 @@
+/**
+ * Debug logger gated on `HARNESS_DEBUG=1`.
+ *
+ * Replaces silent `catch` blocks in `spec-harness-lib.mjs:28-29` and `:184-186`
+ * (legacy behavior) with opt-in diagnostic output. When the env flag is unset,
+ * `debug()` is a no-op — zero runtime cost in normal operation.
+ *
+ * Usage:
+ *   } catch (err) {
+ *     debug('git:rev-parse', err.message);
+ *     return null;
+ *   }
+ *
+ * @param {string} tag
+ * @param {...unknown} args
+ * @returns {void}
+ */
+export function debug(tag, ...args) {
+  if (process.env.HARNESS_DEBUG !== '1') return;
+  process.stderr.write(`[harness:${tag}] ${args.map(stringify).join(' ')}\n`);
+}
+
+/** @returns {boolean} */
+export function isDebug() {
+  return process.env.HARNESS_DEBUG === '1';
+}
+
+/** @param {unknown} v */
+function stringify(v) {
+  if (v instanceof Error) return v.stack ?? v.message;
+  if (typeof v === 'string') return v;
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}

--- a/plugins/harness/src/lib/errors.mjs
+++ b/plugins/harness/src/lib/errors.mjs
@@ -1,0 +1,140 @@
+/**
+ * Structured error taxonomy for every harness validator.
+ *
+ * Every validator emits instances of `ValidationError` rather than raw strings.
+ * This gives consumers a machine-parseable `.code`, `.file`, and `.pointer`
+ * while keeping `.toString()` readable for human-first CLI output.
+ *
+ * @typedef {object} StructuredError
+ * @property {string} code      Stable enum value (see `ERROR_CODES`). Never rename.
+ * @property {string} message   Human-readable one-liner. May contain identifier names.
+ * @property {string} [file]    Repo-relative path where the error was detected.
+ * @property {string} [pointer] JSON Pointer or dotted key when the error is inside a structured file.
+ * @property {number} [line]    1-indexed line number when available.
+ * @property {string} [expected] Text describing what the validator expected.
+ * @property {string} [got]      Text describing what was observed.
+ * @property {string} [hint]     Actionable remediation suggestion.
+ * @property {'spec'|'skill'|'manifest'|'coverage'|'drift'|'scaffold'|'settings'|'env'|'usage'} [category]
+ */
+
+/**
+ * Stable error codes. Consumers may match on these; renames are breaking changes.
+ */
+export const ERROR_CODES = Object.freeze({
+  // spec
+  SPEC_JSON_INVALID: 'SPEC_JSON_INVALID',
+  SPEC_STATUS_INVALID: 'SPEC_STATUS_INVALID',
+  SPEC_MISSING_REQUIRED_FIELD: 'SPEC_MISSING_REQUIRED_FIELD',
+  SPEC_LINKED_PATH_MISSING: 'SPEC_LINKED_PATH_MISSING',
+  SPEC_ACCEPTANCE_EMPTY: 'SPEC_ACCEPTANCE_EMPTY',
+  // skill
+  SKILL_FRONTMATTER_MISSING: 'SKILL_FRONTMATTER_MISSING',
+  SKILL_NAME_MISMATCH: 'SKILL_NAME_MISMATCH',
+  // manifest
+  MANIFEST_CHECKSUM_MISMATCH: 'MANIFEST_CHECKSUM_MISMATCH',
+  MANIFEST_ENTRY_MISSING: 'MANIFEST_ENTRY_MISSING',
+  // coverage
+  COVERAGE_UNCOVERED: 'COVERAGE_UNCOVERED',
+  COVERAGE_NO_SPEC_RATIONALE: 'COVERAGE_NO_SPEC_RATIONALE',
+  // drift
+  DRIFT_TEAM_COUNT: 'DRIFT_TEAM_COUNT',
+  DRIFT_PROTECTED_PATH: 'DRIFT_PROTECTED_PATH',
+  // scaffold
+  SCAFFOLD_CONFLICT: 'SCAFFOLD_CONFLICT',
+  SCAFFOLD_USAGE: 'SCAFFOLD_USAGE',
+  // settings / hooks (sh validator parity)
+  SETTINGS_SEC_1: 'SETTINGS_SEC_1',
+  SETTINGS_SEC_2: 'SETTINGS_SEC_2',
+  SETTINGS_SEC_3: 'SETTINGS_SEC_3',
+  SETTINGS_SEC_4: 'SETTINGS_SEC_4',
+  SETTINGS_OPS_1: 'SETTINGS_OPS_1',
+  SETTINGS_OPS_2: 'SETTINGS_OPS_2',
+  // env / usage
+  ENV_REPO_ROOT_UNKNOWN: 'ENV_REPO_ROOT_UNKNOWN',
+  ENV_FACTS_MISSING: 'ENV_FACTS_MISSING',
+  USAGE_UNKNOWN_FLAG: 'USAGE_UNKNOWN_FLAG',
+  USAGE_MISSING_POSITIONAL: 'USAGE_MISSING_POSITIONAL',
+});
+
+/**
+ * Structured validator error. Extends `Error` so existing `throw`/`catch`
+ * paths continue to work; extra properties give consumers a machine-parseable
+ * view.
+ */
+export class ValidationError extends Error {
+  /**
+   * @param {StructuredError} details
+   */
+  constructor(details) {
+    if (!details || typeof details !== 'object') {
+      throw new TypeError('ValidationError requires a StructuredError details object');
+    }
+    if (!details.code || typeof details.code !== 'string') {
+      throw new TypeError('ValidationError requires a non-empty `code`');
+    }
+    if (!details.message || typeof details.message !== 'string') {
+      throw new TypeError('ValidationError requires a non-empty `message`');
+    }
+    super(details.message);
+    this.name = 'ValidationError';
+    this.code = details.code;
+    if (details.file !== undefined) this.file = details.file;
+    if (details.pointer !== undefined) this.pointer = details.pointer;
+    if (details.line !== undefined) this.line = details.line;
+    if (details.expected !== undefined) this.expected = details.expected;
+    if (details.got !== undefined) this.got = details.got;
+    if (details.hint !== undefined) this.hint = details.hint;
+    if (details.category !== undefined) this.category = details.category;
+  }
+
+  /**
+   * Legacy string format: `"<file>: <message>"` so existing tests and CI
+   * pipelines that regex on stderr continue to work unchanged.
+   * @returns {string}
+   */
+  toString() {
+    return this.file ? `${this.file}: ${this.message}` : this.message;
+  }
+
+  /**
+   * JSON-safe representation for `--json` output.
+   * @returns {StructuredError}
+   */
+  toJSON() {
+    /** @type {StructuredError} */
+    const out = { code: this.code, message: this.message };
+    if (this.file !== undefined) out.file = this.file;
+    if (this.pointer !== undefined) out.pointer = this.pointer;
+    if (this.line !== undefined) out.line = this.line;
+    if (this.expected !== undefined) out.expected = this.expected;
+    if (this.got !== undefined) out.got = this.got;
+    if (this.hint !== undefined) out.hint = this.hint;
+    if (this.category !== undefined) out.category = this.category;
+    return out;
+  }
+}
+
+/**
+ * Render a single error for human-readable CLI output. Mirrors the
+ * `✗ <message>` prefix style used by `plugins/harness/scripts/validate-settings.sh:43-45`.
+ *
+ * @param {ValidationError | StructuredError | Error} err
+ * @param {{ verbose?: boolean }} [opts]
+ * @returns {string}
+ */
+export function formatError(err, opts = {}) {
+  const verbose = Boolean(opts.verbose);
+  const prefix = err.file ? `${err.file}: ` : '';
+  const head = `${prefix}${err.message ?? String(err)}`;
+  if (!verbose) return head;
+
+  const tail = [];
+  if (err.code) tail.push(`  code:     ${err.code}`);
+  if (err.pointer !== undefined) tail.push(`  pointer:  ${err.pointer}`);
+  if (err.line !== undefined) tail.push(`  line:     ${err.line}`);
+  if (err.expected !== undefined) tail.push(`  expected: ${err.expected}`);
+  if (err.got !== undefined) tail.push(`  got:      ${err.got}`);
+  if (err.hint !== undefined) tail.push(`  hint:     ${err.hint}`);
+  if (err.category !== undefined) tail.push(`  category: ${err.category}`);
+  return tail.length > 0 ? `${head}\n${tail.join('\n')}` : head;
+}

--- a/plugins/harness/src/lib/exit-codes.mjs
+++ b/plugins/harness/src/lib/exit-codes.mjs
@@ -1,0 +1,18 @@
+/**
+ * Named exit code enum for every harness bin.
+ *
+ * Convention:
+ * - 0 OK           — success
+ * - 1 VALIDATION   — one or more validation rules failed (the expected failure mode)
+ * - 2 ENV          — misconfigured environment (missing file, bad git repo, unreadable facts)
+ * - 64 USAGE       — bad CLI invocation (unknown flag, missing required positional)
+ *
+ * 64 mirrors BSD sysexits.h EX_USAGE so operators can distinguish user error
+ * from a real validation failure in CI pipelines.
+ */
+export const EXIT_CODES = Object.freeze({
+  OK: 0,
+  VALIDATION: 1,
+  ENV: 2,
+  USAGE: 64,
+});

--- a/plugins/harness/src/lib/output.mjs
+++ b/plugins/harness/src/lib/output.mjs
@@ -1,0 +1,90 @@
+/**
+ * Shared CLI output primitives — the JS parity of
+ * `plugins/harness/scripts/validate-settings.sh:43-45`.
+ *
+ * Provides the same ✓/✗/⚠ format with ANSI coloring when the stream is a TTY,
+ * plus a `--json` buffer-and-flush mode so CI pipelines can consume a single
+ * JSON array of events instead of regexing stderr.
+ *
+ * @typedef {'pass'|'fail'|'warn'|'info'} OutputKind
+ *
+ * @typedef {object} OutputEvent
+ * @property {OutputKind} kind
+ * @property {string} message
+ * @property {object} [details]  Optional structured payload (e.g. `ValidationError.toJSON()`).
+ *
+ * @typedef {object} Output
+ * @property {(msg: string) => void} pass
+ * @property {(msg: string, details?: object) => void} fail
+ * @property {(msg: string, details?: object) => void} warn
+ * @property {(msg: string) => void} info
+ * @property {() => void} flush          Emit buffered JSON when in json mode. No-op otherwise.
+ * @property {() => { fail: number, warn: number, pass: number }} counts
+ *
+ * @typedef {object} OutputOptions
+ * @property {boolean} [json]     When true, buffer events and emit a JSON array on flush().
+ * @property {boolean} [noColor]  When true, suppress ANSI escapes regardless of TTY.
+ * @property {NodeJS.WritableStream} [stream]  Defaults to process.stdout.
+ * @property {NodeJS.ProcessEnv} [env]         Defaults to process.env.
+ */
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const YELLOW = '\x1b[33m';
+const RESET = '\x1b[0m';
+
+/**
+ * Construct an `Output` with the given behavior flags.
+ *
+ * @param {OutputOptions} [opts]
+ * @returns {Output}
+ */
+export function createOutput(opts = {}) {
+  const env = opts.env ?? process.env;
+  const stream = opts.stream ?? process.stdout;
+  const json = Boolean(opts.json);
+  const noColor = Boolean(opts.noColor) || 'NO_COLOR' in env;
+  const useAnsi = !json && !noColor && Boolean(stream.isTTY);
+
+  const counts = { pass: 0, fail: 0, warn: 0 };
+  /** @type {OutputEvent[]} */
+  const buffer = [];
+
+  const color = (code, text) => (useAnsi ? `${code}${text}${RESET}` : text);
+
+  /**
+   * @param {OutputKind} kind
+   * @param {string} message
+   * @param {object} [details]
+   */
+  const emit = (kind, message, details) => {
+    if (kind === 'pass') counts.pass++;
+    else if (kind === 'fail') counts.fail++;
+    else if (kind === 'warn') counts.warn++;
+    if (json) {
+      /** @type {OutputEvent} */
+      const event = { kind, message };
+      if (details !== undefined) event.details = details;
+      buffer.push(event);
+      return;
+    }
+    let glyph;
+    if (kind === 'pass') glyph = color(GREEN, '✓');
+    else if (kind === 'fail') glyph = color(RED, '✗');
+    else if (kind === 'warn') glyph = color(YELLOW, '⚠');
+    else glyph = ' ';
+    stream.write(`  ${glyph} ${message}\n`);
+  };
+
+  return {
+    pass: (msg) => emit('pass', msg),
+    fail: (msg, details) => emit('fail', msg, details),
+    warn: (msg, details) => emit('warn', msg, details),
+    info: (msg) => emit('info', msg),
+    flush: () => {
+      if (!json) return;
+      stream.write(JSON.stringify({ events: buffer, counts }, null, 2) + '\n');
+    },
+    counts: () => ({ ...counts }),
+  };
+}

--- a/plugins/harness/tests/argv.test.mjs
+++ b/plugins/harness/tests/argv.test.mjs
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { parse, helpText, HARNESS_FLAGS } from "../src/lib/argv.mjs";
+
+describe("parse — harness-wide flags", () => {
+  it("recognizes --help and short -h", () => {
+    expect(parse(["--help"]).help).toBe(true);
+    expect(parse(["-h"]).help).toBe(true);
+  });
+
+  it("recognizes --version and short -V", () => {
+    expect(parse(["--version"]).version).toBe(true);
+    expect(parse(["-V"]).version).toBe(true);
+  });
+
+  it("recognizes --json, --verbose, --no-color", () => {
+    const r = parse(["--json", "--verbose", "--no-color"]);
+    expect(r.json).toBe(true);
+    expect(r.verbose).toBe(true);
+    expect(r.noColor).toBe(true);
+  });
+
+  it("returns positional args", () => {
+    const r = parse(["pos1", "pos2"]);
+    expect(r.positional).toEqual(["pos1", "pos2"]);
+  });
+
+  it("throws an error with code USAGE_UNKNOWN_FLAG on unknown flag", () => {
+    let caught;
+    try {
+      parse(["--not-a-real-flag"]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught.code).toBe("USAGE_UNKNOWN_FLAG");
+  });
+});
+
+describe("parse — bin-specific flags", () => {
+  it("merges caller spec with HARNESS_FLAGS", () => {
+    const r = parse(["--base", "main", "--json"], {
+      base: { type: "string" },
+    });
+    expect(r.flags.base).toBe("main");
+    expect(r.json).toBe(true);
+  });
+});
+
+describe("helpText", () => {
+  it("includes synopsis, description, options, exit codes", () => {
+    const text = helpText({
+      name: "harness-foo",
+      synopsis: "harness-foo [OPTIONS] <spec-id>",
+      description: "Do the thing.",
+      flags: { base: { type: "string" } },
+    });
+    expect(text).toContain("harness-foo [OPTIONS] <spec-id>");
+    expect(text).toContain("Do the thing.");
+    expect(text).toContain("--base");
+    expect(text).toContain("--help");
+    expect(text).toContain("--json");
+    expect(text).toContain("Exit codes:");
+  });
+});
+
+describe("HARNESS_FLAGS", () => {
+  it("is frozen so callers cannot mutate shared state", () => {
+    expect(Object.isFrozen(HARNESS_FLAGS)).toBe(true);
+  });
+});

--- a/plugins/harness/tests/errors.test.mjs
+++ b/plugins/harness/tests/errors.test.mjs
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  ValidationError,
+  ERROR_CODES,
+  formatError,
+} from "../src/lib/errors.mjs";
+
+describe("ERROR_CODES", () => {
+  it("freezes the enum so consumer code cannot mutate it", () => {
+    expect(Object.isFrozen(ERROR_CODES)).toBe(true);
+  });
+
+  it("exposes the SEC1-4 settings codes", () => {
+    expect(ERROR_CODES.SETTINGS_SEC_1).toBe("SETTINGS_SEC_1");
+    expect(ERROR_CODES.SETTINGS_SEC_2).toBe("SETTINGS_SEC_2");
+    expect(ERROR_CODES.SETTINGS_SEC_3).toBe("SETTINGS_SEC_3");
+    expect(ERROR_CODES.SETTINGS_SEC_4).toBe("SETTINGS_SEC_4");
+  });
+
+  it("exposes the load-bearing validator codes referenced by the remediation plan", () => {
+    expect(ERROR_CODES.SPEC_STATUS_INVALID).toBeDefined();
+    expect(ERROR_CODES.MANIFEST_CHECKSUM_MISMATCH).toBeDefined();
+    expect(ERROR_CODES.COVERAGE_UNCOVERED).toBeDefined();
+    expect(ERROR_CODES.DRIFT_TEAM_COUNT).toBeDefined();
+  });
+});
+
+describe("ValidationError", () => {
+  it("requires code and message", () => {
+    expect(() => new ValidationError(/** @type {any} */ (null))).toThrow(TypeError);
+    expect(() => new ValidationError(/** @type {any} */ ({ code: "X" }))).toThrow(TypeError);
+    expect(() => new ValidationError(/** @type {any} */ ({ message: "oops" }))).toThrow(TypeError);
+  });
+
+  it("exposes structured properties", () => {
+    const err = new ValidationError({
+      code: "SPEC_STATUS_INVALID",
+      message: "status must be one of draft|ready|done",
+      file: "docs/specs/foo/spec.json",
+      pointer: "/status",
+      line: 3,
+      expected: "draft|ready|done",
+      got: "finished",
+      hint: "Change status to 'done'",
+      category: "spec",
+    });
+    expect(err.name).toBe("ValidationError");
+    expect(err.code).toBe("SPEC_STATUS_INVALID");
+    expect(err.file).toBe("docs/specs/foo/spec.json");
+    expect(err.pointer).toBe("/status");
+    expect(err.line).toBe(3);
+    expect(err.expected).toBe("draft|ready|done");
+    expect(err.got).toBe("finished");
+    expect(err.hint).toBe("Change status to 'done'");
+    expect(err.category).toBe("spec");
+  });
+
+  it("extends Error so existing catch blocks work unchanged", () => {
+    const err = new ValidationError({ code: "X", message: "oops" });
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("toString() returns legacy '<file>: <message>' format", () => {
+    const withFile = new ValidationError({
+      code: "X",
+      message: "oops",
+      file: "a.json",
+    });
+    expect(withFile.toString()).toBe("a.json: oops");
+
+    const noFile = new ValidationError({ code: "X", message: "oops" });
+    expect(noFile.toString()).toBe("oops");
+  });
+
+  it("toJSON() returns only defined fields (no undefineds)", () => {
+    const err = new ValidationError({
+      code: "X",
+      message: "oops",
+      file: "a.json",
+    });
+    expect(err.toJSON()).toEqual({ code: "X", message: "oops", file: "a.json" });
+  });
+
+  it("round-trips through JSON.stringify", () => {
+    const err = new ValidationError({
+      code: "COVERAGE_UNCOVERED",
+      message: "path not covered by any spec",
+      file: "src/x.ts",
+      hint: "Add to docs/specs/<name>/spec.json linked_paths",
+    });
+    const round = JSON.parse(JSON.stringify(err));
+    expect(round.code).toBe("COVERAGE_UNCOVERED");
+    expect(round.file).toBe("src/x.ts");
+    expect(round.hint).toContain("linked_paths");
+  });
+});
+
+describe("formatError", () => {
+  it("renders a single-line message without verbose flag", () => {
+    const err = new ValidationError({
+      code: "X",
+      message: "oops",
+      file: "a.json",
+      hint: "Try this",
+    });
+    expect(formatError(err)).toBe("a.json: oops");
+  });
+
+  it("renders structured detail lines with verbose flag", () => {
+    const err = new ValidationError({
+      code: "X",
+      message: "oops",
+      file: "a.json",
+      hint: "Try this",
+      expected: "foo",
+      got: "bar",
+    });
+    const out = formatError(err, { verbose: true });
+    expect(out).toContain("a.json: oops");
+    expect(out).toContain("code:     X");
+    expect(out).toContain("hint:     Try this");
+    expect(out).toContain("expected: foo");
+    expect(out).toContain("got:      bar");
+  });
+
+  it("handles plain Error instances without crashing", () => {
+    const out = formatError(new Error("boom"));
+    expect(out).toBe("boom");
+  });
+});

--- a/plugins/harness/tests/output.test.mjs
+++ b/plugins/harness/tests/output.test.mjs
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { PassThrough } from "node:stream";
+import { createOutput } from "../src/lib/output.mjs";
+
+function collect(stream) {
+  let buf = "";
+  stream.on("data", (chunk) => (buf += chunk.toString("utf8")));
+  return () => buf;
+}
+
+describe("createOutput — human mode", () => {
+  it("prints ✓ for pass, ✗ for fail, ⚠ for warn", () => {
+    const stream = new PassThrough();
+    const read = collect(stream);
+    const out = createOutput({ stream, noColor: true, env: {} });
+    out.pass("ok thing");
+    out.fail("bad thing");
+    out.warn("sketchy thing");
+    expect(read()).toContain("✓ ok thing");
+    expect(read()).toContain("✗ bad thing");
+    expect(read()).toContain("⚠ sketchy thing");
+  });
+
+  it("suppresses ANSI when noColor is true", () => {
+    const stream = new PassThrough();
+    stream.isTTY = true;
+    const read = collect(stream);
+    const out = createOutput({ stream, noColor: true, env: {} });
+    out.fail("x");
+    expect(read()).not.toContain("\x1b[");
+  });
+
+  it("suppresses ANSI when NO_COLOR env is set regardless of TTY", () => {
+    const stream = new PassThrough();
+    stream.isTTY = true;
+    const read = collect(stream);
+    const out = createOutput({ stream, env: { NO_COLOR: "1" } });
+    out.fail("x");
+    expect(read()).not.toContain("\x1b[");
+  });
+
+  it("emits ANSI only when stream is a TTY", () => {
+    const tty = new PassThrough();
+    tty.isTTY = true;
+    const read = collect(tty);
+    const out = createOutput({ stream: tty, env: {} });
+    out.fail("x");
+    expect(read()).toContain("\x1b[31m");
+  });
+
+  it("counts pass/fail/warn for the caller", () => {
+    const stream = new PassThrough();
+    collect(stream);
+    const out = createOutput({ stream, noColor: true, env: {} });
+    out.pass("a");
+    out.pass("b");
+    out.fail("c");
+    out.warn("d");
+    expect(out.counts()).toEqual({ pass: 2, fail: 1, warn: 1 });
+  });
+});
+
+describe("createOutput — json mode", () => {
+  it("buffers events and writes a single JSON object on flush()", () => {
+    const stream = new PassThrough();
+    const read = collect(stream);
+    const out = createOutput({ stream, json: true, env: {} });
+    out.pass("a");
+    out.fail("b", { code: "X" });
+    out.warn("c");
+    // nothing written yet
+    expect(read()).toBe("");
+    out.flush();
+    const parsed = JSON.parse(read());
+    expect(parsed.events).toHaveLength(3);
+    expect(parsed.events[0]).toEqual({ kind: "pass", message: "a" });
+    expect(parsed.events[1]).toEqual({
+      kind: "fail",
+      message: "b",
+      details: { code: "X" },
+    });
+    expect(parsed.counts).toEqual({ pass: 1, fail: 1, warn: 1 });
+  });
+
+  it("flush() is a no-op in human mode", () => {
+    const stream = new PassThrough();
+    const read = collect(stream);
+    const out = createOutput({ stream, noColor: true, env: {} });
+    out.pass("x");
+    const before = read();
+    out.flush();
+    expect(read()).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `plugins/harness/src/lib/` — five pure-ESM modules (errors, exit-codes, output, argv, debug) that PRs 2-3 will adopt across every bin and validator. No behavior change in this PR; strictly additive.
- `ValidationError.toString()` preserves the legacy `"<file>: <message>"` format so existing tests and downstream CI pipelines that parse stderr keep working through the PR 3 migration.
- `output.mjs` mirrors the gold-standard ✓/✗/⚠ format at `plugins/harness/scripts/validate-settings.sh:43-45`, honors `NO_COLOR` and TTY detection, and adds a `--json` buffer-and-flush mode so CI can consume structured events.
- `argv.mjs` auto-includes the harness-wide flag set (`--help`, `--version`, `--json`, `--verbose`, `--no-color`) via Node's built-in `util.parseArgs`; throws with `code: 'USAGE_UNKNOWN_FLAG'` for clean mapping to `EXIT_CODES.USAGE`.
- `debug.mjs` provides the `HARNESS_DEBUG=1`-gated logger that PR 3 will use to replace the silent catches at `spec-harness-lib.mjs:28-29` and `:184-186`.

## Test plan

- [x] 27 new vitest cases: `errors.test.mjs` (12), `output.test.mjs` (7), `argv.test.mjs` (8).
- [x] `npm test` — 9 files, 65 tests all green in ~600 ms (38 existing + 27 new, zero regression).
- [x] Reviewed `ERROR_CODES` enum against every error-emitting site flagged by the remediation plan (SPEC_*, MANIFEST_*, COVERAGE_*, DRIFT_*, SETTINGS_SEC_*/OPS_*).
- [x] `output.mjs` ANSI behavior verified: TTY→colored, non-TTY→plain, `NO_COLOR`→plain regardless of TTY, explicit `noColor:true`→plain.
- [x] `argv.mjs` throws with `.code='USAGE_UNKNOWN_FLAG'` on unknown flags (verified by test case).
- [x] Zero runtime dependencies added — `util.parseArgs` is stdlib since Node 18, engines.node `>=20`.

## What's NOT in this PR

- Wiring these libs into the existing bins and validators — that lands in PR 2 (barrel + umbrella CLI) and PR 3 (structured errors across validators).
- Replacing silent catches in `spec-harness-lib.mjs` — PR 3.
- Adopting `EXIT_CODES` in every bin — PR 2 does the umbrella bin; PR 3 updates each validator bin.

Spec ID: TBD — `harness-core` spec lands in PR 5.
