### PR TITLE
docs(harness): full docs workstream + ADRs + command frontmatter (PR 6)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,88 +1,88 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-14T17:53:47.436Z",
+  "generatedAt": "2026-04-14T18:16:39.823Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
-      "checksum": "sha256:809afb441a26c8ecca5e22e4728ee45635fc7244493cb4d4875e0f54168f5b60",
+      "checksum": "sha256:5c994b1e8b571c960350e9f6d731a210df18513fb48e96f4afa3b3bd1600286b",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
-      "checksum": "sha256:a187952d790a3c851893dde1c6657bfe45332ab4f7427d6f38c83d2886c8640e",
+      "checksum": "sha256:9b5d6ef4c54ec9889a18369c337a3f60660175a1d8409ca0fe53d2b94a7592dd",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
-      "checksum": "sha256:aa9001809f91041bcf81827ef9c1d142ef6ffb21696fed7a541849d501a70f8f",
+      "checksum": "sha256:d5e0e885b3f33371050316d47b1cdff515c2a1160229ffdc54e69d9401ba3c28",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
-      "checksum": "sha256:a7250ea760a3e70e9d258fc9c0e8f662076b32a544786fa58af4cd95bb244c79",
+      "checksum": "sha256:dc5c88c767dba94c1edff2a1c8e2c7696293402999d282c16ceefa23a1fd229a",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
-      "checksum": "sha256:40af56abe8a70ef6e4fc8fc6148609a890ae1680e7954ffce1e292fd70fe8481",
+      "checksum": "sha256:4583cfb9110adf12f01a2b888eb532931731eabe31607d27b3f9e2792535c08c",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
-      "checksum": "sha256:f574ed8110c7b7b5897be1c52df044f935fdc23dafa85c84e02e704a956de7c9",
+      "checksum": "sha256:f09291cd75e49a8eeb1e715d4aebc600dc17ec3419bcaf6650dfb03930c35d94",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
-      "checksum": "sha256:5296b8b9747203c195cbbca311302f9c0a962f8a2cb49136daf3aa45f80dea3e",
+      "checksum": "sha256:2ce881f525c808c1d1b3731019b538d4126faa150819df04a142bf5ec1d2bd5d",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
-      "checksum": "sha256:38c677158a596c37fa117698195bcc9e5d2169c8f8b5c412eca933fc0edf68df",
+      "checksum": "sha256:c5af180ce541a20d2bc9d536e0e0ae5346794c20d664d88bd602cdfdccf94b21",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
-      "checksum": "sha256:109c4984bd31f21b3113c7ddb389b68b6ee8b7302cdba7727e64b97f8f7e3bd1",
+      "checksum": "sha256:57948660205b9916d0c0f796387c6a7afc0221e0e610bcce14c2f6da0a651fd3",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
-      "checksum": "sha256:258e68b87d46407e65eabee20edb8bb95f6f362eb379b4bb19367b9b527f07a5",
+      "checksum": "sha256:58b7a88382f16f273353bad4a74fa2b312d5a91d062fa7c3928a3e9459b77a1c",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
-      "checksum": "sha256:0be77918cd64f7b48e10ce5df1f66215fa0ecaddf9034ae207a0536396750fbf",
+      "checksum": "sha256:a8f2f8c230140590fd927c5deb67e926d760cec520378d4eb3df9c9147446f71",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
-      "checksum": "sha256:bc8b61a15cc8443477e2937248e98fc91d064e532bf1e5d5988fd69cc6bd52e0",
+      "checksum": "sha256:5e6c66a55312c0d6f09338c59e9121f95b2cc3baa4a19670bab29114f882e5fb",
       "dependencies": [],
       "lastValidated": "2026-04-14"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to `@kaiohenricunha/harness` land here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows
