### PR TITLE
docs: clarify two-path usage model in README and CLAUDE.md

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-15T01:58:08.298Z",
+  "generatedAt": "2026-04-15T02:13:03.074Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -89,7 +89,7 @@
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
-      "checksum": "sha256:318ec86a2b2fe493f40019087c82c0897e3c3a91a4624f598473b1e9c6f05722",
+      "checksum": "sha256:c142391ec09be2601b50f4ac9edfdf0e484e51e5bd7cba0bd657f7c1394b6556",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,19 @@
 # CLAUDE.md — Global Claude Code Rules
 
-> **Persona note.** This file is the global rule floor for the dotfile
-> user's Claude Code environment — it gets symlinked into `~/.claude/CLAUDE.md`
-> by `bootstrap.sh`. **Consumers of `@dotclaude/dotclaude` do NOT
-> inherit it.** The plugin's behavior is defined by its own docs under
-> `plugins/dotclaude/` and [docs/](./docs/). Contributors to this repo
-> should read [CONTRIBUTING.md](./CONTRIBUTING.md) first; this file
-> covers universal working agreements for whoever adopts this dotfile setup,
-> not project-specific development conventions.
+> **Two ways to use dotclaude:**
+>
+> - **TL;DR — just want skills & commands:** Clone this repo and run `./bootstrap.sh`.
+>   That wires `commands/`, `skills/`, and this file into `~/.claude/` in one step.
+>   No npm required.
+> - **Want more flexibility:** Install `@dotclaude/dotclaude` for the full governance
+>   CLI — `dotclaude doctor`, `dotclaude validate-specs`, `dotclaude check-spec-coverage`,
+>   and more. See [README.md](./README.md) or [docs/quickstart.md](./docs/quickstart.md).
+>
+> **This file is for the bootstrap path.** It gets symlinked into `~/.claude/CLAUDE.md`
+> by `bootstrap.sh` and sets the global rule floor for every Claude Code session.
+> **Consumers of `@dotclaude/dotclaude` do NOT inherit it** — the plugin's behavior
+> lives in `plugins/dotclaude/` and [docs/](./docs/). Contributors should read
+> [CONTRIBUTING.md](./CONTRIBUTING.md) first.
 
 Universal behavior for every Claude Code session in every repo. Project-level `CLAUDE.md` files extend and may override these, but should not repeat them.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ spec-driven-development governance into consumer repos.
 
 ## TL;DR — pick your path
 
