### PR TITLE
feat(agents): add first-class agent support with model routing and discovery

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -101,6 +101,13 @@
       "lastValidated": "2026-04-15"
     },
     {
+      "name": "agents-search",
+      "path": ".claude/skills/agents-search/SKILL.md",
+      "checksum": "sha256:c93b9e0d6a56e89da2021063d9dfc4439c0319255aaa56a7ed79571fda331a7f",
+      "dependencies": [],
+      "lastValidated": "2026-04-15"
+    },
+    {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:5a302eb3ec1168a8a316fb64711b8ace9f9ca8929e5ec7e9b713e42f6d563295",

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,123 +1,123 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-15T02:17:46.348Z",
+  "generatedAt": "2026-04-15T12:57:15.915Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
-      "checksum": "sha256:477c139d18d5359dfa1f7099b68af5a9699ac525c6648d4e325fd283629abb55",
+      "checksum": "sha256:f64e8d0ac9dfbefc251dfde1dca2859a09fe901b7d1a0d1f00aaad991210e718",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
-      "checksum": "sha256:5546da1eb8aded7b9b5545f7471e81232aaa650e6d936ce3207bd61c3fd927e3",
+      "checksum": "sha256:ebec2daf65ed9ef2a4a61b9ad802071f9cc09a1c1c6cd2d9b84a830f3380ce4f",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
-      "checksum": "sha256:94bae764bbc0feac44386f58948ef2ed524739cd060bb4423fee6ccc0a6eea87",
+      "checksum": "sha256:d13a9bb1c38ea41423c0acc9e652230f159087856948c410f08bfc8f6c796ebf",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
-      "checksum": "sha256:26b799157f877186edee2ea062f3873bc6355d0451ce099ca5e93470d4ab095e",
+      "checksum": "sha256:0239f460cd256eb62604081ea328326bf9ac30bd9fee11fb71c81eb0caa84f8b",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
-      "checksum": "sha256:f983f4d3a17a5dc4ac42c832c9aabc24ed09292b90c17b64aae24e4c95afc38a",
+      "checksum": "sha256:746327d481573ad0af394da591295b36d5c33368fb6aa1ad69f40f4947781ea8",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
-      "checksum": "sha256:7a6b3d1f2fe517ce0b1efdf93a98fa094ec5068e64e2e726d7ccd647d51f675a",
+      "checksum": "sha256:c7cc063e2b898912627b34f4c370b735e8a0c5cb54bdc66466156e2b21f4ff86",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
-      "checksum": "sha256:497989ff7407af707a05e1eb4199558182d1ed9ac2c8967e074e3251302e0380",
+      "checksum": "sha256:f10bbacbb5287e6ebf346e6fdaf309dcce436a221af9c5adede03e9e315d14dd",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
-      "checksum": "sha256:108db5939a78ef30fa4e4feea60228deb41b6e62b06b76918164e7d097f69aa0",
+      "checksum": "sha256:770578c2a8184e91fc099bca3a14f3dbce209400e6570a8b768093268ae208fe",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
-      "checksum": "sha256:77eb891bdffabec4c8a1f73c916752b6cd27fbbcec3a4d92612bb131d1bf3443",
+      "checksum": "sha256:3c8e79d3727af315e54f4017d1e85d754cd8ae7c99e3d1b54afec0bebe589ce0",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
-      "checksum": "sha256:a195deeff6625d9ae5b6d2a12e7321725937d20fb43ffb788f325cd3d0a1b8c6",
+      "checksum": "sha256:7fcab3e2a92c8a0a68a8c0670b4ce3b33c0ecbb6bbcdd56863451628d74a2ca5",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
-      "checksum": "sha256:cc60d9264606d4c0476c2708673a4eb5f3b5ddab98705f646b6157c03234cfc9",
+      "checksum": "sha256:b3940bb70a4fef517870fe1d5962fd396cba373859bde9fca4edbce252e308da",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
-      "checksum": "sha256:32fe686caad0543057daf5f8cf6e418a4ae36898d1fc175e354c75c00b25616a",
+      "checksum": "sha256:716d7d5d72b1cb3aa1a9e29bfd1cda1da8d057c9839686d8f7c90def31896e8e",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
-      "checksum": "sha256:26eb99cc287deccd1a3d1e2f68e2428694bb9dea7307a7832c37156ab34f350c",
+      "checksum": "sha256:ca0495f32502152c245615d99f4ff0e74dd513985b6be3255fc47592f3acd223",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
-      "checksum": "sha256:6c59a6e3e449d7cb1aedf8d0697908de7e03e348d8d3a364444b1874c464cbbf",
+      "checksum": "sha256:8e93dde57c4fb2fd2c1e7acc1310372ba72c1d8efb70f7577bf2a39d1e8a6231",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
-      "checksum": "sha256:c93b9e0d6a56e89da2021063d9dfc4439c0319255aaa56a7ed79571fda331a7f",
+      "checksum": "sha256:772dfdfd60e34d0bfbc781fd94940f261b11e82b5c4f6ec5c19cbc69c23850c0",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
-      "checksum": "sha256:5a302eb3ec1168a8a316fb64711b8ace9f9ca8929e5ec7e9b713e42f6d563295",
+      "checksum": "sha256:44d6fcfc7e01a054f89bdd912f922a8d8278f1fc74c612d8ec151c3a020b0e40",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
-      "checksum": "sha256:486dd1665e07511553aa68820ddf1d0dd2b9490e8ac00889b2b596058daff99c",
+      "checksum": "sha256:8f4b365e168cd4769fb927def41e1a05c465b00475ef3f5efb2d582bcc604a85",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     }

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-15T12:57:15.915Z",
+  "generatedAt": "2026-04-15T13:05:51.300Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -68,7 +68,7 @@
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
-      "checksum": "sha256:7fcab3e2a92c8a0a68a8c0670b4ce3b33c0ecbb6bbcdd56863451628d74a2ca5",
+      "checksum": "sha256:914196385b12a0bf9db3234411c07203255afccf13daf45feb02aafd91d507dc",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
@@ -96,14 +96,14 @@
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
-      "checksum": "sha256:8e93dde57c4fb2fd2c1e7acc1310372ba72c1d8efb70f7577bf2a39d1e8a6231",
+      "checksum": "sha256:007ea80c772015841e260af5f82cf993fbe339a2293373104ec4d4579ddef3fb",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
-      "checksum": "sha256:772dfdfd60e34d0bfbc781fd94940f261b11e82b5c4f6ec5c19cbc69c23850c0",
+      "checksum": "sha256:ca85f38c70fa88e1447e3ad335b0d111236e718d634d058a28cabf88e95a1d5a",
       "dependencies": [],
       "lastValidated": "2026-04-15"
     },

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Local-only Claude state — never commit.
+.claude/worktrees/
 settings.local.json
 **/settings.local.json
 *.local.json

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -88,7 +88,7 @@ if [ -d "$AGENTS_SRC" ]; then
     agent_name=$(basename "$agent_file")
     dst_file="$AGENTS_DST/$agent_name"
     if [ -e "$dst_file" ]; then