+[SemVer](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Planned
+
+- Marketplace submission for the Claude Code plugin listing.
+- `harness upgrade` subcommand to migrate consumer repos across harness versions.
+- `.d.ts` shipping for stronger type inference (via hand-authored declarations
+  — TypeScript migration is out of scope per ADR-0002).
+
+## [0.2.0] — 2026-04-14
+
+First public release targeting `npm publish --provenance --access public`.
+Productizes the plugin: public Node API barrel, structured-error contract,
+umbrella CLI, shell hardening, full bats + vitest coverage, dogfood wiring,
+and the docs set consumers need to adopt.
+
+### Added
+
+- **Node API barrel** at `plugins/harness/src/index.mjs` — 24+ named exports
+  covering every validator + `ValidationError` + `EXIT_CODES` + `version`.
+- **Structured error taxonomy** (`plugins/harness/src/lib/errors.mjs`): every
+  validator emits `ValidationError` instances with stable `.code`, `.file`,
+  `.pointer`, `.expected`, `.got`, `.hint`, `.category`. Enumerated codes
+  (`SPEC_STATUS_INVALID`, `MANIFEST_CHECKSUM_MISMATCH`,
+  `COVERAGE_UNCOVERED`, `DRIFT_TEAM_COUNT`, …) are a stable contract —
+  renames are breaking.
+- **Named `EXIT_CODES`** (`{OK:0, VALIDATION:1, ENV:2, USAGE:64}`) consumed
+  by every bin. `64` mirrors BSD `sysexits.h EX_USAGE`.
+- **Umbrella `harness` CLI** that dispatches to subcommands:
+  `harness validate-specs|validate-skills|check-spec-coverage|check-instruction-drift|detect-drift|doctor|init`.
+  Every bin also exists as a standalone — `harness-doctor`, `harness-init`,
+  etc.
+- **`harness-doctor`** — runs through env, repo, facts, manifest, specs,
+  drift, and hook checks and reports `✓/✗/⚠` with exit 0/1/2.
+- **`harness-detect-drift`** — wraps `plugins/harness/scripts/detect-branch-drift.mjs`
+  so `npx harness-detect-drift` resolves. Fixes the broken
+  `plugins/harness/templates/workflows/detect-drift.yml:15` invocation.
+- **Universal CLI flags** across every bin: `--help`, `--version`, `--json`,
+  `--verbose`, `--no-color`, plus bin-specific flags (`--update`,
+  `--project-name`, `--force`, `--target-dir`, …).
+- **`--json` output** on every bin and on `validate-settings.sh`, suitable
+  for `jq -r '.events[] | …'` CI pipelines.
+- **`set -euo pipefail`** across every shipped shell script; ✓/✗/⚠ helpers
+  factored into `plugins/harness/scripts/lib/output.sh` and mirrored in
+  `src/lib/output.mjs`.
+- **Hardened `guard-destructive-git.sh`** — normalizes tab whitespace,
+  boundary-anchors `git` tokens, adds blocks for `git branch -D` and
+  `git worktree remove --force`, and exposes `BYPASS_DESTRUCTIVE_GIT=1`
+  bypass. Exit 2 preserved per Claude Code PreToolUse protocol.
+- **`bootstrap.sh --quiet` + `--help`** plus a trailing
+  `run 'harness-doctor' to verify install` hint when the bin is on PATH.
+- **`sync.sh` secret scan** — literal `_KEY` / `_TOKEN` / `_SECRET` + AWS
+  keys + bearer tokens are refused at push time.
+  `HARNESS_SYNC_SKIP_SECRET_SCAN=1` is the documented escape hatch.
+- **bats suite** at `plugins/harness/tests/bats/` (34 tests) covering every
+  hardened shell surface.
+- **Coverage gate** — `vitest run --coverage` enforces lines 85 /
+  functions 85 / branches 80 / statements 85 via `vitest.config.mjs`.
+- **`examples/minimal-consumer/`** — committed post-`harness-init` scaffold.
+- **Dogfood**: root `.claude/{settings,skills-manifest}.json`,
+  `docs/repo-facts.json`, `docs/specs/harness-core/{spec.json,spec.md}`.
+  Every validator exits 0 against the root (see `npm run dogfood`).
+- **Docs set**: `LICENSE`, `CHANGELOG.md` (this file), `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, `docs/{index,quickstart,cli-reference,api-reference,architecture,personas,troubleshooting,upgrade-guide}.md`,
+  `docs/adr/`, `plugins/harness/templates/README.md`. README.md and
+  `plugins/harness/README.md` rewritten for consumer clarity.
+- **Commands** (`.claude/commands/*.md`) get YAML frontmatter matching the
+  `skills/*/SKILL.md` schema.
+
+### Changed
+
+- **Public surface** — deep imports from `plugins/harness/src/*.mjs` are no
+  longer a supported contract. Use the barrel import.
+- **`package.json`** — `"main"` now points at the real barrel; `"exports"`
+  field added; three new `"bin"` entries; `"files"` covers
+  `plugins/harness/scripts/` so `refresh-worktrees.sh`,
+  `detect-branch-drift.mjs`, and `auto-update-manifest.mjs` ship in the
+  tarball; version bumped to `0.2.0`.
+
+### Breaking changes (for early adopters of 0.1.x)
+
+- Validator errors are `ValidationError` instances, not strings. Existing
+  CI pipelines that `grep` stderr continue to work because
+  `ValidationError.prototype.toString()` preserves the
+  `"<file>: <message>"` format; pipelines that consume `--json` get the
+  structured payload.
+- Deep imports (`import { … } from "@kaiohenricunha/harness/src/validate-specs.mjs"`)
+  are no longer a supported contract — use the barrel.
+
+## [0.1.0] — 2026-04-13
+
+Retroactive entry. Initial plugin skeleton: spec-harness library, five
+validators, template tree, hook, and `test_validate_settings.sh`. Never
+published to npm — the first published version is 0.2.0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,14 @@
 # CLAUDE.md — Global Claude Code Rules
 
+> **Persona note.** This file is the global rule floor for Kaio's personal
+> Claude Code environment — it gets symlinked into `~/.claude/CLAUDE.md`
+> by `bootstrap.sh`. **Consumers of `@kaiohenricunha/harness` do NOT
+> inherit it.** The plugin's behavior is defined by its own docs under
+> `plugins/harness/` and [docs/](./docs/). Contributors to this repo
+> should read [CONTRIBUTING.md](./CONTRIBUTING.md) first; this file
+> covers the author's universal working agreements, not project-specific
+> development conventions.
+
 Universal behavior for every Claude Code session in every repo. Project-level `CLAUDE.md` files extend and may override these, but should not repeat them.
 
 ## Local filesystem conventions

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
+as its Code of Conduct. The full text and translations are maintained at
+<https://www.contributor-covenant.org/>.
+
+## Our pledge (summary)
+
+We pledge to make participation in this project a respectful, welcoming, and
+harassment-free experience for everyone, regardless of age, body size,
+visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+## Scope
+
+The Code of Conduct applies within all project spaces — GitHub issues, PRs,
+discussions, release notes, associated chat channels — and when an
+individual is officially representing the project in public.
+
+## Enforcement
+
+Please report violations privately to **kaiohenriquecunha@gmail.com**.
+All reports are reviewed and investigated promptly and fairly. Reporters'
+privacy is respected.
+
+Enforcement guidelines follow the Contributor Covenant 2.1 four-tier
+ladder: correction → warning → temporary ban → permanent ban. See the
+canonical text linked above for full definitions.
+
+## Attribution
+
+Adapted from the Contributor Covenant, version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to `@kaiohenricunha/harness`
+
+Thanks for considering a contribution. This repo is a dual-purpose checkout
+— a portable npm package (`@kaiohenricunha/harness`) **and** Kaio's personal
+global Claude Code config. Most contributions land in the former. See
+`docs/personas.md` for the distinction.
+
+## Quickstart
+
+```bash
+git clone https://github.com/kaiohenricunha/dotclaude.git
+cd dotclaude
+npm ci
+./bootstrap.sh             # only if you also want the dotfiles in ~/.claude/
+npm test                   # vitest: must be 90/90+ green
+bash plugins/harness/tests/test_validate_settings.sh
+npx bats plugins/harness/tests/bats/
+npx harness-doctor         # self-diagnostic
+```
+
+## Development workflow
+
+1. **Start a worktree**, not a branch on the main checkout:
+   ```bash
+   git fetch origin main
+   git worktree add .claude/worktrees/my-change -b feat/my-change origin/main
+   cd .claude/worktrees/my-change
+   ```
+   This keeps multiple agents and humans from stomping on each other's
+   working tree — enforced by `CLAUDE.md §Worktree discipline`.
+2. **Write tests first.** Bug fixes land with a failing regression test that
+   flips green in the same commit.
+3. **Run the local gate** before `gh pr create`:
+   ```bash
+   npm test -- --coverage   # thresholds: 85/85/80/85
+   npx bats plugins/harness/tests/bats/
+   bash plugins/harness/tests/test_validate_settings.sh
+   shellcheck --severity=warning -x bootstrap.sh sync.sh \
+     plugins/harness/scripts/*.sh plugins/harness/scripts/lib/*.sh \
+     plugins/harness/hooks/*.sh plugins/harness/tests/*.sh \
+     plugins/harness/templates/claude/hooks/*.sh \
+     plugins/harness/templates/githooks/pre-commit
+   node scripts/check-jsdoc-coverage.mjs plugins/harness/src
+   npm run dogfood
+   ```
+4. **Follow spec discipline.** Every PR touching a protected path (see
+   `docs/repo-facts.json`) needs `Spec ID: harness-core` or a
+   `## No-spec rationale` section in its body. If you're adding a new
+   subsystem, run `/spec` first to produce the design doc in `docs/specs/`.
+
+## Commit + PR conventions
+
+- **Conventional commits**: `feat(scope): summary`, `fix(scope): summary`,
+  `chore(scope): summary`, …
+- **PR body** must contain `## Summary` + `## Test plan` sections. Use
+  `gh pr create --body-file` to avoid heredoc quoting pitfalls.
+- **Never** force-push someone else's branch, `--amend` a published commit,
+  or pass `--no-verify` / `--no-gpg-sign`.
+- Open commits are preferred over `--amend` once a PR is in review.
+
+## Code style
+
+- **No runtime dependencies.** The `package.json` manifest is zero-dep by
+  contract (ADR-0002). New code ships as plain Node 20+ ESM, no bundler.
+- **JSDoc every export.** `scripts/check-jsdoc-coverage.mjs` fails CI on
+  undocumented `export`s under `plugins/harness/src/`.
+- **Structured errors.** Validators emit `ValidationError` from
+  `src/lib/errors.mjs`, never raw strings. Add new codes to `ERROR_CODES`
+  when the taxonomy doesn't cover your case.
+- **CLI contract.** Every bin honors `--help`, `--version`, `--json`,
+  `--verbose`, `--no-color` and exits via the named `EXIT_CODES`
+  (`{OK:0, VALIDATION:1, ENV:2, USAGE:64}`).
+- **Shell.** `set -euo pipefail` at the top of every script. Source
+  `plugins/harness/scripts/lib/output.sh` for `pass`/`fail`/`warn`. Run
+  `shellcheck --severity=warning` locally.
+
+## What not to send
+
+- **TypeScript migration** — deliberately deferred (ADR-0002).
+- **New runtime dependencies** — budget is zero until there's a very strong
+  case. Devdeps are OK.
+- **Windows-only code paths** — bash-first, `ubuntu-latest` CI only.
+- **Docs-only PRs bypassing `/create-audit`/`/create-assessment`/`/spec`**
+  when those skills apply — the audit trail lives in their output.
+
+## Reporting a vulnerability
+
+See `SECURITY.md`. TL;DR: private disclosure via GitHub Security Advisory,
+not a public issue.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant 2.1](./CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kaio Henrique Cunha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,180 +1,130 @@
-# dotclaude
+# `@kaiohenricunha/harness`
 
-Global Claude Code configuration + a portable harness plugin for spec-driven development.
+[![npm](https://img.shields.io/npm/v/@kaiohenricunha/harness.svg)](https://www.npmjs.com/package/@kaiohenricunha/harness)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![changelog](https://img.shields.io/badge/changelog-keep--a--changelog-orange.svg)](./CHANGELOG.md)
 
-Two things live here:
+Portable Claude Code plugin + zero-dependency npm package that bootstraps
+spec-driven-development governance into consumer repos. Ships a structured-error
+CLI, an umbrella `harness` dispatcher, seven standalone bins, a destructive-git
+PreToolUse hook, and a gold-standard shell settings validator.
 
-1. **`@kaiohenricunha/harness`** — a dual-purpose Claude Code plugin + npm package for SDD governance, skills-manifest validation, and drift detection. Designed to be installed in any repo, not just this one. [Skip to usage →](#harness-plugin-usage)
-2. **Kaio's personal dotfiles** — the global `CLAUDE.md`, slash commands, and skills symlinked into `~/.claude/`. Clone, bootstrap, use. [Skip to dotfiles →](#personal-dotfiles-usage)
+**Two personas live in this repo** (by design — see [docs/personas.md](./docs/personas.md)):
+
+- The **npm package** under `plugins/harness/` (what consumers install).
+- Kaio's **personal dotfiles** at the top level (symlinked into `~/.claude/` via `bootstrap.sh`).
+
+If you're installing the package, ignore the top-level scripts —
+`package.json.files` excludes them from the tarball.
 
 ---
 
-## Harness plugin usage
-
-The harness gives you four CLI validators and a scaffolder:
-
-| Tool | Purpose |
-|---|---|
-| `harness-validate-skills` | Enforces checksums on `.claude/skills-manifest.json` — catches skill files drifting from their inventory entry |
-| `harness-validate-specs` | Validates `docs/specs/<slug>/spec.json` schema + `status` enum + `id/dir-name` match |
-| `harness-check-spec-coverage` | PR-time gate: changes to protected paths must be covered by an approved spec or a `## No-spec rationale` section |
-| `harness-check-instruction-drift` | Cross-checks `CLAUDE.md` ↔ `README.md` ↔ `.github/copilot-instructions.md` ↔ `docs/repo-facts.json` for drift |
-| `harness-init` | Scaffolds the full harness into a fresh repo — `.claude/`, `docs/specs/`, CI workflow, hooks |
-
-### Install
+## Consumer quickstart
 
 ```bash
-# In any repo:
-npm install -D github:kaiohenricunha/dotclaude#main
-```
-
-### Scaffold a fresh repo
-
-```bash
-# In an empty git repo (must have an initial commit):
+npm i -D @kaiohenricunha/harness
 npx harness-init --project-name my-project --project-type node
+npx harness-doctor          # self-diagnostic
+npx harness-validate-specs  # every bin works standalone or via `npx harness <sub>`
 ```
 
-You get:
-- `.claude/{settings.json, settings.headless.json, skills-manifest.json, hooks/guard-destructive-git.sh}`
-- `docs/{repo-facts.json, specs/README.md}`
-- `.github/workflows/{validate-skills.yml, detect-drift.yml, ai-review.yml}`
-- `githooks/pre-commit` (opt-in via `git config core.hooksPath githooks`)
-
-### Wire into CI
-
-Add to `package.json`:
-
-```json
-{
-  "scripts": {
-    "verify:harness": "harness-validate-skills && harness-validate-specs && harness-check-instruction-drift && harness-check-spec-coverage"
-  }
-}
-```
-
-The scaffolded `.github/workflows/validate-skills.yml` runs the chain on every PR + weekly cron.
-
-### Contract your repo must follow
-
-- `docs/repo-facts.json` — canonical source of truth (team count, protected paths, verification commands)
-- `docs/specs/<slug>/spec.json` — spec metadata: `id`, `title`, `status` (one of `draft | approved | implementing | done`), `owners`, `linked_paths`, `acceptance_commands`, `depends_on_specs`, `active_prs`
-- `.claude/skills-manifest.json` — SHA256-checksummed inventory of `.claude/commands/*.md` and `.claude/skills/*/SKILL.md`
+Five minutes end-to-end: [docs/quickstart.md](./docs/quickstart.md).
 
 ### Node API
 
-```javascript
+```js
 import {
   createHarnessContext,
+  validateSpecs,
   validateManifest,
+  checkSpecCoverage,
+  checkInstructionDrift,
+  scaffoldHarness,
   ValidationError,
+  ERROR_CODES,
   EXIT_CODES,
 } from "@kaiohenricunha/harness";
 
-const ctx = createHarnessContext({ repoRoot: "/path/to/repo" });
-const { ok, errors } = validateManifest(ctx);
+const ctx = createHarnessContext();           // resolves repo root via git
+const { ok, errors } = validateSpecs(ctx);    // errors are ValidationError instances
 if (!ok) {
   for (const err of errors) {
-    // err is a ValidationError with .code / .file / .hint / .category
-    console.error(err.toString());
+    if (err.code === ERROR_CODES.SPEC_STATUS_INVALID) {
+      // programmatic reaction to a specific failure class
+    }
   }
   process.exit(EXIT_CODES.VALIDATION);
 }
 ```
 
-All exports (24+ symbols: validators, helpers, `ValidationError`, `ERROR_CODES`, `EXIT_CODES`, `version`) come from the single barrel `@kaiohenricunha/harness`. Deep imports like `@kaiohenricunha/harness/plugins/...` are not a supported contract.
+Full contract: [docs/api-reference.md](./docs/api-reference.md).
 
-All validators accept an explicit `repoRoot` or fall back to `process.env.HARNESS_REPO_ROOT`, then to `git rev-parse --show-toplevel`.
+### CLI contract
 
-### Self-healing scripts (advanced)
+Every bin honors `--help`, `--version`, `--json`, `--verbose`, `--no-color` and exits with the named enum:
 
-- `plugins/harness/scripts/refresh-worktrees.sh` — FF-merges clean worktrees with `origin/main`, skips dirty ones
-- `plugins/harness/scripts/detect-branch-drift.mjs` — flags `.claude/commands/*.md` that diverge from main for more than 14 days
-- `plugins/harness/templates/githooks/pre-commit` — auto-refreshes `skills-manifest.json` checksums when commands/skills change
+| Code | Name | Meaning |
+|---|---|---|
+| 0 | OK | Success |
+| 1 | VALIDATION | Rule failure (expected failure mode) |
+| 2 | ENV | Misconfigured environment |
+| 64 | USAGE | Bad CLI invocation (matches BSD `sysexits.h EX_USAGE`) |
+
+Per-bin details: [docs/cli-reference.md](./docs/cli-reference.md).
 
 ---
 
-## Personal dotfiles usage
+## Hardening decisions
 
-This is the owner's workflow — only relevant if you want to fork-then-adapt this repo for your own setup.
+Each row links to its ADR (see [docs/adr/](./docs/adr/)):
 
-### Fresh distro setup
+| Decision | ADR |
+|---|---|
+| Monorepo dual-persona layout | [0001](./docs/adr/0001-monorepo-dual-persona-layout.md) |
+| No TypeScript; JSDoc + zero runtime deps | [0002](./docs/adr/0002-no-typescript.md) |
+| Structured `ValidationError` contract | [0012](./docs/adr/0012-structured-error-contract.md) |
+| Exit-code convention `{0,1,2,64}` | [0013](./docs/adr/0013-exit-code-convention.md) |
+| CLI ✓/✗/⚠ output format | [0014](./docs/adr/0014-cli-tick-cross-warn-format.md) |
+
+Shell-level hardening (SEC-1..4, OPS-1..2) is enforced today at
+`plugins/harness/scripts/validate-settings.sh`; its 12-case behavioral
+suite at `plugins/harness/tests/test_validate_settings.sh` pins every
+contract.
+
+---
+
+## Personal dotfiles persona
+
+If you're Kaio (or forking for your own dotfiles), the entry-point is:
 
 ```bash
-git clone git@github.com:kaiohenricunha/dotclaude.git ~/Projects/kaiohenricunha/dotclaude
-cd ~/Projects/kaiohenricunha/dotclaude
-./bootstrap.sh
+git clone https://github.com/kaiohenricunha/dotclaude.git ~/projects/kaiohenricunha/dotclaude
+cd ~/projects/kaiohenricunha/dotclaude
+./bootstrap.sh                  # symlinks commands/ + skills/ + CLAUDE.md into ~/.claude/
+./sync.sh pull                  # pull + re-bootstrap
+./sync.sh push                  # secret-scan + commit + push
 ```
 
-`bootstrap.sh` creates idempotent symlinks from this repo into `~/.claude/`:
-- `CLAUDE.md` → `~/.claude/CLAUDE.md` (global rule floor)
-- `commands/*.md` → `~/.claude/commands/*.md` (slash commands like `/create-audit`, `/merge-pr`, `/commit`)
-- `skills/*/` → `~/.claude/skills/*/` (directory-form skills like `spec/`, `validate-spec/`)
-
-Pre-existing real files get backed up to `<name>.bak-<timestamp>` before being replaced — so first run on a populated `~/.claude/` is non-destructive.
-
-### Sync between machines
-
-```bash
-./sync.sh pull    # fetch + rebase + re-run bootstrap
-./sync.sh push    # stage + commit + push
-./sync.sh status  # git status --short
-```
-
-### Adding a new global command or skill
-
-Drop the file at its real home (`commands/new-thing.md` or `skills/new-thing/SKILL.md`), re-run `./bootstrap.sh`, commit, push. No `~/.claude/` editing required.
+See [CLAUDE.md](./CLAUDE.md) for the global rules this installs.
 
 ---
 
-## What ships in the public npm package
+## Further reading
 
-The root `package.json` declares `@kaiohenricunha/harness`. Its `files` field ships only the portable subset:
-
-- `plugins/harness/{src,bin,templates,hooks,README.md,.claude-plugin}/**`
-
-Personal config (`CLAUDE.md`, `commands/`, `skills/`, `bootstrap.sh`, `sync.sh`) is present in the repo but **not** in the published package — consumers installing via `npm install -D github:kaiohenricunha/dotclaude#main` get only the harness.
-
----
-
-## Configuration decisions (2026-04-13 hardening)
-
-Full context: [spec](docs/specs/claude-hardening/) · [audit](docs/audits/claude-code-global-config-2026-04-13.md) · [assessment](docs/assessments/claude-code-global-config-2026-04-13.md) · [plan](docs/plans/2026-04-13-claude-code-global-config-cleanup.md).
-
-| Decision | Rationale | Where enforced |
-|----------|-----------|---------------|
-| **Secrets live in shell env, not `settings.json`** | An external API key was previously embedded literal in global settings. Now sourced from shell env via `${PROVIDER_API_KEY}` reference, exported in `~/.zshrc`. | Validator SEC-1 (regex on `*_KEY`/`*_TOKEN`/`*_SECRET` fields) |
-| **Dangerous-mode confirmation restored** | `skipDangerousModePermissionPrompt` was silently bypassing the prompt globally. Safer default even with more friction on long skill chains. | Validator SEC-2 |
-| **No `@latest` in MCP `args`** | An MCP package was refetching on every session start. Always pin to an explicit version in MCP `args`. Applies to every MCP. | Validator SEC-3 |
-| **`claude-code-lsps` owns LSPs** | Dedicated marketplace beats the generalist `*-lsp@claude-plugins-official` triplet. Those three plugins were uninstalled. | Validator: `enabledPlugins` must contain no `*-lsp@claude-plugins-official` |
-| **Project-bound MCPs live in `<project>/.mcp.json`** | Project-specific MCPs (e.g. language servers, project filesystems) previously pinned at user scope. Moved to `<project>/.mcp.json`. Genuinely cross-project MCPs stay global. | Pre-flight diff + validator MCP-command-exists check |
-| **Hooks block kept minimal** | All 8 Vibecraft events were removed (consumer offline, `events.jsonl` truncated from 779 MB to 0). Only `validate-edit.sh` PostToolUse survives. | Validator: every `hooks[*].command` must exist on disk |
-| **60-day age-based retention** | `~/.claude/projects/` and `~/.claude/file-history/` pruned on `mtime +60`. Soft budget: projects/ ≤ 1.5 GB, file-history/ ≤ 100 MB (warn only). | Validator OPS-2 (disk budget warning) |
-| **`.credentials.json` mode 600** | Token file must never widen. | Validator SEC-4 |
-| **`context7` runs globally, not per-project** | Library docs lookup is cross-project value; used to be pinned to a single project scope. | Global `enabledPlugins` |
-
-### Settings validator
-
-`plugins/harness/scripts/validate-settings.sh` encodes every decision above as a hard or soft check. Also symlinked at `~/.claude/scripts/validate-settings.sh`.
-
-```bash
-~/.claude/scripts/validate-settings.sh            # checks ~/.claude/settings.json
-~/.claude/scripts/validate-settings.sh <path>     # checks an alternative file
-```
-
-Exit 0 = pass, 1 = hard failure. Warnings don't fail exit code. Tests: `plugins/harness/tests/test_validate_settings.sh` (8 fixtures covering positive + negative cases).
-
-### Pre-flight rollback snapshot
-
-Before the 2026-04-13 hardening run, the previous state was captured at `~/.claude/settings.json.preflight-2026-04-13`. Restore with `cp` if anything breaks.
-
-### Standing TODOs
-
-- `~/.claude/projects/` is 1.85 GB (validator warns; soft limit 1.5 GB). Most transcripts are recent (< 60 days); the retention policy will reclaim space over time. For immediate relief, prune stale worktree sessions manually.
-- `frontend-design`, `skill-creator`, `security-guidance`, `context7` show `version: "unknown"` in the install registry. Cosmetic; the marketplace manifest doesn't expose versions for these plugins. `claude plugins update` is a no-op.
-
----
+| | |
+|---|---|
+| [docs/index.md](./docs/index.md) | Nav map with persona-tailored entry points |
+| [docs/quickstart.md](./docs/quickstart.md) | Install → scaffold → first green validator |
+| [docs/cli-reference.md](./docs/cli-reference.md) | Every bin, flag, exit code, `--json` schema |
+| [docs/api-reference.md](./docs/api-reference.md) | Node API surface |
+| [docs/architecture.md](./docs/architecture.md) | Layer diagram + PR-time sequence |
+| [docs/troubleshooting.md](./docs/troubleshooting.md) | Error-code → remediation index |
+| [docs/upgrade-guide.md](./docs/upgrade-guide.md) | 0.1 → 0.2 migration, forking |
+| [docs/personas.md](./docs/personas.md) | Who reads which file |
+| [CONTRIBUTING.md](./CONTRIBUTING.md) | Dev workflow + local gates |
+| [SECURITY.md](./SECURITY.md) | Private vulnerability disclosure |
+| [CHANGELOG.md](./CHANGELOG.md) | Keep-a-Changelog history |
 
 ## License
 
-MIT. See [LICENSE](LICENSE) if present; otherwise the MIT terms apply to the plugin code. Personal config files (CLAUDE.md, commands/, skills/) are provided as-is.
+MIT — see [LICENSE](./LICENSE).

--- a/commands/audit-and-fix.md
+++ b/commands/audit-and-fix.md
@@ -1,3 +1,10 @@
+---
+name: audit-and-fix
+description: >
+  Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to "audit and fix" or kicks off an overnight cleanup run.
+argument-hint: "[domain]"
+---
+
 Run a long-horizon audit-then-implement pipeline: produce a structured audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs.
 
 Trigger: when the user asks for "audit and fix", wants to clean up a domain, or kicks off an overnight cleanup run. Also triggered directly via `/audit-and-fix <domain>`.

--- a/commands/changelog.md
+++ b/commands/changelog.md
@@ -1,3 +1,10 @@
+---
+name: changelog
+description: >
+  count|since-deploy]"|Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.
+argument-hint: "[ref-range
+---
+
 Generate a changelog entry from git history.
 
 Arguments: `$ARGUMENTS` (optional: a ref range like `v1.0..HEAD`, a count like `20`, or `since-deploy` to use the last deploy commit. Default: commits since the last tag, or the last 20 commits if no tags exist.)

