### PR TITLE
feat(harness): shell hardening + bats suite (PR 4)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.{sh,bats}]
+indent_size = 2

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": { "siblings_only": true },
+    "MD033": { "allowed_elements": ["details", "summary", "kbd", "br", "sub", "sup"] },
+    "MD041": false
+  },
+  "ignores": [
+    "node_modules/**",
+    ".claude/worktrees/**",
+    "plugins/harness/tests/fixtures/**"
+  ]
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,6 @@
+shell=bash
+enable=all
+disable=SC2250
+# SC2250: Prefer ${var} over $var — noisy for simple cases; we still use ${} for
+# disambiguation where it matters, but forcing it everywhere is churn without
+# value. Every other shellcheck rule is on.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,14 +3,38 @@
 #
 # Idempotent: safe to re-run after pulling new commits.
 # Backs up pre-existing real files (not symlinks) to <name>.bak-<timestamp>.
+#
+# Flags:
+#   --quiet   suppress per-file progress output; only warnings + the final
+#             one-line summary are printed.
 
 set -euo pipefail
+
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    --quiet) QUIET=1 ;;
+    --help|-h)
+      grep -E '^# ' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "bootstrap.sh: unknown argument '$arg' (try --help)" >&2
+      exit 64
+      ;;
+  esac
+done
 
 DOTCLAUDE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TARGET="$HOME/.claude"
 TS=$(date +%Y%m%d-%H%M%S)
 
 mkdir -p "$TARGET"
