### PR TITLE
feat(harness): barrel index + umbrella CLI + package.json contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,25 @@ The scaffolded `.github/workflows/validate-skills.yml` runs the chain on every P
 ### Node API
 
 ```javascript
-import { createHarnessContext } from "@kaiohenricunha/harness";
-import { validateManifest } from "@kaiohenricunha/harness/plugins/harness/src/validate-skills-inventory.mjs";
+import {
+  createHarnessContext,
+  validateManifest,
+  ValidationError,
+  EXIT_CODES,
+} from "@kaiohenricunha/harness";
 
 const ctx = createHarnessContext({ repoRoot: "/path/to/repo" });
 const { ok, errors } = validateManifest(ctx);
+if (!ok) {
+  for (const err of errors) {
+    // err is a ValidationError with .code / .file / .hint / .category
+    console.error(err.toString());
+  }
+  process.exit(EXIT_CODES.VALIDATION);
+}
 ```
+
+All exports (24+ symbols: validators, helpers, `ValidationError`, `ERROR_CODES`, `EXIT_CODES`, `version`) come from the single barrel `@kaiohenricunha/harness`. Deep imports like `@kaiohenricunha/harness/plugins/...` are not a supported contract.
 
 All validators accept an explicit `repoRoot` or fall back to `process.env.HARNESS_REPO_ROOT`, then to `git rev-parse --show-toplevel`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,19 @@
 {
   "name": "@kaiohenricunha/harness",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kaiohenricunha/harness",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "bin": {
+        "harness": "plugins/harness/bin/harness.mjs",
         "harness-check-instruction-drift": "plugins/harness/bin/harness-check-instruction-drift.mjs",
         "harness-check-spec-coverage": "plugins/harness/bin/harness-check-spec-coverage.mjs",
+        "harness-detect-drift": "plugins/harness/bin/harness-detect-drift.mjs",
+        "harness-doctor": "plugins/harness/bin/harness-doctor.mjs",
         "harness-init": "plugins/harness/bin/harness-init.mjs",
         "harness-validate-skills": "plugins/harness/bin/harness-validate-skills.mjs",
         "harness-validate-specs": "plugins/harness/bin/harness-validate-specs.mjs"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,19 @@
 {
   "name": "@kaiohenricunha/harness",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Portable harness + SDD validators for Claude Code projects.",
   "type": "module",
   "main": "plugins/harness/src/index.mjs",
+  "exports": {
+    ".": "./plugins/harness/src/index.mjs",
+    "./errors": "./plugins/harness/src/lib/errors.mjs",
+    "./exit-codes": "./plugins/harness/src/lib/exit-codes.mjs",
+    "./package.json": "./package.json"
+  },
   "bin": {
+    "harness": "./plugins/harness/bin/harness.mjs",
+    "harness-doctor": "./plugins/harness/bin/harness-doctor.mjs",
+    "harness-detect-drift": "./plugins/harness/bin/harness-detect-drift.mjs",
     "harness-validate-skills": "./plugins/harness/bin/harness-validate-skills.mjs",
     "harness-check-spec-coverage": "./plugins/harness/bin/harness-check-spec-coverage.mjs",
     "harness-validate-specs": "./plugins/harness/bin/harness-validate-specs.mjs",
@@ -13,11 +22,16 @@
   },
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
+    "lint": "echo 'lint target stubs — prettier + markdownlint wiring lands in PR 4/6' && exit 0",
+    "shellcheck": "shellcheck -x bootstrap.sh sync.sh plugins/harness/scripts/*.sh plugins/harness/hooks/*.sh plugins/harness/tests/*.sh plugins/harness/templates/claude/hooks/*.sh plugins/harness/templates/githooks/pre-commit",
+    "dogfood": "npx harness-validate-skills && npx harness-validate-specs && npx harness-check-instruction-drift && npx harness-check-spec-coverage"
   },
   "files": [
     "plugins/harness/src/",
     "plugins/harness/bin/",
+    "plugins/harness/scripts/",
     "plugins/harness/templates/",
     "plugins/harness/hooks/",
     "plugins/harness/README.md",
@@ -34,5 +48,20 @@
     "type": "git",
     "url": "git+https://github.com/kaiohenricunha/dotclaude.git"
   },
+  "homepage": "https://github.com/kaiohenricunha/dotclaude#readme",
+  "bugs": {
+    "url": "https://github.com/kaiohenricunha/dotclaude/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "claude",
+    "harness",
+    "sdd",
+    "spec-driven",
+    "validator",
+    "linter",
+    "governance",
+    "cli"
+  ],
   "license": "MIT"
 }