--- a/commands/create-assessment.md
+++ b/commands/create-assessment.md
@@ -1,3 +1,10 @@
+---
+name: create-assessment
+description: >
+  Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.
+argument-hint: "[target]"
+---
+
 Create a structured assessment document that grades a target on a 0-10 scale using a weighted rubric and save it to the project's `docs/assessments/` directory.
 
 Trigger: when the user asks to grade, rate, score, evaluate, or assess a specific target — a package, a project/repo, a source file, an architecture decision, a pull request, or a document. Also triggered directly via `/create-assessment`. This skill is about **producing a numeric grade**, not listing issues — for issue-triage with severity levels use `/create-audit`.

--- a/commands/create-audit.md
+++ b/commands/create-audit.md
@@ -1,3 +1,10 @@
+---
+name: create-audit
+description: >
+  Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.
+argument-hint: "[subject]"
+---
+
 Create a structured audit document and save it to the project's `docs/audits/` directory.
 
 Trigger: when the user asks for an audit, review, or assessment of any system, feature, data quality, process, or component. Also triggered directly via `/create-audit`.

--- a/commands/dependabot-sweep.md
+++ b/commands/dependabot-sweep.md
@@ -1,3 +1,9 @@
+---
+name: dependabot-sweep
+description: >
+  Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.
+---
+
 Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produce a risk-annotated table and merge only safe bumps.
 
 Trigger: when the user asks to review/merge/rebase Dependabot PRs, or wants to sweep dependency updates. Also triggered directly via `/dependabot-sweep`.

--- a/commands/detect-flaky.md
+++ b/commands/detect-flaky.md
@@ -1,3 +1,10 @@
+---
+name: detect-flaky
+description: >
+  Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.
+argument-hint: "[test-command]"
+---
+
 # /detect-flaky — Flaky Test Detection and Diagnosis Agent
 
 This agent detects, diagnoses, and fixes flaky tests in **Python**, **Go**, and **JavaScript/TypeScript** codebases.

--- a/commands/fix-with-evidence.md
+++ b/commands/fix-with-evidence.md
@@ -1,3 +1,10 @@
+---
+name: fix-with-evidence
+description: >
+  Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.
+argument-hint: "[issue]"
+---
+
 Fix a bug using a strict four-phase evidence loop: Reproduce → Fix → Verify → PR. Each phase gates on the previous.
 
 Trigger: when the user asks for a bug fix, wants to address an issue, or says "fix X". Also triggered directly via `/fix-with-evidence <issue>`.

--- a/commands/git.md
+++ b/commands/git.md
@@ -1,3 +1,10 @@
+---
+name: git
+description: >
+  Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.
+argument-hint: "[subcommand]"
+---
+
 # /git
 
 A project-aware git workflow command: craft conventional commits, create PRs, push with the right safety rails, merge into main, and suggest branch names.

--- a/commands/ground-first.md
+++ b/commands/ground-first.md
@@ -1,3 +1,10 @@
+---
+name: ground-first
+description: >
+  Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.
+argument-hint: "[subject]"
+---
+
 Produce a code-grounded analysis of a subject before any edits are proposed.
 
 Trigger: when the user asks for a fix, change, or investigation on non-trivial code and has not yet confirmed you understand current behavior. Also triggered directly via `/ground-first`.

--- a/commands/markdown.md
+++ b/commands/markdown.md
@@ -1,3 +1,10 @@
+---
+name: markdown
+description: >
+  dir]"|Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.
+argument-hint: "[file
+---
+
 # Command: fix_markdown
 
 ## Purpose

--- a/commands/merge-pr.md
+++ b/commands/merge-pr.md
@@ -1,3 +1,10 @@
+---
+name: merge-pr
+description: >
+  Merge a pull request only after full local verification, with a data-regression gate for PRs touching data/calibration/rankings.
+argument-hint: "[PR#]"
+---
+
 Merge a pull request only after full local verification, with a data-regression gate for PRs touching data/calibration/rankings.
 
 Trigger: when the user asks to merge a PR, especially one that modifies data files, calibration logic, or ranking output. Also triggered directly via `/merge-pr <N>`.

--- a/commands/security-review.md
+++ b/commands/security-review.md
@@ -1,3 +1,10 @@
+---
+name: security-review
+description: >
+  path|staged]"|Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.
+argument-hint: "[PR#
+---
+
 Analyze a diff or set of changed files for common security vulnerabilities.
 
 Arguments: `$ARGUMENTS` (optional: a PR number, file path, or `staged` for staged changes. Default: staged changes.)

