### PR TITLE
feat(harness): bin migration to lib/* + JSDoc rollout (PR 3b)

### DIFF
--- a/plugins/harness/bin/harness-check-instruction-drift.mjs
+++ b/plugins/harness/bin/harness-check-instruction-drift.mjs
@@ -1,18 +1,77 @@
 #!/usr/bin/env node
-import { createHarnessContext } from "../src/spec-harness-lib.mjs";
-import { checkInstructionDrift } from "../src/check-instruction-drift.mjs";
+/**
+ * harness-check-instruction-drift — cross-references `docs/repo-facts.json`
+ * against instruction files (CLAUDE.md, README.md, …) to catch stale
+ * team_count claims, missing protected-path documentation, and broken
+ * instruction-file references.
+ *
+ * Exits: 0 no drift, 1 drift detected, 2 env error, 64 usage error.
+ */
 
-const args = process.argv.slice(2);
-const rrIdx = args.indexOf("--repo-root");
-const repoRoot = rrIdx >= 0 ? args[rrIdx + 1] : undefined;
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { formatError } from "../src/lib/errors.mjs";
+import { version } from "../src/index.mjs";
+import {
+  createHarnessContext,
+  checkInstructionDrift,
+} from "../src/index.mjs";
 
-const ctx = createHarnessContext({ repoRoot });
+const META = {
+  name: "harness-check-instruction-drift",
+  synopsis: "harness-check-instruction-drift [OPTIONS]",
+  description: "Detect drift between docs/repo-facts.json and instruction files (team_count, protected_paths, instruction_files).",
+  flags: {
+    "repo-root": { type: "string" },
+  },
+};
 
-const result = checkInstructionDrift(ctx);
-if (result.ok) {
-  console.log("✅ Instruction files match repo facts.");
-  process.exit(0);
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
 }
-console.error("❌ Instruction drift detected:");
-for (const err of result.errors) console.error(`  - ${err}`);
-process.exit(1);
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const out = createOutput({ json: argv.json, noColor: argv.noColor });
+
+let ctx;
+try {
+  ctx = createHarnessContext({ repoRoot: argv.flags["repo-root"] });
+} catch (err) {
+  out.fail(`could not resolve repo root: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}
+
+let result;
+try {
+  result = checkInstructionDrift(ctx);
+} catch (err) {
+  out.fail(`drift check failed: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}
+
+if (result.ok) {
+  out.pass("instruction files match repo facts");
+  out.flush();
+  process.exit(EXIT_CODES.OK);
+}
+
+for (const err of result.errors) {
+  out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON ? err.toJSON() : undefined);
+}
+out.flush();
+process.exit(EXIT_CODES.VALIDATION);

--- a/plugins/harness/bin/harness-check-spec-coverage.mjs
+++ b/plugins/harness/bin/harness-check-spec-coverage.mjs
@@ -1,18 +1,81 @@
 #!/usr/bin/env node
-import { createHarnessContext, getChangedFiles, getPullRequestContext } from "../src/spec-harness-lib.mjs";
-import { checkSpecCoverage } from "../src/check-spec-coverage.mjs";
+/**
+ * harness-check-spec-coverage — verifies that every change to a protected
+ * path is covered by an approved/implementing/done spec, or the PR body
+ * carries a `## No-spec rationale` section.
+ *
+ * Exits: 0 covered, 1 violation, 2 env error, 64 usage error.
+ */
 
