### PR TITLE
feat(commands): add generic /review-pr slash command

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-15T01:29:37.088Z",
+  "generatedAt": "2026-04-15T01:38:55.141Z",
   "skills": [
     {
       "name": "audit-and-fix",

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,104 +1,111 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-14T18:47:00.554Z",
+  "generatedAt": "2026-04-15T01:29:37.088Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
       "checksum": "sha256:477c139d18d5359dfa1f7099b68af5a9699ac525c6648d4e325fd283629abb55",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:5546da1eb8aded7b9b5545f7471e81232aaa650e6d936ce3207bd61c3fd927e3",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
       "checksum": "sha256:94bae764bbc0feac44386f58948ef2ed524739cd060bb4423fee6ccc0a6eea87",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
       "checksum": "sha256:26b799157f877186edee2ea062f3873bc6355d0451ce099ca5e93470d4ab095e",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:f983f4d3a17a5dc4ac42c832c9aabc24ed09292b90c17b64aae24e4c95afc38a",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
       "checksum": "sha256:7a6b3d1f2fe517ce0b1efdf93a98fa094ec5068e64e2e726d7ccd647d51f675a",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
       "checksum": "sha256:497989ff7407af707a05e1eb4199558182d1ed9ac2c8967e074e3251302e0380",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
       "checksum": "sha256:108db5939a78ef30fa4e4feea60228deb41b6e62b06b76918164e7d097f69aa0",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
       "checksum": "sha256:77eb891bdffabec4c8a1f73c916752b6cd27fbbcec3a4d92612bb131d1bf3443",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:a195deeff6625d9ae5b6d2a12e7321725937d20fb43ffb788f325cd3d0a1b8c6",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:cc60d9264606d4c0476c2708673a4eb5f3b5ddab98705f646b6157c03234cfc9",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
+    },
+    {
+      "name": "review-pr",
+      "path": ".claude/commands/review-pr.md",
+      "checksum": "sha256:a48115edac6ceff5f1521360fcd71646b426ef09b3164e7ac58acbd86671d487",
+      "dependencies": [],
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
       "checksum": "sha256:6c59a6e3e449d7cb1aedf8d0697908de7e03e348d8d3a364444b1874c464cbbf",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:5a302eb3ec1168a8a316fb64711b8ace9f9ca8929e5ec7e9b713e42f6d563295",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:486dd1665e07511553aa68820ddf1d0dd2b9490e8ac00889b2b596058daff99c",
       "dependencies": [],
-      "lastValidated": "2026-04-14"
+      "lastValidated": "2026-04-15"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Universal behavior for every Claude Code session in every repo. Project-level `C
 - Required sections in every PR body:
   - `## Summary` — 1–3 bullets describing the change.
   - `## Test plan` — bulleted markdown checklist.
-  - `Spec ID: <id>` — if the project uses spec IDs (check for `specs/` or `docs/specs/`).
+  - `## Spec ID` heading followed by the spec id — if the project uses spec IDs (check for `specs/` or `docs/specs/`). Must be an H2 heading; `dotclaude-check-spec-coverage` extracts it via H2 regex.
 - Never merge a PR with failing CI without explicit user approval.
 
 ## Shell & Scripting

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -1,47 +1,64 @@
+---
+name: review-pr
+description: >
+  Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.
+argument-hint: "[PR#]"
+---
+
 Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.
 
-Argument: $ARGUMENTS — PR number (required). Example: `/review-pr 42`
+Argument: `$ARGUMENTS` — PR number (required). Example: `/review-pr 42`
 
 ## Workflow
+
+Before any step, bind the PR number:
+
+```bash
+NUMBER="$ARGUMENTS"
+```
 
 ### 1. Fetch PR details
 
 ```bash
-gh pr view $NUMBER --json number,title,headRefName,baseRefName,body,mergeable,mergeStateStatus,additions,deletions
+gh pr view "$NUMBER" --json number,title,headRefName,baseRefName,body,mergeable,mergeStateStatus,additions,deletions
 ```
 
 ### 2. Collect ALL review comments
 
 ```bash
-gh pr view $NUMBER --json reviews,comments
-gh api repos/{owner}/{repo}/pulls/$NUMBER/comments
-gh api repos/{owner}/{repo}/pulls/$NUMBER/reviews
+gh pr view "$NUMBER" --json reviews,comments
+gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments"
+gh api "repos/{owner}/{repo}/pulls/$NUMBER/reviews"
 ```
+
+(`{owner}` and `{repo}` are substituted automatically by `gh api` from the current git remote.)
 
 List every comment with: author, body, file path + line (if applicable), and state (pending/resolved).
 
 ### 3. Validate each comment
 
 For each review comment:
+
 - Read the relevant file and surrounding code context
 - Determine: is this a **valid issue** (real bug, style violation, missing edge case, legit improvement) or a **false positive** (nitpick that's wrong, misunderstanding of intent, outdated concern)?
 - Classify as: `✅ valid — will fix` or `⚠️ false positive — will explain`
 
-### 4. Reply to each comment on GitHub
+### 4. Reply to false positives immediately
 
-For valid issues:
+For each false positive, reply now with a concise explanation:
+
 ```bash
-gh api repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies -f body="Agreed — fixing this now."
+gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies" \
+  -f body="<concise explanation of why this is not an issue>"
 ```
-For false positives:
-```bash
-gh api repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies -f body="<concise explanation of why this is not an issue>"
-```
+
+Hold replies to valid issues until **after** the push in step 7 — do not acknowledge fixes you haven't yet delivered.
 
 ### 5. Apply fixes (in an isolated worktree, never on the caller's branch)
 
 ```bash
 git fetch origin "pull/$NUMBER/head:pr-$NUMBER"
+mkdir -p .claude/worktrees
 if [ ! -d ".claude/worktrees/pr-$NUMBER" ]; then
   git worktree add ".claude/worktrees/pr-$NUMBER" "pr-$NUMBER"
 fi
@@ -56,59 +73,77 @@ Work exclusively inside `.claude/worktrees/pr-$NUMBER/`. Do **not** use `gh pr c
   - `go.mod` → `go test ./...`
   - `pyproject.toml` → `pytest` (or `uv run pytest`)
 - Commit with a clear message referencing the review (e.g., `fix: address PR review — <summary>`).
-- Push to the PR branch. If the push fails (branch protection, network, non-fast-forward), **stop**: do not post replies or resolve threads — the remote does not yet have the commits the replies reference.
 
 Leave the worktree in place when done. Print the cleanup command:
+
 ```bash
 git worktree remove .claude/worktrees/pr-$NUMBER
 ```
 
 ### 6. Security review
 
-After applying fixes (and before pushing), run the security review skill on the PR diff:
+Before pushing, run the security review skill on the PR diff:
+
 ```
 /security-review $NUMBER
 ```
 
 If it flags real issues:
+
 - Fix them in the same branch
 - Add to the commit message (e.g., `fix: address PR review + security findings`)
 - Note them in the summary under a **Security** column
 
 If all findings are false positives, note "security: clean" in the summary.
 
-### 7. Check for merge conflicts
+### 7. Push
+
+Push to the PR branch. If the push fails (branch protection, network, non-fast-forward), **stop**: do not post replies or resolve threads — the remote does not yet have the commits the replies reference.
+
+### 8. Reply to valid comments (after push)
+
+Only after the push succeeds, reply to each valid comment confirming the fix:
 
 ```bash
-gh pr view $NUMBER --json mergeable,mergeStateStatus
+gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies" \
+  -f body="Fixed in <commit-sha> — <one-line description of the fix>."
+```
+
+### 9. Check for merge conflicts
+
+```bash
+gh pr view "$NUMBER" --json mergeable,mergeStateStatus
 ```
 
 If there are conflicts:
+
 - Rebase onto the base branch: `git rebase <base>`
 - Resolve conflicts (prefer the PR branch's intent, integrate base branch updates)
 - Force-push the rebased branch only with explicit user confirmation
 - Verify the build still passes after rebase
 
-### 8. Check failed CI pipelines
+### 10. Check failed CI pipelines
 
 ```bash
-gh pr checks $NUMBER --json name,state,bucket,link
+gh pr checks "$NUMBER" --json name,state,bucket,link
 ```
 
 For any check with `bucket: "fail"`:
+
 1. Fetch the logs:
    ```bash
    gh run list --branch <headRefName> --limit 3 --json databaseId,status,conclusion,name
    gh run view <runId> --log-failed
    ```
 2. Identify the root cause (test failure, lint error, build error, flaky, missing env var).
-3. If the fix is straightforward: apply it on the PR branch, include in the review commit, note "CI fix: <description>" in the summary.
-4. If the failure is infrastructure/flaky: re-trigger with `gh run rerun <runId> --failed`, note "CI: re-triggered flaky <jobName>" in the summary.
-5. If the failure requires design decisions or is out of scope: leave a PR comment explaining it, note "CI: blocked — <reason>" in the summary.
+3. If the fix is straightforward: apply it on the PR branch, include in the review commit, note "CI fix: \<description\>" in the summary.
+4. If the failure is infrastructure/flaky: re-trigger with `gh run rerun <runId> --failed`, note "CI: re-triggered flaky \<jobName\>" in the summary.
+5. If the failure requires design decisions or is out of scope: leave a PR comment explaining it, note "CI: blocked — \<reason\>" in the summary.
 
-### 9. Verify the test plan
+### 11. Verify the test plan
 
 If the PR body has a `## Test plan` section, run each listed command locally from inside `.claude/worktrees/pr-$NUMBER/`. Mark each as:
+
 - `✓ local` — ran and passed
 - `✗ failed` — ran and failed (fix before proceeding)
 - `skipped` — requires infra/services not available locally
@@ -116,26 +151,32 @@ If the PR body has a `## Test plan` section, run each listed command locally fro
 If the PR body has no `## Test plan` section: leave a comment asking the author to add one and note `test-plan: missing` in the summary.
 
 After a passing run, post the evidence as a PR comment:
+
 ```bash
-gh pr comment $NUMBER --body "Test plan verified against HEAD <sha>:
+gh pr comment "$NUMBER" --body "Test plan verified against HEAD <sha>:
 - \`<command>\` — local ✓ (<ms>ms)
 ..."
 ```
 
-### 10. Resolve all review threads
+### 12. Resolve all review threads
 
 After fixes are pushed, resolve every addressed review thread:
+
 ```bash
-# Fetch thread IDs
-gh api graphql -f query='query {
-  repository(owner: "{owner}", name: "{repo}") {
-    pullRequest(number: $NUMBER) {
-      reviewThreads(first: 50) {
-        nodes { id isResolved comments(first: 1) { nodes { body path } } }
+# Fetch thread IDs — pass variables with -F so GraphQL can bind them
+gh api graphql \
+  -F owner="$(gh repo view --json owner -q .owner.login)" \
+  -F repo="$(gh repo view --json name -q .name)" \
+  -F number="$NUMBER" \
+  -f query='query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 50) {
+          nodes { id isResolved comments(first: 1) { nodes { body path } } }
+        }
       }
     }
-  }
-}'
+  }'
 
 # Resolve each addressed unresolved thread
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
@@ -143,15 +184,16 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thre
 
 Do NOT use `minimizeComment` — that hides comments instead of resolving them. Always use `resolveReviewThread` with a thread ID starting with `PRRT_`.
 
-### 11. Summary report
+### 13. Summary report
 
 Output a table:
 
-| PR | Title | Comments | Valid | False Pos | Fixed | Security | CI | Test Plan | Conflicts | Status |
-|----|-------|----------|-------|-----------|-------|----------|----|-----------|-----------|--------|
+| PR  | Title | Comments | Valid | False Pos | Fixed | Security | CI  | Test Plan | Conflicts | Status |
+| --- | ----- | -------- | ----- | --------- | ----- | -------- | --- | --------- | --------- | ------ |
 
 A PR may only be marked `reviewed` if:
-- The §5 push succeeded
+
+- The §7 push succeeded
 - All auto-runnable test plan commands passed (or test plan was missing — flagged)
 - No unresolved CI failures remain
 

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -1,0 +1,160 @@
+Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.
+
+Argument: $ARGUMENTS — PR number (required). Example: `/review-pr 42`
+
+## Workflow
+
+### 1. Fetch PR details
+
+```bash
+gh pr view $NUMBER --json number,title,headRefName,baseRefName,body,mergeable,mergeStateStatus,additions,deletions
+```
+
+### 2. Collect ALL review comments
+
+```bash
+gh pr view $NUMBER --json reviews,comments
+gh api repos/{owner}/{repo}/pulls/$NUMBER/comments
+gh api repos/{owner}/{repo}/pulls/$NUMBER/reviews
+```
+
+List every comment with: author, body, file path + line (if applicable), and state (pending/resolved).
+
+### 3. Validate each comment
+
+For each review comment:
+- Read the relevant file and surrounding code context
+- Determine: is this a **valid issue** (real bug, style violation, missing edge case, legit improvement) or a **false positive** (nitpick that's wrong, misunderstanding of intent, outdated concern)?
+- Classify as: `✅ valid — will fix` or `⚠️ false positive — will explain`
+
+### 4. Reply to each comment on GitHub
+
+For valid issues:
+```bash
+gh api repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies -f body="Agreed — fixing this now."
+```
+For false positives:
+```bash
+gh api repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies -f body="<concise explanation of why this is not an issue>"
+```
+
+### 5. Apply fixes (in an isolated worktree, never on the caller's branch)
+
+```bash
+git fetch origin "pull/$NUMBER/head:pr-$NUMBER"
+if [ ! -d ".claude/worktrees/pr-$NUMBER" ]; then
+  git worktree add ".claude/worktrees/pr-$NUMBER" "pr-$NUMBER"
+fi
+```
+
+Work exclusively inside `.claude/worktrees/pr-$NUMBER/`. Do **not** use `gh pr checkout`, `git checkout`, or `git stash` — these modify the caller's working tree.
+
+- Apply all fixes for valid comments, TDD-first (failing test → fix → green).
+- Detect and run the project test suite:
+  - `Makefile` with `test` target → `make test`
+  - `package.json` → `npm test` (or `pnpm`/`yarn` per lockfile)
+  - `go.mod` → `go test ./...`
+  - `pyproject.toml` → `pytest` (or `uv run pytest`)
+- Commit with a clear message referencing the review (e.g., `fix: address PR review — <summary>`).
+- Push to the PR branch. If the push fails (branch protection, network, non-fast-forward), **stop**: do not post replies or resolve threads — the remote does not yet have the commits the replies reference.
+
+Leave the worktree in place when done. Print the cleanup command:
+```bash
+git worktree remove .claude/worktrees/pr-$NUMBER
+```
+
+### 6. Security review
+
+After applying fixes (and before pushing), run the security review skill on the PR diff:
+```
+/security-review $NUMBER
+```
+
+If it flags real issues:
+- Fix them in the same branch
+- Add to the commit message (e.g., `fix: address PR review + security findings`)
+- Note them in the summary under a **Security** column
+
+If all findings are false positives, note "security: clean" in the summary.
+
+### 7. Check for merge conflicts
+
+```bash
+gh pr view $NUMBER --json mergeable,mergeStateStatus
+```
+
+If there are conflicts:
+- Rebase onto the base branch: `git rebase <base>`
+- Resolve conflicts (prefer the PR branch's intent, integrate base branch updates)
+- Force-push the rebased branch only with explicit user confirmation
+- Verify the build still passes after rebase
+
+### 8. Check failed CI pipelines
+
+```bash
+gh pr checks $NUMBER --json name,state,bucket,link
+```
+
+For any check with `bucket: "fail"`:
+1. Fetch the logs:
+   ```bash
+   gh run list --branch <headRefName> --limit 3 --json databaseId,status,conclusion,name
+   gh run view <runId> --log-failed
+   ```
+2. Identify the root cause (test failure, lint error, build error, flaky, missing env var).
+3. If the fix is straightforward: apply it on the PR branch, include in the review commit, note "CI fix: <description>" in the summary.
+4. If the failure is infrastructure/flaky: re-trigger with `gh run rerun <runId> --failed`, note "CI: re-triggered flaky <jobName>" in the summary.
+5. If the failure requires design decisions or is out of scope: leave a PR comment explaining it, note "CI: blocked — <reason>" in the summary.
+
+### 9. Verify the test plan
+
+If the PR body has a `## Test plan` section, run each listed command locally from inside `.claude/worktrees/pr-$NUMBER/`. Mark each as:
+- `✓ local` — ran and passed
+- `✗ failed` — ran and failed (fix before proceeding)
+- `skipped` — requires infra/services not available locally
+
+If the PR body has no `## Test plan` section: leave a comment asking the author to add one and note `test-plan: missing` in the summary.
+
+After a passing run, post the evidence as a PR comment:
+```bash
+gh pr comment $NUMBER --body "Test plan verified against HEAD <sha>:
+- \`<command>\` — local ✓ (<ms>ms)
+..."
+```
+
+### 10. Resolve all review threads
+
+After fixes are pushed, resolve every addressed review thread:
+```bash
+# Fetch thread IDs
+gh api graphql -f query='query {
+  repository(owner: "{owner}", name: "{repo}") {
+    pullRequest(number: $NUMBER) {
+      reviewThreads(first: 50) {
+        nodes { id isResolved comments(first: 1) { nodes { body path } } }
+      }
+    }
+  }
+}'
+
+# Resolve each addressed unresolved thread
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
+```
+
+Do NOT use `minimizeComment` — that hides comments instead of resolving them. Always use `resolveReviewThread` with a thread ID starting with `PRRT_`.
+
+### 11. Summary report
+
+Output a table:
+
+| PR | Title | Comments | Valid | False Pos | Fixed | Security | CI | Test Plan | Conflicts | Status |
+|----|-------|----------|-------|-----------|-------|----------|----|-----------|-----------|--------|
+
+A PR may only be marked `reviewed` if:
+- The §5 push succeeded
+- All auto-runnable test plan commands passed (or test plan was missing — flagged)
+- No unresolved CI failures remain
+
+Otherwise the row status is `blocked`, `push-failed`, or `test-plan-missing` and the blocker is called out.
+
+End with the commit pushed, the worktree cleanup command, and any remaining action items.


### PR DESCRIPTION
## Summary

- Adds a generic `/review-pr <N>` slash command to dotclaude, available globally after `bootstrap.sh`
- Generified from the `wc-squad-rankings` project-specific `review-prs.md` — strips squad-specific steps (test-scoping script, blog review, ci-job-map, rankings-tune lock) and replaces with auto-detected test runner per CLAUDE.md conventions
- Full workflow: fetch comments → validate → reply → fix in isolated worktree → security review → conflict check → CI check → test plan verify → resolve threads → summary

## Test plan

- [ ] `bootstrap.sh` symlinks `commands/review-pr.md` into `~/.claude/commands/`
- [ ] `/review-pr` is available as a slash command in a Claude Code session
- [ ] Command text references no squad-rankings-specific scripts or paths

## Spec ID

dotclaude-core
