### PR TITLE
fix(ci): use PR_ACTOR to avoid GITHUB_ACTOR builtin collision

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_ACTOR: ${{ github.event.pull_request.user.login || github.actor }}
+          PR_ACTOR: ${{ github.event.pull_request.user.login || github.actor }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: node plugins/dotclaude/bin/dotclaude-check-spec-coverage.mjs
       - run: node plugins/dotclaude/bin/dotclaude-doctor.mjs

--- a/plugins/dotclaude/src/spec-harness-lib.mjs
+++ b/plugins/dotclaude/src/spec-harness-lib.mjs
@@ -337,7 +337,7 @@ export function getPullRequestContext() {
   const event = process.env.GITHUB_EVENT_NAME ?? "";
   const isPullRequest = event === "pull_request";
   const body = process.env.PR_BODY ?? "";
-  const actor = process.env.GITHUB_ACTOR ?? "";
+  const actor = process.env.PR_ACTOR ?? process.env.GITHUB_ACTOR ?? "";
   return { isPullRequest, body, actor };
 }
 

--- a/plugins/dotclaude/src/spec-harness-lib.mjs
+++ b/plugins/dotclaude/src/spec-harness-lib.mjs
@@ -325,7 +325,7 @@ export function isMeaningfulSection(section) {
  * @typedef {object} PullRequestContext
  * @property {boolean} isPullRequest   Derived from `GITHUB_EVENT_NAME === "pull_request"`.
  * @property {string} body             `PR_BODY` env — populated by workflows that pipe PR text in.
- * @property {string} actor            `GITHUB_ACTOR` env.
+ * @property {string} actor            `PR_ACTOR` env (preferred) with `GITHUB_ACTOR` as fallback.
  */
 
 /**

--- a/plugins/dotclaude/tests/spec-harness-lib.test.mjs
+++ b/plugins/dotclaude/tests/spec-harness-lib.test.mjs
@@ -11,6 +11,7 @@ import {
   anyPathMatches,
   listRepoPaths,
   getChangedFiles,
+  getPullRequestContext,
   git,
   isMeaningfulSection,
 } from "../src/spec-harness-lib.mjs";
@@ -138,6 +139,33 @@ describe("silent-catch replacement (debug-gated)", () => {
       stdio: ["ignore", "pipe", "ignore"],
     });
     expect(out).toMatch(/THROWN:.*repoRoot not provided/);
+  });
+
+  it("getPullRequestContext reads PR_ACTOR over GITHUB_ACTOR when both are set", () => {
+    const saved = { PR_ACTOR: process.env.PR_ACTOR, GITHUB_ACTOR: process.env.GITHUB_ACTOR };
+    process.env.PR_ACTOR = "dependabot[bot]";
+    process.env.GITHUB_ACTOR = "kaiohenricunha";
+    try {
+      expect(getPullRequestContext().actor).toBe("dependabot[bot]");
+    } finally {
+      if (saved.PR_ACTOR === undefined) delete process.env.PR_ACTOR;
+      else process.env.PR_ACTOR = saved.PR_ACTOR;
+      if (saved.GITHUB_ACTOR === undefined) delete process.env.GITHUB_ACTOR;
+      else process.env.GITHUB_ACTOR = saved.GITHUB_ACTOR;
+    }
+  });
+
+  it("getPullRequestContext falls back to GITHUB_ACTOR when PR_ACTOR is unset", () => {
+    const saved = { PR_ACTOR: process.env.PR_ACTOR, GITHUB_ACTOR: process.env.GITHUB_ACTOR };
+    delete process.env.PR_ACTOR;
+    process.env.GITHUB_ACTOR = "kaiohenricunha";
+    try {
+      expect(getPullRequestContext().actor).toBe("kaiohenricunha");
+    } finally {
+      if (saved.PR_ACTOR !== undefined) process.env.PR_ACTOR = saved.PR_ACTOR;
+      if (saved.GITHUB_ACTOR === undefined) delete process.env.GITHUB_ACTOR;
+      else process.env.GITHUB_ACTOR = saved.GITHUB_ACTOR;
+    }
   });
 
   it("getChangedFiles returns [] when git diff fails (subprocess run in non-git dir)", () => {


### PR DESCRIPTION
## Summary

- Fix bot-actor detection by renaming `GITHUB_ACTOR` env var to `PR_ACTOR` in dogfood.yml
- `GITHUB_ACTOR` is a GitHub Actions built-in variable set by the runner to whoever triggered the workflow; step-level `env:` blocks cannot reliably override built-in `GITHUB_*` vars
- `getPullRequestContext()` now reads `PR_ACTOR` first (falling back to `GITHUB_ACTOR` for backwards compat), so `isBotActor()` receives the actual PR author (`dependabot[bot]`) rather than the triggering user

## Test plan

- [ ] All 97 unit tests pass locally
- [ ] After merge, rebase Dependabot PR #13 onto new main — dogfood `self (repo root)` should pass via bot bypass without needing `## No-spec rationale`

## Spec ID

dotclaude-core