--- a/docs/adr/0001-monorepo-dual-persona-layout.md
+++ b/docs/adr/0001-monorepo-dual-persona-layout.md
@@ -1,0 +1,62 @@
+# ADR-0001 — Monorepo dual-persona layout
+
+**Status**: Accepted (2026-04-14)
+
+## Context
+
+The work Kaio needs this repo to do splits into two distinct audiences:
+
+1. **Personal dotfiles** — `commands/`, `skills/`, `CLAUDE.md`, bootstrapped
+   into `~/.claude/` via `bootstrap.sh`.
+2. **`@kaiohenricunha/harness` npm package** — a reusable plugin other repos
+   install via `npm i -D`. Lives under `plugins/harness/`.
+
+The overlap is large: both surfaces define slash commands, skills, hooks,
+and CI workflows. Keeping two repos in sync by copy-paste was the status
+quo; drift appeared within days.
+
+## Decision
+
+Single repo. Two top-level trees:
+
+```
+dotclaude/
+├─ commands/  skills/  CLAUDE.md  bootstrap.sh  sync.sh    ← dotfile persona
+└─ plugins/harness/                                         ← npm package
+```
+
+`package.json.files` excludes the dotfile-only paths from the npm tarball.
+Consumers installing the package see only `plugins/harness/`. The author's
+`bootstrap.sh` symlinks from `commands/` and `skills/` into `~/.claude/`.
+
+## Consequences
+
+- One source of truth for every slash command and skill that both personas
+  want to share.
+- Single CI pipeline covers both surfaces; dogfood runs every harness
+  validator against the repo itself.
+- Contributors see two trees and need the [personas.md](../personas.md)
+  matrix to pick their entry-point — added cognitive cost.
+- `package.json.files` becomes a trust boundary: a missing entry there
+  silently ships dotfile scripts into consumer installs. Covered by an
+  integration test that asserts `plugins/harness/scripts/*` *is* shipped
+  and `bootstrap.sh` *is not*.
+
+## Alternatives considered
+
+- **Two repos, cross-repo sync action** — rejected. The sync action itself
+  becomes a load-bearing dependency; every failure mode is a drift between
+  the two repos. Net complexity is higher.
+- **Separate the dotfiles to a second repo, keep the package here** —
+  viable. Rejected for now because the author's friction cost of mirroring
+  changes across two repos is real and unamortized until the dotfile side
+  has third-party contributors (currently it has one, Kaio).
+- **Move the npm package to its own repo, dotfiles stay here** — same
+  objection, inverted.
+
+## Revisit triggers
+
+- The first external contributor to the dotfile tree (implies a third
+  audience, strengthens the split-repo case).
+- The first consumer requesting a tighter tarball that excludes
+  `plugins/harness/tests/`.

--- a/docs/adr/0002-no-typescript.md
+++ b/docs/adr/0002-no-typescript.md
@@ -1,0 +1,60 @@
+# ADR-0002 — No TypeScript
+
+**Status**: Accepted (2026-04-14); revisit at v0.3
+
+## Context
+
+Every new Node package defaults to TypeScript. For `@kaiohenricunha/harness`
+the question was whether to adopt TS from day one or stay on plain `.mjs`
+with JSDoc.
+
+## Decision
+
+**Plain JavaScript ESM + JSDoc `@typedef`s. No TypeScript.**
+
+- Source is `.mjs` only, no `.ts`.
+- Every `export` gets a JSDoc block — enforced by
+  `scripts/check-jsdoc-coverage.mjs` in CI.
+- Public types live as JSDoc `@typedef`s (`HarnessContext`,
+  `ValidationResult`, `StructuredError`, …) consumed via
+  `/** @type {import('./spec-harness-lib.mjs').HarnessContext} */` in
+  consumer code.
+- Zero runtime deps, zero build step, zero transpile — the tarball ships
+  source as-authored.
+
+## Consequences
+
+- **No transpile.** `npm publish` ships the code verbatim. Debugging shows
+  the same file paths consumers see. Source maps are irrelevant.
+- **Instant `npx`**. No TS compile step, no dev/prod parity concerns.
+- **Editor inference** works in VSCode / Neovim / anything that reads
+  JSDoc — about 85 % of what TS provides for API surface work.
+- **No `.d.ts`.** Consumers who want stronger types in their projects get
+  JSDoc inference today. A hand-written `index.d.ts` is a v0.3+ option
+  (not blocking).
+- **Loss of advanced type features** — branded types, conditional types,
+  mapped types. Cost is low for a validator/CLI library.
+- **Linting is weaker.** Prettier + shellcheck + `scripts/check-jsdoc-coverage.mjs`
+  cover most of the ground; we explicitly are not running `tsc --noEmit`.
+
+## Alternatives considered
+
+- **TypeScript with `tsc --noEmit` type-checking, `.mjs` as source** — half
+  the complexity of full TS adoption. Rejected because CI still has to run
+  `tsc` on PRs (slow) and consumers still need to maintain `.d.ts`
+  provenance. Benefit is marginal.
+- **Full TypeScript, ship compiled `.mjs`** — standard for most libraries.
+  Rejected on the "zero runtime deps + zero build step" aesthetic: the
+  harness is supposed to be embarrassingly simple to read. A transpile
+  step contradicts that.
+- **Ship `.d.ts` hand-authored today** — deferred. The JSDoc coverage gate
+  already provides most of the editor experience. Revisit when a consumer
+  files a specific request.
+
+## Revisit triggers
+
+- A consumer filing an issue about type gaps that JSDoc can't close.
+- A public-API change large enough that hand-authored `.d.ts` becomes
+  maintenance burden.
+- An ecosystem shift (e.g. Node gaining first-class type-stripping) that
+  changes the cost/benefit.

--- a/docs/adr/0012-structured-error-contract.md
+++ b/docs/adr/0012-structured-error-contract.md
@@ -1,0 +1,64 @@
+# ADR-0012 — Structured error contract
+
+**Status**: Accepted (2026-04-14)
+
+## Context
+
+The legacy validator surface (pre-0.2.0) pushed raw strings into
+`result.errors`. Consumers who wanted to react programmatically — gate CI
+on a specific kind of failure, or route a subset of errors to a
+different channel — had two bad options:
+
+1. Regex the stderr prose. Brittle. Any message wording change is
+   implicitly a breaking change that CI consumers feel immediately.
+2. Read the source and hardcode the call-site line numbers. Worse.
+
+## Decision
+
+Every validator emits `ValidationError` instances, not strings. A single
+source of truth lives at `plugins/harness/src/lib/errors.mjs`:
+
+- **`class ValidationError extends Error`** with stable fields: `code`,
+  `message`, optional `file`, `pointer`, `line`, `expected`, `got`,
+  `hint`, `category`.
+- **`ERROR_CODES`**, an `Object.freeze({ SPEC_STATUS_INVALID: ..., ... })`
+  enum. Adding codes is safe; renaming is a breaking change.
+- **`ValidationError.prototype.toString()`** returns the legacy
+  `"<file>: <message>"` format so existing `/regex/.test(err)` CI scripts
+  continue to work without migration.
+- **`ValidationError.prototype.toJSON()`** returns a plain object
+  consumable by `JSON.stringify`. Every bin's `--json` flag emits these
+  under `.details`.
+
+## Consequences
+
+- **Backwards-compatible for stderr consumers** — regexing the human
+  message still works.
+- **Forward-compatible for structured consumers** — `jq -r '.events[] |
+  select(.kind == "fail") | .details.code'` is the documented pipeline.
+- **Stability contract** — `ERROR_CODES` entries are load-bearing strings.
+  Renames require a major bump; additions don't.
+- **Discoverability** — `ERROR_CODES` is the authoritative index; the
+  troubleshooting guide mirrors it one-to-one.
+- **Writing cost** — every new error site now lives in a named category and
+  comes with a `hint`. Non-trivial overhead vs `errors.push("msg")`, but
+  one-time.
+
+## Alternatives considered
+
+- **Zod schema + tagged union.** Overkill for a validator library.
+  Introduces a runtime dep (violates the zero-dep guarantee) and a
+  schema-definition layer that changes more often than the codes
+  themselves.
+- **`Result<ok, err>` style (Rust-inspired).** Consumers would have to
+  import a `Result` helper. Too much ceremony for Node; `{ok, errors}` is
+  idiomatic enough.
+- **Keep strings, layer a parser on top.** Rejected — parsers on
+  human-readable text are fragile, and "change the prose" becomes a
+  hidden breaking change.
+
+## Revisit triggers
+
+- A consumer requests richer structured metadata that doesn't fit the
+  flat `StructuredError` shape.
+- Internationalization of `hint` messages becomes in-scope.

