### PR TITLE
fix(commands): strengthen review-pr with branch health gates and mandatory test plan

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-15T02:13:03.074Z",
+  "generatedAt": "2026-04-15T02:17:46.348Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -89,7 +89,7 @@
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
-      "checksum": "sha256:c142391ec09be2601b50f4ac9edfdf0e484e51e5bd7cba0bd657f7c1394b6556",
+      "checksum": "sha256:26eb99cc287deccd1a3d1e2f68e2428694bb9dea7307a7832c37156ab34f350c",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -17,11 +17,23 @@ Before any step, bind the PR number:
 NUMBER="$ARGUMENTS"
 ```
 
-### 1. Fetch PR details
+### 1. Fetch PR details and check branch health
 
 ```bash
 gh pr view "$NUMBER" --json number,title,headRefName,baseRefName,body,mergeable,mergeStateStatus,additions,deletions
 ```
+
+**Immediately inspect `mergeable` and `mergeStateStatus`:**
+
+| `mergeable`   | `mergeStateStatus` | Action                                                                |
+| ------------- | ------------------ | --------------------------------------------------------------------- |
+| `MERGEABLE`   | `CLEAN`            | Proceed normally                                                      |
+| `MERGEABLE`   | `UNSTABLE`         | Proceed — CI failing but no conflict; fix CI in step 10               |
+| `MERGEABLE`   | `BEHIND`           | Rebase onto base branch before collecting comments                    |
+| `CONFLICTING` | `DIRTY`            | **Rebase first** (step 9) before any other work                       |
+| `UNKNOWN`     | any                | Re-fetch after 30 s — GitHub is still computing, do not proceed blind |
+
+If the branch is conflicting or behind, resolve it **before** collecting comments or applying fixes. A stale or conflicting branch produces a misleading diff and stale Copilot comments.
 
 ### 2. Collect ALL review comments
 
@@ -109,18 +121,19 @@ gh api "repos/{owner}/{repo}/pulls/$NUMBER/comments/<comment_id>/replies" \
   -f body="Fixed in <commit-sha> — <one-line description of the fix>."
 ```
 
-### 9. Check for merge conflicts
+### 9. Check for merge conflicts and staleness
 
 ```bash
-gh pr view "$NUMBER" --json mergeable,mergeStateStatus
+gh pr view "$NUMBER" --json mergeable,mergeStateStatus,baseRefName
 ```
 
-If there are conflicts:
+If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `BEHIND`:
 
