### PR TITLE
feat(commands): add /create-inspection slash command

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-15T01:38:55.141Z",
+  "generatedAt": "2026-04-15T01:58:08.298Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -80,9 +80,16 @@
       "lastValidated": "2026-04-15"
     },
     {
+      "name": "create-inspection",
+      "path": ".claude/commands/create-inspection.md",
+      "checksum": "sha256:32fe686caad0543057daf5f8cf6e418a4ae36898d1fc175e354c75c00b25616a",
+      "dependencies": [],
+      "lastValidated": "2026-04-15"
+    },
+    {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
-      "checksum": "sha256:a48115edac6ceff5f1521360fcd71646b426ef09b3164e7ac58acbd86671d487",
+      "checksum": "sha256:318ec86a2b2fe493f40019087c82c0897e3c3a91a4624f598473b1e9c6f05722",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,14 +131,14 @@ or a `## No-spec rationale` section in its body.
 
 Quick-invoke disciplines for recurring friction:
 
-| Command                       | When                                                                                      |
-| ----------------------------- | ----------------------------------------------------------------------------------------- |
-| `/ground-first <subject>`     | Before any non-trivial fix — forces code-inspection analysis before edits                 |
-| `/merge-pr <N>`               | Before merging a PR that touches data/calibration/rankings — runs full local verification |
-| `/fix-with-evidence <issue>`  | For any bug fix — enforces Reproduce → Fix → Verify → PR loop                             |
-| `/dependabot-sweep`           | Batch-triage all open Dependabot PRs with parallel subagents                              |
-| `/audit-and-fix <domain>`     | Long-running audit-then-implement pipeline across many PRs                                |
-| `/create-audit <subject>`        | Evidence-based audit doc to `docs/audits/`                                                |
-| `/create-assessment <target>`    | 0–10 graded assessment doc to `docs/assessments/`                                         |
-| `/create-inspection <problem>`   | Investigate a problem and surface viable fix options to `docs/inspections/`               |
-| `/spec <subject>`                | Only when a spec/design doc is explicitly requested                                       |
+| Command                        | When                                                                                      |
+| ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `/ground-first <subject>`      | Before any non-trivial fix — forces code-inspection analysis before edits                 |
+| `/merge-pr <N>`                | Before merging a PR that touches data/calibration/rankings — runs full local verification |
+| `/fix-with-evidence <issue>`   | For any bug fix — enforces Reproduce → Fix → Verify → PR loop                             |
+| `/dependabot-sweep`            | Batch-triage all open Dependabot PRs with parallel subagents                              |
+| `/audit-and-fix <domain>`      | Long-running audit-then-implement pipeline across many PRs                                |
+| `/create-audit <subject>`      | Evidence-based audit doc to `docs/audits/`                                                |
+| `/create-assessment <target>`  | 0–10 graded assessment doc to `docs/assessments/`                                         |
+| `/create-inspection <problem>` | Investigate a problem and surface viable fix options to `docs/inspections/`               |
+| `/spec <subject>`              | Only when a spec/design doc is explicitly requested                                       |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ Quick-invoke disciplines for recurring friction:
 | `/fix-with-evidence <issue>`  | For any bug fix — enforces Reproduce → Fix → Verify → PR loop                             |
 | `/dependabot-sweep`           | Batch-triage all open Dependabot PRs with parallel subagents                              |
 | `/audit-and-fix <domain>`     | Long-running audit-then-implement pipeline across many PRs                                |
-| `/create-audit <subject>`     | Evidence-based audit doc to `docs/audits/`                                                |
-| `/create-assessment <target>` | 0–10 graded assessment doc to `docs/assessments/`                                         |
-| `/spec <subject>`             | Only when a spec/design doc is explicitly requested                                       |
+| `/create-audit <subject>`        | Evidence-based audit doc to `docs/audits/`                                                |
+| `/create-assessment <target>`    | 0–10 graded assessment doc to `docs/assessments/`                                         |
+| `/create-inspection <problem>`   | Investigate a problem and surface viable fix options to `docs/inspections/`               |
+| `/spec <subject>`                | Only when a spec/design doc is explicitly requested                                       |

--- a/commands/create-inspection.md
+++ b/commands/create-inspection.md
@@ -21,7 +21,7 @@ Arguments: `$ARGUMENTS` — a description of the problem or subject to inspect (
 
 2. **Locate the problem in the codebase.** Use `Grep`, `Glob`, and `Read` to find the relevant files, functions, configs, and tests. Do not guess — verify every claim with a `file:line` citation.
 
-3. **Diagnose root cause.** Read enough code to understand *why* the problem occurs, not just *where*. If there are tests, run them to observe the failure. If the issue is behavioural (performance, flakiness), read logs or run diagnostic commands.
+3. **Diagnose root cause.** Read enough code to understand _why_ the problem occurs, not just _where_. If there are tests, run them to observe the failure. If the issue is behavioural (performance, flakiness), read logs or run diagnostic commands.
 
 4. **Generate at least 2 fix options.** For each option:
    - Describe the approach concisely

--- a/commands/create-inspection.md
+++ b/commands/create-inspection.md
@@ -1,0 +1,94 @@
+---
+name: create-inspection
+description: >
+  Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).
+argument-hint: "[problem or subject]"
+---
+
+Investigate a specific problem and produce a structured fix-path document saved to the project's `docs/inspections/` directory.
+
+Trigger: when the user asks "how should I fix X", "what are my options for Y", "investigate Z before I touch it", or triggers directly via `/create-inspection`. Also useful before running `/fix-with-evidence` to pre-evaluate approaches.
+
+Arguments: `$ARGUMENTS` — a description of the problem or subject to inspect (e.g. "auth token refresh race condition", "N+1 queries in /api/dashboard", "flaky E2E login test"). Required — if empty, ask the user.
+
+## Purpose
+
+`/create-inspection` is **not** an audit (it doesn't enumerate all issues) and **not** a fix (it doesn't implement anything). Its output is a **decision document**: here is what is broken, here are the viable paths to fix it, here is a recommended approach with rationale.
+
+## Steps
+
+1. **Parse the subject** from `$ARGUMENTS`. If empty or vague, ask the user to describe the symptom or problem.
+
+2. **Locate the problem in the codebase.** Use `Grep`, `Glob`, and `Read` to find the relevant files, functions, configs, and tests. Do not guess — verify every claim with a `file:line` citation.
+
+3. **Diagnose root cause.** Read enough code to understand *why* the problem occurs, not just *where*. If there are tests, run them to observe the failure. If the issue is behavioural (performance, flakiness), read logs or run diagnostic commands.
+
+4. **Generate at least 2 fix options.** For each option:
+   - Describe the approach concisely
+   - List the files/components touched
+   - State the trade-offs (complexity, blast radius, test surface, reversibility)
+   - Estimate effort: `low` (< 1 hr), `medium` (1–4 hrs), `high` (> 4 hrs)
+   - Assess risk: `low`, `medium`, `high`
+
+5. **Pick a recommended option** and explain why it best balances correctness, risk, and effort. If options are genuinely tied, say so and flag the deciding factor for the user.
+
+6. **Generate the inspection document** with this structure:
+
+   ```markdown
+   # Inspection: <Subject> — <YYYY-MM-DD>
+
+   <One-sentence description of the problem and its impact.>
+
+   ## Root Cause
+
+   <Evidence-backed explanation of why the problem occurs. Include file:line citations.>
+
+   ## Scope
+
+   Files and components relevant to this problem.
+
+   | File / Component | Role in the problem |
+   | ---------------- | ------------------- |
+   | ...              | ...                 |
+
+   ## Fix Options
+
+   ### Option 1: <Name>
+
+   **Approach:** <description>
+   **Files touched:** <list>
+   **Effort:** low | medium | high
+   **Risk:** low | medium | high
+   **Trade-offs:** <pros and cons>
+
+   ### Option 2: <Name>
+
+   ...
+
+   ## Recommendation
+
+   **Use Option N: <Name>**
+
+   <2-3 sentences explaining why this option is best for the current situation.
+   Call out any assumptions (e.g. "assumes test coverage exists for the path").>
+
+   ## Next Step
+
+   Run `/fix-with-evidence <subject>` using the recommended option,
+   or proceed manually using the approach above.
+   ```
+
+7. **Generate a filename** in the format: `<topic-slug>-<YYYY-MM-DD>.md` (e.g. `auth-refresh-race-2026-04-14.md`). Use lowercase kebab-case.
+
+8. **Write the file** to `docs/inspections/<filename>`. Create the `docs/inspections/` directory if it doesn't exist.
+
+9. **Report to the user**: show the file path, the root cause in one sentence, and the recommended option. Do not dump the full document into chat.
+
+## Rules
+
+- Every root-cause claim must be backed by a `file:line` citation or command output. No assumptions.
+- Always provide at least 2 distinct fix options. Single-option "inspections" are just instructions.
+- Never implement a fix. Surface options and recommend. The user decides.
+- Do not commit the inspection file. Leave it untracked for the user to review.
+- If the problem cannot be localized (e.g. no repro, insufficient context), state that clearly and list what additional information is needed rather than producing a speculative document.
+- Keep the document concise. Tables over prose where possible. No filler.

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -1,53 +1,70 @@
+---
+name: review-pr
+description: >
+  Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.
+argument-hint: "[PR#]"
+---
+
 Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.
 
-Argument: $ARGUMENTS — PR number (required). Example: `/review-pr 42`
+Argument: `$ARGUMENTS` — PR number (required). Example: `/review-pr 42`
 
 ## Workflow
+
+Before any step, bind the PR number:
+
+```bash
+NUMBER="$ARGUMENTS"
+```
 
 ### 1. Fetch PR details
 
 ```bash
-gh pr view $NUMBER --json number,title,headRefName,baseRefName,body,mergeable,mergeStateStatus,additions,deletions
+gh pr view "$NUMBER" --json number,title,headRefName,baseRefName,body,mergeable,mergeStateStatus,additions,deletions
 ```
 
 ### 2. Collect ALL review comments
 
 ```bash
-gh pr view $NUMBER --json reviews,comments
-gh api repos/{owner}/{repo}/pulls/$NUMBER/comments
-gh api repos/{owner}/{repo}/pulls/$NUMBER/reviews
+gh pr view "$NUMBER" --json reviews,comments
+gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments"
+gh api "repos/{owner}/{repo}/pulls/$NUMBER/reviews"
 ```
+
+(`{owner}` and `{repo}` are substituted automatically by `gh api` from the current git remote.)
 
 List every comment with: author, body, file path + line (if applicable), and state (pending/resolved).
 
 ### 3. Validate each comment
 
 For each review comment:
+
 - Read the relevant file and surrounding code context
 - Determine: is this a **valid issue** (real bug, style violation, missing edge case, legit improvement) or a **false positive** (nitpick that's wrong, misunderstanding of intent, outdated concern)?
 - Classify as: `✅ valid — will fix` or `⚠️ false positive — will explain`
 
-### 4. Reply to each comment on GitHub
+### 4. Reply to false positives immediately
 
-For valid issues:
+For each false positive, reply now with a concise explanation:
+
 ```bash
-gh api repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies -f body="Agreed — fixing this now."
+gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies" \
+  -f body="<concise explanation of why this is not an issue>"
 ```
-For false positives:
-```bash
-gh api repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies -f body="<concise explanation of why this is not an issue>"
-```
+
+Hold replies to valid issues until **after** the push in step 7 — do not acknowledge fixes you haven't yet delivered.
 
 ### 5. Apply fixes (in an isolated worktree, never on the caller's branch)
 
 ```bash
 git fetch origin "pull/$NUMBER/head:pr-$NUMBER"
+mkdir -p .claude/worktrees
 if [ ! -d ".claude/worktrees/pr-$NUMBER" ]; then
   git worktree add ".claude/worktrees/pr-$NUMBER" "pr-$NUMBER"
 fi
 ```
 
-Work exclusively inside `.claude/worktrees/pr-$NUMBER/`. Do **not** use `gh pr checkout`, `git checkout`, or `git stash` — these modify the caller's working tree.
+Work exclusively inside `.claude/worktrees/pr-$NUMBER/`. Do **not** use `gh pr checkout` or `git checkout` — those switch the caller's working tree — and do **not** use `git stash`, because stashes are repo-global and can interfere with the caller's stash list.
 
 - Apply all fixes for valid comments, TDD-first (failing test → fix → green).
 - Detect and run the project test suite:
@@ -56,59 +73,77 @@ Work exclusively inside `.claude/worktrees/pr-$NUMBER/`. Do **not** use `gh pr c
   - `go.mod` → `go test ./...`
   - `pyproject.toml` → `pytest` (or `uv run pytest`)
 - Commit with a clear message referencing the review (e.g., `fix: address PR review — <summary>`).
-- Push to the PR branch. If the push fails (branch protection, network, non-fast-forward), **stop**: do not post replies or resolve threads — the remote does not yet have the commits the replies reference.
 
 Leave the worktree in place when done. Print the cleanup command:
+
 ```bash
 git worktree remove .claude/worktrees/pr-$NUMBER
 ```
 
 ### 6. Security review
 
-After applying fixes (and before pushing), run the security review skill on the PR diff:
+Before pushing, run the security review skill on the PR diff:
+
 ```
 /security-review $NUMBER
 ```
 
 If it flags real issues:
+
 - Fix them in the same branch
 - Add to the commit message (e.g., `fix: address PR review + security findings`)
 - Note them in the summary under a **Security** column
 
 If all findings are false positives, note "security: clean" in the summary.
 
-### 7. Check for merge conflicts
+### 7. Push
+
+Push to the PR branch. If the push fails (branch protection, network, non-fast-forward), **stop**: do not post replies or resolve threads — the remote does not yet have the commits the replies reference.
+
+### 8. Reply to valid comments (after push)
+
+Only after the push succeeds, reply to each valid comment confirming the fix:
 
 ```bash
-gh pr view $NUMBER --json mergeable,mergeStateStatus
+gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies" \
+  -f body="Fixed in <commit-sha> — <one-line description of the fix>."
+```
+
+### 9. Check for merge conflicts
+
+```bash
+gh pr view "$NUMBER" --json mergeable,mergeStateStatus
 ```
 
 If there are conflicts:
+
 - Rebase onto the base branch: `git rebase <base>`
 - Resolve conflicts (prefer the PR branch's intent, integrate base branch updates)
 - Force-push the rebased branch only with explicit user confirmation
 - Verify the build still passes after rebase
 
-### 8. Check failed CI pipelines
+### 10. Check failed CI pipelines
 
 ```bash
-gh pr checks $NUMBER --json name,state,bucket,link
+gh pr checks "$NUMBER" --json name,state,bucket,link
 ```
 
 For any check with `bucket: "fail"`:
+
 1. Fetch the logs:
    ```bash
    gh run list --branch <headRefName> --limit 3 --json databaseId,status,conclusion,name
    gh run view <runId> --log-failed
    ```
 2. Identify the root cause (test failure, lint error, build error, flaky, missing env var).
-3. If the fix is straightforward: apply it on the PR branch, include in the review commit, note "CI fix: <description>" in the summary.
-4. If the failure is infrastructure/flaky: re-trigger with `gh run rerun <runId> --failed`, note "CI: re-triggered flaky <jobName>" in the summary.
-5. If the failure requires design decisions or is out of scope: leave a PR comment explaining it, note "CI: blocked — <reason>" in the summary.
+3. If the fix is straightforward: apply it on the PR branch, include in the review commit, note "CI fix: \<description\>" in the summary.
+4. If the failure is infrastructure/flaky: re-trigger with `gh run rerun <runId> --failed`, note "CI: re-triggered flaky \<jobName\>" in the summary.
+5. If the failure requires design decisions or is out of scope: leave a PR comment explaining it, note "CI: blocked — \<reason\>" in the summary.
 
-### 9. Verify the test plan
+### 11. Verify the test plan
 
 If the PR body has a `## Test plan` section, run each listed command locally from inside `.claude/worktrees/pr-$NUMBER/`. Mark each as:
+
 - `✓ local` — ran and passed
 - `✗ failed` — ran and failed (fix before proceeding)
 - `skipped` — requires infra/services not available locally
@@ -116,26 +151,32 @@ If the PR body has a `## Test plan` section, run each listed command locally fro
 If the PR body has no `## Test plan` section: leave a comment asking the author to add one and note `test-plan: missing` in the summary.
 
 After a passing run, post the evidence as a PR comment:
+
 ```bash
-gh pr comment $NUMBER --body "Test plan verified against HEAD <sha>:
+gh pr comment "$NUMBER" --body "Test plan verified against HEAD <sha>:
 - \`<command>\` — local ✓ (<ms>ms)
 ..."
 ```
 
-### 10. Resolve all review threads
+### 12. Resolve all review threads
 
 After fixes are pushed, resolve every addressed review thread:
+
 ```bash
-# Fetch thread IDs
-gh api graphql -f query='query {
-  repository(owner: "{owner}", name: "{repo}") {
-    pullRequest(number: $NUMBER) {
-      reviewThreads(first: 50) {
-        nodes { id isResolved comments(first: 1) { nodes { body path } } }
+# Fetch thread IDs — pass variables with -F so GraphQL can bind them
+gh api graphql \
+  -F owner="$(gh repo view --json owner -q .owner.login)" \
+  -F repo="$(gh repo view --json name -q .name)" \
+  -F number="$NUMBER" \
+  -f query='query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 50) {
+          nodes { id isResolved comments(first: 1) { nodes { body path } } }
+        }
       }
     }
-  }
-}'
+  }'
 
 # Resolve each addressed unresolved thread
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
@@ -143,15 +184,16 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thre
 
 Do NOT use `minimizeComment` — that hides comments instead of resolving them. Always use `resolveReviewThread` with a thread ID starting with `PRRT_`.
 
-### 11. Summary report
+### 13. Summary report
 
 Output a table:
 
-| PR | Title | Comments | Valid | False Pos | Fixed | Security | CI | Test Plan | Conflicts | Status |
-|----|-------|----------|-------|-----------|-------|----------|----|-----------|-----------|--------|
+| PR  | Title | Comments | Valid | False Pos | Fixed | Security | CI  | Test Plan | Conflicts | Status |
+| --- | ----- | -------- | ----- | --------- | ----- | -------- | --- | --------- | --------- | ------ |
 
 A PR may only be marked `reviewed` if:
-- The §5 push succeeded
+
+- The §7 push succeeded
 - All auto-runnable test plan commands passed (or test plan was missing — flagged)
 - No unresolved CI failures remain
 

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -1,64 +1,47 @@
----
-name: review-pr
-description: >
-  Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.
-argument-hint: "[PR#]"
----
-
 Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.
 
-Argument: `$ARGUMENTS` — PR number (required). Example: `/review-pr 42`
+Argument: $ARGUMENTS — PR number (required). Example: `/review-pr 42`
 
 ## Workflow
-
-Before any step, bind the PR number:
-
-```bash
-NUMBER="$ARGUMENTS"
-```
 
 ### 1. Fetch PR details
 
 ```bash
-gh pr view "$NUMBER" --json number,title,headRefName,baseRefName,body,mergeable,mergeStateStatus,additions,deletions
+gh pr view $NUMBER --json number,title,headRefName,baseRefName,body,mergeable,mergeStateStatus,additions,deletions
 ```
 
 ### 2. Collect ALL review comments
 
 ```bash
-gh pr view "$NUMBER" --json reviews,comments
-gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments"
-gh api "repos/{owner}/{repo}/pulls/$NUMBER/reviews"
+gh pr view $NUMBER --json reviews,comments
+gh api repos/{owner}/{repo}/pulls/$NUMBER/comments
+gh api repos/{owner}/{repo}/pulls/$NUMBER/reviews
 ```
-
-(`{owner}` and `{repo}` are substituted automatically by `gh api` from the current git remote.)
 
 List every comment with: author, body, file path + line (if applicable), and state (pending/resolved).
 
 ### 3. Validate each comment
 
 For each review comment:
-
 - Read the relevant file and surrounding code context
 - Determine: is this a **valid issue** (real bug, style violation, missing edge case, legit improvement) or a **false positive** (nitpick that's wrong, misunderstanding of intent, outdated concern)?
 - Classify as: `✅ valid — will fix` or `⚠️ false positive — will explain`
 
-### 4. Reply to false positives immediately
+### 4. Reply to each comment on GitHub
 
-For each false positive, reply now with a concise explanation:
-
+For valid issues:
 ```bash
-gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies" \
-  -f body="<concise explanation of why this is not an issue>"
+gh api repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies -f body="Agreed — fixing this now."
 ```
-
-Hold replies to valid issues until **after** the push in step 7 — do not acknowledge fixes you haven't yet delivered.
+For false positives:
+```bash
+gh api repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies -f body="<concise explanation of why this is not an issue>"
+```
 
 ### 5. Apply fixes (in an isolated worktree, never on the caller's branch)
 
 ```bash
 git fetch origin "pull/$NUMBER/head:pr-$NUMBER"
-mkdir -p .claude/worktrees
 if [ ! -d ".claude/worktrees/pr-$NUMBER" ]; then
   git worktree add ".claude/worktrees/pr-$NUMBER" "pr-$NUMBER"
 fi
@@ -73,77 +56,59 @@ Work exclusively inside `.claude/worktrees/pr-$NUMBER/`. Do **not** use `gh pr c
   - `go.mod` → `go test ./...`
   - `pyproject.toml` → `pytest` (or `uv run pytest`)
 - Commit with a clear message referencing the review (e.g., `fix: address PR review — <summary>`).
+- Push to the PR branch. If the push fails (branch protection, network, non-fast-forward), **stop**: do not post replies or resolve threads — the remote does not yet have the commits the replies reference.
 
 Leave the worktree in place when done. Print the cleanup command:
-
 ```bash
 git worktree remove .claude/worktrees/pr-$NUMBER
 ```
 
 ### 6. Security review
 
-Before pushing, run the security review skill on the PR diff:
-
+After applying fixes (and before pushing), run the security review skill on the PR diff:
 ```
 /security-review $NUMBER
 ```
 
 If it flags real issues:
-
 - Fix them in the same branch
 - Add to the commit message (e.g., `fix: address PR review + security findings`)
 - Note them in the summary under a **Security** column
 
 If all findings are false positives, note "security: clean" in the summary.
 
-### 7. Push
-
-Push to the PR branch. If the push fails (branch protection, network, non-fast-forward), **stop**: do not post replies or resolve threads — the remote does not yet have the commits the replies reference.
-
-### 8. Reply to valid comments (after push)
-
-Only after the push succeeds, reply to each valid comment confirming the fix:
+### 7. Check for merge conflicts
 
 ```bash
-gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies" \
-  -f body="Fixed in <commit-sha> — <one-line description of the fix>."
-```
-
-### 9. Check for merge conflicts
-
-```bash
-gh pr view "$NUMBER" --json mergeable,mergeStateStatus
+gh pr view $NUMBER --json mergeable,mergeStateStatus
 ```
 
 If there are conflicts:
-
 - Rebase onto the base branch: `git rebase <base>`
 - Resolve conflicts (prefer the PR branch's intent, integrate base branch updates)
 - Force-push the rebased branch only with explicit user confirmation
 - Verify the build still passes after rebase
 
-### 10. Check failed CI pipelines
+### 8. Check failed CI pipelines
 
 ```bash
-gh pr checks "$NUMBER" --json name,state,bucket,link
+gh pr checks $NUMBER --json name,state,bucket,link
 ```
 
 For any check with `bucket: "fail"`:
-
 1. Fetch the logs:
    ```bash
    gh run list --branch <headRefName> --limit 3 --json databaseId,status,conclusion,name
    gh run view <runId> --log-failed
    ```
 2. Identify the root cause (test failure, lint error, build error, flaky, missing env var).
-3. If the fix is straightforward: apply it on the PR branch, include in the review commit, note "CI fix: \<description\>" in the summary.
-4. If the failure is infrastructure/flaky: re-trigger with `gh run rerun <runId> --failed`, note "CI: re-triggered flaky \<jobName\>" in the summary.
-5. If the failure requires design decisions or is out of scope: leave a PR comment explaining it, note "CI: blocked — \<reason\>" in the summary.
+3. If the fix is straightforward: apply it on the PR branch, include in the review commit, note "CI fix: <description>" in the summary.
+4. If the failure is infrastructure/flaky: re-trigger with `gh run rerun <runId> --failed`, note "CI: re-triggered flaky <jobName>" in the summary.
+5. If the failure requires design decisions or is out of scope: leave a PR comment explaining it, note "CI: blocked — <reason>" in the summary.
 
-### 11. Verify the test plan
+### 9. Verify the test plan
 
 If the PR body has a `## Test plan` section, run each listed command locally from inside `.claude/worktrees/pr-$NUMBER/`. Mark each as:
-
 - `✓ local` — ran and passed
 - `✗ failed` — ran and failed (fix before proceeding)
 - `skipped` — requires infra/services not available locally
@@ -151,32 +116,26 @@ If the PR body has a `## Test plan` section, run each listed command locally fro
 If the PR body has no `## Test plan` section: leave a comment asking the author to add one and note `test-plan: missing` in the summary.
 
 After a passing run, post the evidence as a PR comment:
-
 ```bash
-gh pr comment "$NUMBER" --body "Test plan verified against HEAD <sha>:
+gh pr comment $NUMBER --body "Test plan verified against HEAD <sha>:
 - \`<command>\` — local ✓ (<ms>ms)
 ..."
 ```
 
-### 12. Resolve all review threads
+### 10. Resolve all review threads
 
 After fixes are pushed, resolve every addressed review thread:
-
 ```bash
-# Fetch thread IDs — pass variables with -F so GraphQL can bind them
-gh api graphql \
-  -F owner="$(gh repo view --json owner -q .owner.login)" \
-  -F repo="$(gh repo view --json name -q .name)" \
-  -F number="$NUMBER" \
-  -f query='query($owner: String!, $repo: String!, $number: Int!) {
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $number) {
-        reviewThreads(first: 50) {
-          nodes { id isResolved comments(first: 1) { nodes { body path } } }
-        }
+# Fetch thread IDs
+gh api graphql -f query='query {
+  repository(owner: "{owner}", name: "{repo}") {
+    pullRequest(number: $NUMBER) {
+      reviewThreads(first: 50) {
+        nodes { id isResolved comments(first: 1) { nodes { body path } } }
       }
     }
-  }'
+  }
+}'
 
 # Resolve each addressed unresolved thread
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
@@ -184,16 +143,15 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thre
 
 Do NOT use `minimizeComment` — that hides comments instead of resolving them. Always use `resolveReviewThread` with a thread ID starting with `PRRT_`.
 
-### 13. Summary report
+### 11. Summary report
 
 Output a table:
 
-| PR  | Title | Comments | Valid | False Pos | Fixed | Security | CI  | Test Plan | Conflicts | Status |
-| --- | ----- | -------- | ----- | --------- | ----- | -------- | --- | --------- | --------- | ------ |
+| PR | Title | Comments | Valid | False Pos | Fixed | Security | CI | Test Plan | Conflicts | Status |
+|----|-------|----------|-------|-----------|-------|----------|----|-----------|-----------|--------|
 
 A PR may only be marked `reviewed` if:
-
-- The §7 push succeeded
+- The §5 push succeeded
 - All auto-runnable test plan commands passed (or test plan was missing — flagged)
 - No unresolved CI failures remain
 


### PR DESCRIPTION
## Summary

- Adds `/create-inspection <problem>` slash command that investigates a specific problem and surfaces viable fix paths with trade-offs, saved to `docs/inspections/`
- Also ships an aligned copy of the `/review-pr <N>` command workflow doc (same fixes as PR #22)
- Fills the gap between `/create-audit` (enumerate findings) and `/fix-with-evidence` (implement the fix) — focused on the decision: *how should I fix this?*
- Updates the Slash Commands Reference table in `CLAUDE.md` with the new command

## Test plan

- [ ] Invoke `/create-inspection <any problem>` and verify it produces a `docs/inspections/<slug>-<date>.md` file with root cause, 2+ fix options, and a recommendation
- [ ] Verify the file is left untracked (not committed)
- [ ] Verify it does not implement any fix — report only
- [ ] Verify at least 2 fix options are always provided
- [ ] Verify the CLAUDE.md slash commands table renders the new row correctly

## No-spec rationale

This is a new slash command (additive, no breaking changes, no architectural decisions), not a change to the project's core infrastructure or data pipeline. A formal spec would be overhead for a command that follows the established pattern of `/create-audit` and `/create-assessment`.
