### PR TITLE
docs(CLAUDE.md): add Karpathy behavioral guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@ Universal behavior for every Claude Code session in every repo. Project-level `C
 - Cite `file:line` references in every analysis. Claims without citations are not grounded.
 - Do not propose edits until the analysis is confirmed against real code. "The file is probably named X" is not grounding — open it.
 - When unsure, run `/ground-first <subject>` to enforce the read-first discipline.
-- **Surface assumptions before coding.** If a request has multiple valid interpretations, list them and ask rather than picking silently. "Make it faster" → clarify which dimension (latency, throughput, perceived UX) before writing code.
-- **Surgical orphan cleanup.** When your changes make an import, variable, or function unused, remove it. But don't remove pre-existing dead code that your changes didn't create — mention it instead.
+- **Surface assumptions before coding.** If a request has multiple valid interpretations, list them explicitly. In interactive sessions, ask before picking one. In autonomous/headless mode, state the chosen interpretation and proceed. "Make it faster" → clarify which dimension (latency, throughput, perceived UX) before writing code.
+- **Surgical orphan cleanup.** When your changes make an import or variable unused, remove it. Remove a function only after verifying it is not part of a public/exported API and has no remaining references (use a repo-wide search); otherwise keep it or deprecate it. Don't remove pre-existing dead code your changes didn't create — mention it instead.
 
 ## Testing
 
@@ -50,7 +50,7 @@ Universal behavior for every Claude Code session in every repo. Project-level `C
 
 - **Always follow TDD for new features:** write tests first (positive, negative, boundary), then implement until tests pass.
 - **For bug fixes:** write a failing test that reproduces the issue, fix, then verify.
-- **Transform vague tasks into verifiable goals before starting.** "Fix the bug" → "write a test that reproduces it, then make it pass." For multi-step tasks, emit a plan with explicit verification at each step: `Step → verify: [check]`.
+- **Transform vague tasks into verifiable goals before starting.** "Fix the bug" → "write a test that reproduces it, then make it pass." For multi-step tasks, emit a concise plan with explicit verification at each step: `Step → verify: [check]`. Default to 5 bullets or fewer; exceed that only when the task is genuinely complex.
 - **When editing Go files, run `gofmt -w <file>` immediately after editing.** Never leave Go files with formatting issues.
 - **When reporting status or roadmap progress, verify each item against actual code or config before marking it complete.** Do not assume completion — show the evidence.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Universal behavior for every Claude Code session in every repo. Project-level `C
 - Cite `file:line` references in every analysis. Claims without citations are not grounded.
 - Do not propose edits until the analysis is confirmed against real code. "The file is probably named X" is not grounding — open it.
 - When unsure, run `/ground-first <subject>` to enforce the read-first discipline.
+- **Surface assumptions before coding.** If a request has multiple valid interpretations, list them and ask rather than picking silently. "Make it faster" → clarify which dimension (latency, throughput, perceived UX) before writing code.
+- **Surgical orphan cleanup.** When your changes make an import, variable, or function unused, remove it. But don't remove pre-existing dead code that your changes didn't create — mention it instead.
 
 ## Testing
 
@@ -48,6 +50,7 @@ Universal behavior for every Claude Code session in every repo. Project-level `C
 
 - **Always follow TDD for new features:** write tests first (positive, negative, boundary), then implement until tests pass.
 - **For bug fixes:** write a failing test that reproduces the issue, fix, then verify.
+- **Transform vague tasks into verifiable goals before starting.** "Fix the bug" → "write a test that reproduces it, then make it pass." For multi-step tasks, emit a plan with explicit verification at each step: `Step → verify: [check]`.
 - **When editing Go files, run `gofmt -w <file>` immediately after editing.** Never leave Go files with formatting issues.
 - **When reporting status or roadmap progress, verify each item against actual code or config before marking it complete.** Do not assume completion — show the evidence.
 


### PR DESCRIPTION
## Summary

- Adds three behavioral rules to `CLAUDE.md` derived from Andrej Karpathy's LLM coding principles ([X post](https://x.com/karpathy/status/2015883857489522876)), closing gaps not already covered by existing dotclaude rules
- **Surface assumptions before coding** — list interpretations and ask rather than picking silently when a request is ambiguous (e.g. "make it faster" → clarify latency vs throughput vs UX before writing code)
- **Surgical orphan cleanup** — when your changes make an import/variable/function unused, remove it; leave pre-existing dead code alone and mention it instead
- **Verifiable goals** — transform vague tasks into `Step → verify: [check]` plans before starting multi-step work (extends the existing TDD rule to all task types)

## Gap analysis

| Karpathy principle | Already in dotclaude? | Gap filled |
|---|---|---|
| Simplicity First | Yes — system prompt + `/simplify` skill | — |
| Surgical Changes (don't touch adjacent code) | Yes — system prompt | — |
| Think Before Coding — surface assumptions | No | ✅ Added |
| Surgical orphan cleanup | No | ✅ Added |
| Goal-Driven Execution — verifiable criteria | Partial (TDD for tests only) | ✅ Extended |

## Test plan

- [ ] Read `CLAUDE.md` and verify the three new rules are present and well-placed
- [ ] Confirm no existing rules were modified or removed
- [ ] Verify rules don't overlap with or contradict existing system-prompt defaults

## No-spec rationale

Documentation-only change to the global CLAUDE.md rule floor. No new code, tooling, or specs required.