-const rrIdx = process.argv.indexOf("--repo-root");
-const repoRoot = rrIdx >= 0 ? process.argv[rrIdx + 1] : undefined;
-const ctx = createHarnessContext({ repoRoot });
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { formatError } from "../src/lib/errors.mjs";
+import { version } from "../src/index.mjs";
+import {
+  createHarnessContext,
+  checkSpecCoverage,
+  getChangedFiles,
+  getPullRequestContext,
+} from "../src/index.mjs";
+
+const META = {
+  name: "harness-check-spec-coverage",
+  synopsis: "harness-check-spec-coverage [OPTIONS]",
+  description: "Check that protected-path changes are covered by a spec (or a No-spec rationale) in the current PR.",
+  flags: {
+    "repo-root": { type: "string" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const out = createOutput({ json: argv.json, noColor: argv.noColor });
+
+let ctx;
+try {
+  ctx = createHarnessContext({ repoRoot: argv.flags["repo-root"] });
+} catch (err) {
+  out.fail(`could not resolve repo root: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}
 
 const { isPullRequest, body, actor } = getPullRequestContext();
 const changedFiles = getChangedFiles();
 
-const r = checkSpecCoverage(ctx, { changedFiles, isPullRequest, body, actor });
-if (r.ok) {
-  console.log(`✅ spec coverage ok (${r.protectedFiles.length} protected file(s) changed).`);
-  process.exit(0);
+let result;
+try {
+  result = checkSpecCoverage(ctx, { changedFiles, isPullRequest, body, actor });
+} catch (err) {
+  out.fail(`coverage check failed: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
 }
-for (const e of r.errors) console.error(`❌ ${e}`);
-process.exit(1);
+
+if (result.ok) {
+  out.pass(`spec coverage ok (${result.protectedFiles.length} protected file(s) changed)`);
+  out.flush();
+  process.exit(EXIT_CODES.OK);
+}
+
+for (const err of result.errors) {
+  out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON ? err.toJSON() : undefined);
+}
+out.flush();
+process.exit(EXIT_CODES.VALIDATION);

--- a/plugins/harness/bin/harness-init.mjs
+++ b/plugins/harness/bin/harness-init.mjs
@@ -1,45 +1,66 @@
 #!/usr/bin/env node
-import { fileURLToPath } from "url";
-import path from "path";
-import { scaffoldHarness } from "../src/init-harness-scaffold.mjs";
+/**
+ * harness-init — scaffold the harness template tree into a target repository.
+ *
+ * Flags:
+ *   --project-name <name>    defaults to basename(cwd)
+ *   --project-type <type>    defaults to "unknown"
+ *   --force                  overwrite an already-initialized repo
+ *   --target-dir <path>      scaffolding destination (defaults to cwd)
+ *
+ * Exits: 0 scaffold complete, 1 ValidationError (SCAFFOLD_CONFLICT), 2 env
+ * error, 64 usage error.
+ */
+
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { formatError, ValidationError } from "../src/lib/errors.mjs";
+import { version } from "../src/index.mjs";
+import { scaffoldHarness } from "../src/index.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// ── Argv parsing (no external deps) ────────────────────────────────────────
+const META = {
+  name: "harness-init",
+  synopsis: "harness-init [OPTIONS]",
+  description: "Scaffold the harness template tree (.claude/, docs/, .github/workflows/, githooks/) into the current repo.",
+  flags: {
+    "project-name": { type: "string" },
+    "project-type": { type: "string" },
+    "target-dir": { type: "string" },
+    force: { type: "boolean" },
+  },
+};
 
-const args = process.argv.slice(2);
-
-function flagValue(flag) {
-  const idx = args.indexOf(flag);
-  if (idx < 0) return undefined;
-  if (idx + 1 >= args.length || args[idx + 1].startsWith("--")) return null;
-  return args[idx + 1];
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
 }
 
-const force = args.includes("--force");
-
-// --project-name: required, defaults to basename(cwd)
-let projectName = flagValue("--project-name") ?? path.basename(process.cwd());
-if (projectName === null) {
-  console.error("Error: --project-name requires a value.");
-  process.exit(64);
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
 }
 
-// --project-type: optional, defaults to "unknown"
-const projectTypeRaw = flagValue("--project-type");
-if (projectTypeRaw === null) {
-  console.error("Error: --project-type requires a value.");
-  process.exit(64);
-}
-const projectType = projectTypeRaw ?? "unknown";
+const out = createOutput({ json: argv.json, noColor: argv.noColor });
 
-// ── Resolve paths ───────────────────────────────────────────────────────────
+const targetDir = /** @type {string} */ (argv.flags["target-dir"] ?? process.cwd());
+const projectName = /** @type {string} */ (argv.flags["project-name"] ?? path.basename(targetDir));
+const projectType = /** @type {string} */ (argv.flags["project-type"] ?? "unknown");
+const force = Boolean(argv.flags.force);
 
 const templatesDir = path.resolve(__dirname, "..", "templates");
-const targetDir = process.cwd();
 const today = new Date().toISOString().slice(0, 10);
-
-// ── Run scaffolder ──────────────────────────────────────────────────────────
 
 try {
   const { filesWritten } = scaffoldHarness(
@@ -50,14 +71,19 @@ try {
     },
     { force }
   );
-
-  console.log(`Harness initialized in ${targetDir}`);
-  console.log(`Files written (${filesWritten.length}):`);
-  for (const f of filesWritten) {
-    console.log(`  ${f}`);
+  out.pass(`harness initialized in ${targetDir} (${filesWritten.length} files)`);
+  if (argv.verbose) {
+    for (const f of filesWritten) out.info(`  ${f}`);
   }
-  process.exit(0);
+  out.flush();
+  process.exit(EXIT_CODES.OK);
 } catch (err) {
-  console.error(`Error: ${err.message}`);
-  process.exit(1);
+  if (err instanceof ValidationError) {
+    out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON());
+    out.flush();
+    process.exit(EXIT_CODES.VALIDATION);
+  }
+  out.fail(`scaffold failed: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
 }

--- a/plugins/harness/bin/harness-validate-skills.mjs
+++ b/plugins/harness/bin/harness-validate-skills.mjs
@@ -1,25 +1,92 @@
 #!/usr/bin/env node
-import { createHarnessContext } from "../src/spec-harness-lib.mjs";
-import { validateManifest, refreshChecksums } from "../src/validate-skills-inventory.mjs";
+/**
+ * harness-validate-skills — validates `.claude/skills-manifest.json` against
+ * the sha256 checksums recorded for every indexed skill/command, and flags
+ * orphan files on disk + dependency cycles.
+ *
+ * Exits: 0 manifest valid, 1 one or more violations, 2 env error, 64 usage
+ * error.
+ */
 
-const args = process.argv.slice(2);
-const update = args.includes("--update");
-const rrIdx = args.indexOf("--repo-root");
-const repoRoot = rrIdx >= 0 ? args[rrIdx + 1] : undefined;
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { formatError } from "../src/lib/errors.mjs";
+import { version } from "../src/index.mjs";
+import {
+  createHarnessContext,
+  validateManifest,
+  refreshChecksums,
+} from "../src/index.mjs";
 
-const ctx = createHarnessContext({ repoRoot });
+const META = {
+  name: "harness-validate-skills",
+  synopsis: "harness-validate-skills [OPTIONS]",
+  description: "Validate .claude/skills-manifest.json checksums, orphans, and DAG. Use --update to rewrite checksums in place.",
+  flags: {
+    "repo-root": { type: "string" },
+    update: { type: "boolean" },
+  },
+};
 
-if (update) {
-  refreshChecksums(ctx);
-  console.log(`✅ Manifest refreshed at ${ctx.manifestPath}`);
-  process.exit(0);
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
 }
 
-const result = validateManifest(ctx);
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const out = createOutput({ json: argv.json, noColor: argv.noColor });
+
+let ctx;
+try {
+  ctx = createHarnessContext({ repoRoot: argv.flags["repo-root"] });
+} catch (err) {
+  out.fail(`could not resolve repo root: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}
+
+if (argv.flags.update) {
+  try {
+    refreshChecksums(ctx);
+    out.pass(`manifest refreshed at ${ctx.manifestPath}`);
+    out.flush();
+    process.exit(EXIT_CODES.OK);
+  } catch (err) {
+    out.fail(`refresh failed: ${err.message}`);
+    out.flush();
+    process.exit(EXIT_CODES.ENV);
+  }
+}
+
+let result;
+try {
+  result = validateManifest(ctx);
+} catch (err) {
+  out.fail(err.message);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}
+
 if (result.ok) {
-  console.log(`✅ Manifest valid (${result.manifest.skills.length} skills).`);
-  process.exit(0);
+  out.pass(`manifest valid (${result.manifest.skills.length} skills)`);
+  out.flush();
+  process.exit(EXIT_CODES.OK);
 }
-console.error("❌ Manifest validation failed:");
-for (const err of result.errors) console.error(`  - ${err}`);
-process.exit(1);
+
+for (const err of result.errors) {
+  out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON ? err.toJSON() : undefined);
+}
+out.flush();
+process.exit(EXIT_CODES.VALIDATION);

--- a/plugins/harness/bin/harness-validate-specs.mjs
+++ b/plugins/harness/bin/harness-validate-specs.mjs
@@ -1,20 +1,70 @@
 #!/usr/bin/env node
-import { createHarnessContext } from "../src/spec-harness-lib.mjs";
-import { validateSpecs } from "../src/validate-specs.mjs";
+/**
+ * harness-validate-specs — validates every `docs/specs/<id>/spec.json` in the
+ * repo against the structured-error contract from `validate-specs.mjs`.
+ *
+ * Exits: 0 all specs valid, 1 one or more validation failures, 2 env error,
+ * 64 usage error.
+ */
 
-const args = process.argv.slice(2);
-const rrIdx = args.indexOf("--repo-root");
-const repoRoot = rrIdx >= 0 ? args[rrIdx + 1] : undefined;
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { formatError } from "../src/lib/errors.mjs";
+import { version } from "../src/index.mjs";
+import {
+  createHarnessContext,
+  listSpecDirs,
+  validateSpecs,
+} from "../src/index.mjs";
 
-const ctx = createHarnessContext({ repoRoot });
+const META = {
+  name: "harness-validate-specs",
+  synopsis: "harness-validate-specs [OPTIONS]",
+  description: "Validate every spec.json under docs/specs/ against the StructuredError contract.",
+  flags: {
+    "repo-root": { type: "string" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const out = createOutput({ json: argv.json, noColor: argv.noColor });
+
+let ctx;
+try {
+  ctx = createHarnessContext({ repoRoot: argv.flags["repo-root"] });
+} catch (err) {
+  out.fail(`could not resolve repo root: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}
 
 const result = validateSpecs(ctx);
 if (result.ok) {
-  const { listSpecDirs } = await import("../src/spec-harness-lib.mjs");
   const count = listSpecDirs(ctx).length;
-  console.log(`✅ ${count} spec(s) valid.`);
-  process.exit(0);
+  out.pass(`${count} spec(s) valid`);
+  out.flush();
+  process.exit(EXIT_CODES.OK);
 }
-console.error("❌ Spec validation failed:");
-for (const err of result.errors) console.error(`  - ${err}`);
-process.exit(1);
+
+for (const err of result.errors) {
+  out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON ? err.toJSON() : undefined);
+}
+out.flush();
+process.exit(EXIT_CODES.VALIDATION);

--- a/plugins/harness/src/check-spec-coverage.mjs
+++ b/plugins/harness/src/check-spec-coverage.mjs
@@ -15,6 +15,22 @@ function normalizeSpecId(v) {
   return v.replace(/^[`'"#]+|[`'"]+$/g, "").trim();
 }
 
+/**
+ * Enforce the spec-coverage contract for a PR: every protected-path change
+ * must be covered by an approved/implementing/done spec, or the PR body must
+ * carry a meaningful `## No-spec rationale` section. Known bot actors bypass
+ * the body contract.
+ *
+ * @param {import('./spec-harness-lib.mjs').HarnessContext} ctx
+ * @param {{ changedFiles: string[], isPullRequest: boolean, body: string, actor: string }} input
+ * @returns {{
+ *   ok: boolean,
+ *   errors: import('./lib/errors.mjs').ValidationError[],
+ *   protectedFiles: string[],
+ *   uncovered: string[],
+ *   note?: string
+ * }}
+ */
 export function checkSpecCoverage(ctx, input) {
   const { changedFiles, isPullRequest, body, actor } = input;
   const errors = [];

--- a/plugins/harness/src/spec-harness-lib.mjs
+++ b/plugins/harness/src/spec-harness-lib.mjs
@@ -3,6 +3,38 @@ import { existsSync, readFileSync, readdirSync } from "fs";
 import path from "path";
 import { debug } from "./lib/debug.mjs";
 
+/**
+ * Execution context threaded through every validator.
+ *
+ * @typedef {object} HarnessContext
+ * @property {string} repoRoot       Absolute path to the repository root.
+ * @property {string} specsRoot      Absolute path to `<repoRoot>/docs/specs`.
+ * @property {string} manifestPath   Absolute path to `<repoRoot>/.claude/skills-manifest.json`.
+ * @property {string} factsPath      Absolute path to `<repoRoot>/docs/repo-facts.json`.
+ */
+
+/**
+ * Uniform shape returned by every validator.
+ *
+ * @typedef {object} ValidationResult
+ * @property {boolean} ok            True when `errors.length === 0`.
+ * @property {Array<import('./lib/errors.mjs').ValidationError>} errors
+ */
+
+/**
+ * Build a {@link HarnessContext} by resolving the repository root through a
+ * three-step fallback:
+ *
+ *   1. `repoRoot` option passed in.
+ *   2. `HARNESS_REPO_ROOT` env var.
+ *   3. `git rev-parse --show-toplevel` in the current working directory.
+ *
+ * Throws when none of the three produce a value (typically when running
+ * outside a git repo with no env override).
+ *
+ * @param {{ repoRoot?: string }} [opts]
+ * @returns {HarnessContext}
+ */
 export function createHarnessContext({ repoRoot } = {}) {
   const root =
     repoRoot ??
@@ -32,30 +64,79 @@ function resolveRepoRootFromGit() {
   }
 }
 
+/**
+ * Convert a platform-native path (which may use `\` on Windows) to a POSIX
+ * path so glob and prefix comparisons are stable across OSes.
+ *
+ * @param {string} p
+ * @returns {string}
+ */
 export function toPosix(p) {
   return p.split(path.sep).join("/");
 }
 
+/**
+ * Read and parse a JSON file at `<repoRoot>/<relativePath>`.
+ * Throws the raw SyntaxError when the file is not valid JSON.
+ *
+ * @param {HarnessContext} ctx
+ * @param {string} relativePath
+ * @returns {any}
+ */
 export function readJson(ctx, relativePath) {
   return JSON.parse(readFileSync(path.join(ctx.repoRoot, relativePath), "utf8"));
 }
 
+/**
+ * Read a file at `<repoRoot>/<relativePath>` as UTF-8 text.
+ *
+ * @param {HarnessContext} ctx
+ * @param {string} relativePath
+ * @returns {string}
+ */
 export function readText(ctx, relativePath) {
   return readFileSync(path.join(ctx.repoRoot, relativePath), "utf8");
 }
 
+/**
+ * Check whether `<repoRoot>/<relativePath>` exists on disk.
+ *
+ * @param {HarnessContext} ctx
+ * @param {string} relativePath
+ * @returns {boolean}
+ */
 export function pathExists(ctx, relativePath) {
   return existsSync(path.join(ctx.repoRoot, relativePath));
 }
 
+/**
+ * Run `git <args>` with `cwd = ctx.repoRoot`, return trimmed stdout.
+ * Lets the underlying error bubble on non-zero exit.
+ *
+ * @param {HarnessContext} ctx
+ * @param {string[]} args
+ * @returns {string}
+ */
 export function git(ctx, args) {
   return execFileSync("git", args, { cwd: ctx.repoRoot, encoding: "utf8" }).trim();
 }
 
+/**
+ * Read the repository's authoritative facts file at `docs/repo-facts.json`.
+ *
+ * @param {HarnessContext} ctx
+ * @returns {any}   Parsed repo-facts.json (shape is repo-specific; see `docs/repo-facts.json`).
+ */
 export function loadFacts(ctx) {
   return readJson(ctx, "docs/repo-facts.json");
 }
 
+/**
+ * List every sub-directory under `docs/specs/` in the repo (spec ids).
+ *
+ * @param {HarnessContext} ctx
+ * @returns {string[]}   Spec ids sorted alphabetically.
+ */
 export function listSpecDirs(ctx) {
   return readdirSync(ctx.specsRoot, { withFileTypes: true })
     .filter((e) => e.isDirectory())
@@ -76,6 +157,16 @@ const DEFAULT_IGNORED_DIRS = new Set([
   "test-results",
 ]);
 
+/**
+ * Recursively list every file under `ctx.repoRoot`, returning repo-relative
+ * POSIX paths. Skips the conventional top-level noise directories (`.git`,
+ * `node_modules`, `dist`, `coverage`) and a curated set of nested ones
+ * (`.claude/worktrees`, `bin`, `api/tmp`, `test-results`).
+ *
+ * @param {HarnessContext} ctx
+ * @param {{ ignoredTopLevel?: Set<string>, ignoredDirectories?: Set<string> }} [opts]
+ * @returns {string[]}   Repo-relative POSIX paths sorted alphabetically.
+ */
 export function listRepoPaths(ctx, { ignoredTopLevel, ignoredDirectories } = {}) {
   const topSkip = ignoredTopLevel ?? DEFAULT_IGNORED_TOP_LEVEL;
   const dirSkip = ignoredDirectories ?? DEFAULT_IGNORED_DIRS;
@@ -99,10 +190,24 @@ export function listRepoPaths(ctx, { ignoredTopLevel, ignoredDirectories } = {})
   return out.sort();
 }
 
+/**
+ * Escape every regex metacharacter in `v` so it can be dropped into a
+ * `new RegExp(...)` literal match.
+ *
+ * @param {string} v
+ * @returns {string}
+ */
 export function escapeRegex(v) {
   return v.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&");
 }
 
+/**
+ * Compile a glob pattern (`**`, `*`, `?`) into a `RegExp` anchored `^…$`.
+ * Uses POSIX semantics — no brace expansion, no character classes.
+ *
+ * @param {string} glob
+ * @returns {RegExp}
+ */
 export function globToRegExp(glob) {
   let regex = "^";
   for (let i = 0; i < glob.length; i += 1) {
@@ -126,10 +231,26 @@ export function globToRegExp(glob) {
   return new RegExp(regex + "$");
 }
 
+/**
+ * Check whether `value` matches the glob `pattern`.
+ *
+ * @param {string} pattern
+ * @param {string} value
+ * @returns {boolean}
+ */
 export function matchesGlob(pattern, value) {
   return globToRegExp(pattern).test(value);
 }
 
+/**
+ * Resolve a `pattern` against an array of candidate paths. Treats bare
+ * (glob-free) patterns as prefix matches so `docs/specs/foo` covers
+ * `docs/specs/foo/spec.json` etc.
+ *
+ * @param {string} pattern
+ * @param {string[]} paths
+ * @returns {boolean}
+ */
 export function anyPathMatches(pattern, paths) {
   const normalized = toPosix(pattern);
   if (!normalized.includes("*") && !normalized.includes("?")) {
@@ -143,6 +264,16 @@ export function anyPathMatches(pattern, paths) {
 }
 
 // ---- PR context helpers (unchanged from squadranks) ----
+
+/**
+ * Extract the body of a markdown H2 section named `heading` (e.g.
+ * `## Spec ID`) from a PR body, case-insensitive. Returns `""` when the
+ * section is absent.
+ *
+ * @param {string} body
+ * @param {string} heading
+ * @returns {string}
+ */
 export function extractTemplateSection(body, heading) {
   if (!body) return "";
   const rx = new RegExp(
@@ -153,12 +284,33 @@ export function extractTemplateSection(body, heading) {
   return m ? m[1].trim() : "";
 }
 
+/**
+ * A section is "meaningful" when it contains at least one non-comment, non-whitespace
+ * character. Strips `<!-- ... -->` HTML comments before the length check.
+ *
+ * @param {string} section
+ * @returns {boolean}
+ */
 export function isMeaningfulSection(section) {
   if (!section) return false;
   const cleaned = section.replace(/<!--[\s\S]*?-->/g, "").trim();
   return cleaned.length > 0;
 }
 
+/**
+ * Pull-request execution context from the GitHub Actions environment.
+ *
+ * @typedef {object} PullRequestContext
+ * @property {boolean} isPullRequest   Derived from `GITHUB_EVENT_NAME === "pull_request"`.
+ * @property {string} body             `PR_BODY` env — populated by workflows that pipe PR text in.
+ * @property {string} actor            `GITHUB_ACTOR` env.
+ */
+
+/**
+ * Read pull-request metadata from the standard GitHub Actions env vars.
+ *
+ * @returns {PullRequestContext}
+ */
 export function getPullRequestContext() {
   const event = process.env.GITHUB_EVENT_NAME ?? "";
   const isPullRequest = event === "pull_request";
@@ -168,10 +320,27 @@ export function getPullRequestContext() {
 }
 
 const BOT_AUTHORS = new Set(["dependabot[bot]", "github-actions[bot]"]);
+
+/**
+ * Report whether `actor` is one of the recognized bot authors that bypasses
+ * the PR-body spec/rationale contract.
+ *
+ * @param {string} actor
+ * @returns {boolean}
+ */
 export function isBotActor(actor) {
   return BOT_AUTHORS.has(actor);
 }
 
+/**
+ * Resolve the list of files changed in the current PR. Prefers
+ * `HARNESS_CHANGED_FILES` (CSV) when set; otherwise falls back to
+ * `git diff --name-only origin/<base>...HEAD`, defaulting `base` to
+ * `GITHUB_BASE_REF || "main"`. Returns `[]` on git failure — the failure is
+ * surfaced via `debug("git:diff", …)` when `HARNESS_DEBUG=1`.
+ *
+ * @returns {string[]}
+ */
 export function getChangedFiles() {
   const csv = process.env.HARNESS_CHANGED_FILES;
   if (csv) return csv.split(",").filter(Boolean);

--- a/plugins/harness/src/validate-skills-inventory.mjs
+++ b/plugins/harness/src/validate-skills-inventory.mjs
@@ -39,6 +39,21 @@ function listSkillFilesRecursive(ctx) {
   return out;
 }
 
+/**
+ * Validate `.claude/skills-manifest.json`:
+ *   - every indexed file exists on disk
+ *   - recorded sha256 checksum matches the current file contents
+ *   - no file on disk under `.claude/commands/` or `.claude/skills/` is
+ *     orphaned (i.e. missing from the manifest)
+ *   - the `dependencies[]` DAG has no cycles
+ *
+ * @param {import('./spec-harness-lib.mjs').HarnessContext} ctx
+ * @returns {{
+ *   ok: boolean,
+ *   errors: import('./lib/errors.mjs').ValidationError[],
+ *   manifest: any
+ * }}
+ */
 export function validateManifest(ctx) {
   const errors = [];
   const manifest = loadManifest(ctx);
@@ -111,6 +126,14 @@ export function validateManifest(ctx) {
   return { ok: errors.length === 0, errors, manifest };
 }
 
+/**
+ * Recompute every sha256 in `.claude/skills-manifest.json` from the current
+ * contents on disk and write the manifest back in place. Does not validate
+ * anything — pair with {@link validateManifest} to confirm the result.
+ *
+ * @param {import('./spec-harness-lib.mjs').HarnessContext} ctx
+ * @returns {any}   The in-memory manifest object just written to disk.
+ */
 export function refreshChecksums(ctx) {
   const manifest = loadManifest(ctx);
   for (const skill of manifest.skills) {

--- a/scripts/check-jsdoc-coverage.mjs
+++ b/scripts/check-jsdoc-coverage.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Verifies every `export` in the target directory tree is preceded by a
+ * JSDoc block (`/** … *\/`). Re-exports (`export { foo } from "./x"`) and
+ * the barrel's type-import helpers are treated as already-documented.
+ *
+ * Usage:
+ *   node scripts/check-jsdoc-coverage.mjs [dir ...]
+ *
+ * Defaults to `plugins/harness/src/` when no argument is passed. Exits 0 on
+ * full coverage, 1 on any uncovered export.
+ *
+ * Intentionally dependency-free — mirrors the zero-runtime-deps promise in
+ * `package.json` and ADR-0002.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve, join, relative, sep } from "node:path";
+
+const argv = process.argv.slice(2);
+const roots = argv.length > 0 ? argv : ["plugins/harness/src"];
+
+/**
+ * Walk a directory recursively, yielding every `.mjs` file.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function walkMjs(dir) {
+  /** @type {string[]} */
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkMjs(abs));
+    } else if (entry.isFile() && entry.name.endsWith(".mjs")) {
+      out.push(abs);
+    }
+  }
+  return out;
+}
+
+/**
+ * Scan one `.mjs` file and return each uncovered export location.
+ *
+ * An export is "covered" when the immediately-preceding non-blank line
+ * belongs to a JSDoc block (`/** …` … ` *\/`). Re-exports and export
+ * declarations that wrap a re-export (`export { … } from …`) are skipped —
+ * the original declaration (in the referenced module) is what needs JSDoc.
+ *
+ * @param {string} file
+ * @returns {{ line: number, snippet: string }[]}
+ */
+function findUncoveredExports(file) {
+  const src = readFileSync(file, "utf8");
+  const lines = src.split("\n");
+  /** @type {{ line: number, snippet: string }[]} */
+  const uncovered = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("export ")) continue;
+
+    // Skip pure re-exports: `export { foo } from "./x";` and `export * from …`.
+    if (/^export\s+\{[^}]*\}\s+from\s+/.test(trimmed)) continue;
+    if (/^export\s+\*\s+from\s+/.test(trimmed)) continue;
+    if (/^export\s+\{[^}]*\};?\s*$/.test(trimmed)) continue;
+    if (/^export\s+default\b/.test(trimmed) && !/^export\s+default\s+(function|class)/.test(trimmed)) continue;
+
+    // Only named declarations that introduce a symbol count.
+    if (!/^export\s+(async\s+)?(function|class|const|let|var)\b/.test(trimmed)) continue;
+
+    // Walk backwards past blank lines to find the preceding non-empty line.
+    let j = i - 1;
+    while (j >= 0 && lines[j].trim() === "") j -= 1;
+    const prev = j >= 0 ? lines[j].trim() : "";
+
+    if (prev.endsWith("*/")) continue;
+
+    uncovered.push({ line: i + 1, snippet: trimmed });
+  }
+  return uncovered;
+}
+
+let total = 0;
+let uncoveredTotal = 0;
+/** @type {string[]} */
+const report = [];
+
+for (const root of roots) {
+  const abs = resolve(root);
+  let files;
+  try {
+    if (!statSync(abs).isDirectory()) {
+      files = [abs];
+    } else {
+      files = walkMjs(abs);
+    }
+  } catch (err) {
+    process.stderr.write(`check-jsdoc-coverage: cannot scan ${root}: ${err.message}\n`);
+    process.exit(2);
+  }
+  for (const file of files) {
+    total += 1;
+    const uncovered = findUncoveredExports(file);
+    if (uncovered.length === 0) continue;
+    uncoveredTotal += uncovered.length;
+    const rel = relative(process.cwd(), file).split(sep).join("/");
+    for (const { line, snippet } of uncovered) {
+      report.push(`  ${rel}:${line}  ${snippet}`);
+    }
+  }
+}
+
+if (uncoveredTotal === 0) {
+  process.stdout.write(`check-jsdoc-coverage: ok — ${total} file(s) scanned, every export documented.\n`);
+  process.exit(0);
+}
+
+process.stderr.write(`check-jsdoc-coverage: ${uncoveredTotal} export(s) missing JSDoc across ${total} file(s):\n`);
+for (const row of report) process.stderr.write(`${row}\n`);
+process.exit(1);


### PR DESCRIPTION
## Summary

- Rewrite all five legacy bins (`harness-validate-specs`, `harness-validate-skills`, `harness-check-instruction-drift`, `harness-check-spec-coverage`, `harness-init`) on top of `src/lib/{argv,output,errors,exit-codes}.mjs`. Every bin now supports `--help`, `--version`, `--json`, `--verbose`, `--no-color`, `--repo-root`, and exits with the named `EXIT_CODES` convention (0 ok, 1 validation failure, 2 env error, 64 usage error — `sysexits.h` EX_USAGE).
- Add JSDoc `@param` / `@returns` / `@typedef HarnessContext` / `@typedef ValidationResult` / `@typedef PullRequestContext` to every export in `plugins/harness/src/spec-harness-lib.mjs` (18 exports). Also document the three previously-undocumented exports in `check-spec-coverage.mjs` and `validate-skills-inventory.mjs`.
- Add `scripts/check-jsdoc-coverage.mjs` — a dependency-free walker that fails CI when any `export` in `plugins/harness/src/` lacks a preceding JSDoc block. Treats re-exports (`export { foo } from "./x"`) as already-documented.

## Test plan

- [x] `npm test` — 74/74 green.
- [x] `node scripts/check-jsdoc-coverage.mjs plugins/harness/src` — `ok — 12 file(s) scanned, every export documented.`
- [x] `--version` prints `0.2.0` on all 5 legacy bins.
- [x] `--help` prints a usage block with the merged `HARNESS_FLAGS` on all 5 legacy bins.
- [x] `--json` emits a `{ events: [{ kind, message, details }], counts }` payload containing `ValidationError.toJSON()` under `details` when a validator fails.
- [x] Unknown flag (`--bogus`) exits 64 on every bin.
- [x] Invalid-spec fixture exits 1 with code `SPEC_STATUS_INVALID` in the JSON payload.
- [x] `harness validate-specs --repo-root <fixture>` via the umbrella dispatcher still returns `✓ 1 spec(s) valid`.

Spec ID: TBD — harness-core lands in PR 5.