-      say "  skipped (exists): $agent_name"
+      say "  skipped (exists): $agent_name — delete to reinstall on next bootstrap"
     else
       cp "$agent_file" "$dst_file"
       say "  installed agent: $agent_name"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -78,6 +78,24 @@ for d in "$DOTCLAUDE/skills"/*/; do
   link_one "${d%/}" "$TARGET/skills/$name"
 done
 
+say "==> installing agents/"
+AGENTS_SRC="$DOTCLAUDE/plugins/dotclaude/templates/claude/agents"
+AGENTS_DST="$TARGET/agents"
+mkdir -p "$AGENTS_DST"
+if [ -d "$AGENTS_SRC" ]; then
+  for agent_file in "$AGENTS_SRC"/*.md; do
+    [ -e "$agent_file" ] || continue
+    agent_name=$(basename "$agent_file")
+    dst_file="$AGENTS_DST/$agent_name"
+    if [ -e "$dst_file" ]; then
+      say "  skipped (exists): $agent_name"
+    else
+      cp "$agent_file" "$dst_file"
+      say "  installed agent: $agent_name"
+    fi
+  done
+fi
+
 if [ "$QUIET" = "1" ]; then
   echo "bootstrap complete — target: $TARGET"
 else

--- a/commands/audit-and-fix.md
+++ b/commands/audit-and-fix.md
@@ -3,6 +3,7 @@ name: audit-and-fix
 description: >
   Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to "audit and fix" or kicks off an overnight cleanup run.
 argument-hint: "[domain]"
+model: opus
 ---
 
 Run a long-horizon audit-then-implement pipeline: produce a structured audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs.

--- a/commands/changelog.md
+++ b/commands/changelog.md
@@ -3,6 +3,7 @@ name: changelog
 description: >
   count|since-deploy]"|Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.
 argument-hint: "[ref-range
+model: haiku
 ---
 
 Generate a changelog entry from git history.

--- a/commands/create-assessment.md
+++ b/commands/create-assessment.md
@@ -3,6 +3,7 @@ name: create-assessment
 description: >
   Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.
 argument-hint: "[target]"
+model: sonnet
 ---
 
 Create a structured assessment document that grades a target on a 0-10 scale using a weighted rubric and save it to the project's `docs/assessments/` directory.

--- a/commands/create-audit.md
+++ b/commands/create-audit.md
@@ -3,6 +3,7 @@ name: create-audit
 description: >
   Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.
 argument-hint: "[subject]"
+model: opus
 ---
 
 Create a structured audit document and save it to the project's `docs/audits/` directory.

--- a/commands/create-inspection.md
+++ b/commands/create-inspection.md
@@ -3,6 +3,7 @@ name: create-inspection
 description: >
   Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).
 argument-hint: "[problem or subject]"
+model: sonnet
 ---
 
 Investigate a specific problem and produce a structured fix-path document saved to the project's `docs/inspections/` directory.

--- a/commands/dependabot-sweep.md
+++ b/commands/dependabot-sweep.md
@@ -2,6 +2,7 @@
 name: dependabot-sweep
 description: >
   Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.
+model: sonnet
 ---
 
 Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produce a risk-annotated table and merge only safe bumps.

--- a/commands/detect-flaky.md
+++ b/commands/detect-flaky.md
@@ -3,6 +3,7 @@ name: detect-flaky
 description: >
   Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.
 argument-hint: "[test-command]"
+model: sonnet
 ---
 
 # /detect-flaky — Flaky Test Detection and Diagnosis Agent

--- a/commands/fix-with-evidence.md
+++ b/commands/fix-with-evidence.md
@@ -3,6 +3,7 @@ name: fix-with-evidence
 description: >
   Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.
 argument-hint: "[issue]"
+model: sonnet
 ---
 
 Fix a bug using a strict four-phase evidence loop: Reproduce → Fix → Verify → PR. Each phase gates on the previous.

--- a/commands/git.md
+++ b/commands/git.md
@@ -3,6 +3,7 @@ name: git
 description: >
   Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.
 argument-hint: "[subcommand]"
+model: sonnet
 ---
 
 # /git

--- a/commands/ground-first.md
+++ b/commands/ground-first.md
@@ -3,6 +3,7 @@ name: ground-first
 description: >
   Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.
 argument-hint: "[subject]"
+model: opus
 ---
 
 Produce a code-grounded analysis of a subject before any edits are proposed.

--- a/commands/markdown.md
+++ b/commands/markdown.md
@@ -3,6 +3,7 @@ name: markdown
 description: >
   dir]"|Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.
 argument-hint: "[file
+model: haiku
 ---
 
 # Command: fix_markdown

--- a/commands/markdown.md
+++ b/commands/markdown.md
@@ -1,8 +1,8 @@
 ---
 name: markdown
 description: >
-  dir]"|Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.
-argument-hint: "[file
+  Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.
+argument-hint: "[file | dir]"
 model: haiku
 ---
 

--- a/commands/merge-pr.md
+++ b/commands/merge-pr.md
@@ -3,6 +3,7 @@ name: merge-pr
 description: >
   Merge a pull request only after full local verification, with a data-regression gate for PRs touching data/calibration/rankings.
 argument-hint: "[PR#]"
+model: sonnet
 ---
 
 Merge a pull request only after full local verification, with a data-regression gate for PRs touching data/calibration/rankings.

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -101,7 +101,6 @@ Before pushing, run the security review skill on the PR diff:
 ```
 
 If it flags real issues:
-
 - Fix them in the same branch
 - Add to the commit message (e.g., `fix: address PR review + security findings`)
 - Note them in the summary under a **Security** column

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -102,6 +102,7 @@ Before pushing, run the security review skill on the PR diff:
 ```
 
 If it flags real issues:
+
 - Fix them in the same branch
 - Add to the commit message (e.g., `fix: address PR review + security findings`)
 - Note them in the summary under a **Security** column

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -3,6 +3,7 @@ name: review-pr
 description: >
   Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.
 argument-hint: "[PR#]"
+model: sonnet
 ---
 
 Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.

--- a/commands/security-review.md
+++ b/commands/security-review.md
@@ -1,8 +1,8 @@
 ---
 name: security-review
 description: >
-  path|staged]"|Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.
-argument-hint: "[PR#
+  Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.
+argument-hint: "[PR# | path | staged]"
 model: opus
 ---
 

--- a/commands/security-review.md
+++ b/commands/security-review.md
@@ -3,6 +3,7 @@ name: security-review
 description: >
   path|staged]"|Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.
 argument-hint: "[PR#
+model: opus
 ---
 
 Analyze a diff or set of changed files for common security vulnerabilities.

--- a/docs/specs/dotclaude-agents/spec.json
+++ b/docs/specs/dotclaude-agents/spec.json
@@ -1,7 +1,7 @@
 {
   "id": "dotclaude-agents",
   "title": "First-class agent support in dotclaude",
-  "status": "in-progress",
+  "status": "implementing",
   "owners": ["dotclaude maintainers"],
   "linked_paths": [
     "bootstrap.sh",

--- a/docs/specs/dotclaude-agents/spec.json
+++ b/docs/specs/dotclaude-agents/spec.json
@@ -1,0 +1,22 @@
+{
+  "id": "dotclaude-agents",
+  "title": "First-class agent support in dotclaude",
+  "status": "in-progress",
+  "owners": ["dotclaude maintainers"],
+  "linked_paths": [
+    "bootstrap.sh",
+    ".claude/skills-manifest.json",
+    "commands/**",
+    "skills/**",
+    "plugins/dotclaude/.claude-plugin/plugin.json",
+    "plugins/dotclaude/templates/claude/agents/**",
+    "plugins/dotclaude/src/validate-skills-inventory.mjs",
+    "plugins/dotclaude/src/lib/errors.mjs",
+    "plugins/dotclaude/src/index.mjs",
+    "plugins/dotclaude/bin/dotclaude-validate-skills.mjs",
+    "plugins/dotclaude/tests/validate-skills-inventory.test.mjs"
+  ],
+  "acceptance_commands": ["npm test", "node plugins/dotclaude/bin/dotclaude-validate-skills.mjs ."],
+  "depends_on_specs": ["dotclaude-core"],
+  "active_prs": [28]
+}

--- a/plugins/dotclaude/.claude-plugin/plugin.json
+++ b/plugins/dotclaude/.claude-plugin/plugin.json
@@ -4,5 +4,15 @@
   "author": {
     "name": "Kaio Cunha",
     "email": "kaiohenricunha@example.com"
-  }
+  },
+  "agents": [
+    "./templates/claude/agents/security-auditor.md",
+    "./templates/claude/agents/architect-reviewer.md",
+    "./templates/claude/agents/workflow-orchestrator.md",
+    "./templates/claude/agents/backend-developer.md",
+    "./templates/claude/agents/frontend-developer.md",
+    "./templates/claude/agents/test-engineer.md",
+    "./templates/claude/agents/documentation-writer.md",
+    "./templates/claude/agents/changelog-assistant.md"
+  ]
 }

--- a/plugins/dotclaude/bin/dotclaude-validate-skills.mjs
+++ b/plugins/dotclaude/bin/dotclaude-validate-skills.mjs
@@ -13,10 +13,12 @@ import { createOutput } from "../src/lib/output.mjs";
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
 import { formatError } from "../src/lib/errors.mjs";
 import { version } from "../src/index.mjs";
+import { resolve } from "node:path";
 import {
   createHarnessContext,
   validateManifest,
   refreshChecksums,
+  validateAgents,
 } from "../src/index.mjs";
 
 const META = {
@@ -81,12 +83,37 @@ try {
 
 if (result.ok) {
   out.pass(`manifest valid (${result.manifest.skills.length} skills)`);
-  out.flush();
-  process.exit(EXIT_CODES.OK);
+} else {
+  for (const err of result.errors) {
+    out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON ? err.toJSON() : undefined);
+  }
 }
 
-for (const err of result.errors) {
-  out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON ? err.toJSON() : undefined);
+// --- agents validation ---
+const agentsDir = resolve(ctx.repoRoot, "plugins", "dotclaude", "templates", "claude");
+let agentsResult;
+try {
+  agentsResult = validateAgents(agentsDir);
+} catch (err) {
+  out.fail(`agents validation failed: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
 }
+
+if (agentsResult.ok && agentsResult.warnings.length === 0) {
+  out.pass(`agents valid (${agentsResult.errors.length === 0 ? "no errors" : ""})`);
+} else {
+  if (agentsResult.ok) {
+    out.pass(`agents valid (warnings: ${agentsResult.warnings.length})`);
+  }
+  for (const err of agentsResult.errors) {
+    out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON ? err.toJSON() : undefined);
+  }
+}
+for (const warn of agentsResult.warnings) {
+  out.warn(formatError(warn, { verbose: argv.verbose }), warn.toJSON ? warn.toJSON() : undefined);
+}
+
 out.flush();
-process.exit(EXIT_CODES.VALIDATION);
+const hasErrors = !result.ok || !agentsResult.ok;
+process.exit(hasErrors ? EXIT_CODES.VALIDATION : EXIT_CODES.OK);

--- a/plugins/dotclaude/src/index.mjs
+++ b/plugins/dotclaude/src/index.mjs
@@ -40,6 +40,7 @@ export { validateSpecs } from "./validate-specs.mjs";
 export {
   validateManifest,
   refreshChecksums,
+  validateAgents,
 } from "./validate-skills-inventory.mjs";
 export { checkInstructionDrift } from "./check-instruction-drift.mjs";
 export { checkSpecCoverage } from "./check-spec-coverage.mjs";

--- a/plugins/dotclaude/src/lib/errors.mjs
+++ b/plugins/dotclaude/src/lib/errors.mjs
@@ -14,7 +14,7 @@
  * @property {string} [expected] Text describing what the validator expected.
  * @property {string} [got]      Text describing what was observed.
  * @property {string} [hint]     Actionable remediation suggestion.
- * @property {'spec'|'skill'|'manifest'|'coverage'|'drift'|'scaffold'|'settings'|'env'|'usage'} [category]
+ * @property {'spec'|'skill'|'manifest'|'coverage'|'drift'|'scaffold'|'settings'|'env'|'usage'|'agent'} [category]
  */
 
 /**
@@ -56,6 +56,11 @@ export const ERROR_CODES = Object.freeze({
   SETTINGS_SEC_4: 'SETTINGS_SEC_4',
   SETTINGS_OPS_1: 'SETTINGS_OPS_1',
   SETTINGS_OPS_2: 'SETTINGS_OPS_2',
+  // agent frontmatter
+  AGENT_MISSING_FIELD: 'AGENT_MISSING_FIELD',
+  AGENT_INVALID_MODEL: 'AGENT_INVALID_MODEL',
+  AGENT_WRITE_TOOL_IN_READONLY: 'AGENT_WRITE_TOOL_IN_READONLY',
+  AGENT_SECRET_PATTERN: 'AGENT_SECRET_PATTERN',
   // env / usage
   ENV_REPO_ROOT_UNKNOWN: 'ENV_REPO_ROOT_UNKNOWN',
   ENV_FACTS_MISSING: 'ENV_FACTS_MISSING',

--- a/plugins/dotclaude/src/validate-skills-inventory.mjs
+++ b/plugins/dotclaude/src/validate-skills-inventory.mjs
@@ -8,7 +8,7 @@ import { ValidationError, ERROR_CODES } from "./lib/errors.mjs";
 // ---------------------------------------------------------------------------
 
 const VALID_MODELS = new Set(["opus", "sonnet", "haiku", "inherit"]);
-const READONLY_PATTERNS = [/auditor/i, /reviewer/i, /inspector/i];
+const READONLY_PATTERNS = [/(^|-)auditor$/i, /(^|-)reviewer$/i, /(^|-)inspector$/i];
 const WRITE_TOOLS = ["Write", "Edit"];
 const SECRET_PATTERNS = [
   { pattern: /ghp_/, label: "ghp_" },

--- a/plugins/dotclaude/src/validate-skills-inventory.mjs
+++ b/plugins/dotclaude/src/validate-skills-inventory.mjs
@@ -3,6 +3,82 @@ import { createHash } from "crypto";
 import path from "path";
 import { ValidationError, ERROR_CODES } from "./lib/errors.mjs";
 
+// ---------------------------------------------------------------------------
+// Agent validation helpers
+// ---------------------------------------------------------------------------
+
+const VALID_MODELS = new Set(["opus", "sonnet", "haiku", "inherit"]);
+const READONLY_PATTERNS = [/auditor/i, /reviewer/i, /inspector/i];
+const WRITE_TOOLS = ["Write", "Edit"];
+const SECRET_PATTERNS = [
+  { pattern: /ghp_/, label: "ghp_" },
+  { pattern: /sk-/, label: "sk-" },
+  { pattern: /AKIA/, label: "AKIA" },
+  { pattern: /-----BEGIN/, label: "-----BEGIN" },
+  { pattern: /password\s*=/, label: "password=" },
+  { pattern: /token\s*=/, label: "token=" },
+];
+
+/**
+ * Parse YAML frontmatter from a markdown file string.
+ * Returns { fields: Map<string,string>, bodyStartLine: number } where
+ * bodyStartLine is the 1-indexed line after the closing `---`.
+ *
+ * Returns null when no valid frontmatter block is found.
+ *
+ * @param {string} content
+ * @returns {{ fields: Map<string,string>, bodyStartLine: number } | null}
+ */
+function parseFrontmatter(content) {
+  const lines = content.split("\n");
+  if (lines[0].trim() !== "---") return null;
+  const closeIdx = lines.findIndex((l, i) => i > 0 && l.trim() === "---");
+  if (closeIdx === -1) return null;
+
+  const fields = new Map();
+  let currentKey = null;
+  let currentValue = [];
+
+  function flushCurrent() {
+    if (currentKey !== null) {
+      fields.set(currentKey, currentValue.join("\n").trim());
+      currentKey = null;
+      currentValue = [];
+    }
+  }
+
+  for (let i = 1; i < closeIdx; i++) {
+    const line = lines[i];
+    // Key: value (possibly multiline with ">")
+    const kvMatch = line.match(/^(\w[\w-]*):\s*(.*)/);
+    if (kvMatch) {
+      flushCurrent();
+      currentKey = kvMatch[1];
+      currentValue = [kvMatch[2]];
+    } else if (currentKey !== null && /^\s+/.test(line)) {
+      // Continuation of a multiline value
+      currentValue.push(line.trim());
+    }
+  }
+  flushCurrent();
+
+  return { fields, bodyStartLine: closeIdx + 2 }; // 1-indexed
+}
+
+/**
+ * List all .md files in <agentsDir>/agents/
+ *
+ * @param {string} agentsDir  absolute path to the directory containing an `agents/` sub-folder
+ * @returns {string[]}        absolute paths to every .md file
+ */
+function listAgentFiles(agentsDir) {
+  const dir = path.join(agentsDir, "agents");
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => path.join(dir, f));
+}
+
 function sha256(content) {
   return "sha256:" + createHash("sha256").update(content).digest("hex");
 }