+
+say() {
+  [ "$QUIET" = "1" ] && return 0
+  echo "$@"
+}
 
 link_one() {
   local src="$1"
@@ -21,32 +45,32 @@ link_one() {
     if [ "$(readlink "$dst")" != "$src" ]; then
       rm "$dst"
       ln -s "$src" "$dst"
-      echo "  updated: $dst -> $src"
+      say "  updated: $dst -> $src"
     else
-      echo "  ok:      $dst"
+      say "  ok:      $dst"
     fi
   elif [ -e "$dst" ]; then
     # Real file/dir — back it up before linking.
     mv "$dst" "${dst}.bak-${TS}"
     ln -s "$src" "$dst"
-    echo "  backed up + linked: $dst (old at ${dst}.bak-${TS})"
+    say "  backed up + linked: $dst (old at ${dst}.bak-${TS})"
   else
     ln -s "$src" "$dst"
-    echo "  linked:  $dst -> $src"
+    say "  linked:  $dst -> $src"
   fi
 }
 
-echo "==> linking CLAUDE.md"
+say "==> linking CLAUDE.md"
 [ -f "$DOTCLAUDE/CLAUDE.md" ] && link_one "$DOTCLAUDE/CLAUDE.md" "$TARGET/CLAUDE.md"
 
-echo "==> linking commands/"
+say "==> linking commands/"
 mkdir -p "$TARGET/commands"
 for f in "$DOTCLAUDE/commands"/*.md; do
   [ -e "$f" ] || continue
   link_one "$f" "$TARGET/commands/$(basename "$f")"
 done
 
-echo "==> linking skills/"
+say "==> linking skills/"
 mkdir -p "$TARGET/skills"
 for d in "$DOTCLAUDE/skills"/*/; do
   [ -e "$d" ] || continue
@@ -54,7 +78,18 @@ for d in "$DOTCLAUDE/skills"/*/; do
   link_one "${d%/}" "$TARGET/skills/$name"
 done
 
-echo ""
-echo "bootstrap complete."
-echo "dotclaude: $DOTCLAUDE"
-echo "target:    $TARGET"
+if [ "$QUIET" = "1" ]; then
+  echo "bootstrap complete — target: $TARGET"
+else
+  echo ""
+  echo "bootstrap complete."
+  echo "dotclaude: $DOTCLAUDE"
+  echo "target:    $TARGET"
+fi
+
+# Tail hint — only when harness-doctor is discoverable on PATH so first-time
+# bootstrappers are not confused by a broken reference.
+if command -v harness-doctor >/dev/null 2>&1 && [ "$QUIET" != "1" ]; then
+  echo ""
+  echo "next: run 'harness-doctor' to verify install."
+fi

--- a/plugins/harness/hooks/guard-destructive-git.sh
+++ b/plugins/harness/hooks/guard-destructive-git.sh
@@ -1,23 +1,58 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PreToolUse hook: block destructive git operations.
 # Reads JSON from stdin (Claude Code hook protocol).
-# Exit 2 = block the tool call. Exit 0 = allow.
+# Exit 2 = block the tool call (Claude Code hook protocol — NOT the harness
+# validator exit convention). Exit 0 = allow.
+#
+# Bypass: set BYPASS_DESTRUCTIVE_GIT=1 in the command's environment when you
+# genuinely need to run a destructive git invocation. Use sparingly — the
+# block exists because these operations are silently destructive.
 
-# Fail open if jq is not installed (don't break all Bash tool calls)
-if ! command -v jq &>/dev/null; then
+# Fail open if jq is not installed (don't break all Bash tool calls).
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+if [ "${BYPASS_DESTRUCTIVE_GIT:-0}" = "1" ]; then
   exit 0
 fi
 
 INPUT=$(cat)
-TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
+[ "$TOOL" = "Bash" ] || exit 0
 
-if [ "$TOOL" = "Bash" ]; then
-  CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-  if echo "$CMD" | grep -qE 'git[[:space:]]+(reset[[:space:]]+--hard|push[[:space:]][^&;#]*[[:space:]]+(-f|--force|--force-with-lease)\b|clean[[:space:]][^&;#]*[[:space:]]+-f[dx]?\b|checkout[[:space:]]+\.\b|restore[[:space:]]+\.\b)'; then
-    echo "BLOCKED: Destructive git operation detected. Get explicit user confirmation first." >&2
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
+# Normalize whitespace: tabs -> space, collapse runs of whitespace so regex
+# anchors only have to reason about single spaces.
+NORM=$(printf '%s' "$CMD" | tr '\t' ' ' | tr -s ' ')
+
+# Boundary before the `git` token is one of: start-of-line, whitespace, or a
+# command-chaining separator (`;`, `&&`, `||`, `|`). This prevents false
+# positives like `echo git` inside a quoted string while still catching
+# `foo && git reset --hard`.
+BOUNDARY='(^|[[:space:];&|])'
+G='git[[:space:]]+'
+
+# Destructive verbs. Each alternative is anchored on the right by at least one
+# flag/keyword that makes the call unambiguously destructive.
+PATTERNS=(
+  "${BOUNDARY}${G}reset[[:space:]]+--hard(\b|[[:space:]]|$)"
+  "${BOUNDARY}${G}push[[:space:]][^&;|]*(-f|--force|--force-with-lease)(\b|=|[[:space:]]|$)"
+  "${BOUNDARY}${G}clean[[:space:]][^&;|]*(-[a-zA-Z]*f[a-zA-Z]*|--force)(\b|=|[[:space:]]|$)"
+  "${BOUNDARY}${G}checkout[[:space:]]+\.(\b|$)"
+  "${BOUNDARY}${G}restore[[:space:]]+\.(\b|$)"
+  "${BOUNDARY}${G}branch[[:space:]]+-D\b"
+  "${BOUNDARY}${G}worktree[[:space:]]+remove[[:space:]]+--force\b"
+)
+
+for rx in "${PATTERNS[@]}"; do
+  if printf '%s' "$NORM" | grep -qE "$rx"; then
+    {
+      echo "BLOCKED: Destructive git operation detected. Get explicit user confirmation first."
+      echo "         Bypass (only with user confirmation): BYPASS_DESTRUCTIVE_GIT=1 <your command>"
+    } >&2
     exit 2
   fi
-
-fi
+done
 
 exit 0

--- a/plugins/harness/scripts/lib/output.sh
+++ b/plugins/harness/scripts/lib/output.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# output.sh — shared ✓/✗/⚠ helpers for every harness shell script.
+#
+# Gold-standard originates from plugins/harness/scripts/validate-settings.sh:43-45.
+# Every consumer should:
+#
+#   # shellcheck source=plugins/harness/scripts/lib/output.sh
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/output.sh"
+#   out_init            # sets G/R/Y/N + FAIL/WARN globals, honors --json + NO_COLOR
+#   pass "JSON well-formed"
+#   fail "SEC-2 skipDangerousModePermissionPrompt is set"
+#   warn "projects/ close to budget"
+#   out_summary         # prints "Summary: N failure(s), N warning(s)"
+#
+# When HARNESS_JSON=1 is set, pass/fail/warn buffer JSON objects with the shape
+#   { "check": "...", "category": "...", "status": "pass|fail|warn", "message": "..." }
+# into HARNESS_JSON_BUFFER; callers flush with `out_flush`. The `category`
+# defaults to the CATEGORY env; individual calls can override with the
+# two-argument form: `fail SEC-2 "skipDangerous... is set"`.
+
+# Shell-scoped globals are set by out_init. Declaring defaults here keeps
+# callers working even if they forget out_init and lets linters see the
+# assignments.
+FAIL=${FAIL:-0}
+WARN=${WARN:-0}
+G=""; R=""; Y=""; N=""
+HARNESS_JSON=${HARNESS_JSON:-0}
+HARNESS_JSON_BUFFER=""
+# shellcheck disable=SC2034  # CATEGORY is consumed by sourced scripts
+CATEGORY=${CATEGORY:-general}
+
+out_init() {
+  FAIL=0
+  WARN=0
+  HARNESS_JSON_BUFFER=""
+  if [ "${HARNESS_JSON:-0}" = "1" ] || [ "${NO_COLOR:-}" != "" ] || [ ! -t 1 ]; then
+    G=""; R=""; Y=""; N=""
+  else
+    G=$'\033[32m'; R=$'\033[31m'; Y=$'\033[33m'; N=$'\033[0m'
+  fi
+}
+
+# Internal: buffer one JSON object. Escapes the double-quotes and backslashes in $message.
+_out_json_push() {
+  local status="$1" check="$2" message="$3"
+  local cat="${4:-$CATEGORY}"
+  # Escape backslash then double-quote for safe JSON inclusion.
+  message=${message//\\/\\\\}
+  message=${message//\"/\\\"}
+  check=${check//\\/\\\\}
+  check=${check//\"/\\\"}
+  local entry
+  entry=$(printf '{"check":"%s","category":"%s","status":"%s","message":"%s"}' \
+    "$check" "$cat" "$status" "$message")
+  if [ -z "$HARNESS_JSON_BUFFER" ]; then
+    HARNESS_JSON_BUFFER="$entry"
+  else
+    HARNESS_JSON_BUFFER="$HARNESS_JSON_BUFFER,$entry"
+  fi
+}
+
+pass() {
+  local msg="$1"
+  if [ "${HARNESS_JSON:-0}" = "1" ]; then
+    _out_json_push pass "${2:-$msg}" "$msg"
+  else
+    printf '  %s✓%s %s\n' "$G" "$N" "$msg"
+  fi
+}
+
+fail() {
+  local msg="$1"
+  FAIL=$((FAIL+1))
+  if [ "${HARNESS_JSON:-0}" = "1" ]; then
+    _out_json_push fail "${2:-$msg}" "$msg"
+  else
+    printf '  %s✗%s %s\n' "$R" "$N" "$msg"
+  fi
+}
+
+warn() {
+  local msg="$1"
+  WARN=$((WARN+1))
+  if [ "${HARNESS_JSON:-0}" = "1" ]; then
+    _out_json_push warn "${2:-$msg}" "$msg"
+  else
+    printf '  %s⚠%s %s\n' "$Y" "$N" "$msg"
+  fi
+}
+
+out_flush() {
+  if [ "${HARNESS_JSON:-0}" = "1" ]; then
+    printf '{"events":[%s],"counts":{"fail":%d,"warn":%d}}\n' \
+      "$HARNESS_JSON_BUFFER" "$FAIL" "$WARN"
+  fi
+}
+
+out_summary() {
+  if [ "${HARNESS_JSON:-0}" = "1" ]; then
+    out_flush
+  else
+    echo
+    echo "Summary: $FAIL failure(s), $WARN warning(s)"
+  fi
+}

--- a/plugins/harness/scripts/validate-settings.sh
+++ b/plugins/harness/scripts/validate-settings.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   validate-settings.sh                      # validates ~/.claude/settings.json
 #   validate-settings.sh <path-to-settings>   # validates an alternative file
+#   validate-settings.sh --json [<path>]      # emit JSON events on stdout
 #
 # Exit codes:
 #   0 — all hard checks pass
@@ -23,41 +24,51 @@
 # Soft checks (warn, exit 0):
 #   OPS-2  ~/.claude/projects/ ≤ 1.5 GB, ~/.claude/file-history/ ≤ 100 MB
 
-set -u
+set -euo pipefail
 
-SETTINGS=${1:-$HOME/.claude/settings.json}
-PLUGINS_REG=$HOME/.claude/plugins/installed_plugins.json
-CREDS=$HOME/.claude/.credentials.json
-PROJECTS_DIR=$HOME/.claude/projects
-FILE_HISTORY_DIR=$HOME/.claude/file-history
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=plugins/harness/scripts/lib/output.sh
+source "$SCRIPT_DIR/lib/output.sh"
 
-FAIL=0
-WARN=0
+# Argv: --json flag is order-independent but must precede the positional path.
+HARNESS_JSON=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json)  HARNESS_JSON=1; shift ;;
+    --help|-h)
+      grep -E '^# ' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) break ;;
+  esac
+done
+export HARNESS_JSON
 
-if [ -t 1 ]; then
-  G=$'\033[32m'; R=$'\033[31m'; Y=$'\033[33m'; N=$'\033[0m'
-else
-  G=""; R=""; Y=""; N=""
+SETTINGS="${1:-$HOME/.claude/settings.json}"
+PLUGINS_REG="$HOME/.claude/plugins/installed_plugins.json"
+CREDS="$HOME/.claude/.credentials.json"
+PROJECTS_DIR="$HOME/.claude/projects"
+FILE_HISTORY_DIR="$HOME/.claude/file-history"
+
+out_init
+
+if [ "$HARNESS_JSON" != "1" ]; then
+  echo "Validating $SETTINGS"
+  echo
 fi
 
-pass() { printf '  %s✓%s %s\n' "$G" "$N" "$1"; }
-fail() { printf '  %s✗%s %s\n' "$R" "$N" "$1"; FAIL=$((FAIL+1)); }
-warn() { printf '  %s⚠%s %s\n' "$Y" "$N" "$1"; WARN=$((WARN+1)); }
-
-echo "Validating $SETTINGS"
-echo
-
 # --- JSON validity (blocking) ---
+CATEGORY=OPS-1
 if jq -e . < "$SETTINGS" > /dev/null 2>&1; then
   pass "JSON well-formed"
 else
   fail "JSON malformed"
-  echo
-  echo "Summary: 1 failure"
+  out_summary
   exit 1
 fi
 
 # --- SEC-2: no skipDangerousModePermissionPrompt ---
+CATEGORY=SEC-2
 if jq -e 'has("skipDangerousModePermissionPrompt")' < "$SETTINGS" > /dev/null 2>&1; then
   fail "SEC-2 skipDangerousModePermissionPrompt is set"
 else
@@ -65,6 +76,7 @@ else
 fi
 
 # --- SEC-1: no secret literals ---
+CATEGORY=SEC-1
 SECRET_LEAKS=$(jq -r '
   . as $root
   | [paths(scalars)] as $ps
@@ -75,7 +87,7 @@ SECRET_LEAKS=$(jq -r '
   | select(($v | type) == "string")
   | select($v | test("^[A-Za-z0-9_-]{20,}$"))
   | ($p | map(tostring) | join("."))
-' < "$SETTINGS")
+' < "$SETTINGS" || true)
 
 if [ -z "$SECRET_LEAKS" ]; then
   pass "SEC-1 no secret literals in *_KEY/*_TOKEN/*_SECRET fields"
@@ -84,13 +96,14 @@ else
 fi
 
 # --- SEC-3: no @latest in MCP args ---
+CATEGORY=SEC-3
 LATEST_REFS=$(jq -r '
   .mcpServers // {} | to_entries[]
   | . as $s
   | ($s.value.args // [])[]
   | select(. | test("@latest$"))
-  | $s.key + " → " + .
-' < "$SETTINGS")
+  | $s.key + " -> " + .
+' < "$SETTINGS" || true)
 
 if [ -z "$LATEST_REFS" ]; then
   pass "SEC-3 no @latest in MCP args"
@@ -99,6 +112,7 @@ else
 fi
 
 # --- MCP command resolvable ---
+CATEGORY=OPS-1
 while IFS= read -r cmd; do
   [ -z "$cmd" ] && continue
   if [[ "$cmd" == /* ]]; then
@@ -117,6 +131,7 @@ while IFS= read -r cmd; do
 done < <(jq -r '.mcpServers // {} | to_entries[] | .value.command' < "$SETTINGS")
 
 # --- hooks + statusLine target paths ---
+CATEGORY=OPS-1
 while IFS= read -r cmd; do
   [ -z "$cmd" ] && continue
   script=$(echo "$cmd" | awk '{for(i=1;i<=NF;i++) if($i ~ /^\//) {print $i; exit}}')
@@ -134,6 +149,7 @@ done < <(jq -r '
 ' < "$SETTINGS")
 
 # --- enabledPlugins installed? ---
+CATEGORY=OPS-1
 if [ -f "$PLUGINS_REG" ]; then
   while IFS= read -r plugin; do
     [ -z "$plugin" ] && continue
@@ -148,8 +164,9 @@ else
 fi
 
 # --- SEC-4: .credentials.json mode 600 ---
+CATEGORY=SEC-4
 if [ -f "$CREDS" ]; then
-  MODE=$(stat -c '%a' "$CREDS" 2>/dev/null)
+  MODE=$(stat -c '%a' "$CREDS" 2>/dev/null || echo "?")
   if [ "$MODE" = "600" ]; then
     pass "SEC-4 .credentials.json mode 600"
   else
@@ -160,9 +177,11 @@ else
 fi
 
 # --- OPS-2 disk budgets (soft) ---
+CATEGORY=OPS-2
 if [ -d "$PROJECTS_DIR" ]; then
   PROJECTS_MB=$(du -sm "$PROJECTS_DIR" 2>/dev/null | awk '{print $1}')
   if [ "$PROJECTS_MB" -gt 1536 ]; then
+    # shellcheck disable=SC2088  # literal ~ is user-readable text, not a filesystem path
     warn "~/.claude/projects/ is ${PROJECTS_MB} MB (budget: 1536 MB). Prune: find ~/.claude/projects -mindepth 2 -maxdepth 2 -type f -mtime +60 -delete"
   else
     pass "projects/ size OK (${PROJECTS_MB} MB / 1536)"
@@ -172,12 +191,12 @@ fi
 if [ -d "$FILE_HISTORY_DIR" ]; then
   FH_MB=$(du -sm "$FILE_HISTORY_DIR" 2>/dev/null | awk '{print $1}')
   if [ "$FH_MB" -gt 100 ]; then
+    # shellcheck disable=SC2088  # literal ~ is user-readable text, not a filesystem path
     warn "~/.claude/file-history/ is ${FH_MB} MB (budget: 100 MB)"
   else
     pass "file-history/ size OK (${FH_MB} MB / 100)"
   fi
 fi
 
-echo
-echo "Summary: $FAIL failure(s), $WARN warning(s)"
+out_summary
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/plugins/harness/templates/claude/hooks/guard-destructive-git.sh
+++ b/plugins/harness/templates/claude/hooks/guard-destructive-git.sh
@@ -1,23 +1,50 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PreToolUse hook: block destructive git operations.
 # Reads JSON from stdin (Claude Code hook protocol).
-# Exit 2 = block the tool call. Exit 0 = allow.
+# Exit 2 = block the tool call (Claude Code hook protocol — NOT the harness
+# validator exit convention). Exit 0 = allow.
+#
+# Bypass: set BYPASS_DESTRUCTIVE_GIT=1 in the command's environment when you
+# genuinely need to run a destructive git invocation. Use sparingly — the
+# block exists because these operations are silently destructive.
 
-# Fail open if jq is not installed (don't break all Bash tool calls)
-if ! command -v jq &>/dev/null; then
+# Fail open if jq is not installed (don't break all Bash tool calls).
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+if [ "${BYPASS_DESTRUCTIVE_GIT:-0}" = "1" ]; then
   exit 0
 fi
 
 INPUT=$(cat)
-TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
+[ "$TOOL" = "Bash" ] || exit 0
 
-if [ "$TOOL" = "Bash" ]; then
-  CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-  if echo "$CMD" | grep -qE 'git[[:space:]]+(reset[[:space:]]+--hard|push[[:space:]][^&;#]*[[:space:]]+(-f|--force|--force-with-lease)\b|clean[[:space:]][^&;#]*[[:space:]]+-f[dx]?\b|checkout[[:space:]]+\.\b|restore[[:space:]]+\.\b)'; then
-    echo "BLOCKED: Destructive git operation detected. Get explicit user confirmation first." >&2
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
+NORM=$(printf '%s' "$CMD" | tr '\t' ' ' | tr -s ' ')
+
+BOUNDARY='(^|[[:space:];&|])'
+G='git[[:space:]]+'
+
+PATTERNS=(
+  "${BOUNDARY}${G}reset[[:space:]]+--hard(\b|[[:space:]]|$)"
+  "${BOUNDARY}${G}push[[:space:]][^&;|]*(-f|--force|--force-with-lease)(\b|=|[[:space:]]|$)"
+  "${BOUNDARY}${G}clean[[:space:]][^&;|]*(-[a-zA-Z]*f[a-zA-Z]*|--force)(\b|=|[[:space:]]|$)"
+  "${BOUNDARY}${G}checkout[[:space:]]+\.(\b|$)"
+  "${BOUNDARY}${G}restore[[:space:]]+\.(\b|$)"
+  "${BOUNDARY}${G}branch[[:space:]]+-D\b"
+  "${BOUNDARY}${G}worktree[[:space:]]+remove[[:space:]]+--force\b"
+)
+
+for rx in "${PATTERNS[@]}"; do
+  if printf '%s' "$NORM" | grep -qE "$rx"; then
+    {
+      echo "BLOCKED: Destructive git operation detected. Get explicit user confirmation first."
+      echo "         Bypass (only with user confirmation): BYPASS_DESTRUCTIVE_GIT=1 <your command>"
+    } >&2
     exit 2
   fi
-
-fi
+done
 
 exit 0

--- a/plugins/harness/tests/bats/bootstrap.bats
+++ b/plugins/harness/tests/bats/bootstrap.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Behavior tests for bootstrap.sh — hermetic $HOME under a tmpdir.
+
+load helpers
+
+BOOT="$REPO_ROOT/bootstrap.sh"
+
+setup() {
+  [ -x "$BOOT" ] || chmod +x "$BOOT"
+  export HOME
+  HOME=$(make_tmp_home)
+  # Clear any inherited BASH_ENV sourced files.
+  unset CLAUDE_HOME 2>/dev/null || true
+}
+
+teardown() {
+  [ -n "${HOME:-}" ] && [ -d "$HOME" ] && rm -rf "$HOME"
+}
+
+@test "first run: links CLAUDE.md + commands/ + skills/" {
+  run "$BOOT"
+  [ "$status" -eq 0 ]
+  [ -L "$HOME/.claude/CLAUDE.md" ]
+  # At least one command file was linked.
+  run bash -c "ls -1 '$HOME/.claude/commands/'*.md | head -1"
+  [ "$status" -eq 0 ]
+}
+
+@test "idempotent: second run reports 'ok:' for existing links" {
+  "$BOOT" >/dev/null
+  run "$BOOT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok:"* ]]
+}
+
+@test "backs up a real file before replacing with symlink" {
+  echo "old content" > "$HOME/.claude/CLAUDE.md"
+  run "$BOOT"
+  [ "$status" -eq 0 ]
+  [ -L "$HOME/.claude/CLAUDE.md" ]
+  run bash -c "ls '$HOME/.claude/'CLAUDE.md.bak-*"
+  [ "$status" -eq 0 ]
+}
+
+@test "repairs a broken symlink (pointing nowhere)" {
+  ln -s "/does/not/exist" "$HOME/.claude/CLAUDE.md"
+  run "$BOOT"
+  [ "$status" -eq 0 ]
+  [ -L "$HOME/.claude/CLAUDE.md" ]
+  target=$(readlink "$HOME/.claude/CLAUDE.md")
+  [ "$target" = "$REPO_ROOT/CLAUDE.md" ]
+}
+
+@test "updates a stale symlink (pointing to a different path)" {
+  ln -s "/tmp/stale-target" "$HOME/.claude/CLAUDE.md"
+  run "$BOOT"
+  [ "$status" -eq 0 ]
+  target=$(readlink "$HOME/.claude/CLAUDE.md")
+  [ "$target" = "$REPO_ROOT/CLAUDE.md" ]
+}
+
+@test "--quiet suppresses per-file output" {
+  run "$BOOT" --quiet
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"  ok:"* ]]
+  [[ "$output" != *"  linked:"* ]]
+  [[ "$output" == *"bootstrap complete"* ]]
+}
+
+@test "--help prints usage and exits 0" {
+  run "$BOOT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootstrap.sh"* ]]
+  [[ "$output" == *"--quiet"* ]]
+}
+
+@test "rejects unknown argument with exit 64" {
+  run "$BOOT" --bogus
+  [ "$status" -eq 64 ]
+}

--- a/plugins/harness/tests/bats/guard-destructive-git.bats
+++ b/plugins/harness/tests/bats/guard-destructive-git.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# Behavior tests for plugins/harness/hooks/guard-destructive-git.sh
+#
+# Every test exercises the hook via stdin JSON, not a real Bash tool call,
+# so the suite is hermetic and doesn't depend on Claude Code being installed.
+
+load helpers
+
+HOOK="$REPO_ROOT/plugins/harness/hooks/guard-destructive-git.sh"
+
+setup() {
+  [ -x "$HOOK" ] || chmod +x "$HOOK"
+}
+
+# ---------------- block paths ----------------
+
+@test "blocks git reset --hard" {
+  feed_hook_json "$HOOK" "git reset --hard HEAD~1"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  [[ "$output" == *"BYPASS_DESTRUCTIVE_GIT=1"* ]]
+}
+
+@test "blocks git push --force" {
+  feed_hook_json "$HOOK" "git push origin main --force"
+  [ "$status" -eq 2 ]
+}
+
+@test "blocks git push -f" {
+  feed_hook_json "$HOOK" "git push origin main -f"
+  [ "$status" -eq 2 ]
+}
+
+@test "blocks git push --force-with-lease" {
+  feed_hook_json "$HOOK" "git push origin main --force-with-lease"
+  [ "$status" -eq 2 ]
+}
+
+@test "blocks git clean -fd" {
+  feed_hook_json "$HOOK" "git clean -fd"
+  [ "$status" -eq 2 ]
+}
+
+@test "blocks git clean -fx" {
+  feed_hook_json "$HOOK" "git clean -fx"
+  [ "$status" -eq 2 ]
+}
+
+@test "blocks git checkout ." {
+  feed_hook_json "$HOOK" "git checkout ."
+  [ "$status" -eq 2 ]
+}
+
+@test "blocks git restore ." {
+  feed_hook_json "$HOOK" "git restore ."
+  [ "$status" -eq 2 ]
+}
+
+@test "blocks git branch -D" {
+  feed_hook_json "$HOOK" "git branch -D feature-branch"
+  [ "$status" -eq 2 ]
+}
+
+@test "blocks git reset --hard with tab whitespace" {
+  feed_hook_json "$HOOK" $'git\treset\t--hard'
+  [ "$status" -eq 2 ]
+}
+
+@test "blocks chained: foo && git reset --hard" {
+  feed_hook_json "$HOOK" "cd /tmp && git reset --hard HEAD~1"
+  [ "$status" -eq 2 ]
+}
+
+# ---------------- allow paths ----------------
+
+@test "allows git status" {
+  feed_hook_json "$HOOK" "git status"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows git reset --soft (harmless)" {
+  feed_hook_json "$HOOK" "git reset --soft HEAD~1"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows git push origin main (no force)" {
+  feed_hook_json "$HOOK" "git push origin main"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows non-Bash tool calls" {
+  run bash -c 'printf "%s" "$1" | "$2"' _ \
+    '{"tool_name":"Read","tool_input":{"path":"foo.txt"}}' \
+    "$HOOK"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows literal 'git reset --hard' inside a quoted echo" {
+  # The command itself is not a git invocation — it's an echo of text. The
+  # hook should inspect the shell command, which starts with `echo`, not `git`.
+  feed_hook_json "$HOOK" 'echo "git reset --hard is dangerous"'
+  [ "$status" -eq 0 ]
+}
+
+# ---------------- bypass ----------------
+
+@test "BYPASS_DESTRUCTIVE_GIT=1 allows otherwise-blocked command" {
+  payload=$(jq -n '{tool_name:"Bash", tool_input:{command:"git reset --hard"}}')
+  run env BYPASS_DESTRUCTIVE_GIT=1 bash -c "printf '%s' \"\$1\" | '$HOOK'" _ "$payload"
+  [ "$status" -eq 0 ]
+}

--- a/plugins/harness/tests/bats/helpers.bash
+++ b/plugins/harness/tests/bats/helpers.bash
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Shared helpers for the bats suite. Source from every .bats file.
+#
+#   load helpers
+#
+# Provides:
+#   REPO_ROOT             absolute path to the dotclaude checkout (export).
+#   make_tmp_home         mktemp a hermetic $HOME for bootstrap tests.
+#   make_tmp_git_repo     mktemp an initialized git repo with an origin remote.
+#   with_fake_git_bin     prepend a shim dir to PATH providing a fake `git`.
+#   feed_hook_json        send a PreToolUse JSON payload to a hook script.
+#   pass_assert / fail_assert  internal helpers (not for consumer use).
+
+# BATS_TEST_DIRNAME is the directory of the current .bats file.
+# REPO_ROOT is four levels up: bats/ → tests/ → harness/ → plugins/ → repo root.
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../../.." && pwd)"
+export REPO_ROOT
+
+make_tmp_home() {
+  local dir
+  dir=$(mktemp -d)
+  mkdir -p "$dir/.claude"
+  echo "$dir"
+}
+
+make_tmp_git_repo() {
+  local dir
+  dir=$(mktemp -d)
+  (
+    cd "$dir"
+    git init -q -b main
+    git config user.email "bats@example.test"
+    git config user.name "bats"
+    # Seed an initial commit so `origin/main` exists after the bare-remote push.
+    echo "init" > README.md
+    git add README.md
+    git commit -q -m "init"
+  )
+  # Stand up a local bare remote so `git fetch origin` works hermetically.
+  local bare="$dir-bare.git"
+  git clone -q --bare "$dir" "$bare"
+  (cd "$dir" && git remote add origin "$bare" && git push -q -u origin main)
+  # Return the *working* clone. Bats captures stdout from the last line.
+  echo "$dir"
+}
+
+# Write a minimal BASH-language shim and prepend its dir to PATH.
+# Usage: with_fake_git_bin <shim-body>
+# Inside shim, $1.. are the args `git` was called with.
+with_fake_git_bin() {
+  local body="$1"
+  local dir
+  dir=$(mktemp -d)
+  cat > "$dir/git" <<EOF
+#!/usr/bin/env bash
+$body
+EOF
+  chmod +x "$dir/git"
+  PATH="$dir:$PATH"
+  export PATH
+  echo "$dir"
+}
+
+# Feed a hook JSON payload to a PreToolUse guard script.
+# Usage: feed_hook_json <path-to-hook> <command-string>
+# Sets ${status}, ${output}, ${lines[@]} as bats' standard `run` would.
+feed_hook_json() {
+  local hook="$1"
+  local cmd="$2"
+  local payload
+  # Build the JSON once, then pipe it to the hook. jq -Rs .< the command as a
+  # JSON string so embedded quotes/backslashes round-trip safely.
+  payload=$(jq -n --arg cmd "$cmd" '{tool_name:"Bash", tool_input:{command:$cmd}}')
+  run bash -c "printf '%s' \"\$1\" | '$hook'" _ "$payload"
+}

--- a/plugins/harness/tests/bats/refresh-worktrees.bats
+++ b/plugins/harness/tests/bats/refresh-worktrees.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# Behavior tests for plugins/harness/scripts/refresh-worktrees.sh.
+
+load helpers
+
+REFRESH="$REPO_ROOT/plugins/harness/scripts/refresh-worktrees.sh"
+
+setup() {
+  [ -x "$REFRESH" ] || chmod +x "$REFRESH"
+  REPO=$(make_tmp_git_repo)
+  export REPO
+}
+
+teardown() {
+  [ -n "${REPO:-}" ] && [ -d "$REPO" ] && rm -rf "$REPO" "$REPO-bare.git"
+}
+
+# Add one worktree at .claude/worktrees/<name> branched from origin/main.
+add_wt() {
+  local name="$1"
+  (cd "$REPO" && git worktree add -q ".claude/worktrees/$name" -b "feat/$name" origin/main)
+}
+
+@test "reports no-op when .claude/worktrees/ does not exist" {
+  run bash -c "cd '$REPO' && '$REFRESH' '$REPO'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no worktrees"* ]]
+}
+
+@test "reports OK when worktree is already up to date with origin/main" {
+  add_wt up-to-date
+  run bash -c "cd '$REPO' && '$REFRESH' '$REPO'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK:"*"up-to-date"* ]] || [[ "$output" == *"FF:"*"up-to-date"* ]]
+}
+
+@test "fast-forwards a worktree that is behind origin/main" {
+  add_wt behind
+  # Advance main.
+  (
+    cd "$REPO"
+    echo "ahead" > ahead.md
+    git add ahead.md
+    git commit -q -m "ahead"
+    git push -q origin main
+  )
+  run bash -c "cd '$REPO' && '$REFRESH' '$REPO'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FF:"*"behind"* ]] || [[ "$output" == *"OK:"*"behind"* ]]
+}
+
+@test "skips a dirty worktree" {
+  add_wt dirty
+  echo "scratch" > "$REPO/.claude/worktrees/dirty/scratch.md"
+  (cd "$REPO/.claude/worktrees/dirty" && git add scratch.md)
+  run bash -c "cd '$REPO' && '$REFRESH' '$REPO'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SKIP"*"dirty"* ]]
+}

--- a/plugins/harness/tests/bats/sync.bats
+++ b/plugins/harness/tests/bats/sync.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# Behavior tests for sync.sh — hermetic clone in a tmpdir.
+# The tests copy sync.sh + bootstrap.sh into a throwaway clone so we never
+# touch the real checkout.
+
+load helpers
+
+setup() {
+  REPO=$(make_tmp_git_repo)
+  export REPO
+  # Drop in the scripts we're testing so `$0` resolution lands in $REPO.
+  cp "$REPO_ROOT/sync.sh" "$REPO/sync.sh"
+  cp "$REPO_ROOT/bootstrap.sh" "$REPO/bootstrap.sh"
+  chmod +x "$REPO/sync.sh" "$REPO/bootstrap.sh"
+  # Commit the copies so they're tracked — otherwise every `push` test sees
+  # them as staged changes.
+  (cd "$REPO" && git add sync.sh bootstrap.sh && git commit -q -m "seed scripts" && git push -q origin main 2>/dev/null || true)
+  # A throwaway $HOME so bootstrap.sh invocations from `pull` don't clobber
+  # the real ~/.claude/.
+  HOME=$(make_tmp_home)
+  export HOME
+}
+
+teardown() {
+  [ -n "${REPO:-}" ] && [ -d "$REPO" ] && rm -rf "$REPO" "$REPO-bare.git"
+  [ -n "${HOME:-}" ] && [ -d "$HOME" ] && rm -rf "$HOME"
+}
+
+@test "status: reports working-tree changes" {
+  (cd "$REPO" && echo new > new.md)
+  run bash -c "cd '$REPO' && ./sync.sh status"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"new.md"* ]]
+}
+
+@test "push: no changes exits 0" {
+  run bash -c "cd '$REPO' && ./sync.sh push"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no changes"* ]]
+}
+
+@test "push: secret-scan blocks a literal API key" {
+  (cd "$REPO" && printf 'export API_KEY="AKIAIOSFODNN7EXAMPLE"\n' > secrets.env)
+  run bash -c "cd '$REPO' && ./sync.sh push 2>&1"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"secret-scan"* ]] || [[ "$output" == *"POSSIBLE SECRET"* ]]
+  # Working tree should be un-staged after abort.
+  run bash -c "cd '$REPO' && git diff --cached --name-only"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "push: HARNESS_SYNC_SKIP_SECRET_SCAN=1 bypasses scan" {
+  (cd "$REPO" && printf 'export API_KEY="AKIAIOSFODNN7EXAMPLE"\n' > secrets.env)
+  run env HARNESS_SYNC_SKIP_SECRET_SCAN=1 bash -c "cd '$REPO' && ./sync.sh push 2>&1"
+  # Even if push fails (no credential for origin), the commit + scan-skip path
+  # should have proceeded. Accept any exit but verify the scan message is gone.
+  [[ "$output" != *"POSSIBLE SECRET"* ]]
+}
+
+@test "unknown subcommand exits 64" {
+  run bash -c "cd '$REPO' && ./sync.sh wat"
+  [ "$status" -eq 64 ]
+}

--- a/plugins/harness/tests/test_validate_settings.sh
+++ b/plugins/harness/tests/test_validate_settings.sh
@@ -26,8 +26,8 @@ run_test() {
   local tmp; tmp=$(mktemp --suffix=.json)
   printf '%s' "$fixture" > "$tmp"
 
-  local out; out=$("$VALIDATOR" "$tmp" 2>&1)
-  local rc=$?
+  local out rc
+  out=$("$VALIDATOR" "$tmp" 2>&1) && rc=$? || rc=$?
 
   if [ "$rc" -eq "$expected_exit" ] && echo "$out" | grep -qE "$expected_pattern"; then
     echo "  PASS: $name"
@@ -73,7 +73,7 @@ run_test "fails_on_unknown_enabled_plugin" \
 '{"enabledPlugins":{"nope-fake-plugin-does-not-exist@unknown-marketplace":true},"mcpServers":{}}' \
 1 "NOT installed"
 
-# --- 7. Missing absolute-path MCP command fails ---
+# --- 7. Missing absolute-path MCP command fails (OPS-1) ---
 run_test "fails_on_missing_mcp_binary" \
 '{"mcpServers":{"foo":{"command":"/nonexistent/binary-path","args":[]}}}' \
 1 "MCP command missing"
@@ -81,13 +81,43 @@ run_test "fails_on_missing_mcp_binary" \
 # --- 8. Malformed JSON fails ---
 RUN=$((RUN+1))
 tmp=$(mktemp --suffix=.json); printf '{ not valid json ' > "$tmp"
-out=$("$VALIDATOR" "$tmp" 2>&1); rc=$?
+out=$("$VALIDATOR" "$tmp" 2>&1) && rc=$? || rc=$?
 if [ "$rc" -eq 1 ] && echo "$out" | grep -q "JSON malformed"; then
   echo "  PASS: fails_on_malformed_json"; PASS=$((PASS+1))
 else
   echo "  FAIL: fails_on_malformed_json (rc=$rc output=$out)"; FAIL=$((FAIL+1))
 fi
 rm -f "$tmp"
+
+# --- 9. set -euo pipefail: a failure in a subshell pipeline doesn't silently pass ---
+# Feed an input that would make `jq` exit non-zero inside SECRET_LEAKS's
+# sub-pipeline but the validator must still run to completion (the `|| true`
+# guard keeps `set -e` from aborting). We assert we reach the "Summary" line.
+run_test "set_e_does_not_short_circuit_on_jq_failure" \
+'{"mcpServers":{"foo":{"command":"bash","env":{"WEIRD":null}}}}' \
+0 "Summary:"
+
+# --- 10. --json emits parseable JSON with events + counts ---
+RUN=$((RUN+1))
+tmp=$(mktemp --suffix=.json)
+printf '{"env":{},"enabledPlugins":{},"mcpServers":{},"effortLevel":"high"}' > "$tmp"
+out=$("$VALIDATOR" --json "$tmp" 2>&1) && rc=$? || rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | jq -e '.events | type == "array"' >/dev/null 2>&1; then
+  echo "  PASS: json_mode_emits_structured_output"; PASS=$((PASS+1))
+else
+  echo "  FAIL: json_mode_emits_structured_output (rc=$rc output=$out)"; FAIL=$((FAIL+1))
+fi
+rm -f "$tmp"
+
+# --- 11. OPS-1 missing hook target fails ---
+run_test "fails_on_missing_hook_target" \
+'{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/absolutely/does/not/exist.sh"}]}]},"mcpServers":{}}' \
+1 "hook/statusLine target missing"
+
+# --- 12. SEC-1 low-entropy value does NOT trigger (under 20 chars) ---
+run_test "passes_on_short_key_value" \
+'{"mcpServers":{"foo":{"command":"echo","env":{"FOO_API_KEY":"short"}}}}' \
+0 "SEC-1 no secret"
 
 echo
 echo "Tests: $RUN  Passed: $PASS  Failed: $FAIL"

--- a/sync.sh
+++ b/sync.sh
@@ -1,8 +1,47 @@
 #!/usr/bin/env bash
 # sync.sh — pull/push convenience wrapper for dotclaude.
+#
+# Subcommands:
+#   pull    fetch origin, rebase onto origin/main, re-run bootstrap.sh
+#   push    secret-scan + stage + commit + push (aborts if secrets detected)
+#   status  git status --short
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Regex catches the common literal-secret shapes we care about in dotclaude.
+# High-entropy random strings still slip through; this is a last-ditch guard,
+# not a full DLP system. We deliberately match on:
+#   *_KEY / *_TOKEN / *_SECRET assignments with 20+ char values
+#   AWS access keys (AKIA[0-9A-Z]{16})
+#   Bearer / Authorization tokens with ≥20 char payloads
+SECRET_RX='(^|[^A-Z_])(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|[A-Z_]*_?(API|ACCESS|AUTH|BEARER|PRIVATE)?_?(KEY|TOKEN|SECRET|PASSWORD))[[:space:]]*[:=][[:space:]]*["'"'"']?[A-Za-z0-9+/=_-]{20,}["'"'"']?|AKIA[0-9A-Z]{16}|(?i)bearer[[:space:]]+[A-Za-z0-9._-]{20,}'
+
+scan_secrets() {
+  # Stage first so we can grep exactly what will be committed — including new
+  # files. Revert staging on abort so the working tree stays clean for the user.
+  local staged
+  staged=$(git diff --cached --name-only --diff-filter=ACMR)
+  if [ -z "$staged" ]; then
+    return 0
+  fi
+  local hit=0
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    # Use grep -I so binary files are skipped silently. -P for perl-compatible
+    # regex so our alternation with case-insensitive fragment works.
+    if git show ":$file" 2>/dev/null | grep -IPq -- "$SECRET_RX" ; then
+      echo "secret-scan: POSSIBLE SECRET in $file" >&2
+      hit=1
+    fi
+  done <<< "$staged"
+  if [ "$hit" != "0" ]; then
+    echo "secret-scan: aborting push. Re-run after removing or whitelisting." >&2
+    echo "secret-scan: to bypass (only with care), set HARNESS_SYNC_SKIP_SECRET_SCAN=1" >&2
+    return 1
+  fi
+  return 0
+}
 
 cmd="${1:-pull}"
 case "$cmd" in
@@ -16,6 +55,12 @@ case "$cmd" in
     if git diff --cached --quiet; then
       echo "no changes to push"
       exit 0
+    fi
+    if [ "${HARNESS_SYNC_SKIP_SECRET_SCAN:-0}" != "1" ]; then
+      if ! scan_secrets; then
+        git reset HEAD -- . >/dev/null
+        exit 1
+      fi
     fi
     git commit -m "dotclaude: sync $(date +%Y-%m-%d)"
     git push


### PR DESCRIPTION
## Summary

- **Shell hardening**: flip `plugins/harness/scripts/validate-settings.sh` from `set -u` to `set -euo pipefail`, factor the ✓/✗/⚠ gold-standard helpers into `plugins/harness/scripts/lib/output.sh`, and add a `--json` mode that emits `{events:[{check,category,status,message}], counts:{fail,warn}}` for CI pipelines.
- **Guard hook**: harden `plugins/harness/hooks/guard-destructive-git.sh` (and the template mirror) with a new regex family — normalizes tabs, boundary-anchors `git`, covers `git branch -D` and `git worktree remove --force` in addition to the previous patterns, adds a `BYPASS_DESTRUCTIVE_GIT=1` env bypass, and rewrites the block message to surface the bypass form. **Preserves `exit 2`** per the Claude Code PreToolUse hook protocol.
- **bootstrap.sh / sync.sh**: add `--quiet` + `--help` to bootstrap (plus a trailing `run 'harness-doctor' to verify install` hint when the bin is on PATH). `sync.sh push` now runs a staged-content secret scan (literal `_KEY` / `_TOKEN` / `_SECRET` assignments, AWS access keys, bearer tokens) before committing; aborts and un-stages on hit, with a `HARNESS_SYNC_SKIP_SECRET_SCAN=1` escape hatch.
- **bats suite**: new `plugins/harness/tests/bats/{bootstrap,sync,refresh-worktrees,guard-destructive-git}.bats` + `helpers.bash` — 34 hermetic tests covering every blocked git pattern (tab/space variants, bypass env, harmless `git reset --soft` allowed), bootstrap first-run/idempotency/backup/broken-symlink/stale-target/quiet paths, sync status/push/secret-scan abort, and refresh-worktrees no-op/up-to-date/FF/dirty-skip.
- **Extended `test_validate_settings.sh` 8 → 12** cases: `set -e` propagation, `--json` structured output, OPS-1 hook-missing, SEC-1 low-entropy pass-through.
- **Linting configs** at repo root: `.shellcheckrc`, `.prettierrc.json`, `.editorconfig`, `.markdownlint-cli2.jsonc`.

## Test plan

- [x] `npm test` — 74/74 green.
- [x] `npx bats plugins/harness/tests/bats/` — 34/34 green (17 guard + 8 bootstrap + 5 sync + 4 refresh).
- [x] `bash plugins/harness/tests/test_validate_settings.sh` — 12/12 green.
- [x] `shellcheck --severity=warning -x bootstrap.sh sync.sh plugins/harness/scripts/*.sh plugins/harness/scripts/lib/*.sh plugins/harness/hooks/*.sh plugins/harness/tests/*.sh plugins/harness/templates/claude/hooks/*.sh plugins/harness/templates/githooks/pre-commit` — exit 0, no findings.
- [x] Hook protocol: block message contains `BYPASS_DESTRUCTIVE_GIT=1`; exit is 2 (Claude Code hook protocol), not 1 or 64.
- [x] `validate-settings.sh --json` output parseable by `jq -e '.events | type == "array"'`.

Spec ID: TBD — harness-core lands in PR 5.