-| What you want | How |
-| --- | --- |
-| Skills & commands library wired into `~/.claude/` | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required |
-| Spec-governance CLI for your own repos | **[Install the CLI](#install-the-cli)** — `npm i -g @dotclaude/dotclaude` |
+| What you want                                     | How                                                                       |
+| ------------------------------------------------- | ------------------------------------------------------------------------- |
+| Skills & commands library wired into `~/.claude/` | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required  |
+| Spec-governance CLI for your own repos            | **[Install the CLI](#install-the-cli)** — `npm i -g @dotclaude/dotclaude` |
 
 Both paths are independent. You can use one or both.
 

--- a/README.md
+++ b/README.md
@@ -5,30 +5,81 @@
 [![changelog](https://img.shields.io/badge/changelog-keep--a--changelog-orange.svg)](./CHANGELOG.md)
 
 Portable Claude Code plugin + zero-dependency npm package that bootstraps
-spec-driven-development governance into consumer repos. Ships a structured-error
-CLI, an umbrella `dotclaude` dispatcher, seven standalone bins, a destructive-git
-PreToolUse hook, and a gold-standard shell settings validator.
-
-**Two personas live in this repo** (by design — see [docs/personas.md](./docs/personas.md)):
-
-- The **npm package** under `plugins/dotclaude/` (what consumers install).
-- **Personal dotfiles** at the top level (symlinked into `~/.claude/` via `bootstrap.sh` — fork this to use your own).
-
-If you're installing the package, ignore the top-level scripts —
-`package.json.files` excludes them from the tarball.
+spec-driven-development governance into consumer repos.
 
 ---
 
-## Consumer quickstart
+## TL;DR — pick your path
+
+| What you want | How |
+| --- | --- |
+| Skills & commands library wired into `~/.claude/` | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required |
+| Spec-governance CLI for your own repos | **[Install the CLI](#install-the-cli)** — `npm i -g @dotclaude/dotclaude` |
+
+Both paths are independent. You can use one or both.
+
+---
+
+## Clone & bootstrap
+
+Just want the skills library, commands, and a global CLAUDE.md? Three lines:
 
 ```bash
-npm i -D @dotclaude/dotclaude
-npx dotclaude-init --project-name my-project --project-type node
-npx dotclaude-doctor          # self-diagnostic
-npx dotclaude-validate-specs  # every bin works standalone or via `npx dotclaude <sub>`
+git clone https://github.com/kaiohenricunha/dotclaude.git ~/projects/dotclaude
+cd ~/projects/dotclaude
+./bootstrap.sh          # symlinks commands/ + skills/ + CLAUDE.md into ~/.claude/
 ```
 
-Five minutes end-to-end: [docs/quickstart.md](./docs/quickstart.md).
+That's it — the full skills and commands library is now available in every
+Claude Code session. To stay current:
+
+```bash
+./sync.sh pull          # pull + re-bootstrap
+./sync.sh push          # secret-scan + commit + push
+```
+
+See [CLAUDE.md](./CLAUDE.md) for the global rules this installs.
+
+---
+
+## Install the CLI
+
+Need spec-governance gates, CI integration, drift detection, or programmatic
+validation in your own projects? Install the CLI:
+
+```bash
+# Global — use dotclaude anywhere
+npm install -g @dotclaude/dotclaude
+
+# Per-project — pin it to a repo (useful for CI)
+npm install -D @dotclaude/dotclaude
+```
+
+Then use the umbrella dispatcher or standalone bins interchangeably:
+
+```bash
+dotclaude doctor                   # self-diagnostic: env, facts, manifest, specs
+dotclaude validate-skills          # verify skills manifest checksums + DAG
+dotclaude validate-specs           # audit spec contracts + dependency cycles
+dotclaude check-spec-coverage      # PR gate: protected paths must be spec-backed
+dotclaude check-instruction-drift  # detect stale CLAUDE.md / README entries
+dotclaude detect-drift             # flag commands diverged from origin/main 14+ days
+dotclaude init                     # scaffold specs, hooks, manifest into a repo
+```
+
+Every subcommand also works as a standalone bin — `npx dotclaude-doctor`,
+`npx dotclaude-validate-specs`, etc. All support `--help`, `--version`,
+`--json`, `--verbose`, `--no-color`.
+
+Five-minute walkthrough: [docs/quickstart.md](./docs/quickstart.md).
+
+### Scaffold a repo
+
+```bash
+npx dotclaude-init --project-name my-project --project-type node
+npx dotclaude-doctor          # verify everything wired up
+npx dotclaude-validate-specs  # run first governance check
+```
 
 ### Node API
 
@@ -59,9 +110,9 @@ if (!ok) {
 
 Full contract: [docs/api-reference.md](./docs/api-reference.md).
 
-### CLI contract
+### CLI exit codes
 
-Every bin honors `--help`, `--version`, `--json`, `--verbose`, `--no-color` and exits with the named enum:
+Every bin honors `--help`, `--version`, `--json`, `--verbose`, `--no-color` and exits with:
 
 | Code | Name       | Meaning                                                |
 | ---- | ---------- | ------------------------------------------------------ |
@@ -90,22 +141,6 @@ Shell-level hardening (SEC-1..4, OPS-1..2) is enforced today at
 `plugins/dotclaude/scripts/validate-settings.sh`; its 12-case behavioral
 suite at `plugins/dotclaude/tests/test_validate_settings.sh` pins every
 contract.
-
----
-
-## Personal dotfiles persona
-
-Fork this repo and use it as your own Claude Code dotfiles:
-
-```bash
-git clone https://github.com/kaiohenricunha/dotclaude.git ~/projects/dotclaude
-cd ~/projects/dotclaude
-./bootstrap.sh                  # symlinks commands/ + skills/ + CLAUDE.md into ~/.claude/
-./sync.sh pull                  # pull + re-bootstrap
-./sync.sh push                  # secret-scan + commit + push
-```
-
-See [CLAUDE.md](./CLAUDE.md) for the global rules this installs.
 
 ---
 

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -17,11 +17,23 @@ Before any step, bind the PR number:
 NUMBER="$ARGUMENTS"
 ```
 
-### 1. Fetch PR details
+### 1. Fetch PR details and check branch health
 
 ```bash
 gh pr view "$NUMBER" --json number,title,headRefName,baseRefName,body,mergeable,mergeStateStatus,additions,deletions
 ```
+
+**Immediately inspect `mergeable` and `mergeStateStatus`:**
+
+| `mergeable`   | `mergeStateStatus` | Action                                                                |
+| ------------- | ------------------ | --------------------------------------------------------------------- |
+| `MERGEABLE`   | `CLEAN`            | Proceed normally                                                      |
+| `MERGEABLE`   | `UNSTABLE`         | Proceed — CI failing but no conflict; fix CI in step 10               |
+| `MERGEABLE`   | `BEHIND`           | Rebase onto base branch before collecting comments                    |
+| `CONFLICTING` | `DIRTY`            | **Rebase first** (step 9) before any other work                       |
+| `UNKNOWN`     | any                | Re-fetch after 30 s — GitHub is still computing, do not proceed blind |
+
+If the branch is conflicting or behind, resolve it **before** collecting comments or applying fixes. A stale or conflicting branch produces a misleading diff and stale Copilot comments.
 
 ### 2. Collect ALL review comments
 
@@ -109,18 +121,19 @@ gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies" \
   -f body="Fixed in <commit-sha> — <one-line description of the fix>."
 ```
 
-### 9. Check for merge conflicts
+### 9. Check for merge conflicts and staleness
 
 ```bash
-gh pr view "$NUMBER" --json mergeable,mergeStateStatus
+gh pr view "$NUMBER" --json mergeable,mergeStateStatus,baseRefName
 ```
 
-If there are conflicts:
+If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `BEHIND`:
 
-- Rebase onto the base branch: `git rebase <base>`
+- Rebase onto the base branch: `git rebase origin/<baseRefName>`
 - Resolve conflicts (prefer the PR branch's intent, integrate base branch updates)
-- Force-push the rebased branch only with explicit user confirmation
+- Force-push with `--force-with-lease` only with explicit user confirmation
 - Verify the build still passes after rebase
+- Do **not** proceed to step 10 until the branch is clean and up-to-date
 
 ### 10. Check failed CI pipelines
 
@@ -184,7 +197,19 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thre
 
 Do NOT use `minimizeComment` — that hides comments instead of resolving them. Always use `resolveReviewThread` with a thread ID starting with `PRRT_`.
 
-### 13. Summary report
+### 13. Final branch health gate
+
+Before writing the summary, re-verify:
+
+```bash
+gh pr view "$NUMBER" --json mergeable,mergeStateStatus
+```
+
+- `mergeable: CONFLICTING` → do not mark `reviewed`; fix conflicts and re-run CI
+- `mergeStateStatus: BEHIND` → rebase onto base and push before closing out
+- Only proceed when `mergeable` is `MERGEABLE` and status is `CLEAN` or `UNSTABLE` (with all CI failures already addressed)
+
+### 14. Summary report
 
 Output a table:
 
@@ -196,7 +221,8 @@ A PR may only be marked `reviewed` if:
 - The §7 push succeeded
 - All auto-runnable test plan commands passed (or test plan was missing — flagged)
 - No unresolved CI failures remain
+- `mergeable` is `MERGEABLE` and branch is not `BEHIND` (verified in step 13)
 
-Otherwise the row status is `blocked`, `push-failed`, or `test-plan-missing` and the blocker is called out.
+Otherwise the row status is `blocked`, `push-failed`, `test-plan-missing`, or `conflicts-unresolved` and the blocker is called out.
 
 End with the commit pushed, the worktree cleanup command, and any remaining action items.

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -155,19 +155,42 @@ For any check with `bucket: "fail"`:
 
 ### 11. Verify the test plan
 
-If the PR body has a `## Test plan` section, run each listed command locally from inside `.claude/worktrees/pr-$NUMBER/`. Mark each as:
+**If the PR body has no `## Test plan` section:** leave a comment asking the author to add one and note `test-plan: missing` in the summary. Do not proceed to step 12.
 
-- `✓ local` — ran and passed
-- `✗ failed` — ran and failed (fix before proceeding)
-- `skipped` — requires infra/services not available locally
-
-If the PR body has no `## Test plan` section: leave a comment asking the author to add one and note `test-plan: missing` in the summary.
-
-After a passing run, post the evidence as a PR comment:
+**If a `## Test plan` section exists**, first check whether CI has already run and passed every item:
 
 ```bash
-gh pr comment "$NUMBER" --body "Test plan verified against HEAD <sha>:
-- \`<command>\` — local ✓ (<ms>ms)
+gh pr checks "$NUMBER" --json name,state,bucket
+```
+
+- If all test-plan items map to passing CI jobs: skip local re-run and proceed directly to ticking the boxes (below).
+- Otherwise: **run every item locally** from inside `.claude/worktrees/pr-$NUMBER/`, regardless of whether some items already pass. Classify each result as:
+  - `✓ local` — ran and passed
+  - `✗ failed` — ran and failed (fix before proceeding; do not tick the box)
+  - `skipped` — requires infra or secrets not available locally (note reason)
+
+**After a successful run, tick the checkboxes in the PR description** for each passing item by patching the PR body:
+
+```bash
+# Fetch the current body
+BODY=$(gh pr view "$NUMBER" --json body -q .body)
+
+# Replace [ ] with [x] for each verified item, then patch
+UPDATED_BODY=$(echo "$BODY" | sed 's/- \[ \] <item text>/- [x] <item text>/g')
+
+gh api "repos/{owner}/{repo}/pulls/$NUMBER" \
+  --method PATCH \
+  -f body="$UPDATED_BODY"
+```
+
+In practice, tick items programmatically — replace `- [ ]` with `- [x]` only for lines whose corresponding local run passed. Leave `- [ ]` for skipped or failed items.
+
+Then post the evidence as a PR comment:
+
+```bash
+gh pr comment "$NUMBER" --body "Test plan verified against HEAD $(git rev-parse HEAD):
+- \`<item>\` — ✓ local
+- \`<item>\` — skipped (requires live DB)
 ..."
 ```
 


### PR DESCRIPTION
## Summary

- Lead README with a TL;DR decision table so readers immediately know which path fits them: clone+bootstrap (skills/commands library, no npm) vs. install the CLI (governance tooling)
- Restructure README so the simpler bootstrap path comes first, followed by the full CLI section
- Update CLAUDE.md persona note to open with the two-path split before explaining what the file covers

## Test plan

- [ ] README renders correctly on GitHub — decision table, both sections, code blocks
- [ ] CLAUDE.md persona note clearly directs readers to the right path
- [ ] `dotclaude --help` still works (CLI installed via `npm link`)

## No-spec rationale

Documentation-only change to `README.md` and `CLAUDE.md`. No logic, API, CLI contract, or protected behavior modified.