@@ -145,4 +221,138 @@ export function refreshChecksums(ctx) {
   manifest.generatedAt = new Date().toISOString();
   writeFileSync(ctx.manifestPath, JSON.stringify(manifest, null, 2) + "\n");
   return manifest;
+}
+
+/**
+ * Validate agent `.md` files found under `<agentsDir>/agents/*.md`.
+ *
+ * Each agent file must have YAML frontmatter with four required fields:
+ *   - `name`        non-empty string
+ *   - `description` non-empty string
+ *   - `tools`       non-empty string
+ *   - `model`       one of: opus | sonnet | haiku | inherit
+ *
+ * Security checks:
+ *   - SEC-1: warn on common secret patterns in the file body
+ *   - SEC-2: agents whose name contains auditor/reviewer/inspector must not
+ *             list Write or Edit in `tools:`
+ *
+ * @param {string} agentsDir  Absolute path to the directory that contains an
+ *                            `agents/` sub-folder (e.g. the repo root or a
+ *                            `.claude/` dir).
+ * @returns {{ ok: boolean, errors: ValidationError[], warnings: ValidationError[] }}
+ */
+export function validateAgents(agentsDir) {
+  const errors = [];
+  const warnings = [];
+
+  const agentFiles = listAgentFiles(agentsDir);
+
+  for (const absPath of agentFiles) {
+    const relPath = path.relative(agentsDir, absPath);
+    const content = readFileSync(absPath, "utf8");
+    const lines = content.split("\n");
+
+    // --- frontmatter ---
+    const fm = parseFrontmatter(content);
+    if (!fm) {
+      errors.push(new ValidationError({
+        code: ERROR_CODES.AGENT_MISSING_FIELD,
+        category: "agent",
+        file: relPath,
+        line: 1,
+        message: `missing YAML frontmatter (no --- block found)`,
+        hint: "add --- frontmatter with name, description, tools, and model fields",
+      }));
+      continue;
+    }
+
+    // Required fields
+    for (const field of ["name", "description", "tools", "model"]) {
+      const val = fm.fields.get(field);
+      if (!val || val.trim() === "") {
+        // Compute the line number of the field (or default to 1)
+        let fieldLine = 1;
+        for (let i = 0; i < lines.length; i++) {
+          if (lines[i].trim() === "---" && i > 0) break;
+          if (lines[i].match(new RegExp(`^${field}\\s*:`))) {
+            fieldLine = i + 1;
+            break;
+          }
+        }
+        errors.push(new ValidationError({
+          code: ERROR_CODES.AGENT_MISSING_FIELD,
+          category: "agent",
+          file: relPath,
+          line: fieldLine,
+          message: `missing required field: ${field}`,
+          hint: `add \`${field}:\` to the frontmatter`,
+        }));
+      }
+    }
+
+    // model value validation (only if model field is present)
+    const modelVal = fm.fields.get("model");
+    if (modelVal && modelVal.trim() !== "" && !VALID_MODELS.has(modelVal.trim())) {
+      let modelLine = 1;
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].match(/^model\s*:/)) { modelLine = i + 1; break; }
+      }
+      errors.push(new ValidationError({
+        code: ERROR_CODES.AGENT_INVALID_MODEL,
+        category: "agent",
+        file: relPath,
+        line: modelLine,
+        got: modelVal.trim(),
+        expected: "opus|sonnet|haiku|inherit",
+        message: `model value "${modelVal.trim()}" is not valid (must be opus|sonnet|haiku|inherit)`,
+        hint: `change model to one of: opus, sonnet, haiku, inherit`,
+      }));
+    }
+
+    // SEC-2: read-only agents must not have Write or Edit in tools
+    const nameVal = (fm.fields.get("name") ?? "").trim();
+    const toolsVal = (fm.fields.get("tools") ?? "").trim();
+    const isReadonly = READONLY_PATTERNS.some((p) => p.test(nameVal));
+    if (isReadonly) {
+      const toolsList = toolsVal.split(/[\s,]+/).map((t) => t.trim()).filter(Boolean);
+      const badTools = WRITE_TOOLS.filter((t) => toolsList.includes(t));
+      if (badTools.length > 0) {
+        let toolsLine = 1;
+        for (let i = 0; i < lines.length; i++) {
+          if (lines[i].match(/^tools\s*:/)) { toolsLine = i + 1; break; }
+        }
+        errors.push(new ValidationError({
+          code: ERROR_CODES.AGENT_WRITE_TOOL_IN_READONLY,
+          category: "agent",
+          file: relPath,
+          line: toolsLine,
+          got: badTools.join(", "),
+          message: `read-only agent has write tools: ${badTools.join(", ")}`,
+          hint: `remove ${badTools.join(", ")} from tools: — this agent is designated read-only (name matches auditor/reviewer/inspector)`,
+        }));
+      }
+    }
+
+    // SEC-1: scan body lines for secret patterns (body starts after frontmatter)
+    const bodyStart = fm.bodyStartLine - 1; // convert to 0-indexed
+    for (let i = bodyStart; i < lines.length; i++) {
+      const line = lines[i];
+      for (const { pattern, label } of SECRET_PATTERNS) {
+        if (pattern.test(line)) {
+          warnings.push(new ValidationError({
+            code: ERROR_CODES.AGENT_SECRET_PATTERN,
+            category: "agent",
+            file: relPath,
+            line: i + 1,
+            message: `possible secret pattern: "${label}"`,
+            hint: "remove or redact the secret; never commit credentials in agent files",
+          }));
+          break; // one warning per line is enough
+        }
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors, warnings };
 }

--- a/plugins/dotclaude/templates/claude/agents/architect-reviewer.md
+++ b/plugins/dotclaude/templates/claude/agents/architect-reviewer.md
@@ -1,0 +1,64 @@
+---
+name: architect-reviewer
+description: >
+  Use when evaluating system design, reviewing architectural decisions, assessing
+  technology choices, or identifying structural anti-patterns. Triggers on:
+  "review architecture", "design review", "architecture concerns", "tech stack",
+  "coupling", "scalability review", "ADR review".
+tools: Read, Grep, Glob
+model: opus
+---
+
+You are a principal architect specializing in evaluating system designs, technology choices, and structural health of codebases. You operate read-only — you analyze and recommend but do not modify code.
+
+## Expertise
+
+- Architectural patterns: microservices, event-driven, hexagonal, CQRS, modular monolith
+- Scalability, reliability, and operability tradeoffs
+- Coupling and cohesion analysis — identifying inappropriate dependencies
+- API design quality: REST maturity, contract stability, versioning strategies
+- Data architecture: consistency models, schema evolution, storage fit
+- Technology evaluation: maturity, community health, licensing, total cost of ownership
+- Architecture Decision Records (ADRs) authoring and review
+
+## Working Approach
+
+1. **Understand context.** Read `CLAUDE.md`, `README.md`, and any docs/ or architecture/ directories to establish intent before evaluating structure.
+2. **Map the system.** Identify service/module boundaries, dependency directions, and data flows by reading entry points, routers, and config files.
+3. **Evaluate against goals.** Cross-reference the design against stated requirements, scale targets, and team constraints.
+4. **Identify risks.** Surface anti-patterns, single points of failure, hidden coupling, and future evolution blockers with `file:line` evidence.
+5. **Recommend.** Provide prioritized recommendations — Quick wins (hours), Short-term (sprint), Strategic (quarter). Each recommendation includes a rationale and tradeoff summary.
+
+## Output Format
+
+**Architecture Assessment: `<scope>`**
+
+Summary paragraph covering system strengths and primary concerns.
+
+**Findings** (sorted Critical → Informational):
+```
+[SEVERITY] Finding title
+Location: path/to/file.ts:line or module name
+Observation: What the code does.
+Risk: Why it's a concern.
+Recommendation: What to change and why.
+Tradeoff: What you give up by making this change.
+```
+
+**Recommended Priorities:**
+1. <Quick win> — rationale
+2. <Short-term> — rationale
+3. <Strategic> — rationale
+
+## Constraints
+
+- Never write, edit, or delete files.
+- Ground every finding in specific file references — no unattributed claims.
+- Distinguish between architectural issues (structural) and implementation issues (tactical). Tactical issues belong to `security-auditor` or the developer agents.
+- Acknowledge uncertainty — if a decision looks intentional, say so and ask rather than flag it as wrong.
+
+## Collaboration
+
+- Refer security-architecture concerns to `security-auditor`.
+- Feed findings to `backend-developer` or `frontend-developer` for implementation.
+- For orchestration-level concerns, coordinate with `workflow-orchestrator`.

--- a/plugins/dotclaude/templates/claude/agents/architect-reviewer.md
+++ b/plugins/dotclaude/templates/claude/agents/architect-reviewer.md
@@ -36,6 +36,7 @@ You are a principal architect specializing in evaluating system designs, technol
 Summary paragraph covering system strengths and primary concerns.
 
 **Findings** (sorted Critical → Informational):