--- a/docs/adr/0013-exit-code-convention.md
+++ b/docs/adr/0013-exit-code-convention.md
@@ -1,0 +1,63 @@
+# ADR-0013 — Exit-code convention
+
+**Status**: Accepted (2026-04-14)
+
+## Context
+
+Each bin originally exited `0` on success and `1` on any other outcome.
+Operators running these in CI couldn't distinguish "a validation rule
+failed" (an expected outcome; the pipeline should fail the PR check) from
+"the CLI was invoked with a bad flag" (a workflow-author bug; the pipeline
+should fail the *workflow* author's attention, not the PR author's).
+
+## Decision
+
+A single named enum, exported as `EXIT_CODES`, consumed by every bin:
+
+| Name | Value | Meaning |
+|---|---|---|
+| `OK` | 0 | Success |
+| `VALIDATION` | 1 | One or more validation rules failed (expected failure mode) |
+| `ENV` | 2 | Misconfigured environment — missing file, bad git repo, unreadable facts |
+| `USAGE` | 64 | Bad CLI invocation — unknown flag, missing required positional |
+
+`64` is chosen deliberately: it matches BSD `sysexits.h EX_USAGE`. Pipeline
+authors can then write:
+
+```yaml
+- run: npx harness-validate-specs
+- if: failure()
+  run: |
+    case $? in
+      1)  echo "validation failed — review the PR"; exit 1 ;;
+      2)  echo "environment issue — check workflow setup"; exit 2 ;;
+      64) echo "bad CLI invocation — the workflow needs editing"; exit 64 ;;
+    esac
+```
+
+## Consequences
+
+- **Actionable CI output.** `ENV` vs `USAGE` vs `VALIDATION` route to
+  different humans.
+- **`sysexits.h` alignment.** Future codes (e.g. `EX_NOPERM`=77 for "hook
+  blocked") have a standard vocabulary to pick from.
+- **The `guard-destructive-git.sh` hook's `exit 2` stays** — it's the
+  Claude Code PreToolUse protocol (block the tool call), not the harness
+  validator `ENV` code. Documented explicitly in the hook header comment.
+- **Test harness** — every bin's exit code is asserted in the integration
+  test; drift fails CI.
+
+## Alternatives considered
+
+- **0/1 only, encode category in stderr.** Rejected — requires parsing,
+  which the structured-error contract already handles elsewhere.
+- **Custom codes in the 100-150 range.** Rejected — `64` is recognized,
+  invented codes aren't.
+- **Match `rustc`'s exit codes.** Rejected — not a convention operators
+  expect from a CLI.
+
+## Revisit triggers
+
+- A failure mode surfaces that doesn't fit any of `{OK, VALIDATION, ENV,
+  USAGE}`. Most likely a "blocked by policy" (hook) case, which would
+  adopt 77.

--- a/docs/adr/0014-cli-tick-cross-warn-format.md
+++ b/docs/adr/0014-cli-tick-cross-warn-format.md
@@ -1,0 +1,71 @@
+# ADR-0014 — CLI ✓/✗/⚠ output format
+
+**Status**: Accepted (2026-04-14)
+
+## Context
+
+The original `validate-settings.sh` prefixed each line with a colored
+glyph — `✓` (green) for pass, `✗` (red) for fail, `⚠` (yellow) for warn.
+Readable, grep-friendly, widely copied across projects.
+
+When `0.2.0` added Node bins, the question was whether to keep this format
+or switch to a structured logger (pino, winston, bunyan). The bins had to
+work well interactively (humans reading terminal output) *and* in CI
+(machine consumers, usually `jq`).
+
+## Decision
+
+**Keep the gold-standard format.** Every bin + every shell script uses the
+same `✓/✗/⚠` prefix, factored into two helpers that stay byte-compatible:
+
+- `plugins/harness/src/lib/output.mjs` — `createOutput({ json, noColor })`
+  returns a `{ pass, fail, warn, info, flush, counts }` interface. Mirrors
+  the shell helper.
+- `plugins/harness/scripts/lib/output.sh` — `pass`/`fail`/`warn`/`out_init`/
+  `out_flush`. Consumed via `source "$SCRIPT_DIR/lib/output.sh"`.
+
+`--json` is the machine mode. In that mode, the ✓/✗/⚠ lines are replaced
+with a single JSON envelope:
+
+```json
+{
+  "events": [
+    { "kind": "fail", "message": "...", "details": { "code": "...", ... } }
+  ],
+  "counts": { "pass": 0, "fail": 1, "warn": 0 }
+}
+```
+
+`--no-color` (or `NO_COLOR=` env) suppresses ANSI. TTY detection falls back
+to no-color automatically when stdout isn't a TTY.
+
+## Consequences
+
+- **One format, two audiences.** Terminal users get ✓/✗/⚠; CI consumers
+  pipe through `jq`.
+- **Cross-language parity.** Shell scripts and Node bins produce identical
+  output shapes — a dogfood workflow can run either and parse results the
+  same way.
+- **ANSI discipline.** Every color escape goes through the helper; no ad-hoc
+  `printf '\033[31m'` anywhere in the codebase (enforced by code review +
+  shellcheck).
+- **The glyph choice is load-bearing.** Changing `✓` to a plain `P` for
+  any reason (low-contrast terminals, screen readers) is a breaking
+  change — consumers grep for the glyph in dashboards.
+
+## Alternatives considered
+
+- **pino / structured logger.** Overkill for a CLI library. Adds a
+  runtime dep (violates zero-dep). JSON mode today serves the same
+  structured-consumer use case.
+- **Plain `[OK]` / `[FAIL]` / `[WARN]` prefixes.** Less visually scannable.
+  Glyphs are the de-facto convention in modern CLIs (npm, pnpm, bun,
+  Docker, k8s operators all use similar symbols).
+- **Different glyphs per bin** (e.g. spec validator uses `📝`). Rejected —
+  consistency across bins is the whole point.
+
+## Revisit triggers
+
+- A credible accessibility complaint (screen reader users, low-contrast
+  environments).
+- A terminal-ecosystem shift that deprecates Unicode glyphs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,37 @@
+# Architectural Decision Records
+
+Short, immutable records of load-bearing decisions. Every file captures:
+
+- **Context** — what forced the decision
+- **Decision** — what we chose
+- **Consequences** — what we gave up, what we unlocked
+- **Alternatives** — what we looked at and rejected
+
+Supersession is fine; amendment is not. To reverse a decision, write a new
+ADR that supersedes the old and link both directions.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| 0001 | [Monorepo dual-persona layout](./0001-monorepo-dual-persona-layout.md) | Accepted |
+| 0002 | [No TypeScript](./0002-no-typescript.md) | Accepted |
+| 0012 | [Structured error contract](./0012-structured-error-contract.md) | Accepted |
+| 0013 | [Exit-code convention](./0013-exit-code-convention.md) | Accepted |
+| 0014 | [CLI ✓/✗/⚠ output format](./0014-cli-tick-cross-warn-format.md) | Accepted |
+
+### Planned (not yet written)
+
+Stub records exist in the issue tracker; they will land as additional ADRs
+when a related change is proposed:
+
+- 0003..0006 SEC-1..4 hardening decisions (enforced today in
+  `plugins/harness/scripts/validate-settings.sh`; the ADRs capture the
+  *why*).
+- 0007..0008 OPS-1..2 hardening decisions (same).
+- 0009 LSP plugins owned by `claude-code-lsps`.
+- 0010 `context7` runs globally.
+- 0011 Project-bound MCPs live in the project.
+
+The gap in numbering (0003..0011) is intentional — numbers are stable
+identifiers, not sequential counters.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,117 @@
+# Node API reference
+
+The public contract lives at `plugins/harness/src/index.mjs` — import from
+the package root, not deep paths:
+
+```js
+import {
+  createHarnessContext,
+  validateSpecs,
+  validateManifest,
+  refreshChecksums,
+  checkSpecCoverage,
+  checkInstructionDrift,
+  scaffoldHarness,
+  ValidationError,
+  ERROR_CODES,
+  formatError,
+  EXIT_CODES,
+  version,
+  // spec-harness helpers
+  readJson, readText, pathExists, git,
+  loadFacts, listSpecDirs, listRepoPaths,
+  escapeRegex, globToRegExp, matchesGlob, anyPathMatches, toPosix,
+  extractTemplateSection, isMeaningfulSection,
+  getPullRequestContext, isBotActor, getChangedFiles,
+} from "@kaiohenricunha/harness";
+```
+
+**Every symbol is documented with JSDoc in-source.** Run
+`node scripts/check-jsdoc-coverage.mjs plugins/harness/src` in the repo to
+assert coverage is complete.
+
+## Typical usage
+
+```js
+import { createHarnessContext, validateSpecs, formatError } from "@kaiohenricunha/harness";
+
+const ctx = createHarnessContext(); // resolves repo root via git or HARNESS_REPO_ROOT
+const { ok, errors } = validateSpecs(ctx);
+
+if (!ok) {
+  for (const err of errors) {
+    console.error(formatError(err, { verbose: true }));
+    // err.code   — stable enum (see ERROR_CODES)
+    // err.file   — repo-relative path
+    // err.pointer — JSON pointer for structured files
+    // err.hint   — actionable remediation
+  }
+  process.exit(1);
+}
+```
+
+## Exported types (JSDoc `@typedef`s)
+
+- **`HarnessContext`** — `{ repoRoot, specsRoot, manifestPath, factsPath }`,
+  the context threaded through every validator.
+- **`ValidationResult`** — `{ ok: boolean, errors: ValidationError[] }`.
+- **`StructuredError`** — the `ValidationError` object shape with
+  `code`, `message`, optional `file`, `pointer`, `line`, `expected`, `got`,
+  `hint`, `category`.
+- **`PullRequestContext`** — `{ isPullRequest, body, actor }`, the shape
+  `getPullRequestContext()` returns.
+
+## Error codes
+
+See `ERROR_CODES` for the full list (it's `Object.freeze`d). Renames are
+breaking changes; additions are not. Enumerated families:
+
+- **spec**: `SPEC_JSON_INVALID`, `SPEC_STATUS_INVALID`,
+  `SPEC_MISSING_REQUIRED_FIELD`, `SPEC_ID_MISMATCH`,
+  `SPEC_LINKED_PATH_MISSING`, `SPEC_ACCEPTANCE_EMPTY`,
+  `SPEC_DEPENDENCY_UNKNOWN`.
+- **skill**: `SKILL_FRONTMATTER_MISSING`, `SKILL_NAME_MISMATCH`.
+- **manifest**: `MANIFEST_ENTRY_MISSING`, `MANIFEST_CHECKSUM_MISMATCH`,
+  `MANIFEST_ORPHAN_FILE`, `MANIFEST_DEPENDENCY_CYCLE`.
+- **coverage**: `COVERAGE_UNCOVERED`, `COVERAGE_NO_SPEC_RATIONALE`,
+  `COVERAGE_UNKNOWN_SPEC_ID`.
+- **drift**: `DRIFT_TEAM_COUNT`, `DRIFT_PROTECTED_PATH`,
+  `DRIFT_INSTRUCTION_FILES`, `DRIFT_INSTRUCTION_FILE_MISSING`.
+- **scaffold**: `SCAFFOLD_CONFLICT`, `SCAFFOLD_USAGE`.
+- **settings**: `SETTINGS_SEC_1`..`SETTINGS_SEC_4`,
+  `SETTINGS_OPS_1`, `SETTINGS_OPS_2`.
+- **env/usage**: `ENV_REPO_ROOT_UNKNOWN`, `ENV_FACTS_MISSING`,
+  `USAGE_UNKNOWN_FLAG`, `USAGE_MISSING_POSITIONAL`.
+
+## Exit codes
+
+`EXIT_CODES` = `{ OK:0, VALIDATION:1, ENV:2, USAGE:64 }`. Use these instead
+of string-matching error messages.
+
+## Subpath exports
+
+A few commonly-reached-for modules are also exposed as sub-paths in
+`package.json.exports`:
+
+```js
+import { ValidationError, ERROR_CODES } from "@kaiohenricunha/harness/errors";
+import { EXIT_CODES } from "@kaiohenricunha/harness/exit-codes";
+```
+
+Deep imports beyond these three subpaths are **not** part of the public
+contract; any reshuffle inside `src/` can happen in a minor bump.
+
+## Versioning
+
+`version` is the package version at import time (read from the installed
+`package.json`). Consumers can gate on it:
+
+```js
+import { version } from "@kaiohenricunha/harness";
+if (!version.startsWith("0.2.")) throw new Error(`unsupported harness: ${version}`);
+```
+
+Semver: minor bumps add new codes/bins. Major bumps can rename codes or
+remove bins. `ValidationError.prototype.toString()` keeps the
+`"<file>: <message>"` format across minor bumps so stderr-grep pipelines
+don't break.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,102 @@
+# Architecture
+
+## Layers
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Consumer repo                                                       │
+│  ┌────────────────────────┐    ┌──────────────────────────────────┐  │
+│  │  GitHub Actions        │    │  Local dev                       │  │
+│  │  validate-skills.yml   │    │  npm test / npx harness-doctor   │  │
+│  │  detect-drift.yml      │    │  pre-commit → auto-update        │  │
+│  │  ai-review.yml         │    │                                  │  │
+│  └──────┬─────────────────┘    └──────────┬───────────────────────┘  │
+└─────────┼─────────────────────────────────┼──────────────────────────┘
+          │                                 │
+┌─────────▼─────────────────────────────────▼──────────────────────────┐
+│  bin/*                                                               │
+│  harness  harness-doctor  harness-init  harness-validate-{specs,     │
+│  skills}  harness-check-{spec-coverage, instruction-drift}           │
+│  harness-detect-drift                                                │
+│  Each bin: parse(lib/argv) → validator → createOutput(lib/output)    │
+│            → formatError(lib/errors) → exit(lib/exit-codes)          │
+└─────────┬────────────────────────────────────────────────────────────┘
+          │
+┌─────────▼────────────────────────────────────────────────────────────┐
+│  src/lib/                                                            │
+│  argv.mjs    output.mjs    errors.mjs    exit-codes.mjs   debug.mjs  │
+└─────────┬────────────────────────────────────────────────────────────┘
+          │
+┌─────────▼────────────────────────────────────────────────────────────┐
+│  Validators (src/*.mjs)                                              │
+│  validate-specs  validate-skills-inventory  check-spec-coverage      │
+│  check-instruction-drift  init-harness-scaffold                      │
+│  — every errors.push() emits a ValidationError(code, …)              │
+└─────────┬────────────────────────────────────────────────────────────┘
+          │
+┌─────────▼────────────────────────────────────────────────────────────┐
+│  spec-harness-lib.mjs (filesystem + git + PR context primitives)     │
+│  createHarnessContext  readJson  readText  pathExists  git           │
+│  listSpecDirs  listRepoPaths  globToRegExp  getChangedFiles  …       │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Top of the stack (bins + CI) is what consumers see. The library layer
+(`src/lib/` + `src/*.mjs`) is the public Node API, exposed via the barrel
+at `src/index.mjs`. Below that, `spec-harness-lib.mjs` holds the small set
+of filesystem/git primitives every validator shares.
+
+## The PR-time coverage check — sequence
+
+This is the most interesting data flow, because it spans the GitHub Actions
+env, git history, and the spec tree.
+
+```
+validate-skills.yml
+       │
+       ▼  (runs `npx harness-check-spec-coverage`)
+bin/harness-check-spec-coverage.mjs
+       │
+       │ 1. parse(argv, {--repo-root})
+       ▼
+createHarnessContext({ repoRoot })
+       │
+       │ 2. resolve repoRoot: arg → HARNESS_REPO_ROOT → git rev-parse
+       ▼
+getPullRequestContext()         ← reads GITHUB_EVENT_NAME / PR_BODY / GITHUB_ACTOR
+getChangedFiles()               ← HARNESS_CHANGED_FILES csv || git diff origin/<base>...HEAD
+       │
+       ▼
+checkSpecCoverage(ctx, input)
+       │
+       │ 3. filter changedFiles ∩ loadFacts(ctx).protected_paths
+       │ 4. listSpecDirs(ctx) → map to {id, status, linked_paths}
+       │ 5. filter status ∈ {approved, implementing, done}
+       │ 6. uncovered = protectedFiles − linked_paths∪
+       │ 7. extractTemplateSection(body, "Spec ID")
+       │ 8. extractTemplateSection(body, "No-spec rationale")
+       │ 9. if isBotActor(actor): short-circuit ok=true
+       │ 10. if uncovered.length && !meaningful(rationale): push
+       │      ValidationError(COVERAGE_UNCOVERED, ...)
+       ▼
+{ ok, errors: [ValidationError] }
+       │
+       ▼
+for each err: out.fail(formatError(err), err.toJSON())
+out.flush()                     ← pretty-print, or emit JSON envelope
+process.exit(EXIT_CODES.VALIDATION)
+```
+
+Every helper on the left of arrows is a standalone JSDoc'd export — the
+pipeline is composable for custom CI scripts that want different gating.
+
+## Key design decisions
+
+See `docs/adr/` for the canonical decision records. Summary:
+
+- **Zero runtime dependencies** (ADR-0002 → Node 20+ ESM, no bundler, no TS).
+- **Dual-persona monorepo** (ADR-0001 → plugin package + personal dotfiles in one checkout).
+- **Structured-error contract** (ADR-0012 → `ValidationError` class with stable `.code`).
+- **Exit-code convention** (ADR-0013 → `{0,1,2,64}` with 64 mirroring BSD `EX_USAGE`).
+- **CLI `✓/✗/⚠` format** (ADR-0014 → gold-standard from `validate-settings.sh:43-45`).
+- **`exit 2` on PreToolUse blocks** (Claude Code hook protocol, documented in the hook comment block).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,180 @@
+# CLI reference
+
+Every bin honors the **harness-wide flag set** in addition to its own:
+
+| Flag | Shape | Behavior |
+|---|---|---|
+| `--help`, `-h` | bool | Print usage and exit 0 |
+| `--version`, `-V` | bool | Print package version and exit 0 |
+| `--json` | bool | Emit `{events:[…], counts:{pass,fail,warn}}` on stdout; suppress ANSI |
+| `--verbose`, `-v` | bool | Print every `StructuredError` field (code, pointer, expected, got, hint, category) |
+| `--no-color` | bool | Suppress ANSI escapes regardless of TTY detection |
+| `NO_COLOR=` env | env | Same as `--no-color`, honors the cross-tool convention |
+| `HARNESS_DEBUG=1` env | env | Route previously-silent catches through `stderr` tagged `[harness:*]` |
+
+**Exit codes** follow a single convention across every bin:
+
+| Code | Name | Meaning |
+|---|---|---|
+| 0 | `OK` | Success |
+| 1 | `VALIDATION` | One or more validation rules failed (expected failure mode) |
+| 2 | `ENV` | Misconfigured environment (missing file, bad git repo, unreadable facts) |
+| 64 | `USAGE` | Bad CLI invocation (unknown flag, missing positional). `64` matches BSD `sysexits.h EX_USAGE` |
+
+**The umbrella `harness`** forwards to each `harness-<sub>` bin:
+
+```
+harness validate-specs [OPTIONS]
+harness validate-skills [OPTIONS]
+harness check-spec-coverage [OPTIONS]
+harness check-instruction-drift [OPTIONS]
+harness detect-drift [OPTIONS]
+harness doctor [OPTIONS]
+harness init [OPTIONS]
+```
+
+Each subcommand also exists standalone — `npx harness-doctor` and
+`npx harness doctor` are identical.
+
+---
+
+## `harness-validate-specs`
+
+Validate every `docs/specs/<id>/spec.json` against the `StructuredError`
+contract.
+
+| Flag | Default | |
+|---|---|---|
+| `--repo-root <path>` | `git rev-parse --show-toplevel` | Override the implicit repo root |
+
+**Typical invocations:**
+
+```bash
+npx harness-validate-specs
+npx harness-validate-specs --json | jq -r '.events[] | select(.kind == "fail") | .details.code'
+```
+
+**Emitted codes**: `SPEC_JSON_INVALID`, `SPEC_STATUS_INVALID`,
+`SPEC_ID_MISMATCH`, `SPEC_MISSING_REQUIRED_FIELD`,
+`SPEC_LINKED_PATH_MISSING`, `SPEC_ACCEPTANCE_EMPTY`,
+`SPEC_DEPENDENCY_UNKNOWN`.
+
+---
+
+## `harness-validate-skills`
+
+Validate `.claude/skills-manifest.json` — checksums, orphan files on disk,
+and the `dependencies[]` DAG.
+
+| Flag | Default | |
+|---|---|---|
+| `--repo-root <path>` | resolved via git | Override the repo root |
+| `--update` | false | Recompute every sha256 and rewrite the manifest in place |
+
+**Emitted codes**: `MANIFEST_ENTRY_MISSING`, `MANIFEST_CHECKSUM_MISMATCH`,
+`MANIFEST_ORPHAN_FILE`, `MANIFEST_DEPENDENCY_CYCLE`.
+
+---
+
+## `harness-check-instruction-drift`
+
+Cross-reference `docs/repo-facts.json` against instruction files (CLAUDE.md,
+README.md). Flags stale `team_count` claims, undocumented `protected_paths`,
+and broken `instruction_files` references.
+
+| Flag | Default | |
+|---|---|---|
+| `--repo-root <path>` | resolved via git | Override |
+
+**Emitted codes**: `DRIFT_TEAM_COUNT`, `DRIFT_PROTECTED_PATH`,
+`DRIFT_INSTRUCTION_FILES`, `DRIFT_INSTRUCTION_FILE_MISSING`.
+
+---
+
+## `harness-check-spec-coverage`
+
+PR-time gate. Confirms every change to a protected path is covered by an
+`approved|implementing|done` spec, or the PR body carries a
+`## No-spec rationale` section. Bot actors (`dependabot[bot]`,
+`github-actions[bot]`) bypass.
+
+Reads context from the environment — designed for GitHub Actions:
+
+| Env var | Role |
+|---|---|
+| `GITHUB_EVENT_NAME` | Must be `pull_request` for gating to activate |
+| `GITHUB_BASE_REF` | Base branch for the diff (defaults to `main`) |
+| `GITHUB_ACTOR` | Actor login, used for bot-bypass |
+| `PR_BODY` | PR body text (workflow pipes it in) |
+| `HARNESS_CHANGED_FILES` | CSV override — skip the git-diff probe |
+
+**Emitted codes**: `COVERAGE_UNCOVERED`, `COVERAGE_NO_SPEC_RATIONALE`,
+`COVERAGE_UNKNOWN_SPEC_ID`.
+
+---
+
+## `harness-doctor`
+
+Self-diagnostic. Walks env → repo → facts → manifest → specs → drift →
+hook. Prints `✓/✗/⚠` per check.
+
+| Flag | Default | |
+|---|---|---|
+| `--repo-root <path>` | resolved via git | Override |
+
+**Exits 2** (`ENV`) when env/repo checks fail before validation can run.
+
+---
+
+## `harness-detect-drift`
+
+Flags `.claude/commands/*.md` that have diverged from `origin/main` for
+longer than 14 days. Thin wrapper over
+`plugins/harness/scripts/detect-branch-drift.mjs`.
+
+| Flag | Default | |
+|---|---|---|
+| `--repo-root <path>` | resolved via git | Override |
+
+Exits 0 when nothing is stale; 1 when any file has been behind `origin/main`
+for more than 14 days.
+
+---
+
+## `harness-init`
+
+Scaffold the template tree into a target repo.
+
+| Flag | Default | |
+|---|---|---|
+| `--project-name <name>` | `basename(cwd)` | Substituted for `{{project_name}}` |
+| `--project-type <type>` | `"unknown"` | Substituted for `{{project_type}}` |
+| `--target-dir <path>` | `cwd` | Destination directory |
+| `--force` | false | Overwrite an already-initialized repo |
+
+Throws `ValidationError(SCAFFOLD_CONFLICT)` when
+`.claude/skills-manifest.json` or `docs/specs/` already exists — use
+`--force` to overwrite.
+
+---
+
+## `validate-settings.sh`
+
+Shell validator for `~/.claude/settings.json`. Enforces the hardening
+contract:
+
+- **SEC-1** no secret literals in `*_KEY`/`*_TOKEN`/`*_SECRET` fields
+- **SEC-2** `skipDangerousModePermissionPrompt` must not be present
+- **SEC-3** no `@latest` in MCP args
+- **SEC-4** `.credentials.json` mode 600
+- **OPS-1** JSON well-formed; every MCP command resolves; every hook target
+  exists; every `enabledPlugins` key is installed
+- **OPS-2** disk-size budget warnings on `~/.claude/projects/` and
+  `~/.claude/file-history/`
+
+```bash
+bash plugins/harness/scripts/validate-settings.sh
+bash plugins/harness/scripts/validate-settings.sh --json <path>
+```
+
+`--json` emits `{events:[{check,category,status,message}], counts:{fail,warn}}`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,44 @@
+# `@kaiohenricunha/harness` — docs
+
+The harness is a portable npm package + Claude Code plugin that bootstraps
+spec-driven-development governance into consumer repos. It ships a
+zero-dependency Node API, an umbrella CLI, a gold-standard shell settings
+validator, and a destructive-git PreToolUse hook.
+
+## Start here
+
+| If you are… | Read |
+|---|---|
+| A consumer evaluating the plugin | [quickstart.md](./quickstart.md) — 5 minutes from install to first green validator |
+| Integrating the library in CI | [cli-reference.md](./cli-reference.md) and the `--json` payload examples |
+| Importing the Node API | [api-reference.md](./api-reference.md) |
+| Debugging a validator failure | [troubleshooting.md](./troubleshooting.md) (indexed by `ERROR_CODES`) |
+| Upgrading or forking | [upgrade-guide.md](./upgrade-guide.md) |
+| Contributing | [../CONTRIBUTING.md](../CONTRIBUTING.md) |
+
+## Deeper references
+
+- [architecture.md](./architecture.md) — layer diagram + PR-time coverage check sequence
+- [personas.md](./personas.md) — consumer vs dotfile user vs contributor entry-point matrix
+- [adr/](./adr/) — architectural decision records (one per load-bearing decision)
+- [specs/harness-core/](./specs/harness-core/) — the canonical spec this repo governs itself with
+
+## What this package gives you
+
+- **Structured-error contract.** Every validator emits `ValidationError`
+  instances with stable `.code` values (see [troubleshooting.md](./troubleshooting.md)).
+- **Umbrella CLI + standalone bins.** `harness validate-specs` or
+  `harness-validate-specs` — both exist, same behavior.
+- **Universal flags.** `--help`, `--version`, `--json`, `--verbose`,
+  `--no-color` on every bin.
+- **Named exit codes.** `{OK:0, VALIDATION:1, ENV:2, USAGE:64}` — `64`
+  mirrors BSD `sysexits.h`.
+- **Zero runtime dependencies.** Plain Node 20+, no bundler, no type system
+  runtime cost.
+
+## Governance
+
+This package is itself a consumer of its own validators — see
+[../CLAUDE.md](../CLAUDE.md) §Protected paths. Every PR touching a
+protected path either carries `Spec ID: harness-core` or a
+`## No-spec rationale` section; `dogfood.yml` enforces this on every push.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,0 +1,35 @@
+# Personas — who reads which file
+
+This repo is a dual-purpose checkout. Three distinct audiences consume
+parts of it. Pick yours, then follow the "Start here" column.
+
+| Persona | What you want | Start here |
+|---|---|---|
+| **Consumer** — installing the plugin to govern your own repo | Install, scaffold, run validators, wire CI | [quickstart.md](./quickstart.md) → [cli-reference.md](./cli-reference.md) |
+| **Library user** — importing the Node API into your own tooling | Import, typed signatures, error codes | [api-reference.md](./api-reference.md) |
+| **Dotfile user** — personal Claude Code config via `bootstrap.sh` | Symlink into `~/.claude/`, manage your own commands/skills | [../CLAUDE.md](../CLAUDE.md) + [../bootstrap.sh](../bootstrap.sh) |
+| **Contributor** — sending PRs to this repo | Dev workflow, local gates, spec discipline | [../CONTRIBUTING.md](../CONTRIBUTING.md) |
+| **Security researcher** | Private disclosure, threat model | [../SECURITY.md](../SECURITY.md) |
+
+## Where the split happens
+
+| Path | Who consumes it |
+|---|---|
+| `package.json`, `plugins/harness/src/**`, `plugins/harness/bin/**` | Consumer + library user |
+| `plugins/harness/templates/**` | Consumer (installed by `harness-init`) |
+| `plugins/harness/.claude-plugin/plugin.json` | Claude Code when the plugin is enabled |
+| `bootstrap.sh`, `sync.sh`, `commands/**`, `skills/**` | Dotfile user (Kaio) |
+| `CLAUDE.md`, `docs/specs/harness-core/**`, `.claude/**` at repo root | Contributors + the dogfood CI |
+| `docs/**` (excluding `specs/harness-core/`) | All of the above |
+
+## Why the dual-purpose layout
+
+ADR-0001 records the decision. Short version: the dotfiles and the plugin
+cover the same surface area (Claude Code commands/skills/hooks), the
+author wants a single source of truth, and npm install ignores the
+dotfile-specific top-level scripts (`bootstrap.sh`, `sync.sh`, `commands/`,
+`skills/`) via `package.json.files`.
+
+If the dotfile side feels like noise when you're only consuming the npm
+package: **it is.** Install via `npm i -D @kaiohenricunha/harness` and you
+never see `bootstrap.sh` — only `node_modules/@kaiohenricunha/harness/plugins/harness/`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,101 @@
+# Quickstart — install to first green validator in under 10 minutes
+
+## 1. Install
+
+```bash
+cd your-project
+npm install --save-dev @kaiohenricunha/harness
+```
+
+The package has **zero runtime dependencies**. It registers seven bins under
+`node_modules/.bin/`:
+
+```
+harness
+harness-doctor
+harness-detect-drift
+harness-init
+harness-validate-specs
+harness-validate-skills
+harness-check-spec-coverage
+harness-check-instruction-drift
+```
+
+## 2. Scaffold the governance tree
+
+```bash
+npx harness-init --project-name your-project --project-type node
+```
+
+This writes:
+
+- `.claude/settings.json`, `.claude/settings.headless.json`, `.claude/skills-manifest.json`
+- `.claude/hooks/guard-destructive-git.sh`
+- `docs/repo-facts.json`, `docs/specs/README.md`
+- `.github/workflows/{ai-review,detect-drift,validate-skills}.yml`
+- `githooks/pre-commit`
+
+Every placeholder (`{{project_name}}`, `{{project_type}}`, `{{today}}`) is
+substituted at scaffold time.
+
+## 3. Run the self-diagnostic
+
+```bash
+npx harness-doctor
+```
+
+You should see `✓` rows for env, repo, facts, manifest, specs, drift, hook.
+The first run may warn about missing artifacts (e.g. `docs/specs/` empty) —
+that's expected until you draft your first spec.
+
+## 4. Your first spec
+
+Use the `/spec` skill (if you're in a Claude Code session) or scaffold
+manually:
+
+```
+docs/specs/my-first-feature/
+├── spec.json
+└── spec.md
+```
+
+Minimum viable `spec.json`:
+
+```json
+{
+  "id": "my-first-feature",
+  "title": "My first feature",
+  "status": "draft",
+  "owners": ["Your Name"],
+  "linked_paths": ["src/my-feature/**"],
+  "acceptance_commands": ["npm test"],
+  "depends_on_specs": [],
+  "active_prs": []
+}
+```
+
+Validate it:
+
+```bash
+npx harness-validate-specs
+```
+
+Green. You're done.
+
+## 5. Wire the PR gate
+
+In GitHub branch protection, require the three shipped workflows:
+
+- `validate-skills` — manifest + drift + specs
+- `detect-drift` — flags stale `.claude/commands/*.md`
+- `ai-review` — PR review (optional)
+
+Any PR touching a protected path (see `docs/repo-facts.json`) must now carry
+a `Spec ID:` or `## No-spec rationale` section. `harness-check-spec-coverage`
+enforces it.
+
+## Next
+
+- [cli-reference.md](./cli-reference.md) — every flag, exit code, `--json` schema.
+- [troubleshooting.md](./troubleshooting.md) — look up any failing `ERROR_CODE`.
+- [personas.md](./personas.md) — map your role to the right entry-point.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,82 @@
+# Template catalog
+
+Every file under `plugins/harness/templates/` is written verbatim into a
+consumer repo by `harness-init`, with `{{placeholder}}` tokens substituted
+at scaffold time.
+
+Substitution logic lives at
+[`../plugins/harness/src/init-harness-scaffold.mjs`](../plugins/harness/src/init-harness-scaffold.mjs);
+test coverage (including the "unrecognized placeholder survives" contract)
+is at
+[`../plugins/harness/tests/init-harness-scaffold.test.mjs`](../plugins/harness/tests/init-harness-scaffold.test.mjs).
+
+## Placeholders
+
+| Token | Source | Default |
+|---|---|---|
+| `{{project_name}}` | `harness-init --project-name` | `basename(cwd)` |
+| `{{project_type}}` | `harness-init --project-type` | `"unknown"` |
+| `{{today}}` | `new Date().toISOString().slice(0,10)` (scaffold time) | — |
+
+Tokens not listed above pass through unchanged. That's intentional — a
+consumer template can reference e.g. `{{custom_marker}}` knowing the
+scaffolder won't touch it.
+
+## Tree
+
+```
+templates/
+├── claude/
+│   ├── hooks/
+│   │   └── guard-destructive-git.sh      → .claude/hooks/
+│   ├── skills-manifest.json              → .claude/skills-manifest.json
+│   ├── settings.json                     → .claude/settings.json
+│   └── settings.headless.json            → .claude/settings.headless.json
+├── docs/
+│   ├── repo-facts.json                   → docs/repo-facts.json
+│   └── specs/
+│       └── README.md                     → docs/specs/README.md
+├── githooks/
+│   └── pre-commit                        → githooks/pre-commit
+└── workflows/
+    ├── ai-review.yml                     → .github/workflows/ai-review.yml
+    ├── detect-drift.yml                  → .github/workflows/detect-drift.yml
+    └── validate-skills.yml               → .github/workflows/validate-skills.yml
+```
+
+## Per-template rationale
+
+- **`claude/hooks/guard-destructive-git.sh`** — PreToolUse hook that blocks
+  destructive git calls. Exit 2 per Claude Code hook protocol. See
+  [ADR-0014](../../../docs/adr/) for the ✓/✗/⚠ format inheritance.
+- **`claude/skills-manifest.json`** — minimal `{version:1, skills:[]}`
+  seed. Run `npx harness-validate-skills --update` after adding skills to
+  populate checksums.
+- **`claude/settings.json`** — wires the guard hook into PreToolUse.
+- **`claude/settings.headless.json`** — same surface but with CI-friendly
+  permissions (no interactive prompts).
+- **`docs/repo-facts.json`** — the facts source of truth.
+  `harness-check-instruction-drift` cross-references it with `CLAUDE.md`
+  and `README.md`.
+- **`docs/specs/README.md`** — onboarding doc for the spec workflow.
+- **`githooks/pre-commit`** — auto-refreshes the manifest when a skill
+  file changes.
+- **`workflows/validate-skills.yml`** — runs every validator on PR + push.
+- **`workflows/detect-drift.yml`** — weekly cron flagging stale commands.
+- **`workflows/ai-review.yml`** — Claude Code review wiring (same-repo PR
+  gating).
+
+## Changing a template
+
+1. Edit the file under `plugins/harness/templates/…`.
+2. Re-run the scaffolder into a scratch tmpdir:
+   ```bash
+   TMP=$(mktemp -d); cd $TMP; git init -q
+   node /path/to/dotclaude/plugins/harness/bin/harness-init.mjs \
+     --project-name scratch --project-type node
+   ```
+3. Inspect the output.
+4. **Regenerate `examples/minimal-consumer/`** in the same PR so the
+   dogfood workflow stays current. See
+   [../examples/minimal-consumer/README.md](../examples/minimal-consumer/README.md)
+   for the exact command.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,151 @@
+# Troubleshooting
+
+Indexed by `ERROR_CODES`. When a validator fails, look up the `.code` value
+from its `ValidationError` here.
+
+Debug flag: set `HARNESS_DEBUG=1` to route previously-silent git-probe
+catches (`resolveRepoRootFromGit`, `getChangedFiles`) to stderr tagged
+`[harness:git:*]`.
+
+---
+
+## Spec errors
+
+### `SPEC_JSON_INVALID`
+`docs/specs/<id>/spec.json` is missing or fails to parse.
+**Fix**: `node -e "JSON.parse(require('fs').readFileSync('docs/specs/<id>/spec.json','utf8'))"` to locate the parse error, or create the file.
+
+### `SPEC_STATUS_INVALID`
+`status` is not one of `draft | approved | implementing | done`.
+**Fix**: pick a valid status. Only `approved|implementing|done` gate PR coverage.
+
+### `SPEC_ID_MISMATCH`
+`spec.json.id` does not equal the directory name.
+**Fix**: rename the directory or update `id` — they must match.
+
+### `SPEC_MISSING_REQUIRED_FIELD`
+A required field (`title`, `owners`, `depends_on_specs`, `active_prs`, …) is missing or wrong type.
+**Fix**: the `pointer` on the error tells you which field.
+
+### `SPEC_LINKED_PATH_MISSING`
+`linked_paths` is missing, empty, or contains a non-string entry.
+**Fix**: every entry must be a non-empty string glob or path.
+
+### `SPEC_ACCEPTANCE_EMPTY`
+`acceptance_commands` is empty or contains a non-string entry.
+**Fix**: at least one command that CI can run.
+
+### `SPEC_DEPENDENCY_UNKNOWN`
+`depends_on_specs` references an id that does not exist under `docs/specs/`.
+**Fix**: create the dependency spec or remove the reference.
+
+---
+
+## Manifest errors
+
+### `MANIFEST_ENTRY_MISSING`
+A `.claude/skills-manifest.json` entry points at a path that does not exist on disk.
+**Fix**: remove the entry, or restore the file.
+
+### `MANIFEST_CHECKSUM_MISMATCH`
+A file's content drifted from the recorded sha256.
+**Fix**: `npx harness-validate-skills --update` to recompute and accept the new content, or restore the file to its original state.
+
+### `MANIFEST_ORPHAN_FILE`
+A file under `.claude/commands/` or `.claude/skills/<name>/SKILL.md` is not indexed in the manifest.
+**Fix**: `npx harness-validate-skills --update` to pick it up (add a manifest entry), or delete the file.
+
+### `MANIFEST_DEPENDENCY_CYCLE`
+The `dependencies[]` graph has a cycle.
+**Fix**: break the cycle. The error `.got` field shows the path `A -> B -> A`.
+
+---
+
+## Coverage errors
+
+### `COVERAGE_UNCOVERED`
+A protected path changed in the PR but no `approved|implementing|done` spec covers it, and the PR body has no `## No-spec rationale` section.
+**Fix**: draft a covering spec (status ≥ `approved`) or add a rationale to the PR body.
+
+### `COVERAGE_NO_SPEC_RATIONALE`
+The PR body has neither a `## Spec ID` nor a `## No-spec rationale` section, but protected files changed.
+**Fix**: add one of the two sections.
+
+### `COVERAGE_UNKNOWN_SPEC_ID`
+The PR body references a `Spec ID:` that does not exist under `docs/specs/`.
+**Fix**: check the spec directory, or create the spec first.
+
+---
+
+## Drift errors
+
+### `DRIFT_TEAM_COUNT`
+An instruction file (CLAUDE.md, README.md) mentions `N team(s)` with N ≠ `docs/repo-facts.json` `team_count`.
+**Fix**: update either the file prose or `repo-facts.json.team_count`.
+
+### `DRIFT_PROTECTED_PATH`
+A `docs/repo-facts.json` `protected_paths` entry is either non-string or absent from `CLAUDE.md`.
+**Fix**: add the entry to `CLAUDE.md` §Protected paths, or remove it from the facts file.
+
+### `DRIFT_INSTRUCTION_FILES`
+`instruction_files` is missing or non-array in `docs/repo-facts.json`.
+**Fix**: add it as a non-empty array, e.g. `["CLAUDE.md", "README.md"]`.
+
+### `DRIFT_INSTRUCTION_FILE_MISSING`
+An `instruction_files` entry points at a path that does not exist.
+**Fix**: create the file or drop the entry.
+
+---
+
+## Scaffold errors
+
+### `SCAFFOLD_CONFLICT`
+`harness-init` refuses to overwrite an already-initialized repo.
+**Fix**: pass `--force` to overwrite, or remove `.claude/skills-manifest.json` / `docs/specs/` first.
+
+### `SCAFFOLD_USAGE`
+Bad CLI invocation of `harness-init` (e.g. flag without a value).
+**Fix**: see `--help`.
+
+---
+
+## Settings-validator errors (`validate-settings.sh`)
+
+### `SETTINGS_SEC_1`
+A `*_KEY` / `*_TOKEN` / `*_SECRET` field in `~/.claude/settings.json` holds
+a literal 20+ character value. **Fix**: replace with `${ENV_VAR}` reference.
+
+### `SETTINGS_SEC_2`
+`skipDangerousModePermissionPrompt` is set. **Fix**: remove it.
+
+### `SETTINGS_SEC_3`
+An MCP server args include `@latest`. **Fix**: pin the version.
+
+### `SETTINGS_SEC_4`
+`~/.claude/.credentials.json` is not mode `600`. **Fix**: `chmod 600 ~/.claude/.credentials.json`.
+
+### `SETTINGS_OPS_1`
+Settings JSON is malformed OR an MCP command / hook target / enabled plugin does not resolve.
+**Fix**: read the specific message — it names the unresolved target.
+
+### `SETTINGS_OPS_2`
+`~/.claude/projects/` or `~/.claude/file-history/` exceeded its disk budget.
+**Fix**: the warn message includes a `find … -delete` command to prune.
+
+---
+
+## Env + usage
+
+### `ENV_REPO_ROOT_UNKNOWN`
+`createHarnessContext()` could not resolve a repo root.
+**Fix**: pass `--repo-root <path>` or `HARNESS_REPO_ROOT=<path>`, or run inside a git worktree.
+
+### `ENV_FACTS_MISSING`
+`docs/repo-facts.json` is missing or unreadable.
+**Fix**: scaffold with `harness-init` or author the file (see `plugins/harness/templates/docs/repo-facts.json`).
+
+### `USAGE_UNKNOWN_FLAG`
+An unknown flag was passed. Exit 64. **Fix**: see `--help`.
+
+### `USAGE_MISSING_POSITIONAL`
+A required positional argument is missing. Exit 64. **Fix**: see `--help`.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,0 +1,95 @@
+# Upgrade guide
+
+## 0.1.x → 0.2.0
+
+`0.1.x` was never published to npm — it was the local skeleton on the
+author's machine. The first public release is `0.2.0`. If you're starting
+from a checked-out development copy of `0.1.x`, the migration surface is:
+
+### Breaking
+
+- **Errors are `ValidationError`, not strings.** Pipelines that ran
+  `errors.some((e) => /regex/.test(e))` continue to work because
+  `ValidationError.prototype.toString()` preserves the
+  `"<file>: <message>"` format. If you programmatically accessed
+  `result.errors[0]` as a raw string, migrate to `.code` + `.message`:
+
+  ```js
+  // before
+  if (result.errors[0].startsWith("docs/specs/foo: invalid status")) …
+
+  // after
+  if (result.errors[0].code === ERROR_CODES.SPEC_STATUS_INVALID) …
+  ```
+
+- **Deep imports are no longer a supported contract.** Rewrite:
+
+  ```js
+  // before
+  import { validateSpecs } from "@kaiohenricunha/harness/plugins/harness/src/validate-specs.mjs";
+
+  // after
+  import { validateSpecs } from "@kaiohenricunha/harness";
+  ```
+
+  The subpath exports `./errors` and `./exit-codes` are supported; any
+  other deep path may move without notice.
+
+- **Exit codes** moved to the named `EXIT_CODES` enum. If you wrote
+  `process.exit(1)` in a wrapper, keep using `1`; if you scripted against
+  "any non-zero", you're fine. `64` (`USAGE`) is new — treat it distinctly
+  from `1` (`VALIDATION`).
+
+### New capabilities
+
+- `--help`, `--version`, `--json`, `--verbose`, `--no-color` on every bin.
+- Umbrella `harness` CLI and `harness-doctor` self-diagnostic.
+- `validate-settings.sh --json` structured output.
+- Hardened `guard-destructive-git.sh` with `BYPASS_DESTRUCTIVE_GIT=1` bypass.
+- `bootstrap.sh --quiet`, `sync.sh` secret scan on push.
+
+## Forking the dotfiles
+
+If you want to fork the repo to keep your *own* personal Claude Code
+config, the key files to edit are:
+
+- `commands/**/*.md` — your slash commands.
+- `skills/**/SKILL.md` — your skills.
+- `CLAUDE.md` — your global rules.
+
+Run `./bootstrap.sh` after the fork to symlink them into `~/.claude/`.
+
+The plugin surface (`plugins/harness/**`) should remain a strict upstream
+of `kaiohenricunha/dotclaude` — pull changes from upstream rather than
+forking divergent plugin code.
+
+## Migrating a hand-written `.claude/` tree
+
+If you already maintain a hand-written `.claude/` tree in a consumer repo
+and want to start using the harness:
+
+1. **Inventory what you have.** `npx harness-validate-skills --update`
+   from an empty manifest will seed the checksums; you then have to choose
+   between treating each existing file as indexed (keep the entry) or
+   removed (delete it + rerun `--update`).
+2. **Draft `docs/repo-facts.json`** with your `team_count`,
+   `protected_paths`, and `instruction_files`.
+3. **Draft at least one spec** (`docs/specs/<id>/spec.json`). It can be
+   `status: draft` initially — gating only kicks in at
+   `approved|implementing|done`.
+4. Run `npx harness-doctor` and iterate on every `✗` it reports.
+5. Wire the three shipped workflows into `.github/workflows/`.
+
+## Running `v0.2.0` in CI without a published npm
+
+Until `release.yml` lands (PR 7), consumers can point `package.json` at a
+git commit:
+
+```json
+"devDependencies": {
+  "@kaiohenricunha/harness": "github:kaiohenricunha/dotclaude#v0.2.0"
+}
+```
+
+Swap to the published version once `npm view @kaiohenricunha/harness@0.2.0`
+returns a hit.

--- a/plugins/harness/README.md
+++ b/plugins/harness/README.md
@@ -1,48 +1,68 @@
-# @kaiohenricunha/harness
+# `@kaiohenricunha/harness`
 
-Portable SDD + harness engineering kit. Dual-purpose:
-- **As a Claude Code plugin:** ships slash commands (`/init-harness`), skills, hooks, and templates.
-- **As an npm package:** ships CLI validators (`harness-validate-skills`, `harness-check-spec-coverage`, `harness-validate-specs`, `harness-check-instruction-drift`) for CI use.
+Portable Claude Code plugin + zero-dependency npm package for
+spec-driven-development governance. Installs seven CLI bins, a Node API
+barrel, a destructive-git PreToolUse hook, and a gold-standard shell
+settings validator.
+
+This README is the npm tarball's entry point. **The full docs set lives at
+<https://github.com/kaiohenricunha/dotclaude/tree/main/docs>.**
 
 ## Install
 
 ```bash
-npm install -D git+https://github.com/kaiohenricunha/dotclaude.git#main:plugins/harness
+npm i -D @kaiohenricunha/harness
 ```
 
-For the Claude plugin side, install via `/plugin install git+https://github.com/kaiohenricunha/dotclaude.git#main:plugins/harness`.
+Zero runtime dependencies. Engines: Node `>=20`.
 
-## Contract
-
-Your repo must follow these conventions:
-
-- `docs/repo-facts.json` — canonical source of truth (team count, protected paths, etc.)
-- `docs/specs/<slug>/spec.json` — spec metadata (id, status, owners, linked_paths, acceptance_commands, depends_on_specs, active_prs)
-- `.claude/skills-manifest.json` — SHA256 checksummed inventory of `.claude/commands/*.md` and `.claude/skills/*/SKILL.md`
-- `.github/workflows/validate-skills.yml` — weekly CI plus per-PR check
-
-## CLI
+## Scaffold + validate
 
 ```bash