--- a/plugins/harness/README.md
+++ b/plugins/harness/README.md
@@ -35,9 +35,14 @@ All bins default to `git rev-parse --show-toplevel` when no `--repo-root` is pas
 ## API
 
 ```javascript
-import { createHarnessContext } from "@kaiohenricunha/harness";
-import { validateManifest } from "@kaiohenricunha/harness/src/validate-skills-inventory.mjs";
+import {
+  createHarnessContext,
+  validateManifest,
+  EXIT_CODES,
+} from "@kaiohenricunha/harness";
 
 const ctx = createHarnessContext({ repoRoot: "/path/to/repo" });
 const result = validateManifest(ctx);
 ```
+
+Every export comes from the single barrel. Deep imports are not a supported contract.

--- a/plugins/harness/bin/harness-detect-drift.mjs
+++ b/plugins/harness/bin/harness-detect-drift.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * harness-detect-drift — thin bin wrapping `plugins/harness/scripts/detect-branch-drift.mjs`
+ * so `npx harness-detect-drift` works (fixes the broken invocation at
+ * `plugins/harness/templates/workflows/detect-drift.yml:15`).
+ *
+ * Forwards every flag through. Owns --help / --version only.
+ *
+ * Exit codes: whatever detect-branch-drift.mjs returns.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { version } from "../src/index.mjs";
+
+const args = process.argv.slice(2);
+if (args.includes("--help") || args.includes("-h")) {
+  process.stdout.write(
+    [
+      "harness-detect-drift [OPTIONS]",
+      "",
+      "Flag .claude/commands/*.md and skills/**/SKILL.md that diverge from origin/main",
+      "for longer than the drift threshold. Wraps plugins/harness/scripts/detect-branch-drift.mjs.",
+      "",
+      "Options:",
+      "  --help, -h           show this help",
+      "  --version, -V        print harness version",
+      "  (all other flags are forwarded to the underlying script)",
+      "",
+      "Exit codes: 0 ok, 1 drift detected, 2 env error.",
+      "",
+    ].join("\n")
+  );
+  process.exit(EXIT_CODES.OK);
+}
+if (args.includes("--version") || args.includes("-V")) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const scriptPath = resolve(__dirname, "..", "scripts", "detect-branch-drift.mjs");
+
+const child = spawn(process.execPath, [scriptPath, ...args], { stdio: "inherit" });
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? EXIT_CODES.ENV);
+});