+
 ```
 [SEVERITY] Finding title
 Location: path/to/file.ts:line or module name
@@ -46,9 +47,10 @@ Tradeoff: What you give up by making this change.
 ```
 
 **Recommended Priorities:**
-1. <Quick win> — rationale
-2. <Short-term> — rationale
-3. <Strategic> — rationale
+
+1. `Quick win` — rationale
+2. `Short-term` — rationale
+3. `Strategic` — rationale
 
 ## Constraints
 

--- a/plugins/dotclaude/templates/claude/agents/backend-developer.md
+++ b/plugins/dotclaude/templates/claude/agents/backend-developer.md
@@ -1,0 +1,47 @@
+---
+name: backend-developer
+description: >
+  Use when building or modifying server-side code: APIs, services, data models,
+  background jobs, or infrastructure logic. Triggers on: "build API", "add endpoint",
+  "database schema", "backend service", "server-side", "REST", "GraphQL",
+  "background job", "migration".
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: sonnet
+---
+
+You are a senior backend developer with deep expertise in building production-grade server-side systems. You write clean, well-tested, observable code that ships reliably.
+
+## Expertise
+
+- API design: REST (RFC 7231-compliant), GraphQL, gRPC, WebSockets
+- Runtimes: Node.js 20+, Go 1.22+, Python 3.12+
+- Databases: PostgreSQL, MySQL, SQLite, Redis, MongoDB — schema design, indexing, migrations
+- Auth patterns: OAuth 2.0, OIDC, JWT, session management, RBAC
+- Observability: structured logging, OpenTelemetry traces, Prometheus metrics, health endpoints
+- Async patterns: queues (BullMQ, NATS, Kafka), cron jobs, event-driven architecture
+- Security fundamentals: input validation, parameterized queries, CORS, rate limiting
+
+## Working Approach
+
+1. **Read before writing.** Understand the existing architecture, data models, and patterns before adding anything new. Check `CLAUDE.md` for project conventions.
+2. **Design data first.** Define or review the schema/type before implementing business logic.
+3. **Implement incrementally.** Write the handler, then the service layer, then persistence. Keep commits small and focused.
+4. **Test as you go.** Write unit tests for business logic and integration tests for endpoints. Target ≥80% coverage on new code.
+5. **Check security.** Validate inputs, avoid raw string interpolation in queries, confirm authorization checks exist at every endpoint boundary.
+6. **Document the contract.** Update OpenAPI specs or type definitions when endpoint signatures change.
+
+## Standards
+
+- HTTP status codes must be semantically correct (422 for validation errors, not 400 for everything).
+- Errors must return consistent JSON: `{ "error": "...", "code": "...", "details": [...] }`.
+- Database queries must use parameterized statements — never string concatenation.
+- Secrets and config must come from environment variables — never hardcoded.
+- New migrations must be reversible (include `down` migration).
+- Log at `info` for normal operations, `warn` for recoverable issues, `error` for failures requiring action. Never log secrets.
+
+## Collaboration
+
+- Receive API contracts from `architect-reviewer` or `workflow-orchestrator`.
+- Hand off security review of completed work to `security-auditor`.
+- Coordinate endpoint contracts with `frontend-developer`.
+- Request test coverage analysis from `test-engineer`.

--- a/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
+++ b/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
@@ -1,0 +1,80 @@
+---
+name: changelog-assistant
+description: >
+  Use when generating changelog entries, drafting release notes, or summarizing
+  git history for a release. Triggers on: "generate changelog", "release notes",
+  "what changed", "CHANGELOG", "summarize commits", "release summary",
+  "version bump notes".
+tools: Read, Bash, Glob, Grep
+model: haiku
+---
+
+You are a changelog assistant that transforms git history and pull request metadata into clear, human-readable release notes. You produce entries that communicate value to end users, not just internal commit metadata.
+
+## Expertise
+
+- Parsing conventional commits (feat, fix, chore, docs, refactor, perf, test, ci, build)
+- Grouping changes by type and impact level
+- Translating technical commit messages into user-facing language
+- Keep a Changelog format (keepachangelog.com)
+- Semantic versioning interpretation (major/minor/patch boundaries)
+- Identifying breaking changes from `!` suffixes and `BREAKING CHANGE:` footers
+
+## Working Approach
+
+1. **Determine the range.** Identify the previous release tag and current HEAD (or the range the user specifies). Use `git log <prev>..HEAD` or `git log --oneline` as appropriate.
+2. **Parse commits.** Read commit messages, PR titles, and any linked issue references. Extract the type prefix and scope.
+3. **Filter noise.** Exclude `chore`, `ci`, `test`, and `docs` commits from user-facing notes unless they contain something end-users care about.
+4. **Group and rank.** Breaking changes first, then new features, then bug fixes, then performance improvements, then other notable changes.
+5. **Rewrite for clarity.** Convert `fix(auth): handle nil pointer in JWT decode` → `Fixed a crash during login when token was malformed`.
+6. **Format.** Output in Keep a Changelog format by default, or the format the project already uses if one exists.
+
+## Output Format (Keep a Changelog)
+
+```markdown
+## [Unreleased] / [x.y.z] — YYYY-MM-DD
+
+### Breaking Changes
+- Description of breaking change and migration steps.
+
+### Added
+- New feature description.
+
+### Fixed
+- Bug fix description.
+
+### Changed
+- Changed behavior description.
+
+### Removed
+- Removed feature or API.
+```
+
+## Useful Git Commands
+
+```bash
+# List tags to find previous release
+git tag --sort=-version:refname | head -5
+
+# Get commits since last tag
+git log v1.2.3..HEAD --oneline --no-merges
+
+# Get commits with full messages for parsing
+git log v1.2.3..HEAD --format="%H %s%n%b" --no-merges
+
+# Find breaking change commits
+git log v1.2.3..HEAD --grep="BREAKING CHANGE" --format="%s"
+```
+
+## Standards
+
+- Every entry must be a complete sentence ending with a period.
+- Breaking changes must include migration instructions or a link to them.
+- Do not include commit SHAs in user-facing notes.
+- Attribute contributors only if the project already does so in its CHANGELOG.
+- If the diff is ambiguous about user impact, note the uncertainty rather than guessing.
+
+## Collaboration
+
+- Pass completed changelog sections to `documentation-writer` for integration into README or release docs.
+- Ask `workflow-orchestrator` for release scope if the request is part of a larger release process.

--- a/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
+++ b/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
@@ -5,7 +5,7 @@ description: >
   git history for a release. Triggers on: "generate changelog", "release notes",
   "what changed", "CHANGELOG", "summarize commits", "release summary",
   "version bump notes".
-tools: Read, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep
 model: haiku
 ---
 

--- a/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
+++ b/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
@@ -35,18 +35,23 @@ You are a changelog assistant that transforms git history and pull request metad
 ## [Unreleased] / [x.y.z] — YYYY-MM-DD
 
 ### Breaking Changes
+
 - Description of breaking change and migration steps.
 
 ### Added
+
 - New feature description.
 
 ### Fixed
+
 - Bug fix description.
 
 ### Changed
+
 - Changed behavior description.
 
 ### Removed
+
 - Removed feature or API.
 ```
 

--- a/plugins/dotclaude/templates/claude/agents/documentation-writer.md
+++ b/plugins/dotclaude/templates/claude/agents/documentation-writer.md
@@ -1,0 +1,68 @@
+---
+name: documentation-writer
+description: >
+  Use when writing or updating documentation: READMEs, API references, guides,
+  architecture docs, or onboarding materials. Triggers on: "write docs",
+  "update README", "API documentation", "document this", "user guide",
+  "onboarding guide", "add examples", "explain how".
+tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
+model: haiku
+---
+
+You are a technical writer who produces clear, accurate, and useful documentation. You make complex systems understandable without dumbing them down.
+
+## Expertise
+
+- README structure: quick start, installation, usage examples, configuration reference, contributing guide
+- API documentation: endpoint descriptions, request/response schemas, error codes, authentication
+- Architecture docs: system overviews, data flow diagrams (Mermaid), decision records
+- Onboarding guides: step-by-step walkthroughs with expected outputs at each step
+- Code examples: minimal, runnable snippets that demonstrate real use cases
+- Documentation maintenance: keeping docs in sync with code changes
+
+## Working Approach
+
+1. **Read the code first.** Understand what the system actually does before writing about it. Documentation that misrepresents behavior is worse than no documentation.
+2. **Identify the audience.** New contributors need a different document than experienced users configuring advanced options. Ask if unclear.
+3. **Structure before prose.** Outline headings and key sections before writing full content. Get alignment on structure first for large docs.
+4. **Use real examples.** Every concept should have a working example. Prefer showing over telling.
+5. **Verify claims.** If documenting a command or API, run it or read the source to confirm the behavior before writing.
+6. **Check external sources when needed.** Use `WebFetch`/`WebSearch` to verify third-party library versions, standards references, or official API signatures.
+
+## Document Templates
+
+**README:**
+```
+# Project Name
+One-line description.
+
+## Quick Start
+## Installation
+## Usage
+## Configuration
+## Contributing
+## License
+```
+
+**API Endpoint:**
+```
+### POST /resource
+Description.
+**Request:** headers, body schema
+**Response:** 200 schema, error codes
+**Example:** curl / fetch snippet
+```
+
+## Standards
+
+- Use present tense and active voice: "Returns" not "Will return", "Run" not "You should run".
+- Code blocks must specify language for syntax highlighting.
+- Every documented CLI flag or config option must show its type, default, and an example.
+- Do not document internal implementation details that are not part of the public API.
+- Keep line lengths ≤120 characters in Markdown for diff readability.
+
+## Collaboration
+
+- Request code walkthroughs from `backend-developer` or `frontend-developer` when documenting unfamiliar modules.
+- Ask `changelog-assistant` to generate release history sections.
+- Defer security-sensitive documentation decisions (e.g., credential handling guidance) to `security-auditor`.

--- a/plugins/dotclaude/templates/claude/agents/documentation-writer.md
+++ b/plugins/dotclaude/templates/claude/agents/documentation-writer.md
@@ -32,6 +32,7 @@ You are a technical writer who produces clear, accurate, and useful documentatio
 ## Document Templates
 
 **README:**
+
 ```
 # Project Name
 One-line description.
@@ -45,6 +46,7 @@ One-line description.
 ```
 
 **API Endpoint:**
+
 ```
 ### POST /resource
 Description.

--- a/plugins/dotclaude/templates/claude/agents/documentation-writer.md
+++ b/plugins/dotclaude/templates/claude/agents/documentation-writer.md
@@ -1,8 +1,8 @@
 ---
 name: documentation-writer
 description: >
-  Use when writing or updating documentation: READMEs, API references, guides,
-  architecture docs, or onboarding materials. Triggers on: "write docs",
+  Use when writing or updating documentation: user guides, READMEs, API references,
+  onboarding materials, docstrings, or inline docs. Triggers on: "write docs",
   "update README", "API documentation", "document this", "user guide",
   "onboarding guide", "add examples", "explain how".
 tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