-harness-validate-skills [--repo-root <path>] [--update]
-harness-check-spec-coverage [--repo-root <path>]    # reads PR_BODY, GITHUB_BASE_REF, GITHUB_ACTOR from env
-harness-validate-specs [--repo-root <path>]
-harness-check-instruction-drift [--repo-root <path>]
+npx harness-init --project-name my-project --project-type node
+npx harness-doctor           # self-diagnostic
+npx harness-validate-specs   # or: npx harness validate-specs
 ```
 
-All bins default to `git rev-parse --show-toplevel` when no `--repo-root` is passed.
+## Node API
 
-## API
-
-```javascript
+```js
 import {
-  createHarnessContext,
-  validateManifest,
+  createHarnessContext, validateSpecs, validateManifest, checkSpecCoverage,
+  checkInstructionDrift, scaffoldHarness, ValidationError, ERROR_CODES,
   EXIT_CODES,
 } from "@kaiohenricunha/harness";
 
-const ctx = createHarnessContext({ repoRoot: "/path/to/repo" });
-const result = validateManifest(ctx);
+const ctx = createHarnessContext();
+const { ok, errors } = validateSpecs(ctx);  // errors are ValidationError instances
 ```
 
-Every export comes from the single barrel. Deep imports are not a supported contract.
+See [api-reference](https://github.com/kaiohenricunha/dotclaude/blob/main/docs/api-reference.md)
+for the full surface.
+
+## Bins
+
+- `harness` — umbrella dispatcher (`harness validate-specs`, `harness doctor`, …)
+- `harness-doctor` — self-diagnostic
+- `harness-init` — scaffold governance tree
+- `harness-validate-specs`, `harness-validate-skills`
+- `harness-check-spec-coverage`, `harness-check-instruction-drift`
+- `harness-detect-drift`
+
+Every bin supports `--help`, `--version`, `--json`, `--verbose`, `--no-color`.
+
+## Exit codes
+
+`{OK:0, VALIDATION:1, ENV:2, USAGE:64}` — `64` mirrors BSD `sysexits.h EX_USAGE`.
+
+## License
+
+MIT. See <https://github.com/kaiohenricunha/dotclaude/blob/main/LICENSE>.
+
+## Links
+
+- [Changelog](https://github.com/kaiohenricunha/dotclaude/blob/main/CHANGELOG.md)
+- [Contributing](https://github.com/kaiohenricunha/dotclaude/blob/main/CONTRIBUTING.md)
+- [Security](https://github.com/kaiohenricunha/dotclaude/blob/main/SECURITY.md)
+- [Quickstart](https://github.com/kaiohenricunha/dotclaude/blob/main/docs/quickstart.md)
+- [Troubleshooting](https://github.com/kaiohenricunha/dotclaude/blob/main/docs/troubleshooting.md)


### PR DESCRIPTION
## Summary

- **Foundational docs**: add `LICENSE` (MIT), `CHANGELOG.md` (Keep-a-Changelog with retroactive 0.1.0 + full 0.2.0), `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, linked out to the canonical text to avoid reproducing the full anti-harassment enumeration).
- **`docs/` set**: `index.md` (persona-tailored nav), `quickstart.md` (5-minute install → first green validator), `cli-reference.md` (every flag + exit code + `--json` schema per bin), `api-reference.md` (Node API contract + `ERROR_CODES` families), `architecture.md` (layer diagram + PR-time coverage sequence), `personas.md` (consumer / library user / dotfile user / contributor matrix), `troubleshooting.md` (indexed by every `ERROR_CODES` entry), `upgrade-guide.md` (0.1→0.2 migration + forking instructions), `templates.md` (placeholder catalog + per-template rationale).
- **`docs/adr/`** — 5 load-bearing ADRs: 0001 monorepo dual-persona, 0002 no-TypeScript, 0012 structured-error contract, 0013 exit-code convention, 0014 CLI ✓/✗/⚠ format. Remaining ADRs (SEC/OPS hardening, LSP ownership, context7, project-bound MCPs) are captured as planned stubs in the ADR index.
- **YAML frontmatter** prepended to all 12 `commands/*.md` matching the `skills/*/SKILL.md` schema (`name:`, `description:`, `argument-hint:`).
- **README.md full rewrite** — persona-split quickstart, working barrel import, hardening decisions table linking ADRs, further-reading table. `plugins/harness/README.md` slimmed to an npm-tarball entry point pointing at the repo's `docs/`.
- **CLAUDE.md persona header** marking it as Kaio's global-rules floor (consumers do not inherit).
- Manifest checksums refreshed to reflect the new frontmatter headers on every command file.

## Test plan

- [x] `npm test` — 90/90 green.
- [x] `npm run coverage` thresholds (85/85/80/85) met.
- [x] `npx bats plugins/harness/tests/bats/` — 34/34 green.
- [x] `bash plugins/harness/tests/test_validate_settings.sh` — 12/12 green.
- [x] `node scripts/check-jsdoc-coverage.mjs plugins/harness/src` — ok.
- [x] Root dogfood: all four validators exit 0 against the repo root.
- [x] `shellcheck --severity=warning -x` — exit 0, no findings.
- [x] Every doc file links to real paths (manual pass; lychee automation lands in PR 7).

## No-spec rationale

This PR is purely documentation: 9 `docs/` files, 4 repo-root docs, 5 ADRs, 12 command frontmatter prefixes, plus `README.md` / `plugins/harness/README.md` / `CLAUDE.md` updates that describe the already-landed code. No behavior change; every command and library surface is unchanged. The spec-anchored workflow's intent is to gate *behavior* changes to protected paths; pure docs additions pointing at the existing surface don't introduce governance drift. Manifest checksums are refreshed because the commands gained frontmatter, but the command *contents* (their behavioral instructions) are untouched.

Spec ID: harness-core