-- Rebase onto the base branch: `git rebase <base>`
+- Rebase onto the base branch: `git rebase origin/<baseRefName>`
 - Resolve conflicts (prefer the PR branch's intent, integrate base branch updates)
-- Force-push the rebased branch only with explicit user confirmation
+- Force-push with `--force-with-lease` only with explicit user confirmation
 - Verify the build still passes after rebase
+- Do **not** proceed to step 10 until the branch is clean and up-to-date
 
 ### 10. Check failed CI pipelines
 
@@ -184,7 +197,19 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thre
 
 Do NOT use `minimizeComment` — that hides comments instead of resolving them. Always use `resolveReviewThread` with a thread ID starting with `PRRT_`.
 
-### 13. Summary report
+### 13. Final branch health gate
+
+Before writing the summary, re-verify:
+
+```bash
+gh pr view "$NUMBER" --json mergeable,mergeStateStatus
+```
+
+- `mergeable: CONFLICTING` → do not mark `reviewed`; fix conflicts and re-run CI
+- `mergeStateStatus: BEHIND` → rebase onto base and push before closing out
+- Only proceed when `mergeable` is `MERGEABLE` and status is `CLEAN` or `UNSTABLE` (with all CI failures already addressed)
+
+### 14. Summary report
 
 Output a table:
 
@@ -196,7 +221,8 @@ A PR may only be marked `reviewed` if:
 - The §7 push succeeded
 - All auto-runnable test plan commands passed (or test plan was missing — flagged)
 - No unresolved CI failures remain
+- `mergeable` is `MERGEABLE` and branch is not `BEHIND` (verified in step 13)
 
-Otherwise the row status is `blocked`, `push-failed`, or `test-plan-missing` and the blocker is called out.
+Otherwise the row status is `blocked`, `push-failed`, `test-plan-missing`, or `conflicts-unresolved` and the blocker is called out.
 
 End with the commit pushed, the worktree cleanup command, and any remaining action items.

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -129,7 +129,8 @@ gh pr view "$NUMBER" --json mergeable,mergeStateStatus,baseRefName
 
 If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `BEHIND`:
 
-- Rebase onto the base branch: `git rebase origin/<baseRefName>`
+- Fetch the latest base ref: `git fetch origin <baseRefName>`
+- Rebase onto the updated base: `git rebase origin/<baseRefName>`
 - Resolve conflicts (prefer the PR branch's intent, integrate base branch updates)
 - Force-push with `--force-with-lease` only with explicit user confirmation
 - Verify the build still passes after rebase
@@ -155,35 +156,32 @@ For any check with `bucket: "fail"`:
 
 ### 11. Verify the test plan
 
-**If the PR body has no `## Test plan` section:** leave a comment asking the author to add one and note `test-plan: missing` in the summary. Do not proceed to step 12.
+**If the PR body has no `## Test plan` section:** leave a comment asking the author to add one, record `test-plan: missing` in the final summary, and skip steps 12 and 13. Jump directly to the summary with status `test-plan-missing`.
 
-**If a `## Test plan` section exists**, first check whether CI has already run and passed every item:
+**If a `## Test plan` section exists**, check whether the CI-skip exception applies:
 
 ```bash
 gh pr checks "$NUMBER" --json name,state,bucket
 ```
 
-- If all test-plan items map to passing CI jobs: skip local re-run and proceed directly to ticking the boxes (below).
-- Otherwise: **run every item locally** from inside `.claude/worktrees/pr-$NUMBER/`, regardless of whether some items already pass. Classify each result as:
-  - `✓ local` — ran and passed
-  - `✗ failed` — ran and failed (fix before proceeding; do not tick the box)
-  - `skipped` — requires infra or secrets not available locally (note reason)
+**CI-skip rule (narrow):** skip the local run only if _every_ test-plan item is a runnable command whose exact text matches a named, passing CI check label. If any item is manual, prose-only, or has no CI counterpart, run all items locally.
 
-**After a successful run, tick the checkboxes in the PR description** for each passing item by patching the PR body:
+Otherwise: **run every item locally** from inside `.claude/worktrees/pr-$NUMBER/`. Classify each result as:
+
+- `✓ local` — ran and passed
+- `✗ failed` — ran and failed (fix before proceeding; do not tick the box)
+- `skipped` — requires infra or secrets not available locally (note reason)
+
+**After running, tick the checkboxes in the PR description** for each passing item. Use `printf` (not `echo`) to avoid escape-sequence corruption, and substitute the real checklist line text — the sed pattern below is pseudocode illustrating the shape of the transform:
 
 ```bash
-# Fetch the current body
+# Pseudocode — substitute real checklist line text for <item text>
 BODY=$(gh pr view "$NUMBER" --json body -q .body)
-
-# Replace [ ] with [x] for each verified item, then patch
-UPDATED_BODY=$(echo "$BODY" | sed 's/- \[ \] <item text>/- [x] <item text>/g')
-
-gh api "repos/{owner}/{repo}/pulls/$NUMBER" \
-  --method PATCH \
-  -f body="$UPDATED_BODY"
+UPDATED=$(printf '%s' "$BODY" | sed 's/- \[ \] <item text>/- [x] <item text>/g')
+gh api "repos/{owner}/{repo}/pulls/$NUMBER" --method PATCH -f body="$UPDATED"
 ```
 
-In practice, tick items programmatically — replace `- [ ]` with `- [x]` only for lines whose corresponding local run passed. Leave `- [ ]` for skipped or failed items.
+Replace `- [ ]` with `- [x]` only for lines whose local run passed; leave `- [ ]` for skipped or failed items.
 
 Then post the evidence as a PR comment:
 
@@ -242,7 +240,7 @@ Output a table:
 A PR may only be marked `reviewed` if:
 
 - The §7 push succeeded
-- All auto-runnable test plan commands passed (or test plan was missing — flagged)
+- A test plan is present and all auto-runnable commands passed
 - No unresolved CI failures remain
 - `mergeable` is `MERGEABLE` and branch is not `BEHIND` (verified in step 13)
 

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -155,19 +155,42 @@ For any check with `bucket: "fail"`:
 
 ### 11. Verify the test plan
 
-If the PR body has a `## Test plan` section, run each listed command locally from inside `.claude/worktrees/pr-$NUMBER/`. Mark each as:
+**If the PR body has no `## Test plan` section:** leave a comment asking the author to add one and note `test-plan: missing` in the summary. Do not proceed to step 12.
 
-- `✓ local` — ran and passed
-- `✗ failed` — ran and failed (fix before proceeding)
-- `skipped` — requires infra/services not available locally
-
-If the PR body has no `## Test plan` section: leave a comment asking the author to add one and note `test-plan: missing` in the summary.
-
-After a passing run, post the evidence as a PR comment:
+**If a `## Test plan` section exists**, first check whether CI has already run and passed every item:
 
 ```bash
-gh pr comment "$NUMBER" --body "Test plan verified against HEAD <sha>:
-- \`<command>\` — local ✓ (<ms>ms)
+gh pr checks "$NUMBER" --json name,state,bucket
+```
+
+- If all test-plan items map to passing CI jobs: skip local re-run and proceed directly to ticking the boxes (below).
+- Otherwise: **run every item locally** from inside `.claude/worktrees/pr-$NUMBER/`, regardless of whether some items already pass. Classify each result as:
+  - `✓ local` — ran and passed
+  - `✗ failed` — ran and failed (fix before proceeding; do not tick the box)
+  - `skipped` — requires infra or secrets not available locally (note reason)
+
+**After a successful run, tick the checkboxes in the PR description** for each passing item by patching the PR body:
+
+```bash
+# Fetch the current body
+BODY=$(gh pr view "$NUMBER" --json body -q .body)
+
+# Replace [ ] with [x] for each verified item, then patch
+UPDATED_BODY=$(echo "$BODY" | sed 's/- \[ \] <item text>/- [x] <item text>/g')
+
+gh api "repos/{owner}/{repo}/pulls/$NUMBER" \
+  --method PATCH \
+  -f body="$UPDATED_BODY"
+```
+
+In practice, tick items programmatically — replace `- [ ]` with `- [x]` only for lines whose corresponding local run passed. Leave `- [ ]` for skipped or failed items.
+
+Then post the evidence as a PR comment:
+
+```bash
+gh pr comment "$NUMBER" --body "Test plan verified against HEAD $(git rev-parse HEAD):
+- \`<item>\` — ✓ local
+- \`<item>\` — skipped (requires live DB)
 ..."
 ```
 


### PR DESCRIPTION
## Summary

- Step 1 now inspects `mergeable`/`mergeStateStatus` immediately after fetching PR details, with an action table — mandates rebase before collecting comments if the branch is `CONFLICTING` or `BEHIND`
- Step 9 extended to cover `BEHIND` staleness in addition to `CONFLICTING`, blocking progress until the branch is clean
- New step 13 re-verifies branch health right before the summary — `conflicts-unresolved` blocks the `reviewed` status
- Test plan execution is now mandatory: always run locally (exception: skip if all items already map to passing CI jobs), tick passing checkboxes in the PR description via `gh api PATCH`, and leave failing items unchecked

## Test plan

- [ ] Run `/review-pr` on a PR with a conflicting branch — verify it rebases before collecting comments
- [ ] Run `/review-pr` on a PR with a `BEHIND` branch — verify it rebases before proceeding
- [ ] Run `/review-pr` on a PR with a test plan — verify checkboxes are ticked in the PR description after local run
- [ ] Run `/review-pr` on a PR where all test-plan items pass in CI — verify local run is skipped

## No-spec rationale

Skill-only change to `commands/review-pr.md`. No source code, API contract, or protected path logic modified. Improvements derived directly from friction observed during PR #24 review.