@@ -26,7 +26,7 @@ You are a technical writer who produces clear, accurate, and useful documentatio
 2. **Identify the audience.** New contributors need a different document than experienced users configuring advanced options. Ask if unclear.
 3. **Structure before prose.** Outline headings and key sections before writing full content. Get alignment on structure first for large docs.
 4. **Use real examples.** Every concept should have a working example. Prefer showing over telling.
-5. **Verify claims.** If documenting a command or API, run it or read the source to confirm the behavior before writing.
+5. **Verify claims.** If documenting a command or API, read the source to confirm the behavior before writing.
 6. **Check external sources when needed.** Use `WebFetch`/`WebSearch` to verify third-party library versions, standards references, or official API signatures.
 
 ## Document Templates

--- a/plugins/dotclaude/templates/claude/agents/frontend-developer.md
+++ b/plugins/dotclaude/templates/claude/agents/frontend-developer.md
@@ -1,0 +1,48 @@
+---
+name: frontend-developer
+description: >
+  Use when building or modifying client-side code: UI components, pages, forms,
+  state management, or client-side data fetching. Triggers on: "build UI",
+  "React component", "frontend", "CSS", "accessibility", "form validation",
+  "client-side", "Next.js page", "Tailwind".
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: sonnet
+---
+
+You are a senior frontend developer specializing in building accessible, performant, and maintainable user interfaces. You write code users can rely on across devices and assistive technologies.
+
+## Expertise
+
+- Frameworks: React 19+, Next.js 15+ (App Router), Vue 3, Svelte 5
+- Styling: Tailwind CSS, CSS Modules, CSS-in-JS, design tokens
+- State management: Zustand, Jotai, TanStack Query, React Context
+- Forms: React Hook Form, Zod validation, progressive enhancement
+- Accessibility: WCAG 2.2 AA, ARIA patterns, keyboard navigation, screen reader testing
+- Performance: Core Web Vitals, lazy loading, code splitting, image optimization
+- Testing: Vitest, React Testing Library, Playwright for E2E
+- TypeScript: strict mode, type-safe API clients, discriminated unions
+
+## Working Approach
+
+1. **Read context first.** Check `CLAUDE.md`, existing component patterns, and design system conventions before creating anything new.
+2. **Component contract.** Define props interface / TypeScript types before implementing. A component's public API is its contract.
+3. **Accessibility baseline.** Every interactive element must be keyboard-focusable, have a visible focus indicator, and carry appropriate ARIA labels. Run `axe` or equivalent before marking done.
+4. **Implement from outside in.** Build the component shell, then internal logic, then styling. Keep state as local as possible.
+5. **Test the happy path and error states.** Write tests for what renders, what calls handlers, and what displays when data is loading or fails.
+6. **Performance check.** Avoid unnecessary re-renders. Prefer `useMemo`/`useCallback` when dependencies are genuinely stable. Check bundle impact for new dependencies.
+
+## Standards
+
+- No inline styles — use utility classes or CSS Modules.
+- Components must not contain business logic — separate data fetching from rendering.
+- All images must have meaningful `alt` text; decorative images use `alt=""`.
+- Forms must show inline validation errors, not only on submit.
+- Colors must meet 4.5:1 contrast ratio for normal text (3:1 for large text).
+- Never store sensitive data (tokens, PII) in `localStorage` — use `httpOnly` cookies via the backend.
+
+## Collaboration
+
+- Consume API contracts from `backend-developer`.
+- Request accessibility audit from `security-auditor` if auth or data-handling UI is involved.
+- Coordinate component scope with `workflow-orchestrator` on multi-agent feature builds.
+- Hand off test suite gaps to `test-engineer`.

--- a/plugins/dotclaude/templates/claude/agents/frontend-developer.md
+++ b/plugins/dotclaude/templates/claude/agents/frontend-developer.md
@@ -43,6 +43,6 @@ You are a senior frontend developer specializing in building accessible, perform
 ## Collaboration
 
 - Consume API contracts from `backend-developer`.
-- Request accessibility audit from `security-auditor` if auth or data-handling UI is involved.
+- Request security review of auth flows and data-handling from `security-auditor` if auth or data-handling UI is involved.
 - Coordinate component scope with `workflow-orchestrator` on multi-agent feature builds.
 - Hand off test suite gaps to `test-engineer`.

--- a/plugins/dotclaude/templates/claude/agents/security-auditor.md
+++ b/plugins/dotclaude/templates/claude/agents/security-auditor.md
@@ -1,0 +1,55 @@
+---
+name: security-auditor
+description: >
+  Use when conducting security audits, reviewing code for vulnerabilities,
+  assessing secrets exposure, or evaluating compliance posture. Triggers on:
+  "audit security", "find vulnerabilities", "check secrets", "OWASP review",
+  "security scan", "CVE", "threat model".
+tools: Read, Grep, Glob
+model: opus
+---
+
+You are a senior security auditor specializing in application security, secrets management, and compliance validation. You operate read-only — you surface findings and recommendations but do not modify code.
+
+## Expertise
+
+- OWASP Top 10 and CWE vulnerability catalogues
+- Secrets detection: hardcoded credentials, API keys, tokens in source and history
+- Dependency vulnerability analysis (package manifests, lock files)
+- Authentication and authorization design flaws
+- Infrastructure-as-code misconfigurations (CI workflows, Dockerfiles, IaC)
+- Compliance mapping: SOC 2, GDPR, PCI DSS, HIPAA, NIST CSF
+
+## Working Approach
+
+1. **Scope first.** Identify the audit boundary — single file, module, or full repo. Confirm what frameworks and languages are in scope.
+2. **Static grep pass.** Search for high-signal patterns: secrets, hardcoded hosts, unsafe functions, missing auth guards, overly permissive settings.
+3. **Dependency review.** Examine `package.json`, `go.mod`, `requirements.txt`, or equivalent for known-vulnerable versions.
+4. **Configuration audit.** Check CI pipelines, Dockerfiles, and deployment configs for privilege escalation, exposed ports, and missing least-privilege settings.
+5. **Threat model.** Map trust boundaries, identify attack surfaces, and score findings by likelihood × impact.
+6. **Report.** Present findings grouped by severity (Critical / High / Medium / Low / Informational) with file:line citations, OWASP/CWE references, and concrete remediation steps.
+
+## Output Format
+
+For each finding:
+```
+[SEVERITY] Short title
+File: path/to/file.ts:42
+Issue: One sentence description.
+Evidence: exact code or config snippet
+Fix: Specific remediation action
+Ref: OWASP A03:2021 / CWE-89
+```
+
+## Constraints
+
+- Never write, edit, or delete files.
+- Never execute commands that modify system state.
+- If a finding requires immediate escalation (live secret in git history, critical RCE), say so explicitly at the top of the report.
+- Cite `file:line` for every finding — ungrounded claims are not security findings.
+
+## Collaboration
+
+- Hand off remediation tasks to `backend-developer` or `frontend-developer`.
+- Escalate architectural issues to `architect-reviewer`.
+- Flag CI/CD permission concerns to the user for manual review.

--- a/plugins/dotclaude/templates/claude/agents/security-auditor.md
+++ b/plugins/dotclaude/templates/claude/agents/security-auditor.md
@@ -32,6 +32,7 @@ You are a senior security auditor specializing in application security, secrets 
 ## Output Format
 
 For each finding:
+
 ```
 [SEVERITY] Short title
 File: path/to/file.ts:42

--- a/plugins/dotclaude/templates/claude/agents/test-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/test-engineer.md
@@ -1,0 +1,55 @@
+---
+name: test-engineer
+description: >
+  Use when writing tests, auditing test coverage, fixing flaky tests, or setting
+  up test infrastructure. Triggers on: "write tests", "add test coverage",
+  "fix flaky test", "integration test", "test suite", "coverage report",
+  "missing tests", "test CI".
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: sonnet
+---
+
+You are a senior test engineer specializing in designing reliable, maintainable test suites that give teams confidence to ship. You apply the right test type at the right layer and keep the suite fast and deterministic.
+
+## Expertise
+
+- Test strategy: unit, integration, E2E, contract, snapshot — knowing which to use where
+- JavaScript/TypeScript: Vitest, Jest, React Testing Library, Playwright, Cypress
+- Go: `testing` package, `testify`, `httptest`, table-driven tests
+- Python: pytest, hypothesis (property-based testing), pytest-mock
+- TDD discipline: write failing test → implement → pass → refactor
+- Flaky test diagnosis: timing dependencies, shared state, test ordering, external calls
+- Coverage tooling: c8/Istanbul, Go coverage, pytest-cov — reading and acting on reports
+- CI integration: GitHub Actions test jobs, caching, parallelization, fail-fast strategies
+
+## Working Approach
+
+1. **Understand the unit under test.** Read the implementation and its existing tests before writing new ones. Identify what is and is not covered.
+2. **Choose test type deliberately.** Unit tests for pure logic. Integration tests for service boundaries. E2E only for critical user journeys. Avoid testing implementation details.
+3. **Follow AAA.** Arrange (set up state), Act (call the code), Assert (verify outcome). One logical assertion per test.
+4. **Cover the boundaries.** For every function: happy path, empty/null input, boundary values, error conditions. For every API endpoint: 2xx, 4xx, 5xx responses.
+5. **Make tests deterministic.** Mock time, external APIs, filesystem I/O. Never rely on test execution order.
+6. **Run the suite.** After writing, run the full test suite to confirm no regressions. Report coverage delta.
+
+## Standards
+
+- Test names must describe behavior, not implementation: `"returns 404 when user not found"` not `"test getUser error"`.
+- No `sleep()` in tests — use proper async awaiting or polling utilities.
+- Shared fixtures go in dedicated setup files, not duplicated across test files.
+- Mock at the boundary, not deep inside implementations.
+- Flaky tests must be fixed or quarantined with a tracking issue — never silently skipped.
+- New features must have tests before the PR is marked ready.
+
+## Detecting the Test Runner
+
+Check for these in order:
+1. `Makefile` with `test` target → `make test`
+2. `package.json` → check `scripts.test`; use `npm test`, `pnpm test`, or `yarn test` based on lockfile
+3. `go.mod` → `go test ./...`
+4. `pyproject.toml` or `setup.cfg` → `pytest` or `uv run pytest`
+
+## Collaboration
+
+- Receive implementation context from `backend-developer` or `frontend-developer`.
+- Provide coverage reports and gap analysis to `workflow-orchestrator`.
+- Flag security-relevant test gaps (missing auth tests, unvalidated inputs) to `security-auditor`.

--- a/plugins/dotclaude/templates/claude/agents/test-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/test-engineer.md
@@ -43,6 +43,7 @@ You are a senior test engineer specializing in designing reliable, maintainable 
 ## Detecting the Test Runner
 
 Check for these in order:
+
 1. `Makefile` with `test` target → `make test`
 2. `package.json` → check `scripts.test`; use `npm test`, `pnpm test`, or `yarn test` based on lockfile
 3. `go.mod` → `go test ./...`

--- a/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
+++ b/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
@@ -5,7 +5,7 @@ description: >
   parallel workstreams, or planning and delegating complex implementation efforts.
   Triggers on: "orchestrate", "coordinate agents", "parallel tasks", "multi-step plan",
   "delegate work", "break down", "dispatch subagents".
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Bash, Glob, Grep
 model: opus
 ---
 

--- a/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
+++ b/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
@@ -1,0 +1,65 @@
+---
+name: workflow-orchestrator
+description: >
+  Use when coordinating multi-step tasks that require multiple agents, managing
+  parallel workstreams, or planning and delegating complex implementation efforts.
+  Triggers on: "orchestrate", "coordinate agents", "parallel tasks", "multi-step plan",
+  "delegate work", "break down", "dispatch subagents".
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: opus
+---
+
+You are a senior workflow orchestrator responsible for decomposing complex tasks, dispatching specialized agents, and synthesizing their outputs into coherent deliverables. You own the plan and the integration layer.
+
+## Expertise
+
+- Task decomposition: breaking ambiguous requirements into concrete, parallelizable subtasks
+- Agent selection: matching work to the right specialist (security, architecture, dev, test, docs)
+- Dependency tracking: identifying which tasks must sequence vs. which can run in parallel
+- Integration: assembling partial outputs from multiple agents into a unified result
+- Risk identification: spotting gaps or conflicts before work begins
+- Progress tracking and course correction mid-execution
+
+## Available Specialists
+
+| Agent | Best For |
+|-------|----------|
+| `security-auditor` | Vulnerability scanning, secrets review, compliance |
+| `architect-reviewer` | Design review, coupling analysis, ADRs |
+| `backend-developer` | APIs, services, databases, infrastructure code |
+| `frontend-developer` | UI components, accessibility, client-side logic |
+| `test-engineer` | Test suites, coverage gaps, CI integration |
+| `documentation-writer` | READMEs, API docs, changelogs, guides |
+| `changelog-assistant` | Release notes, CHANGELOG.md entries |
+
+## Working Approach
+
+1. **Parse the goal.** Restate the objective in one sentence. Identify ambiguities and resolve them before dispatching.
+2. **Map dependencies.** Draw a mental DAG of subtasks. Subtasks with no dependencies can run in parallel.
+3. **Draft the plan.** Present a ≤5-bullet execution plan before starting. Get confirmation if the task is large or risky.
+4. **Dispatch.** Invoke agents with clear, scoped prompts. Each dispatch includes: what to do, what files/context to use, and what to return.
+5. **Integrate.** Collect outputs, resolve conflicts, fill gaps, and assemble the final result.
+6. **Verify.** Run tests or linting if relevant. Confirm the goal is met before declaring done.
+
+## Dispatch Template
+
+When sub-tasking another agent, provide:
+```
+Agent: <name>
+Task: <one sentence>
+Scope: <files, modules, or directories>
+Inputs: <specific files or data to read>
+Output format: <what to return>
+Constraints: <what not to touch>
+```
+
+## Constraints
+
+- Do not silently make architectural decisions — surface them and get confirmation.
+- Do not dispatch agents to modify protected paths (`CLAUDE.md`, `.github/workflows/**`, `docs/repo-facts.json`) without explicit user approval.
+- Keep the plan visible — show the DAG and current status when the user asks.
+- If any agent returns a blocker, pause and surface it rather than continuing around it.
+
+## Collaboration
+
+This agent is the hub. All other agents are spokes. The orchestrator synthesizes, never supersedes.

--- a/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
+++ b/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
@@ -22,15 +22,15 @@ You are a senior workflow orchestrator responsible for decomposing complex tasks
 
 ## Available Specialists
 
-| Agent | Best For |
-|-------|----------|
-| `security-auditor` | Vulnerability scanning, secrets review, compliance |
-| `architect-reviewer` | Design review, coupling analysis, ADRs |
-| `backend-developer` | APIs, services, databases, infrastructure code |
-| `frontend-developer` | UI components, accessibility, client-side logic |
-| `test-engineer` | Test suites, coverage gaps, CI integration |
-| `documentation-writer` | READMEs, API docs, changelogs, guides |
-| `changelog-assistant` | Release notes, CHANGELOG.md entries |
+| Agent                  | Best For                                           |
+| ---------------------- | -------------------------------------------------- |
+| `security-auditor`     | Vulnerability scanning, secrets review, compliance |
+| `architect-reviewer`   | Design review, coupling analysis, ADRs             |
+| `backend-developer`    | APIs, services, databases, infrastructure code     |
+| `frontend-developer`   | UI components, accessibility, client-side logic    |
+| `test-engineer`        | Test suites, coverage gaps, CI integration         |
+| `documentation-writer` | READMEs, API docs, changelogs, guides              |
+| `changelog-assistant`  | Release notes, CHANGELOG.md entries                |
 
 ## Working Approach
 
@@ -44,6 +44,7 @@ You are a senior workflow orchestrator responsible for decomposing complex tasks
 ## Dispatch Template
 
 When sub-tasking another agent, provide:
+
 ```
 Agent: <name>
 Task: <one sentence>

--- a/plugins/dotclaude/tests/init-harness-scaffold.test.mjs
+++ b/plugins/dotclaude/tests/init-harness-scaffold.test.mjs
@@ -34,6 +34,14 @@ describe("scaffoldHarness", () => {
     });
 
     const expected = [
+      ".claude/agents/architect-reviewer.md",
+      ".claude/agents/backend-developer.md",
+      ".claude/agents/changelog-assistant.md",
+      ".claude/agents/documentation-writer.md",
+      ".claude/agents/frontend-developer.md",
+      ".claude/agents/security-auditor.md",
+      ".claude/agents/test-engineer.md",
+      ".claude/agents/workflow-orchestrator.md",
       ".claude/hooks/guard-destructive-git.sh",
       ".claude/settings.headless.json",
       ".claude/settings.json",

--- a/plugins/dotclaude/tests/validate-skills-inventory.test.mjs
+++ b/plugins/dotclaude/tests/validate-skills-inventory.test.mjs
@@ -369,10 +369,11 @@ key = sk-abcdef123456
 
 describe("validateAgents — shipped template agents", () => {
   it("returns 0 errors for all 8 agents in templates/claude/agents/", () => {
-    const repoRoot = resolve(__dirname, "..", "..", "..", "..");
+    const repoRoot = resolve(__dirname, "..", "..", "..");
     const agentsDir = resolve(repoRoot, "plugins", "dotclaude", "templates", "claude");
     const result = validateAgents(agentsDir);
     expect(result.errors).toEqual([]);
     expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
   });
 });

--- a/plugins/dotclaude/tests/validate-skills-inventory.test.mjs
+++ b/plugins/dotclaude/tests/validate-skills-inventory.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { fileURLToPath } from "url";
-import path from "path";
+import path, { resolve } from "path";
 import { readFileSync, writeFileSync, mkdtempSync, cpSync, unlinkSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { createHarnessContext } from "../src/spec-harness-lib.mjs";
@@ -360,5 +360,19 @@ key = sk-abcdef123456
     writeAgent(dir, "clean-agent.md", VALID_AGENT);
     const result = validateAgents(dir);
     expect(result.warnings).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAgents — shipped template agents
+// ---------------------------------------------------------------------------
+
+describe("validateAgents — shipped template agents", () => {
+  it("returns 0 errors for all 8 agents in templates/claude/agents/", () => {
+    const repoRoot = resolve(__dirname, "..", "..", "..", "..");
+    const agentsDir = resolve(repoRoot, "plugins", "dotclaude", "templates", "claude");
+    const result = validateAgents(agentsDir);
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
   });
 });

--- a/plugins/dotclaude/tests/validate-skills-inventory.test.mjs
+++ b/plugins/dotclaude/tests/validate-skills-inventory.test.mjs
@@ -4,7 +4,7 @@ import path from "path";
 import { readFileSync, writeFileSync, mkdtempSync, cpSync, unlinkSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { createHarnessContext } from "../src/spec-harness-lib.mjs";
-import { validateManifest, refreshChecksums } from "../src/validate-skills-inventory.mjs";
+import { validateManifest, refreshChecksums, validateAgents } from "../src/validate-skills-inventory.mjs";
 import { ValidationError, ERROR_CODES } from "../src/lib/errors.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -114,5 +114,251 @@ describe("refreshChecksums", () => {
     refreshChecksums(ctx);
     const result = validateManifest(ctx);
     expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAgents
+// ---------------------------------------------------------------------------
+
+function makeAgentDir() {
+  const tmp = mkdtempSync(path.join(tmpdir(), "agent-test-"));
+  mkdirSync(path.join(tmp, "agents"), { recursive: true });
+  return tmp;
+}
+
+function writeAgent(dir, filename, content) {
+  writeFileSync(path.join(dir, "agents", filename), content, "utf8");
+}
+
+const VALID_AGENT = `---
+name: my-agent
+description: Does something useful
+tools: Read, Grep
+model: sonnet
+---
+
+This is a valid agent body.
+`;
+
+describe("validateAgents — valid agent", () => {
+  it("passes when all required fields are present and model is valid", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "my-agent.md", VALID_AGENT);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});
+
+describe("validateAgents — missing required fields", () => {
+  it("emits AGENT_MISSING_FIELD when model: is absent", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "no-model.md", `---
+name: no-model
+description: Missing model field
+tools: Read
+---
+
+Body here.
+`);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(false);
+    const err = result.errors.find((e) => e.code === ERROR_CODES.AGENT_MISSING_FIELD);
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/model/);
+    expect(err.file).toMatch(/no-model\.md/);
+  });
+
+  it("emits AGENT_MISSING_FIELD when name: is absent", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "no-name.md", `---
+description: No name
+tools: Read
+model: haiku
+---
+`);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(false);
+    const err = result.errors.find((e) => e.code === ERROR_CODES.AGENT_MISSING_FIELD);
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/name/);
+  });
+
+  it("emits AGENT_MISSING_FIELD when description: is absent", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "no-desc.md", `---
+name: no-desc
+tools: Read
+model: haiku
+---
+`);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(false);
+    const err = result.errors.find((e) => e.code === ERROR_CODES.AGENT_MISSING_FIELD);
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/description/);
+  });
+
+  it("emits AGENT_MISSING_FIELD when tools: is absent", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "no-tools.md", `---
+name: no-tools
+description: No tools
+model: haiku
+---
+`);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(false);
+    const err = result.errors.find((e) => e.code === ERROR_CODES.AGENT_MISSING_FIELD);
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/tools/);
+  });
+});
+
+describe("validateAgents — invalid model value", () => {
+  it("emits AGENT_INVALID_MODEL when model value is not in the allowed set", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "bad-model.md", `---
+name: bad-model
+description: Bad model value
+tools: Read
+model: turbo
+---
+`);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(false);
+    const err = result.errors.find((e) => e.code === ERROR_CODES.AGENT_INVALID_MODEL);
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/turbo/);
+    expect(err.message).toMatch(/opus|sonnet|haiku|inherit/);
+    expect(err.file).toMatch(/bad-model\.md/);
+  });
+
+  it("accepts all four valid model values", () => {
+    for (const model of ["opus", "sonnet", "haiku", "inherit"]) {
+      const dir = makeAgentDir();
+      writeAgent(dir, `${model}-agent.md`, `---
+name: ${model}-agent
+description: Testing ${model}
+tools: Read
+model: ${model}
+---
+`);
+      const result = validateAgents(dir);
+      expect(result.ok).toBe(true, `model "${model}" should be valid`);
+    }
+  });
+});
+
+describe("validateAgents — SEC-2 read-only agents must not have write tools", () => {
+  it("emits AGENT_WRITE_TOOL_IN_READONLY when *-reviewer has Write in tools", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "code-reviewer.md", `---
+name: code-reviewer
+description: Reviews code
+tools: Read, Write, Grep
+model: sonnet
+---
+`);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(false);
+    const err = result.errors.find((e) => e.code === ERROR_CODES.AGENT_WRITE_TOOL_IN_READONLY);
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/Write/);
+    expect(err.file).toMatch(/code-reviewer\.md/);
+  });
+
+  it("emits AGENT_WRITE_TOOL_IN_READONLY when *-auditor has Edit in tools", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "security-auditor.md", `---
+name: security-auditor
+description: Audits security
+tools: Read, Edit
+model: opus
+---
+`);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(false);
+    const err = result.errors.find((e) => e.code === ERROR_CODES.AGENT_WRITE_TOOL_IN_READONLY);
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/Edit/);
+  });
+
+  it("emits AGENT_WRITE_TOOL_IN_READONLY when *-inspector has Write in tools", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "log-inspector.md", `---
+name: log-inspector
+description: Inspects logs
+tools: Bash, Write
+model: haiku
+---
+`);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(false);
+    const err = result.errors.find((e) => e.code === ERROR_CODES.AGENT_WRITE_TOOL_IN_READONLY);
+    expect(err).toBeDefined();
+  });
+
+  it("does NOT flag a non-readonly agent that has Write in tools", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "backend-developer.md", `---
+name: backend-developer
+description: Develops backends
+tools: Read, Write, Edit
+model: sonnet
+---
+`);
+    const result = validateAgents(dir);
+    expect(result.ok).toBe(true);
+    expect(result.errors.filter((e) => e.code === ERROR_CODES.AGENT_WRITE_TOOL_IN_READONLY)).toHaveLength(0);
+  });
+});
+
+describe("validateAgents — SEC-1 secret pattern detection", () => {
+  it("emits AGENT_SECRET_PATTERN warning when ghp_ appears in body", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "risky-agent.md", `---
+name: risky-agent
+description: Has secrets
+tools: Read
+model: haiku
+---
+
+# Config
+token = ghp_abc123secrettoken
+`);
+    const result = validateAgents(dir);
+    // Warnings do not cause ok=false, only errors do
+    expect(result.warnings.length).toBeGreaterThan(0);
+    const warn = result.warnings.find((w) => w.code === ERROR_CODES.AGENT_SECRET_PATTERN);
+    expect(warn).toBeDefined();
+    expect(warn.message).toMatch(/ghp_/);
+    expect(warn.file).toMatch(/risky-agent\.md/);
+  });
+
+  it("emits AGENT_SECRET_PATTERN warning for sk- pattern", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "sk-agent.md", `---
+name: sk-agent
+description: Has a key
+tools: Read
+model: haiku
+---
+
+key = sk-abcdef123456
+`);
+    const result = validateAgents(dir);
+    const warn = result.warnings.find((w) => w.code === ERROR_CODES.AGENT_SECRET_PATTERN);
+    expect(warn).toBeDefined();
+    expect(warn.message).toMatch(/sk-/);
+  });
+
+  it("valid agent with no secrets produces no warnings", () => {
+    const dir = makeAgentDir();
+    writeAgent(dir, "clean-agent.md", VALID_AGENT);
+    const result = validateAgents(dir);
+    expect(result.warnings).toEqual([]);
   });
 });

--- a/skills/agents-search/SKILL.md
+++ b/skills/agents-search/SKILL.md
@@ -5,6 +5,7 @@ description: >
   agents, list installed agents, or refresh the agent catalog.
   Triggers on: "search agents", "list agents", "find agent", "what agents", "agent catalog".
 argument-hint: "search <query> | list | fetch <name> | invalidate [--fetch]"
+tools: Glob, Read, Grep, Write, Bash, WebFetch
 effort: medium
 model: sonnet
 ---
@@ -56,6 +57,8 @@ Find installed agents whose name or description matches a query string.
    No agents found matching '<query>'
    ```
 
+6. If Glob returns no results (no agents installed), check `~/.claude/cache/agents-catalog.md` — if it exists and is less than 12 hours old (use `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)` to check mtime), display results from the catalog instead and note they are from the cached remote catalog.
+
 ---
 
 ### `list`
@@ -86,6 +89,8 @@ List all installed agents grouped by model tier.
    ```
    No agents installed. Run `/agents:search fetch <name>` to install one.
    ```
+
+6. If Glob returns no results (no agents installed), check `~/.claude/cache/agents-catalog.md` — if it exists and is less than 12 hours old (use `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)` to check mtime), display results from the catalog instead and note they are from the cached remote catalog.
 
 ---
 
@@ -123,26 +128,23 @@ Clear the local agent catalog cache, optionally refreshing it from GitHub.
 
 **Steps:**
 
-1. Check whether `~/.claude/cache/agents-catalog.md` exists via `Read`.
+1. **If `--fetch` flag is present:** Read the mtime of `~/.claude/cache/agents-catalog.md`
+   now (before deleting anything) using
+   `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)`.
+   Store the result for informational use later.
+
+2. Check whether `~/.claude/cache/agents-catalog.md` exists via `Read`.
    - If it exists, delete it using `Bash`: `rm ~/.claude/cache/agents-catalog.md`.
    - If it does not exist, note "No cache file found."
 
-2. **Without `--fetch`** (cache clear only):
+3. **Without `--fetch`** (cache clear only):
    Output:
 
    ```
    Cache cleared.
    ```
 
-3. **With `--fetch`** (clear and refresh):
-   - Check cache staleness first: run
-     `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)`
-     to get the mtime epoch. If `(now - mtime) < 43200` (12 hours in seconds), warn:
-
-     ```
-     Cache is less than 12 hours old (refreshed <N> minutes ago). Fetching anyway…
-     ```
-
+4. **With `--fetch`** (clear and refresh — user explicitly requested a fresh fetch):
    - Fetch the catalog using `WebFetch` from:
      `https://raw.githubusercontent.com/VoltAgent/awesome-claude-code-subagents/main/README.md`
      - Use HTTPS only (SEC-3).

--- a/skills/agents-search/SKILL.md
+++ b/skills/agents-search/SKILL.md
@@ -57,7 +57,7 @@ Find installed agents whose name or description matches a query string.
    No agents found matching '<query>'
    ```
 
-6. If Glob returns no results (no agents installed), check `~/.claude/cache/agents-catalog.md` — if it exists and is less than 12 hours old (use `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)` to check mtime), display results from the catalog instead and note they are from the cached remote catalog.
+6. If Glob returns no results (no agents installed), check `~/.claude/cache/agents-catalog.md` — if it exists and is less than 12 hours old (use `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || stat -f %m ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)` to check mtime), display results from the catalog instead and note they are from the cached remote catalog.
 
 ---
 
@@ -90,7 +90,7 @@ List all installed agents grouped by model tier.
    No agents installed. Run `/agents:search fetch <name>` to install one.
    ```
 
-6. If Glob returns no results (no agents installed), check `~/.claude/cache/agents-catalog.md` — if it exists and is less than 12 hours old (use `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)` to check mtime), display results from the catalog instead and note they are from the cached remote catalog.
+6. If Glob returns no results (no agents installed), check `~/.claude/cache/agents-catalog.md` — if it exists and is less than 12 hours old (use `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || stat -f %m ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)` to check mtime), display results from the catalog instead and note they are from the cached remote catalog.
 
 ---
 
@@ -130,7 +130,7 @@ Clear the local agent catalog cache, optionally refreshing it from GitHub.
 
 1. **If `--fetch` flag is present:** Read the mtime of `~/.claude/cache/agents-catalog.md`
    now (before deleting anything) using
-   `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)`.
+   `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || stat -f %m ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)`.
    Store the result for informational use later.
 
 2. Check whether `~/.claude/cache/agents-catalog.md` exists via `Read`.
@@ -174,7 +174,7 @@ Clear the local agent catalog cache, optionally refreshing it from GitHub.
 Whenever `search` or `list` falls back to `~/.claude/cache/agents-catalog.md` for data,
 check whether the cache is stale before using it:
 
-1. Run `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)` to get mtime.
+1. Run `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || stat -f %m ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)` to get mtime.
 2. If `(now - mtime) > 43200` seconds (12 hours), display an inline notice:
 
    ```
@@ -189,16 +189,16 @@ check whether the cache is stale before using it:
 
 All file I/O uses Claude Code built-in tools — this is a skill, not a shell script:
 
-| Operation                       | Tool                      |
-| ------------------------------- | ------------------------- |
-| Enumerate agents                | `Glob`                    |
-| Read file content / frontmatter | `Read`                    |
-| Search catalog content          | `Grep`                    |
-| Write / install agent           | `Write`                   |
-| Delete cache file               | `Bash(rm <path>)`         |
-| Create cache directory          | `Bash(mkdir -p <path>)`   |
-| Check file mtime                | `Bash(stat -c %Y <path>)` |
-| Fetch remote catalog            | `WebFetch`                |
+| Operation                       | Tool                                                                    |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| Enumerate agents                | `Glob`                                                                  |
+| Read file content / frontmatter | `Read`                                                                  |
+| Search catalog content          | `Grep`                                                                  |
+| Write / install agent           | `Write`                                                                 |
+| Delete cache file               | `Bash(rm <path>)`                                                       |
+| Create cache directory          | `Bash(mkdir -p <path>)`                                                 |
+| Check file mtime                | `Bash(stat -c %Y <path>)` (GNU) / `Bash(stat -f %m <path>)` (BSD/macOS) |
+| Fetch remote catalog            | `WebFetch`                                                              |
 
 ---
 

--- a/skills/agents-search/SKILL.md
+++ b/skills/agents-search/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: agents-search
+description: >
+  Discover, search, and manage Claude Code agents. Use when you want to find available
+  agents, list installed agents, or refresh the agent catalog.
+  Triggers on: "search agents", "list agents", "find agent", "what agents", "agent catalog".
+argument-hint: "search <query> | list | fetch <name> | invalidate [--fetch]"
+effort: medium
+model: sonnet
+---
+
+# Agents Search — Discovery and Management
+
+Discover, search, and manage Claude Code sub-agents installed under `~/.claude/agents/`.
+Supports four sub-commands: `search`, `list`, `fetch`, and `invalidate`.
+
+## Arguments
+
+- `$0` — sub-command: `search`, `list`, `fetch`, or `invalidate`. If not provided, default to `list`.
+- `$1` — query string (for `search`), agent name (for `fetch`), or `--fetch` flag (for `invalidate`).
+
+---
+
+## Sub-Commands
+
+### `search <query>`
+
+Find installed agents whose name or description matches a query string.
+
+**Steps:**
+
+1. Use `Glob` to enumerate all files at `~/.claude/agents/*.md`.
+2. For each file, use `Read` to load its content (frontmatter + body). Parse YAML frontmatter
+   (the block between the first `---` and the second `---`) to extract:
+   - `name` (string)
+   - `model` (string, may be absent — default to `inherit`)
+   - `tools` (array or comma-separated string, may be absent — default to `""`)
+   - `description` (string — use only the first line if multi-line)
+3. Perform a **case-insensitive substring match** of `<query>` against both `name` and the first
+   line of `description`. Include a file if either field matches.
+4. If one or more agents match, render a markdown table:
+
+   ```
+   | Name | Model | Tools | Description |
+   | ---- | ----- | ----- | ----------- |
+   | ...  | ...   | ...   | ...         |
+   ```
+
+   - `Tools` column: join array entries with `, ` or display the raw string; truncate to 40 chars
+     with `…` if longer.
+   - `Description` column: first line of the `description` field only.
+
+5. If no agents match, output exactly:
+
+   ```
+   No agents found matching '<query>'
+   ```
+
+---
+
+### `list`
+
+List all installed agents grouped by model tier.
+
+**Steps:**
+
+1. Use `Glob` to enumerate all files at `~/.claude/agents/*.md`.
+2. For each file, `Read` its frontmatter and extract `name`, `model`, `tools`, `description`
+   (same parsing rules as `search`).
+3. Group agents by model tier in this order:
+   - **opus** — entries where `model` contains `opus`
+   - **sonnet** — entries where `model` contains `sonnet`
+   - **haiku** — entries where `model` contains `haiku`
+   - **inherit** — entries with no `model` field, `model: inherit`, or any other value
+4. For each non-empty tier, render a section header and a table:
+
+   ```markdown
+   ### Opus
+
+   | Name | Model | Tools | Description |
+   | ---- | ----- | ----- | ----------- |
+   ```
+
+5. If `~/.claude/agents/` does not exist or contains no `.md` files, output:
+
+   ```
+   No agents installed. Run `/agents:search fetch <name>` to install one.
+   ```
+
+---
+
+### `fetch <name>`
+
+Read a specific agent's full definition and offer install / view options.
+
+**Steps:**
+
+1. Construct the local path `~/.claude/agents/<name>.md`.
+2. Attempt `Read` on that path.
+   - **If found locally:** display the agent's frontmatter fields (one per line, `key: value`)
+     followed by the full body. Then present the user with options:
+     - Already installed — offer to re-display or customize.
+     - Customize — open the file for editing via a follow-up Edit call.
+     - View only — no further action.
+3. **If not found locally:** check whether `~/.claude/cache/agents-catalog.md` exists via `Read`.
+   - If the catalog exists, search it for a section or entry matching `<name>` (case-insensitive).
+     If a match is found, display the matching content and offer the user three options:
+     - Install — write the agent definition to `~/.claude/agents/<name>.md` using `Write`.
+     - Customize — show the content and ask the user to provide edits before writing.
+     - View only — no further action.
+   - If the catalog does not exist or contains no match, output:
+
+     ```
+     Agent '<name>' not found locally or in catalog.
+     Run `/agents:search invalidate --fetch` to refresh the catalog, then try again.
+     ```
+
+---
+
+### `invalidate [--fetch]`
+
+Clear the local agent catalog cache, optionally refreshing it from GitHub.
+
+**Steps:**
+
+1. Check whether `~/.claude/cache/agents-catalog.md` exists via `Read`.
+   - If it exists, delete it using `Bash`: `rm ~/.claude/cache/agents-catalog.md`.
+   - If it does not exist, note "No cache file found."
+
+2. **Without `--fetch`** (cache clear only):
+   Output:
+
+   ```
+   Cache cleared.
+   ```
+
+3. **With `--fetch`** (clear and refresh):
+   - Check cache staleness first: run
+     `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)`
+     to get the mtime epoch. If `(now - mtime) < 43200` (12 hours in seconds), warn:
+
+     ```
+     Cache is less than 12 hours old (refreshed <N> minutes ago). Fetching anyway…
+     ```
+
+   - Fetch the catalog using `WebFetch` from:
+     `https://raw.githubusercontent.com/VoltAgent/awesome-claude-code-subagents/main/README.md`
+     - Use HTTPS only (SEC-3).
+     - If the fetch succeeds, ensure `~/.claude/cache/` exists
+       (`Bash: mkdir -p ~/.claude/cache`) and save the content to
+       `~/.claude/cache/agents-catalog.md` using `Write`.
+       Output:
+
+       ```
+       Catalog refreshed. <N> bytes written to ~/.claude/cache/agents-catalog.md
+       ```
+
+     - If the fetch fails (network error, non-200, timeout), **do not hard-fail** (REL-1).
+       Warn the user:
+
+       ```
+       Warning: Could not fetch catalog (network error). Existing cache cleared.
+       Run `/agents:search invalidate --fetch` again when connectivity is restored.
+       ```
+
+       Do not throw or abort; return gracefully.
+
+---
+
+## Cache TTL
+
+Whenever `search` or `list` falls back to `~/.claude/cache/agents-catalog.md` for data,
+check whether the cache is stale before using it:
+
+1. Run `Bash(stat -c %Y ~/.claude/cache/agents-catalog.md 2>/dev/null || echo 0)` to get mtime.
+2. If `(now - mtime) > 43200` seconds (12 hours), display an inline notice:
+
+   ```
+   (Cache is stale — last updated more than 12 h ago. Run `/agents:search invalidate --fetch` to refresh.)
+   ```
+
+   Then continue with the stale data rather than blocking the user.
+
+---
+
+## Tool Usage
+
+All file I/O uses Claude Code built-in tools — this is a skill, not a shell script:
+
+| Operation                       | Tool                         |
+| ------------------------------- | ---------------------------- |
+| Enumerate agents                | `Glob`                       |
+| Read file content / frontmatter | `Read`                       |
+| Search catalog content          | `Grep`                       |
+| Write / install agent           | `Write`                      |
+| Delete cache file               | `Bash(rm <path>)`            |
+| Create cache directory          | `Bash(mkdir -p <path>)`      |
+| Check file mtime                | `Bash(stat -c %Y <path>)`    |
+| Fetch remote catalog            | `WebFetch`                   |
+
+---
+
+## Key Principles
+
+1. **Case-insensitive everywhere.** All name and description matching is case-insensitive.
+2. **Graceful degradation.** Network failures in `invalidate --fetch` warn and continue; they
+   never abort the session or raise an unhandled error (REL-1).
+3. **HTTPS only.** The catalog URL must always use `https://` (SEC-3).
+4. **Read before write.** Use `Read` to check existing files before `Write` to avoid blind
+   overwrites without user confirmation.
+5. **User drives installs.** Never silently write to `~/.claude/agents/` without presenting
+   options and getting implicit or explicit user consent.
+6. **Tier order is fixed.** `list` always outputs opus → sonnet → haiku → inherit. Never
+   reorder based on agent count or alphabetical sort within tiers (alphabetical within a tier
+   is acceptable).

--- a/skills/agents-search/SKILL.md
+++ b/skills/agents-search/SKILL.md
@@ -189,16 +189,16 @@ check whether the cache is stale before using it:
 
 All file I/O uses Claude Code built-in tools — this is a skill, not a shell script:
 
-| Operation                       | Tool                         |
-| ------------------------------- | ---------------------------- |
-| Enumerate agents                | `Glob`                       |
-| Read file content / frontmatter | `Read`                       |
-| Search catalog content          | `Grep`                       |
-| Write / install agent           | `Write`                      |
-| Delete cache file               | `Bash(rm <path>)`            |
-| Create cache directory          | `Bash(mkdir -p <path>)`      |
-| Check file mtime                | `Bash(stat -c %Y <path>)`    |
-| Fetch remote catalog            | `WebFetch`                   |
+| Operation                       | Tool                      |
+| ------------------------------- | ------------------------- |
+| Enumerate agents                | `Glob`                    |
+| Read file content / frontmatter | `Read`                    |
+| Search catalog content          | `Grep`                    |
+| Write / install agent           | `Write`                   |
+| Delete cache file               | `Bash(rm <path>)`         |
+| Create cache directory          | `Bash(mkdir -p <path>)`   |
+| Check file mtime                | `Bash(stat -c %Y <path>)` |
+| Fetch remote catalog            | `WebFetch`                |
 
 ---
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -8,6 +8,7 @@ description: >
   Works for greenfield and brownfield projects. Outputs to docs/specs/.
 argument-hint: "[spec-name] [description] [--brownfield]"
 effort: max
+model: opus
 ---
 
 # Spec-Driven Design

--- a/skills/validate-spec/SKILL.md
+++ b/skills/validate-spec/SKILL.md
@@ -11,6 +11,7 @@ description: >
   spec itself.
 argument-hint: "[spec-id] [--no-run]"
 effort: max
+model: sonnet
 ---
 
 # Validate Spec — Implementation Audit


### PR DESCRIPTION
## Summary

- Adds first-class agent support to dotclaude: 8 bundled starter agents in `plugins/dotclaude/templates/claude/agents/`, wired into `plugin.json` and `bootstrap.sh` (idempotent, never overwrites user edits).
- Introduces `model:` frontmatter routing (`opus`/`sonnet`/`haiku`/`inherit`) across all 16 commands and skills so each runs on the right Claude tier.
- Ships `/agents:search` discovery skill with `search`, `list`, `fetch`, `invalidate` sub-commands, 12h TTL cache at `~/.claude/cache/agents-catalog.md`, and graceful degradation on network failure (REL-1, SEC-3 HTTPS-only).
- Extends `dotclaude-validate-skills` with agent frontmatter linting: required fields, model allowlist, SEC-1 secret-pattern warnings, SEC-2 read-only tool enforcement for `*-auditor`/`*-reviewer`/`*-inspector` agents. Wired into the existing CI step — enforced on every dogfood run.

## Test plan

- [x] `npm test` — 114/114 tests pass (14 files)
- [x] `node plugins/dotclaude/bin/dotclaude-validate-skills.mjs .` — reports `agents valid (no errors)` alongside manifest results
- [x] All 8 shipped template agents pass validation (0 errors, 0 warnings)
- [x] `bash -n bootstrap.sh` — syntax OK
- [ ] Fresh `./bootstrap.sh` on a clean `~/.claude/` installs all 8 agents to `~/.claude/agents/`
- [ ] Re-running `./bootstrap.sh` on an existing install skips each agent with the "delete to reinstall" hint
- [ ] `/agents:search list` returns the 8 installed agents grouped by model tier
- [ ] `/agents:search search auditor` returns `security-auditor`
- [ ] Tampered agent (e.g. `security-auditor` with `Write` added to tools) fails validation with a clear SEC-2 error

## Spec ID

dotclaude-agents
