### PR TITLE
fix(ci): use PR author for bot-actor detection in dogfood

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_ACTOR: ${{ github.event.pull_request.user.login || github.actor }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: node plugins/dotclaude/bin/dotclaude-check-spec-coverage.mjs
       - run: node plugins/dotclaude/bin/dotclaude-doctor.mjs


### PR DESCRIPTION
## Summary

- Fix bot-actor detection in dogfood workflow for Dependabot PRs
- `github.actor` becomes the human who triggered `gh run rerun`, not the PR author — causing `isBotActor()` to return false for Dependabot PRs reruns
- Switch to `github.event.pull_request.user.login || github.actor` so the PR author is used for bot detection, falling back to the actor on push/workflow_dispatch events

## Test plan

- [ ] Merge this PR; the `actions/upload-artifact` Dependabot PR (#13) should pass the `self (repo root)` dogfood check without needing `## No-spec rationale`

## Spec ID

dotclaude-core