--- a/plugins/harness/bin/harness-doctor.mjs
+++ b/plugins/harness/bin/harness-doctor.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * harness-doctor — diagnostic self-check.
+ *
+ * Walks through every invariant a consumer repo (or the harness repo itself,
+ * when dogfooding) must satisfy for validators to run:
+ *
+ *   env          Node >= 20, git on PATH
+ *   repo         git rev-parse --show-toplevel resolves; repoRoot usable
+ *   facts        docs/repo-facts.json exists and parses
+ *   manifest     .claude/skills-manifest.json checksums match (via validateManifest)
+ *   specs        docs/specs/ scanned; validateSpecs clean
+ *   drift        checkInstructionDrift clean
+ *   hook         plugins/harness/hooks/guard-destructive-git.sh present + exec bit
+ *
+ * Exit codes: 0 all green, 1 one or more checks failed (validation), 2 env error.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { version } from "../src/index.mjs";
+import {
+  createHarnessContext,
+  validateManifest,
+  validateSpecs,
+  checkInstructionDrift,
+  pathExists,
+} from "../src/index.mjs";
+
+const META = {
+  name: "harness-doctor",
+  synopsis: "harness-doctor [OPTIONS]",
+  description: "Run the harness self-diagnostic across env, repo, facts, manifest, specs, drift, and hooks.",
+  flags: {
+    "repo-root": { type: "string" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const out = createOutput({
+  json: argv.json,
+  noColor: argv.noColor,
+});
+
+let envError = false;
+
+// env: Node + git
+const nodeMajor = Number(process.versions.node.split(".")[0]);
+if (nodeMajor >= 20) {
+  out.pass(`Node ${process.versions.node} (>=20 required)`);
+} else {
+  out.fail(`Node ${process.versions.node} is below the >=20 requirement`);
+  envError = true;
+}
+try {
+  const gitVersion = execFileSync("git", ["--version"], { encoding: "utf8" }).trim();
+  out.pass(`git available — ${gitVersion}`);
+} catch {
+  out.fail("git is not on PATH");
+  envError = true;
+}
+
+// repo: resolve context
+const repoRoot = /** @type {string | undefined} */ (argv.flags["repo-root"]);
+let ctx;
+try {
+  ctx = createHarnessContext({ repoRoot });
+  out.pass(`repo root resolved to ${ctx.repoRoot}`);
+} catch (err) {
+  out.fail(`could not resolve repo root: ${err.message}`);
+  envError = true;
+}
+
+if (envError) {
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}
+
+// facts
+if (pathExists(ctx, "docs/repo-facts.json")) {
+  out.pass("docs/repo-facts.json present");
+} else {
+  out.warn("docs/repo-facts.json missing — coverage/drift checks will be no-ops");
+}
+
+// manifest
+if (pathExists(ctx, ".claude/skills-manifest.json")) {
+  const r = validateManifest(ctx);
+  if (r.ok) out.pass(`manifest valid (${r.manifest.skills.length} skills)`);
+  else out.fail(`manifest has ${r.errors.length} error(s)`, { errors: r.errors });
+} else {
+  out.warn(".claude/skills-manifest.json missing — skill inventory not indexed");
+}
+
+// specs
+if (pathExists(ctx, "docs/specs")) {
+  const r = validateSpecs(ctx);
+  if (r.ok) out.pass("specs valid");
+  else out.fail(`specs have ${r.errors.length} error(s)`, { errors: r.errors });
+} else {
+  out.warn("docs/specs/ missing — no specs to validate");
+}
+
+// drift
+try {
+  const r = checkInstructionDrift(ctx);
+  if (r.ok) out.pass("instruction drift clean");
+  else out.fail(`instruction drift: ${r.errors.length} issue(s)`, { errors: r.errors });
+} catch (err) {
+  out.warn(`drift check skipped: ${err.message}`);
+}
+
+// hook
+const hookPath = resolve(ctx.repoRoot, "plugins/harness/hooks/guard-destructive-git.sh");
+if (existsSync(hookPath)) {
+  const mode = statSync(hookPath).mode & 0o111;
+  if (mode) out.pass("guard-destructive-git.sh present + executable");
+  else out.fail("guard-destructive-git.sh present but NOT executable (chmod +x)");
+} else {
+  out.warn("guard-destructive-git.sh missing — destructive git commands are unguarded");
+}
+
+out.flush();
+const { fail } = out.counts();
+process.exit(fail > 0 ? EXIT_CODES.VALIDATION : EXIT_CODES.OK);

--- a/plugins/harness/bin/harness.mjs
+++ b/plugins/harness/bin/harness.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Umbrella dispatcher. Usage:
+ *
+ *   harness --version
+ *   harness --help
+ *   harness <subcommand> [args...]      # delegates to harness-<subcommand>.mjs
+ *
+ * Known subcommands mirror the bin/* entries shipped by the package:
+ *   validate-skills, validate-specs, check-spec-coverage,
+ *   check-instruction-drift, detect-drift, doctor, init.
+ *
+ * Exits: 0 ok, 1 delegated failure, 2 env error, 64 usage error.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { version } from "../src/index.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+
+const SUBCOMMANDS = [
+  "validate-skills",
+  "validate-specs",
+  "check-spec-coverage",
+  "check-instruction-drift",
+  "detect-drift",
+  "doctor",
+  "init",
+];
+
+function printUsage() {
+  process.stdout.write(
+    [
+      "harness — structured-error-emitting CLI for @kaiohenricunha/harness",
+      "",
+      "Usage:",
+      "  harness <subcommand> [options]",
+      "  harness --version",
+      "  harness --help",
+      "",
+      "Subcommands:",
+      ...SUBCOMMANDS.map((s) => `  ${s.padEnd(26)}runs harness-${s}`),
+      "",
+      "Every subcommand also exists as a standalone bin (e.g. `npx harness-doctor`).",
+      "Each subcommand supports --help / --version / --json / --verbose / --no-color.",
+      "",
+      "Exit codes: 0 ok, 1 validation failure, 2 env error, 64 usage error.",
+      "",
+    ].join("\n")
+  );
+}
+
+const args = process.argv.slice(2);
+
+if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+  printUsage();
+  process.exit(EXIT_CODES.OK);
+}
+
+if (args[0] === "--version" || args[0] === "-V") {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const sub = args[0];
+if (!SUBCOMMANDS.includes(sub)) {
+  process.stderr.write(
+    `harness: unknown subcommand '${sub}'. Run 'harness --help' for the list.\n`
+  );
+  process.exit(EXIT_CODES.USAGE);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const binPath = resolve(__dirname, `harness-${sub}.mjs`);
+if (!existsSync(binPath)) {
+  process.stderr.write(
+    `harness: bin 'harness-${sub}' not found at ${binPath}. Did the package install correctly?\n`
+  );
+  process.exit(EXIT_CODES.ENV);
+}
+
+const child = spawn(process.execPath, [binPath, ...args.slice(1)], {
+  stdio: "inherit",
+});
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? EXIT_CODES.ENV);
+});

--- a/plugins/harness/src/index.mjs
+++ b/plugins/harness/src/index.mjs
@@ -1,0 +1,57 @@
+/**
+ * Public barrel for `@kaiohenricunha/harness`.
+ *
+ * Consumer contract:
+ *   import { createHarnessContext, validateSpecs, EXIT_CODES, ValidationError } from "@kaiohenricunha/harness";
+ *
+ * The surface intentionally stays small — deep imports are NOT a supported
+ * contract. If you find yourself reaching for an internal helper that is not
+ * re-exported here, open an issue.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// --- spec-harness-lib (18 exports) ---
+export {
+  createHarnessContext,
+  toPosix,
+  readJson,
+  readText,
+  pathExists,
+  git,
+  loadFacts,
+  listSpecDirs,
+  listRepoPaths,
+  escapeRegex,
+  globToRegExp,
+  matchesGlob,
+  anyPathMatches,
+  extractTemplateSection,
+  isMeaningfulSection,
+  getPullRequestContext,
+  isBotActor,
+  getChangedFiles,
+} from "./spec-harness-lib.mjs";
+
+// --- validators (6 entry points) ---
+export { validateSpecs } from "./validate-specs.mjs";
+export {
+  validateManifest,
+  refreshChecksums,
+} from "./validate-skills-inventory.mjs";
+export { checkInstructionDrift } from "./check-instruction-drift.mjs";
+export { checkSpecCoverage } from "./check-spec-coverage.mjs";
+export { scaffoldHarness } from "./init-harness-scaffold.mjs";
+
+// --- error taxonomy + exit codes ---
+export { ValidationError, ERROR_CODES, formatError } from "./lib/errors.mjs";
+export { EXIT_CODES } from "./lib/exit-codes.mjs";
+
+// --- package version (read from root package.json) ---
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(__dirname, "..", "..", "..", "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+/** The `@kaiohenricunha/harness` package version at import time. */
+export const version = pkg.version;

--- a/plugins/harness/templates/workflows/detect-drift.yml
+++ b/plugins/harness/templates/workflows/detect-drift.yml
@@ -12,4 +12,4 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with: { node-version: '22' }
-      - run: npx @kaiohenricunha/harness detect-drift
+      - run: npx --yes @kaiohenricunha/harness harness-detect-drift

--- a/plugins/harness/tests/index.test.mjs
+++ b/plugins/harness/tests/index.test.mjs
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import * as barrel from "../src/index.mjs";
+
+describe("package barrel — @kaiohenricunha/harness", () => {
+  it("exports at least 24 named symbols (public API surface guard)", () => {
+    expect(Object.keys(barrel).length).toBeGreaterThanOrEqual(24);
+  });
+
+  it("exports the spec-harness-lib surface (18 helpers)", () => {
+    const expected = [
+      "createHarnessContext",
+      "toPosix",
+      "readJson",
+      "readText",
+      "pathExists",
+      "git",
+      "loadFacts",
+      "listSpecDirs",
+      "listRepoPaths",
+      "escapeRegex",
+      "globToRegExp",
+      "matchesGlob",
+      "anyPathMatches",
+      "extractTemplateSection",
+      "isMeaningfulSection",
+      "getPullRequestContext",
+      "isBotActor",
+      "getChangedFiles",
+    ];
+    for (const name of expected) expect(barrel[name]).toBeTypeOf("function");
+  });
+
+  it("exports the 6 validator entry points", () => {
+    for (const name of [
+      "validateSpecs",
+      "validateManifest",
+      "refreshChecksums",
+      "checkInstructionDrift",
+      "checkSpecCoverage",
+      "scaffoldHarness",
+    ]) {
+      expect(barrel[name]).toBeTypeOf("function");
+    }
+  });
+
+  it("exports ValidationError, ERROR_CODES, formatError, EXIT_CODES, version", () => {
+    expect(barrel.ValidationError).toBeTypeOf("function");
+    expect(barrel.ERROR_CODES).toBeTypeOf("object");
+    expect(barrel.formatError).toBeTypeOf("function");
+    expect(barrel.EXIT_CODES).toBeTypeOf("object");
+    expect(barrel.version).toBeTypeOf("string");
+  });
+
+  it("version string matches package.json", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, resolve } = await import("node:path");
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(
+      readFileSync(resolve(__dirname, "..", "..", "..", "package.json"), "utf8")
+    );
+    expect(barrel.version).toBe(pkg.version);
+  });
+
+  it("EXIT_CODES is frozen with the documented convention", () => {
+    expect(Object.isFrozen(barrel.EXIT_CODES)).toBe(true);
+    expect(barrel.EXIT_CODES).toEqual({ OK: 0, VALIDATION: 1, ENV: 2, USAGE: 64 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `plugins/harness/src/index.mjs` — the single public barrel. Fixes `package.json:6` `"main"` which had been pointing at a non-existent file since 0.1.0. Exports 29 named symbols: 18 from `spec-harness-lib`, 6 validator entry points, `ValidationError`, `ERROR_CODES`, `formatError`, `EXIT_CODES`, `version`. Both READMEs' import blocks rewritten; deep imports are no longer a supported contract.
- Adds three new bins wired through `package.json "bin"`: `harness` (umbrella dispatcher; owns `--version` / `--help`), `harness-doctor` (env + repo + facts + manifest + specs + drift + hook self-diagnostic using the PR 1 lib primitives), `harness-detect-drift` (thin wrapper over `plugins/harness/scripts/detect-branch-drift.mjs` so `npx harness-detect-drift` actually works).
- Fixes `plugins/harness/templates/workflows/detect-drift.yml:15` — replaces the non-existent `npx @kaiohenricunha/harness detect-drift` subcommand with `npx --yes @kaiohenricunha/harness harness-detect-drift`.
- `package.json` bumped to `0.2.0`; adds `"exports"` with four subpaths, `"homepage"`, `"bugs"`, `"keywords"`, six new scripts (`coverage`, `lint`, `shellcheck`, `dogfood`, plus existing test/test:watch), and `plugins/harness/scripts/` to `"files"` so the scripts this package already advertises are actually shipped in the npm tarball.

## Test plan

- [x] `npm test` — 10 files, 71 tests green (65 from PR 1 + 6 new index.test.mjs).
- [x] `node -e 'import("./plugins/harness/src/index.mjs").then(m => process.exit(Object.keys(m).length >= 24 ? 0 : 1))'` exits 0 (29 exports; >= 24 target).
- [x] `harness --help` renders usage with all 7 subcommands.
- [x] `harness --version` and `harness-doctor --version` print `0.2.0`.
- [x] `harness bogus` → stderr error + exit 64 (USAGE).
- [x] `harness validate-skills` correctly forwards child exit code (exit 1 when manifest is missing, as expected in the current pre-dogfood state).
- [x] `harness-doctor` against this worktree reports: 3 PASS (env + git + repo-root), 3 WARN (docs/repo-facts.json, .claude/skills-manifest.json, docs/specs/ — all scheduled for PR 5), 1 PASS (guard-destructive-git.sh present + exec bit), drift check auto-skipped. Exit 0.
- [x] Verified `chmod +x` on all three new bins.
- [x] Both READMEs' imports point at the barrel only; `grep -R "@kaiohenricunha/harness/plugins" README.md plugins/harness/README.md` returns nothing.

## What's NOT in this PR

- Migrating the existing five validator bins to the new lib primitives (`argv`, `output`, `EXIT_CODES`). That's PR 3 along with the structured-error rewrite — this PR's existing bins keep their legacy string-based behavior so the PR stays reviewable.
- Implementing a `scaffoldHarness` `.pr-body.md` convention in the templates — out of scope; the scaffolder stays as-is.

Spec ID: TBD — `harness-core` spec lands in PR 5.
