### PR TITLE
feat(cli): bootstrap + sync subcommands for global ~/.claude/ lifecycle

### DIFF
--- a/docs/specs/cli-bootstrap-command/README.md
+++ b/docs/specs/cli-bootstrap-command/README.md
@@ -6,16 +6,16 @@
 
 ## Status
 
-| #   | Section                     | Status     |
-| --- | --------------------------- | ---------- |
-| 1   | Problem / Motivation        | [x] done   |
-| 2   | Scope                       | [x] done   |
-| 3   | High-Level Architecture     | [x] done   |
-| 4   | Data Flow / Components      | [x] done   |
-| 5   | Interfaces and APIs         | [x] done   |
-| 6   | Implementation Plan         | [x] done   |
-| 7   | Non-Functional Requirements | [x] done   |
-| 8   | Risks and Alternatives      | [x] done   |
+| #   | Section                     | Status   |
+| --- | --------------------------- | -------- |
+| 1   | Problem / Motivation        | [x] done |
+| 2   | Scope                       | [x] done |
+| 3   | High-Level Architecture     | [x] done |
+| 4   | Data Flow / Components      | [x] done |
+| 5   | Interfaces and APIs         | [x] done |
+| 6   | Implementation Plan         | [x] done |
+| 7   | Non-Functional Requirements | [x] done |
+| 8   | Risks and Alternatives      | [x] done |
 
 ## Quick Start
 

--- a/docs/specs/cli-bootstrap-command/README.md
+++ b/docs/specs/cli-bootstrap-command/README.md
@@ -1,0 +1,29 @@
+# cli-bootstrap-command — Engineering Spec
+
+> Add `dotclaude bootstrap` and `dotclaude sync` commands to the CLI so developers can set up and update their global `~/.claude/` configuration without running `bootstrap.sh` directly.
+>
+> Created: 2026-04-15
+
+## Status
+
+| #   | Section                     | Status     |
+| --- | --------------------------- | ---------- |
+| 1   | Problem / Motivation        | [x] done   |
+| 2   | Scope                       | [x] done   |
+| 3   | High-Level Architecture     | [x] done   |
+| 4   | Data Flow / Components      | [x] done   |
+| 5   | Interfaces and APIs         | [x] done   |
+| 6   | Implementation Plan         | [x] done   |
+| 7   | Non-Functional Requirements | [x] done   |
+| 8   | Risks and Alternatives      | [x] done   |
+
+## Quick Start
+
+1. **Problem:** [`spec/1-problem-motivation.md`](spec/1-problem-motivation.md) — why the CLI/bootstrap split is the issue
+2. **What to build:** [`spec/5-interfaces-apis.md`](spec/5-interfaces-apis.md) — exact CLI flags, Node API, and `package.json` changes
+3. **How to build it:** [`spec/6-implementation-plan.md`](spec/6-implementation-plan.md) — 4 phased prompts with TDD test names
+4. **Key decisions:** [`spec/4-data-flow-components.md`](spec/4-data-flow-components.md#key-decisions) — KD-1 (agents copy), KD-2 (secret-scan), KD-3 (symlink-to-npm-dir)
+
+## Research Sources
+
+See [research/sources.md](research/sources.md) for indexed source documents (DOC-1 through DOC-8).

--- a/docs/specs/cli-bootstrap-command/research/sources.md
+++ b/docs/specs/cli-bootstrap-command/research/sources.md
@@ -1,0 +1,12 @@
+# Research Sources
+
+> Indexed documents feeding into this spec. Each tagged with which sections it informs.
+
+- **DOC-1**: `bootstrap.sh` — shell script that symlinks dotclaude files into `~/.claude/`; canonical reference for the symlinking algorithm, backup behavior, and agent-copy logic. Feeds: §1, §4, §6.
+- **DOC-2**: `sync.sh` — pull/push/status wrapper; canonical reference for git rebase flow, secret-scan regex (`SECRET_RX`), and `HARNESS_SYNC_SKIP_SECRET_SCAN` escape hatch. Feeds: §4, §6, §7.
+- **DOC-3**: `plugins/dotclaude/bin/dotclaude.mjs` — umbrella dispatcher; defines `SUBCOMMANDS` array and spawn pattern all bins must follow. Feeds: §3, §5, §6.
+- **DOC-4**: `plugins/dotclaude/bin/dotclaude-init.mjs` — reference implementation for a bin entry-point (arg parsing, META, exit code mapping). Feeds: §6.
+- **DOC-5**: `plugins/dotclaude/src/lib/output.mjs` — `createOutput` / ✓/✗/⚠ format contract all new modules must use. Feeds: §4, §5.
+- **DOC-6**: `plugins/dotclaude/src/lib/argv.mjs` — `parse()` / `helpText()` contract; defines `HARNESS_FLAGS` and the `FlagsSpec` type. Feeds: §5.
+- **DOC-7**: `package.json` — `files` array and `bin` map; defines what ships in the tarball and what bins are registered. Feeds: §2, §5, §6.
+- **DOC-8**: `docs/repo-facts.json` — protected paths list; confirms that `commands/`, `skills/`, `CLAUDE.md` are not currently in the `files` array of the npm package. Feeds: §2.

--- a/docs/specs/cli-bootstrap-command/spec.json
+++ b/docs/specs/cli-bootstrap-command/spec.json
@@ -1,0 +1,31 @@
+{
+  "id": "cli-bootstrap-command",
+  "title": "dotclaude bootstrap + sync CLI commands",
+  "status": "draft",
+  "owners": ["dotclaude maintainers"],
+  "linked_paths": [
+    "package.json",
+    "bootstrap.sh",
+    "sync.sh",
+    "commands/**",
+    "skills/**",
+    "CLAUDE.md",
+    "plugins/dotclaude/src/bootstrap-global.mjs",
+    "plugins/dotclaude/src/sync-global.mjs",
+    "plugins/dotclaude/src/index.mjs",
+    "plugins/dotclaude/bin/dotclaude-bootstrap.mjs",
+    "plugins/dotclaude/bin/dotclaude-sync.mjs",
+    "plugins/dotclaude/bin/dotclaude.mjs",
+    "plugins/dotclaude/bin/dotclaude-doctor.mjs",
+    "plugins/dotclaude/tests/bootstrap-global.test.mjs",
+    "plugins/dotclaude/tests/sync-global.test.mjs"
+  ],
+  "acceptance_commands": [
+    "npm test",
+    "node plugins/dotclaude/bin/dotclaude-bootstrap.mjs --help",
+    "node plugins/dotclaude/bin/dotclaude-sync.mjs --help",
+    "npx dotclaude-validate-specs"
+  ],
+  "depends_on_specs": ["dotclaude-core"],
+  "active_prs": []
+}

--- a/docs/specs/cli-bootstrap-command/spec/1-problem-motivation.md
+++ b/docs/specs/cli-bootstrap-command/spec/1-problem-motivation.md
@@ -1,0 +1,54 @@
+# §1 — Problem / Motivation
+
+> Why does this exist? What's broken? Why now?
+
+## Why
+
+The dotclaude distribution is currently split across two disconnected tools:
+`bootstrap.sh` (a shell script that wires `~/.claude/`) and the `dotclaude`
+CLI (an npm package that governs per-repo spec workflows). A developer who
+installs `npm install -g @dotclaude/dotclaude` gets no way to set up their
+global `~/.claude/` from the same tool — they must separately discover,
+clone, and run `bootstrap.sh`. Likewise, keeping the global config current
+requires knowing where the clone lives and running `./sync.sh pull` from it.
+
+This creates two classes of friction:
+
+1. **Onboarding gap.** New developers must learn two separate entry-points,
+   two invocation styles (bash vs npm), and two update flows. Telling a new
+   dev "install the CLI, then separately clone the repo and run bootstrap.sh"
+   creates unnecessary cognitive load when the CLI could handle both.
+
+2. **Update friction.** Pulling recent configuration changes requires
+   navigating to the dotclaude clone and running a shell script. There is no
+   `dotclaude sync pull` that a developer can run from any directory.
+
+## What
+
+Add two new subcommands to the `dotclaude` CLI:
+
+- **`dotclaude bootstrap`** — sets up (or refreshes) `~/.claude/` by
+  symlinking `commands/`, `skills/`, `CLAUDE.md`, and the agents template
+  directory into place. Works in two modes:
+  - **npm mode** (default): sources files from the npm package's own install
+    directory; no git clone required.
+  - **clone mode** (`--source <path>` / `DOTCLAUDE_DIR`): sources files from
+    a local git clone, identical behavior to `bootstrap.sh`.
+
+- **`dotclaude sync`** — manages keeping the global config current:
+  - `pull`: in npm mode, runs `npm update -g @dotclaude/dotclaude` then
+    re-bootstraps; in clone mode, `git fetch + rebase` then re-bootstraps.
+  - `status`: in npm mode, reports current vs. latest npm version; in clone
+    mode, delegates to `git status --short` on the clone.
+  - `push`: clone-mode-only; mirrors `sync.sh push` (secret-scan + commit +
+    push).
+
+`bootstrap.sh` and `sync.sh` are not removed — they remain the zero-npm
+fallback for users who prefer a shell-only path.
+
+## Why Now
+
+The new developer onboarding conversation exposed that the split creates a
+confusing "two tools for one concept" story. As the project grows its user
+base, the CLI is the natural single entry-point; `bootstrap.sh` should become
+an implementation detail rather than a required step in the setup docs.

--- a/docs/specs/cli-bootstrap-command/spec/2-scope.md
+++ b/docs/specs/cli-bootstrap-command/spec/2-scope.md
@@ -29,14 +29,14 @@
 
 ## Boundaries
 
-| Touches | Does Not Touch |
-| ------- | -------------- |
-| `plugins/dotclaude/bin/` — two new bins | `bootstrap.sh`, `sync.sh` |
-| `plugins/dotclaude/src/` — two new modules | `validate-specs.mjs`, `check-spec-coverage.mjs` |
-| `plugins/dotclaude/src/index.mjs` — two new exports | `spec-harness-lib.mjs` |
-| `plugins/dotclaude/bin/dotclaude.mjs` — SUBCOMMANDS array | Per-repo `.claude/` scaffold logic |
-| `package.json` — `files`, `bin` | `docs/repo-facts.json` protected paths (no new paths) |
-| `plugins/dotclaude/bin/dotclaude-doctor.mjs` — bootstrap check | Any downstream consumer repos |
+| Touches                                                        | Does Not Touch                                        |
+| -------------------------------------------------------------- | ----------------------------------------------------- |
+| `plugins/dotclaude/bin/` — two new bins                        | `bootstrap.sh`, `sync.sh`                             |
+| `plugins/dotclaude/src/` — two new modules                     | `validate-specs.mjs`, `check-spec-coverage.mjs`       |
+| `plugins/dotclaude/src/index.mjs` — two new exports            | `spec-harness-lib.mjs`                                |
+| `plugins/dotclaude/bin/dotclaude.mjs` — SUBCOMMANDS array      | Per-repo `.claude/` scaffold logic                    |
+| `package.json` — `files`, `bin`                                | `docs/repo-facts.json` protected paths (no new paths) |
+| `plugins/dotclaude/bin/dotclaude-doctor.mjs` — bootstrap check | Any downstream consumer repos                         |
 
 ## Urgency
 

--- a/docs/specs/cli-bootstrap-command/spec/2-scope.md
+++ b/docs/specs/cli-bootstrap-command/spec/2-scope.md
@@ -1,0 +1,45 @@
+# §2 — Scope
+
+> What's in, what's out, and where are the boundaries?
+
+## In Scope
+
+- New `dotclaude-bootstrap.mjs` bin and `bootstrap-global.mjs` src module
+- New `dotclaude-sync.mjs` bin and `sync-global.mjs` src module
+- `dotclaude.mjs` dispatcher updated to recognise `bootstrap` and `sync` subcommands
+- `package.json` `files` array extended to ship `commands/`, `skills/`, `CLAUDE.md`
+- `package.json` `bin` map extended with `dotclaude-bootstrap` and `dotclaude-sync`
+- `index.mjs` barrel extended with `bootstrapGlobal` and `syncGlobal` exports
+- Unit + integration tests for both new modules
+- README and CLI reference docs updated
+- `dotclaude-doctor` updated to check bootstrap state (symlinks present + valid)
+
+## Out of Scope
+
+- Removing or modifying `bootstrap.sh` / `sync.sh` — they remain the zero-npm
+  fallback path and keep working unchanged
+- A `sync push` equivalent in npm mode — secret-scanning and auto-committing
+  the dotclaude repo is a clone-mode-only concern
+- Windows support — `~/.claude/` symlinking on Windows requires elevated
+  permissions and is deferred; the bins will emit a clear `OPS-1` error on
+  `win32` platform
+- GUI / TUI — the commands follow the existing ✓/✗/⚠ output convention
+- `dotclaude update` as an alias — subcommand naming stays consistent with
+  existing conventions (`sync pull` mirrors `sync.sh pull`)
+
+## Boundaries
+
+| Touches | Does Not Touch |
+| ------- | -------------- |
+| `plugins/dotclaude/bin/` — two new bins | `bootstrap.sh`, `sync.sh` |
+| `plugins/dotclaude/src/` — two new modules | `validate-specs.mjs`, `check-spec-coverage.mjs` |
+| `plugins/dotclaude/src/index.mjs` — two new exports | `spec-harness-lib.mjs` |
+| `plugins/dotclaude/bin/dotclaude.mjs` — SUBCOMMANDS array | Per-repo `.claude/` scaffold logic |
+| `package.json` — `files`, `bin` | `docs/repo-facts.json` protected paths (no new paths) |
+| `plugins/dotclaude/bin/dotclaude-doctor.mjs` — bootstrap check | Any downstream consumer repos |
+
+## Urgency
+
+No hard deadline. This is a developer-experience improvement, not a bug fix.
+Blocking on merging any in-flight spec work (`dotclaude-agents`, PR #28)
+that also touches `index.mjs` and the bin list would reduce merge friction.

--- a/docs/specs/cli-bootstrap-command/spec/3-high-level-architecture.md
+++ b/docs/specs/cli-bootstrap-command/spec/3-high-level-architecture.md
@@ -1,0 +1,74 @@
+# §3 — High-Level Architecture
+
+> System view: components, data stores, external dependencies, deployment.
+
+## System Overview
+
+The feature adds a "global config layer" to the CLI. Today the CLI only
+operates on a per-repo target directory; the new commands operate on the
+developer's home directory (`~/.claude/`).
+
+```
+Developer machine
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│  dotclaude bootstrap / sync                             │
+│         │                                               │
+│         ▼                                               │
+│  bootstrap-global.mjs ◄── source resolver               │
+│         │                  ├─ npm mode:                 │
+│         │                  │   import.meta.url → pkg    │
+│         │                  │   root → commands/ skills/ │
+│         │                  └─ clone mode:               │
+│         │                      DOTCLAUDE_DIR / --source │
+│         │                                               │
+│         ▼                                               │
+│  ~/.claude/                                             │
+│    ├── CLAUDE.md          ← symlink                     │
+│    ├── commands/*.md      ← symlinks                    │
+│    ├── skills/*/          ← symlinks                    │
+│    └── agents/*.md        ← copies (skip if exists)     │
+│                                                         │
+│  sync-global.mjs                                        │
+│    ├── npm mode:  npm update -g → bootstrap             │
+│    └── clone mode: git fetch/rebase → bootstrap         │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+ARCH-1: All writes are idempotent. Re-running `dotclaude bootstrap` on an
+already-bootstrapped machine must produce the same state without data loss.
+Existing symlinks are updated if they point elsewhere; real files are backed
+up with a `.bak-<timestamp>` suffix before overwriting (identical to
+`bootstrap.sh` behavior).
+
+ARCH-2: Source resolution is deterministic and explicit. The resolution order
+is: `--source` flag → `DOTCLAUDE_DIR` env var → npm package root (derived
+from `import.meta.url`). No silent fallbacks.
+
+ARCH-3: The two modes (npm / clone) share the same `bootstrap-global.mjs`
+logic. Only the source path resolution differs; the symlinking operations are
+identical.
+
+## Data Stores
+
+| Store | Role | Access Pattern |
+| ----- | ---- | -------------- |
+| `~/.claude/` | Target directory for symlinks | Read on status checks; write on bootstrap |
+| npm global registry (`registry.npmjs.org`) | Version check + update for `sync pull` in npm mode | Read-only HTTP GET; only on explicit `sync pull` |
+| git remote (`origin`) | Source of truth for clone mode `sync pull` | Read-only fetch + rebase on explicit `sync pull` |
+
+## External APIs / Dependencies
+
+| Service | Purpose | Rate Limits / Constraints |
+| ------- | ------- | ------------------------- |
+| `registry.npmjs.org` | `npm view @dotclaude/dotclaude version` for `sync status` + `npm update -g` for `sync pull` | npm rate-limits unauthenticated fetches to ~1 req/sec; trivial for interactive CLI use |
+| `git` binary | Clone-mode `sync pull` / `push` / `status` | Must be present in PATH; absence is an ENV error (exit 2) |
+| `npm` binary | npm-mode `sync pull` | Must be present in PATH; absence is an ENV error (exit 2) |
+
+## Deployment
+
+Shipped as part of the `@dotclaude/dotclaude` npm package. No additional
+infrastructure. The two new source files are bundled in the same package;
+`commands/`, `skills/`, and `CLAUDE.md` are added to the `files` array so
+they are included in the published tarball.

--- a/docs/specs/cli-bootstrap-command/spec/3-high-level-architecture.md
+++ b/docs/specs/cli-bootstrap-command/spec/3-high-level-architecture.md
@@ -52,19 +52,19 @@ identical.
 
 ## Data Stores
 
-| Store | Role | Access Pattern |
-| ----- | ---- | -------------- |
-| `~/.claude/` | Target directory for symlinks | Read on status checks; write on bootstrap |
+| Store                                      | Role                                               | Access Pattern                                   |
+| ------------------------------------------ | -------------------------------------------------- | ------------------------------------------------ |
+| `~/.claude/`                               | Target directory for symlinks                      | Read on status checks; write on bootstrap        |
 | npm global registry (`registry.npmjs.org`) | Version check + update for `sync pull` in npm mode | Read-only HTTP GET; only on explicit `sync pull` |
-| git remote (`origin`) | Source of truth for clone mode `sync pull` | Read-only fetch + rebase on explicit `sync pull` |
+| git remote (`origin`)                      | Source of truth for clone mode `sync pull`         | Read-only fetch + rebase on explicit `sync pull` |
 
 ## External APIs / Dependencies
 
-| Service | Purpose | Rate Limits / Constraints |
-| ------- | ------- | ------------------------- |
+| Service              | Purpose                                                                                     | Rate Limits / Constraints                                                              |
+| -------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | `registry.npmjs.org` | `npm view @dotclaude/dotclaude version` for `sync status` + `npm update -g` for `sync pull` | npm rate-limits unauthenticated fetches to ~1 req/sec; trivial for interactive CLI use |
-| `git` binary | Clone-mode `sync pull` / `push` / `status` | Must be present in PATH; absence is an ENV error (exit 2) |
-| `npm` binary | npm-mode `sync pull` | Must be present in PATH; absence is an ENV error (exit 2) |
+| `git` binary         | Clone-mode `sync pull` / `push` / `status`                                                  | Must be present in PATH; absence is an ENV error (exit 2)                              |
+| `npm` binary         | npm-mode `sync pull`                                                                        | Must be present in PATH; absence is an ENV error (exit 2)                              |
 
 ## Deployment
 

--- a/docs/specs/cli-bootstrap-command/spec/4-data-flow-components.md
+++ b/docs/specs/cli-bootstrap-command/spec/4-data-flow-components.md
@@ -1,0 +1,127 @@
+# §4 — Data Flow / Components
+
+> Current state analysis + target architecture.
+
+## Current State
+
+Bootstrap flow today:
+
+```
+Developer
+  │
+  ├─ clone dotclaude repo
+  ├─ cd ~/projects/dotclaude
+  └─ ./bootstrap.sh
+       ├─ symlink CLAUDE.md → ~/.claude/CLAUDE.md
+       ├─ symlink commands/*.md → ~/.claude/commands/
+       ├─ symlink skills/*/ → ~/.claude/skills/
+       └─ copy agents templates → ~/.claude/agents/
+
+Sync flow today:
+  └─ ./sync.sh pull
+       ├─ git fetch origin
+       ├─ git rebase origin/main
+       └─ ./bootstrap.sh   (re-run)
+```
+
+Both flows require the developer to be inside the dotclaude clone directory.
+The npm CLI has no awareness of these operations.
+
+## Component Boundaries
+
+| Component | File | Responsibility |
+| --------- | ---- | -------------- |
+| `dotclaude-bootstrap.mjs` | `bin/` | CLI entry-point: arg parsing, help text, exit codes |
+| `dotclaude-sync.mjs` | `bin/` | CLI entry-point for `sync <subcommand>`; routes to sync-global |
+| `bootstrap-global.mjs` | `src/` | Core symlinking logic: source resolution, backup, link-one, agents copy |
+| `sync-global.mjs` | `src/` | Pull (npm update / git rebase) + status + push; delegates bootstrap step |
+| `dotclaude.mjs` | `bin/` | Umbrella dispatcher; adds `bootstrap` + `sync` to SUBCOMMANDS |
+| `dotclaude-doctor.mjs` | `bin/` | Existing diagnostic; extended to check bootstrap state |
+
+## Shared State
+
+- `~/.claude/` — written by bootstrap, read by doctor. No locking needed;
+  the CLI is not designed for concurrent invocations.
+- `DOTCLAUDE_DIR` environment variable — read by both `bootstrap-global.mjs`
+  and `sync-global.mjs` to locate the clone in clone mode.
+
+## Target Architecture
+
+### bootstrap-global.mjs
+
+```
+bootstrapGlobal(opts)
+  opts: { source?, target?, quiet?, json?, noColor? }
+
+1. resolveSource(opts.source)
+   └─ --source → DOTCLAUDE_DIR → pkgRoot()     [ARCH-2]
+2. resolveTarget(opts.target)
+   └─ opts.target ?? $HOME/.claude
+3. mkdir -p target
+4. linkOne(source/CLAUDE.md, target/CLAUDE.md)
+5. for f in source/commands/*.md:
+     linkOne(f, target/commands/<name>)
+6. for d in source/skills/*/:
+     linkOne(d, target/skills/<name>)
+7. for f in source/plugins/dotclaude/templates/claude/agents/*.md:
+     copyAgent(f, target/agents/<name>)   ← skip if exists [KD-1]
+8. out.pass/fail/warn per step            [ARCH-1]
+
+linkOne(src, dst):
+  if dst is symlink pointing to src → out.pass "ok"
+  if dst is symlink pointing elsewhere → rm + ln -s + out.pass "updated"
+  if dst is real file/dir → mv to dst.bak-<ts> + ln -s + out.warn "backed up"
+  else → ln -s + out.pass "linked"
+```
+
+### sync-global.mjs
+
+```
+syncGlobal(subcommand, opts)
+  subcommand: 'pull' | 'status' | 'push'
+  opts: { source?, quiet?, json?, noColor? }
+
+mode = resolveMode(opts.source)   ← 'npm' | 'clone'
+
+pull (npm mode):
+  1. npm view @dotclaude/dotclaude version → latestVer
+  2. if latestVer === currentVer → out.info "already up to date"
+  3. else: spawnSync('npm', ['update', '-g', '@dotclaude/dotclaude'])
+  4. bootstrapGlobal(opts)
+
+pull (clone mode):
+  1. spawnSync('git', ['-C', source, 'fetch', 'origin'])
+  2. spawnSync('git', ['-C', source, 'rebase', 'origin/main'])
+  3. bootstrapGlobal({ ...opts, source })
+
+status (npm mode):
+  1. currentVer = version (from index.mjs)
+  2. latestVer = npm view @dotclaude/dotclaude version
+  3. out.info "installed: <currentVer>  latest: <latestVer>"
+
+status (clone mode):
+  1. spawnSync('git', ['-C', source, 'status', '--short'])
+
+push (clone mode only):
+  1. secretScan(source)   [KD-2]
+  2. git add -A
+  3. git commit -m "dotclaude: sync <date>"
+  4. git push
+push (npm mode): out.fail "sync push is only available in clone mode (--source)"
+```
+
+### Key Decisions
+
+KD-1: Agents are **copied** (not symlinked) to `~/.claude/agents/` and skipped
+if already present. This mirrors the existing `bootstrap.sh` behavior and
+allows developers to customise their local agent files without having changes
+overwritten on re-bootstrap.
+
+KD-2: `sync push` secret-scanning uses the same regex logic from `sync.sh`
+but reimplemented in Node so the bin is cross-platform (no bash dependency).
+The regex is lifted verbatim into `sync-global.mjs`.
+
+KD-3: In npm mode, symlinks point to the npm package's install directory
+(resolved via `pkgRoot()` which walks up from `import.meta.url`). After
+`npm update -g`, npm replaces the package directory contents, so all symlinks
+automatically reflect the new version without needing to re-run bootstrap.

--- a/docs/specs/cli-bootstrap-command/spec/4-data-flow-components.md
+++ b/docs/specs/cli-bootstrap-command/spec/4-data-flow-components.md
@@ -29,14 +29,14 @@ The npm CLI has no awareness of these operations.
 
 ## Component Boundaries
 
-| Component | File | Responsibility |
-| --------- | ---- | -------------- |
-| `dotclaude-bootstrap.mjs` | `bin/` | CLI entry-point: arg parsing, help text, exit codes |
-| `dotclaude-sync.mjs` | `bin/` | CLI entry-point for `sync <subcommand>`; routes to sync-global |
-| `bootstrap-global.mjs` | `src/` | Core symlinking logic: source resolution, backup, link-one, agents copy |
-| `sync-global.mjs` | `src/` | Pull (npm update / git rebase) + status + push; delegates bootstrap step |
-| `dotclaude.mjs` | `bin/` | Umbrella dispatcher; adds `bootstrap` + `sync` to SUBCOMMANDS |
-| `dotclaude-doctor.mjs` | `bin/` | Existing diagnostic; extended to check bootstrap state |
+| Component                 | File   | Responsibility                                                           |
+| ------------------------- | ------ | ------------------------------------------------------------------------ |
+| `dotclaude-bootstrap.mjs` | `bin/` | CLI entry-point: arg parsing, help text, exit codes                      |
+| `dotclaude-sync.mjs`      | `bin/` | CLI entry-point for `sync <subcommand>`; routes to sync-global           |
+| `bootstrap-global.mjs`    | `src/` | Core symlinking logic: source resolution, backup, link-one, agents copy  |
+| `sync-global.mjs`         | `src/` | Pull (npm update / git rebase) + status + push; delegates bootstrap step |
+| `dotclaude.mjs`           | `bin/` | Umbrella dispatcher; adds `bootstrap` + `sync` to SUBCOMMANDS            |
+| `dotclaude-doctor.mjs`    | `bin/` | Existing diagnostic; extended to check bootstrap state                   |
 
 ## Shared State
 

--- a/docs/specs/cli-bootstrap-command/spec/5-interfaces-apis.md
+++ b/docs/specs/cli-bootstrap-command/spec/5-interfaces-apis.md
@@ -66,8 +66,8 @@ Examples:
 
 ```js
 const SUBCOMMANDS = [
-  "bootstrap",   // ← new
-  "sync",        // ← new
+  "bootstrap", // ← new
+  "sync", // ← new
   "validate-skills",
   "validate-specs",
   "check-spec-coverage",
@@ -142,16 +142,16 @@ export { syncGlobal } from "./sync-global.mjs";
     "plugins/dotclaude/.claude-plugin/"
   ],
   "bin": {
-    "dotclaude":                     "./plugins/dotclaude/bin/dotclaude.mjs",
-    "dotclaude-bootstrap":           "./plugins/dotclaude/bin/dotclaude-bootstrap.mjs",
-    "dotclaude-sync":                "./plugins/dotclaude/bin/dotclaude-sync.mjs",
-    "dotclaude-doctor":              "./plugins/dotclaude/bin/dotclaude-doctor.mjs",
-    "dotclaude-detect-drift":        "./plugins/dotclaude/bin/dotclaude-detect-drift.mjs",
-    "dotclaude-validate-skills":     "./plugins/dotclaude/bin/dotclaude-validate-skills.mjs",
+    "dotclaude": "./plugins/dotclaude/bin/dotclaude.mjs",
+    "dotclaude-bootstrap": "./plugins/dotclaude/bin/dotclaude-bootstrap.mjs",
+    "dotclaude-sync": "./plugins/dotclaude/bin/dotclaude-sync.mjs",
+    "dotclaude-doctor": "./plugins/dotclaude/bin/dotclaude-doctor.mjs",
+    "dotclaude-detect-drift": "./plugins/dotclaude/bin/dotclaude-detect-drift.mjs",
+    "dotclaude-validate-skills": "./plugins/dotclaude/bin/dotclaude-validate-skills.mjs",
     "dotclaude-check-spec-coverage": "./plugins/dotclaude/bin/dotclaude-check-spec-coverage.mjs",
-    "dotclaude-validate-specs":      "./plugins/dotclaude/bin/dotclaude-validate-specs.mjs",
+    "dotclaude-validate-specs": "./plugins/dotclaude/bin/dotclaude-validate-specs.mjs",
     "dotclaude-check-instruction-drift": "./plugins/dotclaude/bin/dotclaude-check-instruction-drift.mjs",
-    "dotclaude-init":                "./plugins/dotclaude/bin/dotclaude-init.mjs"
+    "dotclaude-init": "./plugins/dotclaude/bin/dotclaude-init.mjs"
   }
 }
 ```

--- a/docs/specs/cli-bootstrap-command/spec/5-interfaces-apis.md
+++ b/docs/specs/cli-bootstrap-command/spec/5-interfaces-apis.md
@@ -1,0 +1,157 @@
+# §5 — Interfaces and APIs
+
+> CLI interface, Node API surface, updated dispatcher.
+
+## CLI Interface
+
+### `dotclaude bootstrap`
+
+```
+dotclaude-bootstrap [OPTIONS]
+
+Set up (or refresh) ~/.claude/ by symlinking commands/, skills/, CLAUDE.md,
+and copying agent templates into place. Idempotent — safe to re-run.
+
+Options:
+  --source <path>   Path to a local dotclaude git clone. Overrides DOTCLAUDE_DIR.
+                    Default: npm package install directory.
+  --target <dir>    Override destination directory. Default: ~/.claude
+  --quiet           Suppress per-file progress; print summary only.
+  --json            Emit a JSON array of {kind, message} events on stdout.
+  --no-color        Suppress ANSI colour.
+  --help, -h
+  --version, -V
+
+Exit codes: 0 ok, 1 validation failure, 2 env error, 64 usage error.
+
+Examples:
+  dotclaude bootstrap
+  dotclaude bootstrap --source ~/projects/dotclaude
+  DOTCLAUDE_DIR=~/projects/dotclaude dotclaude bootstrap --quiet
+```
+
+### `dotclaude sync`
+
+```
+dotclaude-sync <subcommand> [OPTIONS]
+
+Subcommands:
+  pull      Update dotclaude and re-bootstrap ~/.claude/
+            npm mode:   npm update -g @dotclaude/dotclaude, then bootstrap
+            clone mode: git fetch + rebase origin/main, then bootstrap
+  status    Show current version vs. latest (npm mode) or git status (clone mode)
+  push      [clone mode only] Secret-scan, commit, and push the dotclaude clone
+
+Options:
+  --source <path>   Path to local dotclaude git clone (activates clone mode).
+                    Overrides DOTCLAUDE_DIR.
+  --quiet           Summary output only.
+  --json            JSON output mode.
+  --no-color
+  --help, -h
+  --version, -V
+
+Exit codes: 0 ok, 1 failure, 2 env error (git/npm not found), 64 usage error.
+
+Examples:
+  dotclaude sync pull
+  dotclaude sync status
+  dotclaude sync pull --source ~/projects/dotclaude
+  dotclaude sync push --source ~/projects/dotclaude
+```
+
+### Updated `dotclaude` dispatcher
+
+`dotclaude.mjs` SUBCOMMANDS array gains two entries:
+
+```js
+const SUBCOMMANDS = [
+  "bootstrap",   // ← new
+  "sync",        // ← new
+  "validate-skills",
+  "validate-specs",
+  "check-spec-coverage",
+  "check-instruction-drift",
+  "detect-drift",
+  "doctor",
+  "init",
+];
+```
+
+### Updated `dotclaude-doctor`
+
+Doctor gains one new check section — **bootstrap** — reporting the state of
+each expected symlink in `~/.claude/`:
+
+```
+  ✓ CLAUDE.md         → /path/to/dotclaude/CLAUDE.md
+  ✓ commands/         → 14 files linked
+  ✓ skills/           → 12 dirs linked
+  ⚠ agents/           → 0 files (run dotclaude bootstrap to install)
+```
+
+If `~/.claude/` has never been bootstrapped, doctor emits a single `warn`
+suggesting `dotclaude bootstrap` rather than failing with an error.
+
+## Node API Surface
+
+Two new exports added to `index.mjs`:
+
+```js
+/**
+ * Set up or refresh ~/.claude/ by symlinking source files into the target.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.source]   Path to dotclaude root. Defaults to pkg root.
+ * @param {string} [opts.target]   Destination dir. Defaults to $HOME/.claude.
+ * @param {boolean} [opts.quiet]
+ * @param {boolean} [opts.json]
+ * @param {boolean} [opts.noColor]
+ * @returns {{ ok: boolean, linked: number, skipped: number, backed_up: number }}
+ */
+export { bootstrapGlobal } from "./bootstrap-global.mjs";
+
+/**
+ * Pull updates (npm or git) and re-bootstrap, or query status.
+ *
+ * @param {'pull'|'status'|'push'} subcommand
+ * @param {object} [opts]
+ * @param {string} [opts.source]   Activates clone mode.
+ * @param {boolean} [opts.quiet]
+ * @param {boolean} [opts.json]
+ * @param {boolean} [opts.noColor]
+ * @returns {{ ok: boolean, mode: 'npm'|'clone', summary: string }}
+ */
+export { syncGlobal } from "./sync-global.mjs";
+```
+
+## package.json Changes
+
+```json
+{
+  "files": [
+    "commands/",
+    "skills/",
+    "CLAUDE.md",
+    "plugins/dotclaude/src/",
+    "plugins/dotclaude/bin/",
+    "plugins/dotclaude/scripts/",
+    "plugins/dotclaude/templates/",
+    "plugins/dotclaude/hooks/",
+    "plugins/dotclaude/README.md",
+    "plugins/dotclaude/.claude-plugin/"
+  ],
+  "bin": {
+    "dotclaude":                     "./plugins/dotclaude/bin/dotclaude.mjs",
+    "dotclaude-bootstrap":           "./plugins/dotclaude/bin/dotclaude-bootstrap.mjs",
+    "dotclaude-sync":                "./plugins/dotclaude/bin/dotclaude-sync.mjs",
+    "dotclaude-doctor":              "./plugins/dotclaude/bin/dotclaude-doctor.mjs",
+    "dotclaude-detect-drift":        "./plugins/dotclaude/bin/dotclaude-detect-drift.mjs",
+    "dotclaude-validate-skills":     "./plugins/dotclaude/bin/dotclaude-validate-skills.mjs",
+    "dotclaude-check-spec-coverage": "./plugins/dotclaude/bin/dotclaude-check-spec-coverage.mjs",
+    "dotclaude-validate-specs":      "./plugins/dotclaude/bin/dotclaude-validate-specs.mjs",
+    "dotclaude-check-instruction-drift": "./plugins/dotclaude/bin/dotclaude-check-instruction-drift.mjs",
+    "dotclaude-init":                "./plugins/dotclaude/bin/dotclaude-init.mjs"
+  }
+}
+```

--- a/docs/specs/cli-bootstrap-command/spec/6-implementation-plan.md
+++ b/docs/specs/cli-bootstrap-command/spec/6-implementation-plan.md
@@ -1,0 +1,193 @@
+# §6 — Implementation Plan
+
+> Phases, workstreams, prompts, tests, migrations, rollback.
+
+## 6.1 Phased Rollout
+
+```
+Phase 1 — ship commands/skills/CLAUDE.md in the package (package.json only)
+    ↓
+Phase 2 — implement bootstrap-global.mjs + bin + tests
+    ↓
+Phase 3 — implement sync-global.mjs + bin + tests
+    ↓
+Phase 4 — update dispatcher + doctor + exports + docs
+```
+
+Phases 2 and 3 are independent once Phase 1 is merged.
+
+## 6.2 Workstream Breakdown
+
+| Track | Owner | Depends On | Deliverable |
+| ----- | ----- | ---------- | ----------- |
+| A — package.json | any | — | `files` + `bin` updated; `npm pack` includes commands/ skills/ CLAUDE.md |
+| B — bootstrap-global | any | Track A | `bootstrap-global.mjs` + `dotclaude-bootstrap.mjs` + tests |
+| C — sync-global | any | Track B (uses bootstrapGlobal) | `sync-global.mjs` + `dotclaude-sync.mjs` + tests |
+| D — wiring + docs | any | Tracks B + C | dispatcher, doctor, index.mjs exports, README, cli-reference |
+
+## 6.3 Prompt Sequence
+
+### Prompt B1 — bootstrap-global.mjs (core logic)
+
+```
+Read first:
+  - bootstrap.sh (full file — source of truth for the symlinking algorithm)
+  - plugins/dotclaude/src/init-harness-scaffold.mjs (pattern for fs operations)
+  - plugins/dotclaude/src/lib/output.mjs (createOutput interface)
+  - plugins/dotclaude/src/lib/errors.mjs (ValidationError, ERROR_CODES)
+  - plugins/dotclaude/src/lib/exit-codes.mjs
+
+Write plugins/dotclaude/src/bootstrap-global.mjs implementing bootstrapGlobal(opts):
+  - resolveSource: --source → DOTCLAUDE_DIR → pkgRoot() via import.meta.url
+  - resolveTarget: opts.target ?? path.join(os.homedir(), '.claude')
+  - linkOne(src, dst): matches bootstrap.sh behavior exactly:
+      symlink pointing to src → ok
+      symlink pointing elsewhere → rm + ln -s → updated
+      real file/dir → mv to .bak-<ts> + ln -s → backed up + linked (out.warn)
+      missing → ln -s → linked
+  - bootstrapGlobal: link CLAUDE.md, commands/*.md, skills/*/, copy agents
+  - return { ok, linked, skipped, backed_up }
+
+TDD: write these failing tests first in
+plugins/dotclaude/tests/bootstrap-global.test.mjs:
+  - bootstrapGlobal creates symlinks in a temp target dir
+  - bootstrapGlobal is idempotent (second run produces same state, no extra backups)
+  - bootstrapGlobal backs up a real file before overwriting
+  - bootstrapGlobal updates a stale symlink
+  - bootstrapGlobal skips existing agent files
+  - bootstrapGlobal returns { ok: false } when source is missing
+  - resolveSource uses DOTCLAUDE_DIR when no --source given
+  - resolveSource falls back to pkgRoot() when DOTCLAUDE_DIR is unset
+```
+
+### Prompt B2 — dotclaude-bootstrap.mjs bin
+
+```
+Read first:
+  - plugins/dotclaude/bin/dotclaude-init.mjs (bin pattern to replicate)
+  - plugins/dotclaude/src/lib/argv.mjs
+  - plugins/dotclaude/src/bootstrap-global.mjs
+
+Write plugins/dotclaude/bin/dotclaude-bootstrap.mjs:
+  - META with name, synopsis, description, flags: source (string), target (string), quiet (boolean)
+  - parse argv, handle --help/--version
+  - call bootstrapGlobal, map result to exit codes
+  - on win32 platform: out.fail with OPS-1 message, exit 2
+```
+
+### Prompt C1 — sync-global.mjs (core logic)
+
+```
+Read first:
+  - sync.sh (full file — source of truth for pull/push/status logic)
+  - plugins/dotclaude/src/bootstrap-global.mjs
+  - plugins/dotclaude/src/lib/output.mjs
+  - plugins/dotclaude/src/lib/errors.mjs
+
+Write plugins/dotclaude/src/sync-global.mjs implementing syncGlobal(subcommand, opts):
+
+  resolveMode(opts.source): 'clone' if source provided, else 'npm'
+
+  pull (npm mode):
+    1. spawnSync('npm', ['view', '@dotclaude/dotclaude', 'version'])
+    2. if current === latest: out.info "already up to date (v<x>)"
+    3. else: spawnSync('npm', ['update', '-g', '@dotclaude/dotclaude'])
+    4. bootstrapGlobal(opts)
+
+  pull (clone mode):
+    1. spawnSync('git', ['-C', source, 'fetch', 'origin'])
+    2. spawnSync('git', ['-C', source, 'rebase', 'origin/main'])
+    3. bootstrapGlobal({ ...opts, source })
+
+  status (npm mode):
+    1. currentVer from version export
+    2. latestVer from npm registry
+    3. out.info lines
+
+  status (clone mode):
+    1. result = spawnSync('git', ['-C', source, 'status', '--short'])
+    2. print stdout
+
+  push (npm mode):
+    out.fail "sync push is only available in clone mode"
+
+  push (clone mode):
+    Port SECRET_RX regex from sync.sh verbatim.
+    1. secretScan(source) — check staged files via git show ":$file"
+    2. git -C source add -A
+    3. git -C source commit -m "dotclaude: sync <date>"
+    4. git -C source push
+
+TDD: write failing tests first in plugins/dotclaude/tests/sync-global.test.mjs:
+  - syncGlobal pull (npm mode) calls npm update when newer version available
+  - syncGlobal pull (npm mode) skips update when already up to date
+  - syncGlobal pull (clone mode) runs git fetch + rebase then bootstraps
+  - syncGlobal status (npm mode) emits current vs latest
+  - syncGlobal status (clone mode) delegates to git status
+  - syncGlobal push (npm mode) exits with fail message
+  - syncGlobal resolveMode returns 'clone' when --source is set
+  - syncGlobal resolveMode returns 'npm' when no source
+```
+
+### Prompt C2 — dotclaude-sync.mjs bin
+
+```
+Read first:
+  - plugins/dotclaude/bin/dotclaude-init.mjs (bin pattern)
+  - plugins/dotclaude/src/sync-global.mjs
+
+Write plugins/dotclaude/bin/dotclaude-sync.mjs:
+  - positional[0] is the subcommand: 'pull' | 'status' | 'push'
+  - flags: source (string), quiet (boolean)
+  - missing subcommand: print usage, exit 64
+  - unknown subcommand: stderr + exit 64
+  - delegate to syncGlobal, map exit codes
+```
+
+### Prompt D1 — wiring
+
+```
+Read first:
+  - plugins/dotclaude/bin/dotclaude.mjs
+  - plugins/dotclaude/src/index.mjs
+  - plugins/dotclaude/bin/dotclaude-doctor.mjs
+  - package.json
+
+Four surgical edits:
+  1. dotclaude.mjs: add 'bootstrap', 'sync' to SUBCOMMANDS array and help text
+  2. index.mjs: add bootstrapGlobal export from bootstrap-global.mjs
+               add syncGlobal export from sync-global.mjs
+  3. package.json: add commands/, skills/, CLAUDE.md to files array
+                   add dotclaude-bootstrap + dotclaude-sync to bin map
+  4. dotclaude-doctor.mjs: add bootstrap check section (symlinks present + valid)
+```
+
+## 6.4 Testing Strategy
+
+| Unit | UNIT | INTEGRATION | POST-DEPLOY |
+| ---- | ---- | ----------- | ----------- |
+| `bootstrap-global.mjs` | Symlink/backup/idempotency logic with temp dirs | `npm pack` then `npm install` in a temp prefix; run `dotclaude bootstrap` and verify `~/.claude/` state | `dotclaude doctor` shows all ✓ after bootstrap |
+| `sync-global.mjs` | resolveMode, secretScan regex, npm/git spawn stubs | Clone-mode pull against a local bare git repo | `dotclaude sync status` returns correct version string |
+| `dotclaude-bootstrap.mjs` | `--help`, `--version`, win32 guard, exit codes | Full bin invocation via `node bin/dotclaude-bootstrap.mjs` | — |
+| `dotclaude-sync.mjs` | Unknown subcommand → exit 64 | Full bin invocation | — |
+| Dispatcher | `bootstrap` + `sync` in SUBCOMMANDS | `dotclaude bootstrap --help` exits 0 | — |
+
+## 6.5 Migration Sequence
+
+1. Add `commands/`, `skills/`, `CLAUDE.md` to `package.json` `files` (no behavior change; just ships more files in the tarball)
+2. Add new src modules (no exports yet; safe to land early)
+3. Export from `index.mjs` (additive; existing consumers unaffected)
+4. Add new bins and update `package.json` `bin` map
+5. Update dispatcher + doctor (last — requires bins to exist)
+6. Bump minor version (`0.3.x → 0.4.0`) — new public exports + new bins = minor bump
+
+All steps are additive. Nothing is renamed or removed.
+
+## 6.6 Rollback Plan
+
+| Scenario | Action | Notes |
+| -------- | ------ | ----- |
+| bootstrap-global.mjs corrupts `~/.claude/` | Restore from `.bak-<timestamp>` files written by the tool itself | ARCH-1 guarantees backups exist |
+| npm mode symlinks break after `npm update -g` | Re-run `dotclaude bootstrap`; links will be refreshed | Idempotent by design |
+| New bins cause regression in existing subcommands | Revert the `dotclaude.mjs` SUBCOMMANDS change; new bins still ship but are not reachable via umbrella dispatcher | Dispatcher change is one-line; easy to revert independently |
+| `package.json` `files` change causes unexpected tarball size | `npm pack --dry-run` to audit; revert the files entry | No code change required |

--- a/docs/specs/cli-bootstrap-command/spec/6-implementation-plan.md
+++ b/docs/specs/cli-bootstrap-command/spec/6-implementation-plan.md
@@ -18,12 +18,12 @@ Phases 2 and 3 are independent once Phase 1 is merged.
 
 ## 6.2 Workstream Breakdown
 
-| Track | Owner | Depends On | Deliverable |
-| ----- | ----- | ---------- | ----------- |
-| A — package.json | any | — | `files` + `bin` updated; `npm pack` includes commands/ skills/ CLAUDE.md |
-| B — bootstrap-global | any | Track A | `bootstrap-global.mjs` + `dotclaude-bootstrap.mjs` + tests |
-| C — sync-global | any | Track B (uses bootstrapGlobal) | `sync-global.mjs` + `dotclaude-sync.mjs` + tests |
-| D — wiring + docs | any | Tracks B + C | dispatcher, doctor, index.mjs exports, README, cli-reference |
+| Track                | Owner | Depends On                     | Deliverable                                                              |
+| -------------------- | ----- | ------------------------------ | ------------------------------------------------------------------------ |
+| A — package.json     | any   | —                              | `files` + `bin` updated; `npm pack` includes commands/ skills/ CLAUDE.md |
+| B — bootstrap-global | any   | Track A                        | `bootstrap-global.mjs` + `dotclaude-bootstrap.mjs` + tests               |
+| C — sync-global      | any   | Track B (uses bootstrapGlobal) | `sync-global.mjs` + `dotclaude-sync.mjs` + tests                         |
+| D — wiring + docs    | any   | Tracks B + C                   | dispatcher, doctor, index.mjs exports, README, cli-reference             |
 
 ## 6.3 Prompt Sequence
 
@@ -164,13 +164,13 @@ Four surgical edits:
 
 ## 6.4 Testing Strategy
 
-| Unit | UNIT | INTEGRATION | POST-DEPLOY |
-| ---- | ---- | ----------- | ----------- |
-| `bootstrap-global.mjs` | Symlink/backup/idempotency logic with temp dirs | `npm pack` then `npm install` in a temp prefix; run `dotclaude bootstrap` and verify `~/.claude/` state | `dotclaude doctor` shows all ✓ after bootstrap |
-| `sync-global.mjs` | resolveMode, secretScan regex, npm/git spawn stubs | Clone-mode pull against a local bare git repo | `dotclaude sync status` returns correct version string |
-| `dotclaude-bootstrap.mjs` | `--help`, `--version`, win32 guard, exit codes | Full bin invocation via `node bin/dotclaude-bootstrap.mjs` | — |
-| `dotclaude-sync.mjs` | Unknown subcommand → exit 64 | Full bin invocation | — |
-| Dispatcher | `bootstrap` + `sync` in SUBCOMMANDS | `dotclaude bootstrap --help` exits 0 | — |
+| Unit                      | UNIT                                               | INTEGRATION                                                                                             | POST-DEPLOY                                            |
+| ------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `bootstrap-global.mjs`    | Symlink/backup/idempotency logic with temp dirs    | `npm pack` then `npm install` in a temp prefix; run `dotclaude bootstrap` and verify `~/.claude/` state | `dotclaude doctor` shows all ✓ after bootstrap         |
+| `sync-global.mjs`         | resolveMode, secretScan regex, npm/git spawn stubs | Clone-mode pull against a local bare git repo                                                           | `dotclaude sync status` returns correct version string |
+| `dotclaude-bootstrap.mjs` | `--help`, `--version`, win32 guard, exit codes     | Full bin invocation via `node bin/dotclaude-bootstrap.mjs`                                              | —                                                      |
+| `dotclaude-sync.mjs`      | Unknown subcommand → exit 64                       | Full bin invocation                                                                                     | —                                                      |
+| Dispatcher                | `bootstrap` + `sync` in SUBCOMMANDS                | `dotclaude bootstrap --help` exits 0                                                                    | —                                                      |
 
 ## 6.5 Migration Sequence
 
@@ -185,9 +185,9 @@ All steps are additive. Nothing is renamed or removed.
 
 ## 6.6 Rollback Plan
 
-| Scenario | Action | Notes |
-| -------- | ------ | ----- |
-| bootstrap-global.mjs corrupts `~/.claude/` | Restore from `.bak-<timestamp>` files written by the tool itself | ARCH-1 guarantees backups exist |
-| npm mode symlinks break after `npm update -g` | Re-run `dotclaude bootstrap`; links will be refreshed | Idempotent by design |
-| New bins cause regression in existing subcommands | Revert the `dotclaude.mjs` SUBCOMMANDS change; new bins still ship but are not reachable via umbrella dispatcher | Dispatcher change is one-line; easy to revert independently |
-| `package.json` `files` change causes unexpected tarball size | `npm pack --dry-run` to audit; revert the files entry | No code change required |
+| Scenario                                                     | Action                                                                                                           | Notes                                                       |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| bootstrap-global.mjs corrupts `~/.claude/`                   | Restore from `.bak-<timestamp>` files written by the tool itself                                                 | ARCH-1 guarantees backups exist                             |
+| npm mode symlinks break after `npm update -g`                | Re-run `dotclaude bootstrap`; links will be refreshed                                                            | Idempotent by design                                        |
+| New bins cause regression in existing subcommands            | Revert the `dotclaude.mjs` SUBCOMMANDS change; new bins still ship but are not reachable via umbrella dispatcher | Dispatcher change is one-line; easy to revert independently |
+| `package.json` `files` change causes unexpected tarball size | `npm pack --dry-run` to audit; revert the files entry                                                            | No code change required                                     |

--- a/docs/specs/cli-bootstrap-command/spec/7-non-functional-requirements.md
+++ b/docs/specs/cli-bootstrap-command/spec/7-non-functional-requirements.md
@@ -30,10 +30,12 @@ exits non-zero. Report the npm error and exit 1.
 
 OPS-1: On `win32` platform, `dotclaude bootstrap` and `dotclaude sync` must
 exit with code 2 and emit a clear message:
+
 ```
 ✗ bootstrap is not supported on Windows (symlinks require elevated permissions).
   Use WSL or run bootstrap.sh from Git Bash.
 ```
+
 No silent failure; no partial execution.
 
 OPS-2: `DOTCLAUDE_DIR` environment variable must be documented in

--- a/docs/specs/cli-bootstrap-command/spec/7-non-functional-requirements.md
+++ b/docs/specs/cli-bootstrap-command/spec/7-non-functional-requirements.md
@@ -1,0 +1,65 @@
+# §7 — Non-Functional Requirements
+
+> Performance, reliability, operational, security constraints.
+
+## Performance
+
+PERF-1: `dotclaude bootstrap` must complete in under 2 seconds on a cold run
+(first-time setup, ~30 symlink operations). The only I/O is filesystem
+symlink creation and a single `readdir` per source directory.
+
+PERF-2: `dotclaude sync status` (npm mode) must not block for more than
+5 seconds. The npm registry version check is a single HTTP GET to
+`registry.npmjs.org`; implement with a 3-second timeout and degrade
+gracefully (show current version + `⚠ registry unreachable`).
+
+## Reliability
+
+REL-1: All filesystem operations must be atomic at the individual file level.
+Write backup before overwriting; never leave `~/.claude/` in a half-written
+state. If the process is interrupted mid-bootstrap, the next run
+(`ARCH-1` idempotency) must be able to complete cleanly.
+
+REL-2: `sync pull` (clone mode) must not run bootstrap if the git
+fetch/rebase fails. Abort and report the git error; do not partially apply.
+
+REL-3: `sync pull` (npm mode) must not re-run bootstrap if `npm update -g`
+exits non-zero. Report the npm error and exit 1.
+
+## Operational
+
+OPS-1: On `win32` platform, `dotclaude bootstrap` and `dotclaude sync` must
+exit with code 2 and emit a clear message:
+```
+✗ bootstrap is not supported on Windows (symlinks require elevated permissions).
+  Use WSL or run bootstrap.sh from Git Bash.
+```
+No silent failure; no partial execution.
+
+OPS-2: `DOTCLAUDE_DIR` environment variable must be documented in
+`--help` output for both `dotclaude-bootstrap` and `dotclaude-sync`.
+Undocumented env vars are a maintenance hazard.
+
+OPS-3: `dotclaude-doctor` must report bootstrap state so that CI-based
+onboarding checks can verify a developer machine is set up without running
+bootstrap again. The check should be non-fatal (warn, not fail) when `~/.claude/`
+has never been bootstrapped — doctor is a diagnostic, not a gate.
+
+## Security
+
+SEC-1: `sync push` (clone mode) must perform secret-scanning before staging
+any files. The regex is ported verbatim from `sync.sh` (`SECRET_RX`). The
+scan reads file contents via `git show ":$file"` so only staged content is
+inspected (not the working tree). The escape hatch `HARNESS_SYNC_SKIP_SECRET_SCAN=1`
+is preserved for parity with `sync.sh`.
+
+SEC-2: `--source` and `DOTCLAUDE_DIR` paths must be validated as existing
+directories before any filesystem operation. A non-existent source exits 2
+with a clear error; it must not silently create an empty `~/.claude/` or
+produce broken symlinks.
+
+SEC-3: The npm package tarball now includes `commands/`, `skills/`, and
+`CLAUDE.md`. None of these files should contain secrets. The existing
+`sync push` secret-scan and `.gitignore` cover the source; a `dotclaude-doctor`
+check should verify no `.env` or credential files are present in `commands/`
+or `skills/` at publish time (enforced via `prepublishOnly` npm script).

--- a/docs/specs/cli-bootstrap-command/spec/8-risks-alternatives.md
+++ b/docs/specs/cli-bootstrap-command/spec/8-risks-alternatives.md
@@ -4,13 +4,13 @@
 
 ## Risks
 
-| ID  | Risk | Likelihood | Impact | Mitigation |
-| --- | ---- | ---------- | ------ | ----------- |
-| R-1 | npm global install directory varies by platform (nvm, volta, brew, system node) — `pkgRoot()` via `import.meta.url` may resolve to an unexpected path | Medium | Medium | Log the resolved source path on every bootstrap run so users can verify it. Document the resolution algorithm in `--help`. |
-| R-2 | `npm update -g` in `sync pull` updates ALL globally installed packages, not just `@dotclaude/dotclaude` | Low | Low | Use `npm update -g @dotclaude/dotclaude` (package-scoped) not `npm update -g` bare. |
-| R-3 | Adding `commands/` and `skills/` to the npm tarball significantly increases package size | Low | Low | `npm pack --dry-run` before publishing; current skills/commands total ~200 KB. Acceptable. |
-| R-4 | `bootstrap.sh` and `dotclaude bootstrap` diverge over time — someone updates one but not the other | Medium | Medium | Add a note in `bootstrap.sh` referencing the CLI equivalent. The integration test for bootstrap-global.mjs runs against the same expected outputs as the bootstrap.sh test. |
-| R-5 | Symlinking the npm package directory into `~/.claude/` means updating the package breaks the symlinks briefly during the npm update window | Low | Low | npm replaces package contents atomically (via rename); symlinks remain valid throughout. |
+| ID  | Risk                                                                                                                                                  | Likelihood | Impact | Mitigation                                                                                                                                                                  |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R-1 | npm global install directory varies by platform (nvm, volta, brew, system node) — `pkgRoot()` via `import.meta.url` may resolve to an unexpected path | Medium     | Medium | Log the resolved source path on every bootstrap run so users can verify it. Document the resolution algorithm in `--help`.                                                  |
+| R-2 | `npm update -g` in `sync pull` updates ALL globally installed packages, not just `@dotclaude/dotclaude`                                               | Low        | Low    | Use `npm update -g @dotclaude/dotclaude` (package-scoped) not `npm update -g` bare.                                                                                         |
+| R-3 | Adding `commands/` and `skills/` to the npm tarball significantly increases package size                                                              | Low        | Low    | `npm pack --dry-run` before publishing; current skills/commands total ~200 KB. Acceptable.                                                                                  |
+| R-4 | `bootstrap.sh` and `dotclaude bootstrap` diverge over time — someone updates one but not the other                                                    | Medium     | Medium | Add a note in `bootstrap.sh` referencing the CLI equivalent. The integration test for bootstrap-global.mjs runs against the same expected outputs as the bootstrap.sh test. |
+| R-5 | Symlinking the npm package directory into `~/.claude/` means updating the package breaks the symlinks briefly during the npm update window            | Low        | Low    | npm replaces package contents atomically (via rename); symlinks remain valid throughout.                                                                                    |
 
 ## Rejected Alternatives
 

--- a/docs/specs/cli-bootstrap-command/spec/8-risks-alternatives.md
+++ b/docs/specs/cli-bootstrap-command/spec/8-risks-alternatives.md
@@ -1,0 +1,47 @@
+# §8 — Risks and Alternatives
+
+> Known risks with mitigations, rejected approaches with reasoning.
+
+## Risks
+
+| ID  | Risk | Likelihood | Impact | Mitigation |
+| --- | ---- | ---------- | ------ | ----------- |
+| R-1 | npm global install directory varies by platform (nvm, volta, brew, system node) — `pkgRoot()` via `import.meta.url` may resolve to an unexpected path | Medium | Medium | Log the resolved source path on every bootstrap run so users can verify it. Document the resolution algorithm in `--help`. |
+| R-2 | `npm update -g` in `sync pull` updates ALL globally installed packages, not just `@dotclaude/dotclaude` | Low | Low | Use `npm update -g @dotclaude/dotclaude` (package-scoped) not `npm update -g` bare. |
+| R-3 | Adding `commands/` and `skills/` to the npm tarball significantly increases package size | Low | Low | `npm pack --dry-run` before publishing; current skills/commands total ~200 KB. Acceptable. |
+| R-4 | `bootstrap.sh` and `dotclaude bootstrap` diverge over time — someone updates one but not the other | Medium | Medium | Add a note in `bootstrap.sh` referencing the CLI equivalent. The integration test for bootstrap-global.mjs runs against the same expected outputs as the bootstrap.sh test. |
+| R-5 | Symlinking the npm package directory into `~/.claude/` means updating the package breaks the symlinks briefly during the npm update window | Low | Low | npm replaces package contents atomically (via rename); symlinks remain valid throughout. |
+
+## Rejected Alternatives
+
+A-1: **Ship only a wrapper that calls `bootstrap.sh`** — have `dotclaude bootstrap`
+`exec` the shell script from the npm package directory. Rejected because it
+requires bash, breaks on Windows (OPS-1), and ties the npm package's behavior
+to a shell script rather than the tested JS module system. It would also make
+the Node API (`bootstrapGlobal`) impossible to implement without shelling out.
+
+A-2: **Clone dotclaude from GitHub if no local clone is detected** — have
+`dotclaude bootstrap` run `git clone` in npm mode to create a local clone in
+`~/.dotclaude/` and then symlink from there. Rejected because it introduces
+an unconditional network call at bootstrap time, adds complexity (what if the
+clone already exists? what version to clone?), and the npm package already
+ships the right files. The npm install is the natural distribution channel.
+
+A-3: **Copy files instead of symlink in npm mode** — skip symlinks entirely
+and just copy `commands/`, `skills/`, `CLAUDE.md` into `~/.claude/`. Rejected
+because copies drift silently — after `npm update -g`, the files in `~/.claude/`
+would be stale until the user manually re-runs bootstrap. Symlinks (KD-3)
+make the update atomic: the npm update replaces the package dir contents, and
+all symlinks immediately reflect the new version.
+
+A-4: **Use a `dotclaude setup` name instead of `dotclaude bootstrap`** —
+more general naming. Rejected because `bootstrap` is already the established
+term in the README, `bootstrap.sh`, and onboarding docs. Consistent naming
+reduces confusion; new devs who know `./bootstrap.sh` will find `dotclaude bootstrap`
+immediately intuitive.
+
+A-5: **Merge `sync` into `bootstrap` as flags** — `dotclaude bootstrap --pull`
+to update before symlinking. Rejected because pull and bootstrap are distinct
+operations with different failure modes and different exit semantics. Keeping
+them as separate subcommands follows the existing pattern (each subcommand has
+a single responsibility) and makes error attribution unambiguous.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotclaude/dotclaude",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "dotclaude — portable SDD validators and Claude Code governance for any project.",
   "type": "module",
   "main": "plugins/dotclaude/src/index.mjs",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
   },
   "bin": {
     "dotclaude": "./plugins/dotclaude/bin/dotclaude.mjs",
+    "dotclaude-bootstrap": "./plugins/dotclaude/bin/dotclaude-bootstrap.mjs",
     "dotclaude-doctor": "./plugins/dotclaude/bin/dotclaude-doctor.mjs",
     "dotclaude-detect-drift": "./plugins/dotclaude/bin/dotclaude-detect-drift.mjs",
     "dotclaude-validate-skills": "./plugins/dotclaude/bin/dotclaude-validate-skills.mjs",
     "dotclaude-check-spec-coverage": "./plugins/dotclaude/bin/dotclaude-check-spec-coverage.mjs",
     "dotclaude-validate-specs": "./plugins/dotclaude/bin/dotclaude-validate-specs.mjs",
     "dotclaude-check-instruction-drift": "./plugins/dotclaude/bin/dotclaude-check-instruction-drift.mjs",
-    "dotclaude-init": "./plugins/dotclaude/bin/dotclaude-init.mjs"
+    "dotclaude-init": "./plugins/dotclaude/bin/dotclaude-init.mjs",
+    "dotclaude-sync": "./plugins/dotclaude/bin/dotclaude-sync.mjs"
   },
   "scripts": {
     "test": "vitest run",
@@ -30,6 +32,9 @@
     "dogfood": "npx dotclaude-validate-skills && npx dotclaude-validate-specs && npx dotclaude-check-instruction-drift && npx dotclaude-check-spec-coverage"
   },
   "files": [
+    "commands/",
+    "skills/",
+    "CLAUDE.md",
     "plugins/dotclaude/src/",
     "plugins/dotclaude/bin/",
     "plugins/dotclaude/scripts/",

--- a/plugins/dotclaude/bin/dotclaude-bootstrap.mjs
+++ b/plugins/dotclaude/bin/dotclaude-bootstrap.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * dotclaude-bootstrap — set up or refresh ~/.claude/.
+ *
+ * Symlinks commands/, skills/, CLAUDE.md, and copies agent templates into place.
+ * Idempotent — safe to re-run.
+ *
+ * Flags:
+ *   --source <path>      Path to a local dotclaude git clone. Overrides DOTCLAUDE_DIR.
+ *   --target <dir>       Override destination directory. Default: ~/.claude
+ *   --quiet              Suppress per-file progress; print summary only.
+ *   --json               Emit a JSON array of events on stdout.
+ *   --no-color           Suppress ANSI colour.
+ *   --help / -h
+ *   --version / -V
+ *
+ * Exits: 0 bootstrap complete, 1 validation error, 2 env error, 64 usage error.
+ */
+
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { version } from "../src/index.mjs";
+import { bootstrapGlobal } from "../src/bootstrap-global.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const META = {
+  name: "dotclaude-bootstrap",
+  synopsis: "dotclaude-bootstrap [OPTIONS]",
+  description: "Set up (or refresh) ~/.claude/ by symlinking commands/, skills/, CLAUDE.md, and copying agent templates into place. Idempotent — safe to re-run.",
+  flags: {
+    source: { type: "string" },
+    target: { type: "string" },
+    quiet: { type: "boolean" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+// Windows symlink check
+if (process.platform === "win32") {
+  const out = createOutput({ json: argv.json, noColor: argv.noColor });
+  out.fail("bootstrap is not supported on Windows (symlinks require elevated permissions).\n  Use WSL or run bootstrap.sh from Git Bash.");
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}
+
+const out = createOutput({ json: argv.json, noColor: argv.noColor });
+
+const source = /** @type {string|undefined} */ (argv.flags.source);
+const target = /** @type {string|undefined} */ (argv.flags.target);
+const quiet = Boolean(argv.flags.quiet);
+
+try {
+  const result = await bootstrapGlobal({
+    source,
+    target,
+    quiet,
+    json: argv.json,
+    noColor: argv.noColor,
+  });
+
+  if (result.ok) {
+    out.pass(`bootstrap complete — linked: ${result.linked}, skipped: ${result.skipped}, backed_up: ${result.backed_up}`);
+    out.flush();
+    process.exit(EXIT_CODES.OK);
+  } else {
+    out.fail("bootstrap failed");
+    out.flush();
+    process.exit(EXIT_CODES.ENV);
+  }
+} catch (err) {
+  out.fail(`bootstrap failed: ${err instanceof Error ? err.message : String(err)}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}

--- a/plugins/dotclaude/bin/dotclaude-bootstrap.mjs
+++ b/plugins/dotclaude/bin/dotclaude-bootstrap.mjs
@@ -17,15 +17,11 @@
  * Exits: 0 bootstrap complete, 1 validation error, 2 env error, 64 usage error.
  */
 
-import { fileURLToPath } from "node:url";
-import path from "node:path";
 import { parse, helpText } from "../src/lib/argv.mjs";
 import { createOutput } from "../src/lib/output.mjs";
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
 import { version } from "../src/index.mjs";
 import { bootstrapGlobal } from "../src/bootstrap-global.mjs";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const META = {
   name: "dotclaude-bootstrap",

--- a/plugins/dotclaude/bin/dotclaude-doctor.mjs
+++ b/plugins/dotclaude/bin/dotclaude-doctor.mjs
@@ -12,13 +12,15 @@
  *   specs        docs/specs/ scanned; validateSpecs clean
  *   drift        checkInstructionDrift clean
  *   hook         plugins/dotclaude/hooks/guard-destructive-git.sh present + exec bit
+ *   bootstrap    ~/.claude/CLAUDE.md symlink present (informational — warn only)
  *
  * Exit codes: 0 all green, 1 one or more checks failed (validation), 2 env error.
  */
 
-import { existsSync, statSync } from "node:fs";
+import { existsSync, lstatSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 import { parse, helpText } from "../src/lib/argv.mjs";
 import { createOutput } from "../src/lib/output.mjs";
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
@@ -138,6 +140,19 @@ if (existsSync(hookPath)) {
   else out.fail("guard-destructive-git.sh present but NOT executable (chmod +x)");
 } else {
   out.warn("guard-destructive-git.sh missing — destructive git commands are unguarded");
+}
+
+// bootstrap: is ~/.claude/ wired up? (informational — warn only)
+const globalClaudeMd = join(homedir(), ".claude", "CLAUDE.md");
+try {
+  const l = lstatSync(globalClaudeMd);
+  if (l.isSymbolicLink()) {
+    out.pass(`~/.claude/CLAUDE.md is a symlink (bootstrap active)`);
+  } else {
+    out.warn(`~/.claude/CLAUDE.md exists but is not a symlink — run 'dotclaude bootstrap' to wire it up`);
+  }
+} catch {
+  out.warn(`~/.claude/CLAUDE.md missing — run 'dotclaude bootstrap' to install global config`);
 }
 
 out.flush();

--- a/plugins/dotclaude/bin/dotclaude-sync.mjs
+++ b/plugins/dotclaude/bin/dotclaude-sync.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * dotclaude-sync — pull, push, or show status for a dotclaude installation.
+ *
+ * Subcommands:
+ *   pull     Fetch the latest dotclaude version and re-bootstrap ~/.claude/.
+ *   status   Show the current version / git status.
+ *   push     Commit and push local changes (clone mode only).
+ *
+ * Options:
+ *   --source <path>   Path to a local dotclaude git clone. Activates clone mode.
+ *   --quiet           Suppress per-file progress; print summary only.
+ *   --json            Emit a JSON array of events on stdout.
+ *   --no-color        Suppress ANSI colour.
+ *   --help / -h
+ *   --version / -V
+ *
+ * Exits: 0 ok, 1 sync error, 64 usage error.
+ */
+
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { version } from "../src/index.mjs";
+import { syncGlobal } from "../src/sync-global.mjs";
+
+const VALID_SUBCOMMANDS = ["pull", "status", "push"];
+
+const META = {
+  name: "dotclaude-sync",
+  synopsis: "dotclaude-sync <subcommand> [OPTIONS]",
+  description: "Pull, push, or show status for a dotclaude installation. Subcommands: pull, status, push.",
+  flags: {
+    source: { type: "string" },
+    quiet: { type: "boolean" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const subcommand = argv.positional[0];
+
+if (!subcommand) {
+  process.stderr.write(`${META.synopsis}\n\nNo subcommand provided. Valid subcommands: ${VALID_SUBCOMMANDS.join(", ")}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (!VALID_SUBCOMMANDS.includes(subcommand)) {
+  process.stderr.write(`Unknown subcommand: ${subcommand}\nValid subcommands: ${VALID_SUBCOMMANDS.join(", ")}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+const source = /** @type {string|undefined} */ (argv.flags.source);
+const quiet = Boolean(argv.flags.quiet);
+
+try {
+  const result = await syncGlobal(subcommand, {
+    source,
+    quiet,
+    json: argv.json,
+    noColor: argv.noColor,
+  });
+
+  process.exit(result.ok ? EXIT_CODES.OK : EXIT_CODES.VALIDATION);
+} catch (err) {
+  process.stderr.write(`sync failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(EXIT_CODES.VALIDATION);
+}

--- a/plugins/dotclaude/bin/dotclaude.mjs
+++ b/plugins/dotclaude/bin/dotclaude.mjs
@@ -8,7 +8,8 @@
  *
  * Known subcommands mirror the bin/* entries shipped by the package:
  *   validate-skills, validate-specs, check-spec-coverage,
- *   check-instruction-drift, detect-drift, doctor, init.
+ *   check-instruction-drift, detect-drift, doctor, init,
+ *   bootstrap, sync.
  *
  * Exits: 0 ok, 1 delegated failure, 2 env error, 64 usage error.
  */
@@ -28,6 +29,8 @@ const SUBCOMMANDS = [
   "detect-drift",
   "doctor",
   "init",
+  "bootstrap",
+  "sync",
 ];
 
 function printUsage() {

--- a/plugins/dotclaude/src/bootstrap-global.mjs
+++ b/plugins/dotclaude/src/bootstrap-global.mjs
@@ -1,0 +1,243 @@
+/**
+ * bootstrap-global.mjs — JS port of bootstrap.sh
+ *
+ * Symlinks dotclaude's CLAUDE.md, commands/, and skills/ into a target
+ * directory (default: ~/.claude/), and copies agent templates on first install.
+ *
+ * Exported API:
+ *   bootstrapGlobal(opts)  — main entry point
+ *   resolveSource(sourceOpt, env)  — exported for testability
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import { createOutput } from "./lib/output.mjs";
+
+// ---------------------------------------------------------------------------
+// pkgRoot() — walk up from this file until we find a directory containing
+// bootstrap.sh. That is the dotclaude repo root. Works both:
+//   • in the git checkout (where bootstrap.sh lives at the repo root), and
+//   • in an npm install (the package ships with the same layout).
+// ---------------------------------------------------------------------------
+
+function pkgRoot() {
+  const start = path.dirname(fileURLToPath(import.meta.url));
+  let cur = start;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (fs.existsSync(path.join(cur, "bootstrap.sh"))) {
+      return cur;
+    }
+    const parent = path.dirname(cur);
+    if (parent === cur) {
+      // Reached filesystem root without finding bootstrap.sh.
+      // Fall back to two levels up from this file (plugins/dotclaude/src →
+      // repo root) as a best-effort.
+      return path.resolve(start, "..", "..", "..");
+    }
+    cur = parent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resolveSource — exported so tests can exercise the env-var + fallback logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the dotclaude source directory.
+ *
+ * Priority:
+ *   1. `sourceOpt` (explicit --source flag)
+ *   2. `env.DOTCLAUDE_DIR`
+ *   3. `pkgRoot()` — walk up to find bootstrap.sh
+ *
+ * @param {string|undefined} sourceOpt
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string}
+ */
+export function resolveSource(sourceOpt, env) {
+  if (sourceOpt) return sourceOpt;
+  if (env && env.DOTCLAUDE_DIR) return env.DOTCLAUDE_DIR;
+  return pkgRoot();
+}
+
+// ---------------------------------------------------------------------------
+// linkOne — mirrors bootstrap.sh link_one()
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} LinkResult
+ * @property {'ok'|'updated'|'linked'|'backed_up'} action
+ */
+
+/**
+ * Create or update a symlink at `dst` pointing to `src`.
+ * Backs up a real file/dir at `dst` before replacing it.
+ *
+ * @param {string} src
+ * @param {string} dst
+ * @param {import('./lib/output.mjs').Output} out
+ * @param {string} ts  Timestamp string for backup suffix
+ * @returns {LinkResult}
+ */
+function linkOne(src, dst, out, ts) {
+  let lstat;
+  try {
+    lstat = fs.lstatSync(dst);
+  } catch {
+    // dst does not exist
+    fs.symlinkSync(src, dst);
+    out.pass(`linked: ${dst} -> ${src}`);
+    return { action: "linked" };
+  }
+
+  if (lstat.isSymbolicLink()) {
+    const current = fs.readlinkSync(dst);
+    if (current === src) {
+      out.pass(`ok: ${dst}`);
+      return { action: "ok" };
+    }
+    // Stale symlink — update it
+    fs.unlinkSync(dst);
+    fs.symlinkSync(src, dst);
+    out.pass(`updated: ${dst} -> ${src}`);
+    return { action: "updated" };
+  }
+
+  // Real file or directory — back up then link
+  const bakPath = `${dst}.bak-${ts}`;
+  fs.renameSync(dst, bakPath);
+  fs.symlinkSync(src, dst);
+  out.warn(`backed up + linked: ${dst} (old at ${bakPath})`);
+  return { action: "backed_up" };
+}
+
+// ---------------------------------------------------------------------------
+// bootstrapGlobal — main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} BootstrapOpts
+ * @property {string} [source]   Override source directory (default: resolveSource).
+ * @property {string} [target]   Override target directory (default: ~/.claude).
+ * @property {boolean} [quiet]   Suppress per-file output.
+ * @property {boolean} [json]    Buffer output as JSON.
+ * @property {boolean} [noColor] Suppress ANSI colors.
+ *
+ * @typedef {object} BootstrapResult
+ * @property {boolean} ok
+ * @property {number} linked
+ * @property {number} skipped
+ * @property {number} backed_up
+ */
+
+/**
+ * Bootstrap dotclaude into the target directory.
+ *
+ * @param {BootstrapOpts} [opts]
+ * @returns {Promise<BootstrapResult>}
+ */
+export async function bootstrapGlobal(opts = {}) {
+  const source = resolveSource(opts.source, process.env);
+  const target = opts.target ?? path.join(os.homedir(), ".claude");
+
+  const out = createOutput({
+    noColor: opts.noColor ?? true,
+    json: opts.json ?? false,
+  });
+
+  // Validate source exists
+  if (!fs.existsSync(source)) {
+    out.fail(`source directory does not exist: ${source}`);
+    return { ok: false, linked: 0, skipped: 0, backed_up: 0 };
+  }
+
+  const ts = new Date()
+    .toISOString()
+    .replace(/[-:T]/g, "")
+    .replace(/\..+$/, "")
+    .slice(0, 15); // YYYYMMDDTHHmmss → "20260415T113000"
+
+  // Reformat to match bootstrap.sh: YYYYMMDD-HHmmss
+  const datePart = ts.slice(0, 8);
+  const timePart = ts.slice(9, 15);
+  const timestamp = `${datePart}-${timePart}`;
+
+  fs.mkdirSync(target, { recursive: true });
+
+  let linked = 0;
+  let skipped = 0;
+  let backed_up = 0;
+
+  /**
+   * Wrapper that counts outcomes.
+   */
+  function doLink(src, dst) {
+    const r = linkOne(src, dst, out, timestamp);
+    if (r.action === "linked" || r.action === "updated") linked++;
+    else if (r.action === "ok") {
+      // already correct — counts as "linked" for idempotency metrics but no
+      // new work done; we keep it in the linked tally
+      linked++;
+    } else if (r.action === "backed_up") {
+      backed_up++;
+      linked++;
+    }
+  }
+
+  // --- CLAUDE.md ---
+  const claudeMdSrc = path.join(source, "CLAUDE.md");
+  if (fs.existsSync(claudeMdSrc)) {
+    doLink(claudeMdSrc, path.join(target, "CLAUDE.md"));
+  }
+
+  // --- commands/*.md ---
+  const commandsSrc = path.join(source, "commands");
+  if (fs.existsSync(commandsSrc)) {
+    fs.mkdirSync(path.join(target, "commands"), { recursive: true });
+    const entries = fs.readdirSync(commandsSrc);
+    for (const entry of entries) {
+      if (!entry.endsWith(".md")) continue;
+      const src = path.join(commandsSrc, entry);
+      const dst = path.join(target, "commands", entry);
+      doLink(src, dst);
+    }
+  }
+
+  // --- skills/*/ (directories) ---
+  const skillsSrc = path.join(source, "skills");
+  if (fs.existsSync(skillsSrc)) {
+    fs.mkdirSync(path.join(target, "skills"), { recursive: true });
+    const entries = fs.readdirSync(skillsSrc, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const src = path.join(skillsSrc, entry.name);
+      const dst = path.join(target, "skills", entry.name);
+      doLink(src, dst);
+    }
+  }
+
+  // --- agents (copy, not symlink) ---
+  const agentsSrc = path.join(source, "plugins", "dotclaude", "templates", "claude", "agents");
+  const agentsDst = path.join(target, "agents");
+  if (fs.existsSync(agentsSrc)) {
+    fs.mkdirSync(agentsDst, { recursive: true });
+    const agentFiles = fs.readdirSync(agentsSrc);
+    for (const agentFile of agentFiles) {
+      if (!agentFile.endsWith(".md")) continue;
+      const dstFile = path.join(agentsDst, agentFile);
+      if (fs.existsSync(dstFile)) {
+        out.info(`skipped (exists): ${agentFile}`);
+        skipped++;
+      } else {
+        fs.copyFileSync(path.join(agentsSrc, agentFile), dstFile);
+        out.pass(`installed agent: ${agentFile}`);
+      }
+    }
+  }
+
+  out.flush();
+  return { ok: true, linked, skipped, backed_up };
+}

--- a/plugins/dotclaude/src/bootstrap-global.mjs
+++ b/plugins/dotclaude/src/bootstrap-global.mjs
@@ -144,7 +144,7 @@ export async function bootstrapGlobal(opts = {}) {
   const target = opts.target ?? path.join(os.homedir(), ".claude");
 
   const out = createOutput({
-    noColor: opts.noColor ?? true,
+    noColor: opts.noColor ?? false,
     json: opts.json ?? false,
   });
 
@@ -154,16 +154,14 @@ export async function bootstrapGlobal(opts = {}) {
     return { ok: false, linked: 0, skipped: 0, backed_up: 0 };
   }
 
+  // Build YYYYMMDD-HHmmss timestamp matching bootstrap.sh's date +%Y%m%d-%H%M%S.
+  // After replace(/[-:T]/g, "") the ISO string becomes "YYYYMMDDHHmmss.mmmZ",
+  // so datePart is slice(0,8) and timePart is slice(8,14) — no T separator remains.
   const ts = new Date()
     .toISOString()
     .replace(/[-:T]/g, "")
-    .replace(/\..+$/, "")
-    .slice(0, 15); // YYYYMMDDTHHmmss → "20260415T113000"
-
-  // Reformat to match bootstrap.sh: YYYYMMDD-HHmmss
-  const datePart = ts.slice(0, 8);
-  const timePart = ts.slice(9, 15);
-  const timestamp = `${datePart}-${timePart}`;
+    .replace(/\..+$/, ""); // → "YYYYMMDDHHmmss"
+  const timestamp = `${ts.slice(0, 8)}-${ts.slice(8, 14)}`;
 
   fs.mkdirSync(target, { recursive: true });
 

--- a/plugins/dotclaude/src/bootstrap-global.mjs
+++ b/plugins/dotclaude/src/bootstrap-global.mjs
@@ -17,9 +17,11 @@ import { createOutput } from "./lib/output.mjs";
 
 // ---------------------------------------------------------------------------
 // pkgRoot() — walk up from this file until we find a directory containing
-// bootstrap.sh. That is the dotclaude repo root. Works both:
-//   • in the git checkout (where bootstrap.sh lives at the repo root), and
-//   • in an npm install (the package ships with the same layout).
+// bootstrap.sh. That is the dotclaude repo root. Works in a git checkout
+// where bootstrap.sh lives at the repo root. In a published npm install
+// bootstrap.sh is not shipped, so the loop hits the filesystem root and
+// falls back to two levels up from this file (src/ → plugins/dotclaude/ →
+// repo root), which is correct for the npm package layout.
 // ---------------------------------------------------------------------------
 
 function pkgRoot() {
@@ -146,11 +148,13 @@ export async function bootstrapGlobal(opts = {}) {
   const out = createOutput({
     noColor: opts.noColor ?? false,
     json: opts.json ?? false,
+    quiet: opts.quiet ?? false,
   });
 
   // Validate source exists
   if (!fs.existsSync(source)) {
     out.fail(`source directory does not exist: ${source}`);
+    out.flush();
     return { ok: false, linked: 0, skipped: 0, backed_up: 0 };
   }
 

--- a/plugins/dotclaude/src/index.mjs
+++ b/plugins/dotclaude/src/index.mjs
@@ -46,6 +46,10 @@ export { checkInstructionDrift } from "./check-instruction-drift.mjs";
 export { checkSpecCoverage } from "./check-spec-coverage.mjs";
 export { scaffoldHarness } from "./init-harness-scaffold.mjs";
 
+// --- bootstrap + sync (global ~/.claude/ lifecycle) ---
+export { bootstrapGlobal, resolveSource } from "./bootstrap-global.mjs";
+export { syncGlobal, resolveMode } from "./sync-global.mjs";
+
 // --- error taxonomy + exit codes ---
 export { ValidationError, ERROR_CODES, formatError } from "./lib/errors.mjs";
 export { EXIT_CODES } from "./lib/exit-codes.mjs";

--- a/plugins/dotclaude/src/lib/output.mjs
+++ b/plugins/dotclaude/src/lib/output.mjs
@@ -24,6 +24,7 @@
  * @typedef {object} OutputOptions
  * @property {boolean} [json]     When true, buffer events and emit a JSON array on flush().
  * @property {boolean} [noColor]  When true, suppress ANSI escapes regardless of TTY.
+ * @property {boolean} [quiet]    When true, suppress pass/info events; fail/warn still emit.
  * @property {NodeJS.WritableStream} [stream]  Defaults to process.stdout.
  * @property {NodeJS.ProcessEnv} [env]         Defaults to process.env.
  */
@@ -44,6 +45,7 @@ export function createOutput(opts = {}) {
   const stream = opts.stream ?? process.stdout;
   const json = Boolean(opts.json);
   const noColor = Boolean(opts.noColor) || 'NO_COLOR' in env;
+  const quiet = Boolean(opts.quiet);
   const useAnsi = !json && !noColor && Boolean(stream.isTTY);
 
   const counts = { pass: 0, fail: 0, warn: 0 };
@@ -61,6 +63,8 @@ export function createOutput(opts = {}) {
     if (kind === 'pass') counts.pass++;
     else if (kind === 'fail') counts.fail++;
     else if (kind === 'warn') counts.warn++;
+    // quiet mode: suppress per-file progress (pass/info); fail/warn always surface
+    if (quiet && (kind === 'pass' || kind === 'info')) return;
     if (json) {
       /** @type {OutputEvent} */
       const event = { kind, message };

--- a/plugins/dotclaude/src/sync-global.mjs
+++ b/plugins/dotclaude/src/sync-global.mjs
@@ -116,6 +116,10 @@ async function statusNpm(out) {
 
 async function statusClone(out, source) {
   const res = run("git", ["-C", source, "status", "--short"]);
+  if (res.status !== 0) {
+    out.fail(`git status failed: ${trim(res.stderr || res.stdout)}`);
+    return { ok: false, mode: "clone", summary: "git status failed" };
+  }
   out.info(trim(res.stdout));
   return { ok: true, mode: "clone", summary: "git status shown" };
 }

--- a/plugins/dotclaude/src/sync-global.mjs
+++ b/plugins/dotclaude/src/sync-global.mjs
@@ -67,6 +67,10 @@ function trim(s) {
 
 async function pullNpm(out, opts) {
   const res = run("npm", ["view", "@dotclaude/dotclaude", "version"]);
+  if (res.status !== 0) {
+    out.fail(`npm view failed: ${trim(res.stderr || res.stdout)}`);
+    return { ok: false, mode: "npm", summary: "npm view failed" };
+  }
   const latest = trim(res.stdout);
 
   if (currentVersion === latest) {
@@ -80,7 +84,7 @@ async function pullNpm(out, opts) {
   }
 
   await bootstrapGlobal({ quiet: opts.quiet, json: opts.json, noColor: opts.noColor });
-  return { ok: true, mode: "npm", summary: `updated to v${latest ?? currentVersion}` };
+  return { ok: true, mode: "npm", summary: `updated to v${latest || currentVersion}` };
 }
 
 async function pullClone(out, source, opts) {
@@ -131,13 +135,21 @@ async function pushNpm(out) {
 
 async function pushClone(out, source) {
   // Stage all changes
-  run("git", ["-C", source, "add", "-A"]);
+  const addRes = run("git", ["-C", source, "add", "-A"]);
+  if (addRes.status !== 0) {
+    out.fail(`git add failed: ${trim(addRes.stderr)}`);
+    return { ok: false, mode: "clone", summary: "git add failed" };
+  }
 
-  // Check if anything is staged
+  // Check if anything is staged (exit 0 = nothing staged, exit 1 = changes staged, >1 = error)
   const diffRes = run("git", ["-C", source, "diff", "--cached", "--quiet"]);
   if (diffRes.status === 0) {
     out.info("no changes to push");
     return { ok: true, mode: "clone", summary: "nothing to push" };
+  }
+  if (diffRes.status > 1) {
+    out.fail(`git diff failed: ${trim(diffRes.stderr)}`);
+    return { ok: false, mode: "clone", summary: "git diff failed" };
   }
 
   // Secret scan: get list of staged files
@@ -149,12 +161,20 @@ async function pushClone(out, source) {
     "--name-only",
     "--diff-filter=ACMR",
   ]);
+  if (stagedRes.status !== 0) {
+    out.fail(`git diff --name-only failed: ${trim(stagedRes.stderr)}`);
+    return { ok: false, mode: "clone", summary: "git diff --name-only failed" };
+  }
   const stagedFiles = trim(stagedRes.stdout)
     .split("\n")
     .filter((f) => f.length > 0);
 
   for (const file of stagedFiles) {
     const showRes = run("git", ["-C", source, "show", `:${file}`]);
+    if (showRes.status !== 0) {
+      out.fail(`secret-scan: could not read staged file ${file}`);
+      return { ok: false, mode: "clone", summary: `could not read staged file ${file}` };
+    }
     if (SECRET_RX.test(showRes.stdout)) {
       out.fail(`secret-scan: POSSIBLE SECRET in ${file}`);
       out.fail(
@@ -212,20 +232,24 @@ export async function syncGlobal(subcommand, opts = {}) {
 
   const out = createOutput({ quiet, json, noColor });
 
-  if (subcommand === "pull") {
-    return mode === "clone"
-      ? pullClone(out, source, opts)
-      : pullNpm(out, opts);
-  }
+  try {
+    if (subcommand === "pull") {
+      return await (mode === "clone"
+        ? pullClone(out, source, opts)
+        : pullNpm(out, opts));
+    }
 
-  if (subcommand === "status") {
-    return mode === "clone" ? statusClone(out, source) : statusNpm(out);
-  }
+    if (subcommand === "status") {
+      return await (mode === "clone" ? statusClone(out, source) : statusNpm(out));
+    }
 
-  if (subcommand === "push") {
-    return mode === "clone" ? pushClone(out, source) : pushNpm(out);
-  }
+    if (subcommand === "push") {
+      return await (mode === "clone" ? pushClone(out, source) : pushNpm(out));
+    }
 
-  out.fail(`unknown subcommand: ${subcommand}`);
-  return { ok: false, mode, summary: `unknown subcommand: ${subcommand}` };
+    out.fail(`unknown subcommand: ${subcommand}`);
+    return { ok: false, mode, summary: `unknown subcommand: ${subcommand}` };
+  } finally {
+    out.flush();
+  }
 }

--- a/plugins/dotclaude/src/sync-global.mjs
+++ b/plugins/dotclaude/src/sync-global.mjs
@@ -1,0 +1,227 @@
+/**
+ * sync-global.mjs — JS port of sync.sh
+ *
+ * Handles pull/push/status for dotclaude in both npm and clone modes.
+ *
+ * Exported API:
+ *   resolveMode(sourceOpt)        — 'clone' | 'npm'
+ *   syncGlobal(subcommand, opts)  — main entry point
+ */
+
+import { spawnSync } from "node:child_process";
+import { createOutput } from "./lib/output.mjs";
+import { bootstrapGlobal } from "./bootstrap-global.mjs";
+import { version as currentVersion } from "./index.mjs";
+
+// ---------------------------------------------------------------------------
+// SECRET_RX — verbatim port from sync.sh
+// Catches common literal-secret shapes. High-entropy strings still slip
+// through; this is a last-ditch guard, not a full DLP system.
+// ---------------------------------------------------------------------------
+
+const SECRET_RX =
+  /(^|[^A-Z_])(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|[A-Z_]*_?(API|ACCESS|AUTH|BEARER|PRIVATE)?_?(KEY|TOKEN|SECRET|PASSWORD))[  ]*[:=][  ]*["']?[A-Za-z0-9+/=_-]{20,}["']?|AKIA[0-9A-Z]{16}|bearer[ \t]+[A-Za-z0-9._-]{20,}/im;
+
+// ---------------------------------------------------------------------------
+// resolveMode
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine operating mode.
+ *
+ * @param {string|undefined} sourceOpt
+ * @returns {'clone'|'npm'}
+ */
+export function resolveMode(sourceOpt) {
+  return sourceOpt ? "clone" : "npm";
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a subprocess synchronously. Returns the result.
+ *
+ * @param {string} cmd
+ * @param {string[]} args
+ * @returns {{ stdout: string, stderr: string, status: number }}
+ */
+function run(cmd, args) {
+  return spawnSync(cmd, args, { encoding: "utf8" });
+}
+
+/**
+ * Trim trailing whitespace / newlines from spawnSync stdout.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function trim(s) {
+  return (s ?? "").trim();
+}
+
+// ---------------------------------------------------------------------------
+// subcommand implementations
+// ---------------------------------------------------------------------------
+
+async function pullNpm(out, opts) {
+  const res = run("npm", ["view", "@dotclaude/dotclaude", "version"]);
+  const latest = trim(res.stdout);
+
+  if (currentVersion === latest) {
+    out.info(`already up to date (v${currentVersion})`);
+  } else {
+    const updateRes = run("npm", ["update", "-g", "@dotclaude/dotclaude"]);
+    if (updateRes.status !== 0) {
+      out.fail(`npm update failed: ${trim(updateRes.stderr)}`);
+      return { ok: false, mode: "npm", summary: "npm update failed" };
+    }
+  }
+
+  await bootstrapGlobal({ quiet: opts.quiet, json: opts.json, noColor: opts.noColor });
+  return { ok: true, mode: "npm", summary: `updated to v${latest ?? currentVersion}` };
+}
+
+async function pullClone(out, source, opts) {
+  const fetchRes = run("git", ["-C", source, "fetch", "origin"]);
+  if (fetchRes.status !== 0) {
+    out.fail(`git fetch failed: ${trim(fetchRes.stderr)}`);
+    return { ok: false, mode: "clone", summary: "git fetch failed" };
+  }
+
+  const rebaseRes = run("git", ["-C", source, "rebase", "origin/main"]);
+  if (rebaseRes.status !== 0) {
+    out.fail(`git rebase failed: ${trim(rebaseRes.stderr)}`);
+    return { ok: false, mode: "clone", summary: "git rebase failed" };
+  }
+
+  await bootstrapGlobal({ source, quiet: opts.quiet, json: opts.json, noColor: opts.noColor });
+  return { ok: true, mode: "clone", summary: "pulled and re-bootstrapped from clone" };
+}
+
+async function statusNpm(out) {
+  const res = run("npm", ["view", "@dotclaude/dotclaude", "version"]);
+  const latest = trim(res.stdout);
+
+  const msg = `installed: v${currentVersion}  latest: v${latest}`;
+  if (latest && currentVersion !== latest) {
+    out.warn(msg);
+  } else {
+    out.info(msg);
+  }
+
+  return { ok: true, mode: "npm", summary: msg };
+}
+
+async function statusClone(out, source) {
+  const res = run("git", ["-C", source, "status", "--short"]);
+  out.info(trim(res.stdout));
+  return { ok: true, mode: "clone", summary: "git status shown" };
+}
+
+async function pushNpm(out) {
+  out.fail("sync push is only available in clone mode (--source <path>)");
+  return { ok: false, mode: "npm", summary: "push unavailable in npm mode — use clone mode (--source <path>)" };
+}
+
+async function pushClone(out, source) {
+  // Stage all changes
+  run("git", ["-C", source, "add", "-A"]);
+
+  // Check if anything is staged
+  const diffRes = run("git", ["-C", source, "diff", "--cached", "--quiet"]);
+  if (diffRes.status === 0) {
+    out.info("no changes to push");
+    return { ok: true, mode: "clone", summary: "nothing to push" };
+  }
+
+  // Secret scan: get list of staged files
+  const stagedRes = run("git", [
+    "-C",
+    source,
+    "diff",
+    "--cached",
+    "--name-only",
+    "--diff-filter=ACMR",
+  ]);
+  const stagedFiles = trim(stagedRes.stdout)
+    .split("\n")
+    .filter((f) => f.length > 0);
+
+  for (const file of stagedFiles) {
+    const showRes = run("git", ["-C", source, "show", `:${file}`]);
+    if (SECRET_RX.test(showRes.stdout)) {
+      out.fail(`secret-scan: POSSIBLE SECRET in ${file}`);
+      out.fail(
+        "secret-scan: aborting push. Re-run after removing or whitelisting."
+      );
+      return { ok: false, mode: "clone", summary: `secret detected in ${file}` };
+    }
+  }
+
+  // Commit
+  const date = new Date().toISOString().slice(0, 10);
+  const commitRes = run("git", ["-C", source, "commit", "-m", `dotclaude: sync ${date}`]);
+  if (commitRes.status !== 0) {
+    out.fail(`git commit failed: ${trim(commitRes.stderr)}`);
+    return { ok: false, mode: "clone", summary: "git commit failed" };
+  }
+
+  // Push
+  const pushRes = run("git", ["-C", source, "push"]);
+  if (pushRes.status !== 0) {
+    out.fail(`git push failed: ${trim(pushRes.stderr)}`);
+    return { ok: false, mode: "clone", summary: "git push failed" };
+  }
+
+  return { ok: true, mode: "clone", summary: `pushed dotclaude: sync ${date}` };
+}
+
+// ---------------------------------------------------------------------------
+// syncGlobal — main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} SyncOpts
+ * @property {string} [source]   Path to dotclaude clone (triggers clone mode).
+ * @property {boolean} [quiet]
+ * @property {boolean} [json]
+ * @property {boolean} [noColor]
+ *
+ * @typedef {object} SyncResult
+ * @property {boolean} ok
+ * @property {'npm'|'clone'} mode
+ * @property {string} summary
+ */
+
+/**
+ * Run a sync subcommand.
+ *
+ * @param {'pull'|'status'|'push'} subcommand
+ * @param {SyncOpts} [opts]
+ * @returns {Promise<SyncResult>}
+ */
+export async function syncGlobal(subcommand, opts = {}) {
+  const { source, quiet, json, noColor } = opts;
+  const mode = resolveMode(source);
+
+  const out = createOutput({ quiet, json, noColor });
+
+  if (subcommand === "pull") {
+    return mode === "clone"
+      ? pullClone(out, source, opts)
+      : pullNpm(out, opts);
+  }
+
+  if (subcommand === "status") {
+    return mode === "clone" ? statusClone(out, source) : statusNpm(out);
+  }
+
+  if (subcommand === "push") {
+    return mode === "clone" ? pushClone(out, source) : pushNpm(out);
+  }
+
+  out.fail(`unknown subcommand: ${subcommand}`);
+  return { ok: false, mode, summary: `unknown subcommand: ${subcommand}` };
+}

--- a/plugins/dotclaude/tests/bootstrap-global.test.mjs
+++ b/plugins/dotclaude/tests/bootstrap-global.test.mjs
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { fileURLToPath } from "url";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import { bootstrapGlobal, resolveSource } from "../src/bootstrap-global.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Path to the real dotclaude repo root (two levels up from plugins/dotclaude)
+const REAL_SOURCE = path.resolve(__dirname, "..", "..", "..");
+
+let tmpDirs = [];
+
+function makeTmpDir(prefix = "bootstrap-global-test-") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs = [];
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — build a minimal fake source tree that mirrors the bootstrap.sh
+// expectations.
+// ---------------------------------------------------------------------------
+
+function buildFakeSource(dir) {
+  // CLAUDE.md
+  fs.writeFileSync(path.join(dir, "CLAUDE.md"), "# CLAUDE\n");
+
+  // commands/*.md
+  fs.mkdirSync(path.join(dir, "commands"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "commands", "foo.md"), "# foo\n");
+  fs.writeFileSync(path.join(dir, "commands", "bar.md"), "# bar\n");
+
+  // skills/<name>/  (directory entries)
+  fs.mkdirSync(path.join(dir, "skills", "alpha"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "skills", "alpha", "skill.md"), "# alpha\n");
+  fs.mkdirSync(path.join(dir, "skills", "beta"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "skills", "beta", "skill.md"), "# beta\n");
+
+  // agents template
+  fs.mkdirSync(path.join(dir, "plugins", "dotclaude", "templates", "claude", "agents"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "plugins", "dotclaude", "templates", "claude", "agents", "my-agent.md"),
+    "---\nname: my-agent\n---\n"
+  );
+
+  // bootstrap.sh marker (needed for pkgRoot() detection)
+  fs.writeFileSync(path.join(dir, "bootstrap.sh"), "#!/usr/bin/env bash\n");
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — creates symlinks for CLAUDE.md, commands/, skills/
+// ---------------------------------------------------------------------------
+
+describe("bootstrapGlobal", () => {
+  it("creates symlinks for CLAUDE.md, commands/, skills/ in a temp target dir", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    const result = await bootstrapGlobal({ source: src, target: tgt });
+
+    expect(result.ok).toBe(true);
+
+    // CLAUDE.md symlink
+    const claudeMd = path.join(tgt, "CLAUDE.md");
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(claudeMd)).toBe(path.join(src, "CLAUDE.md"));
+
+    // commands/foo.md symlink
+    const fooCmd = path.join(tgt, "commands", "foo.md");
+    expect(fs.lstatSync(fooCmd).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(fooCmd)).toBe(path.join(src, "commands", "foo.md"));
+
+    // skills/alpha symlink (directory)
+    const alphaSkill = path.join(tgt, "skills", "alpha");
+    expect(fs.lstatSync(alphaSkill).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(alphaSkill)).toBe(path.join(src, "skills", "alpha"));
+
+    // agents/my-agent.md is a real copy (not a symlink)
+    const agentDst = path.join(tgt, "agents", "my-agent.md");
+    expect(fs.existsSync(agentDst)).toBe(true);
+    expect(fs.lstatSync(agentDst).isSymbolicLink()).toBe(false);
+
+    expect(result.linked).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2 — idempotent
+  // -------------------------------------------------------------------------
+
+  it("is idempotent — second run produces same state, no extra backups", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    await bootstrapGlobal({ source: src, target: tgt });
+    const result2 = await bootstrapGlobal({ source: src, target: tgt });
+
+    expect(result2.ok).toBe(true);
+    // No new backups on second run
+    expect(result2.backed_up).toBe(0);
+
+    // symlinks still correct
+    const claudeMd = path.join(tgt, "CLAUDE.md");
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(claudeMd)).toBe(path.join(src, "CLAUDE.md"));
+
+    // No extra .bak files created
+    const tgtEntries = fs.readdirSync(tgt);
+    expect(tgtEntries.some((e) => e.includes(".bak"))).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3 — backs up a real file before overwriting with symlink
+  // -------------------------------------------------------------------------
+
+  it("backs up a real file before overwriting with symlink", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    // Pre-create a real CLAUDE.md in target
+    fs.writeFileSync(path.join(tgt, "CLAUDE.md"), "# old content\n");
+
+    const result = await bootstrapGlobal({ source: src, target: tgt });
+
+    expect(result.ok).toBe(true);
+    expect(result.backed_up).toBeGreaterThan(0);
+
+    // The destination is now a symlink
+    const claudeMd = path.join(tgt, "CLAUDE.md");
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(true);
+
+    // A backup file with .bak- prefix exists
+    const tgtEntries = fs.readdirSync(tgt);
+    const bak = tgtEntries.find((e) => e.startsWith("CLAUDE.md.bak-"));
+    expect(bak).toBeDefined();
+
+    // Backup has the old content
+    expect(fs.readFileSync(path.join(tgt, bak), "utf8")).toBe("# old content\n");
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4 — updates a stale symlink pointing elsewhere
+  // -------------------------------------------------------------------------
+
+  it("updates a stale symlink pointing elsewhere", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    // Pre-create a symlink pointing to wrong target
+    const staleTarget = path.join(src, "some-other-file.md");
+    fs.writeFileSync(staleTarget, "stale\n");
+    fs.symlinkSync(staleTarget, path.join(tgt, "CLAUDE.md"));
+
+    const result = await bootstrapGlobal({ source: src, target: tgt });
+
+    expect(result.ok).toBe(true);
+
+    // Symlink should now point to the correct CLAUDE.md
+    const claudeMd = path.join(tgt, "CLAUDE.md");
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(claudeMd)).toBe(path.join(src, "CLAUDE.md"));
+
+    // No backup was made (stale symlinks are just replaced)
+    expect(result.backed_up).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5 — skips copying agents if file already exists in target
+  // -------------------------------------------------------------------------
+
+  it("skips copying agents if file already exists in target", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    // Pre-create the agents dir with the agent already installed
+    fs.mkdirSync(path.join(tgt, "agents"), { recursive: true });
+    const existingContent = "# existing agent\n";
+    fs.writeFileSync(path.join(tgt, "agents", "my-agent.md"), existingContent);
+
+    const result = await bootstrapGlobal({ source: src, target: tgt });
+
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBeGreaterThan(0);
+
+    // Original content must be preserved (not overwritten)
+    const agentContent = fs.readFileSync(path.join(tgt, "agents", "my-agent.md"), "utf8");
+    expect(agentContent).toBe(existingContent);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 6 — returns { ok: false } when source directory does not exist
+  // -------------------------------------------------------------------------
+
+  it("returns { ok: false } when source directory does not exist", async () => {
+    const tgt = makeTmpDir("bg-tgt-");
+    const nonexistent = path.join(os.tmpdir(), "this-does-not-exist-" + Date.now());
+
+    const result = await bootstrapGlobal({ source: nonexistent, target: tgt });
+
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7 & 8 — resolveSource
+// ---------------------------------------------------------------------------
+
+describe("resolveSource", () => {
+  it("uses DOTCLAUDE_DIR env var when no --source given", () => {
+    const fakeDir = "/tmp/fake-dotclaude";
+    const resolved = resolveSource(undefined, { DOTCLAUDE_DIR: fakeDir });
+    expect(resolved).toBe(fakeDir);
+  });
+
+  it("falls back to pkgRoot() when DOTCLAUDE_DIR is unset", () => {
+    // When neither sourceOpt nor DOTCLAUDE_DIR is given, resolveSource must
+    // return a path that actually contains bootstrap.sh (the repo root).
+    const resolved = resolveSource(undefined, {});
+    expect(fs.existsSync(path.join(resolved, "bootstrap.sh"))).toBe(true);
+  });
+});

--- a/plugins/dotclaude/tests/bootstrap-global.test.mjs
+++ b/plugins/dotclaude/tests/bootstrap-global.test.mjs
@@ -1,14 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { fileURLToPath } from "url";
+import { describe, it, expect, afterEach } from "vitest";
 import path from "path";
 import fs from "fs";
 import os from "os";
 import { bootstrapGlobal, resolveSource } from "../src/bootstrap-global.mjs";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-// Path to the real dotclaude repo root (two levels up from plugins/dotclaude)
-const REAL_SOURCE = path.resolve(__dirname, "..", "..", "..");
 
 let tmpDirs = [];
 

--- a/plugins/dotclaude/tests/sync-global.test.mjs
+++ b/plugins/dotclaude/tests/sync-global.test.mjs
@@ -1,0 +1,186 @@
+/**
+ * Tests for sync-global.mjs
+ *
+ * Uses vitest with vi.mock / vi.spyOn to intercept spawnSync and bootstrapGlobal.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock child_process spawnSync before importing the module under test
+// ---------------------------------------------------------------------------
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+// Mock bootstrapGlobal so tests don't touch the real filesystem
+vi.mock("../src/bootstrap-global.mjs", () => ({
+  bootstrapGlobal: vi.fn().mockResolvedValue({ ok: true, linked: 3, skipped: 0, backed_up: 0 }),
+}));
+
+// Mock index.mjs version export
+vi.mock("../src/index.mjs", () => ({
+  version: "1.2.3",
+}));
+
+import { spawnSync } from "node:child_process";
+import { bootstrapGlobal } from "../src/bootstrap-global.mjs";
+import { resolveMode, syncGlobal } from "../src/sync-global.mjs";
+
+// ---------------------------------------------------------------------------
+// Test 1 & 2 — resolveMode
+// ---------------------------------------------------------------------------
+
+describe("resolveMode", () => {
+  it("returns 'clone' when source option is provided", () => {
+    expect(resolveMode("/home/user/dotclaude")).toBe("clone");
+  });
+
+  it("returns 'npm' when no source is provided", () => {
+    expect(resolveMode(undefined)).toBe("npm");
+    expect(resolveMode(null)).toBe("npm");
+    expect(resolveMode("")).toBe("npm");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests 3–8 — syncGlobal
+// ---------------------------------------------------------------------------
+
+describe("syncGlobal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3 — pull (npm mode) calls npm update when newer version is available
+  // -------------------------------------------------------------------------
+
+  it("pull (npm mode) calls npm update when newer version is available", async () => {
+    // npm view returns a newer version
+    spawnSync
+      .mockReturnValueOnce({ stdout: "1.3.0\n", stderr: "", status: 0 })   // npm view
+      .mockReturnValueOnce({ stdout: "", stderr: "", status: 0 });           // npm update
+
+    const result = await syncGlobal("pull", {});
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npm",
+      ["view", "@dotclaude/dotclaude", "version"],
+      expect.objectContaining({ encoding: "utf8" })
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npm",
+      ["update", "-g", "@dotclaude/dotclaude"],
+      expect.objectContaining({ encoding: "utf8" })
+    );
+    expect(bootstrapGlobal).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("npm");
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4 — pull (npm mode) skips update when already at latest version
+  // -------------------------------------------------------------------------
+
+  it("pull (npm mode) skips update when already at latest version", async () => {
+    // npm view returns the same version as current (1.2.3)
+    spawnSync.mockReturnValueOnce({ stdout: "1.2.3\n", stderr: "", status: 0 });
+
+    const result = await syncGlobal("pull", {});
+
+    // npm update should NOT have been called
+    const updateCalls = spawnSync.mock.calls.filter(
+      (call) => call[0] === "npm" && call[1].includes("update")
+    );
+    expect(updateCalls).toHaveLength(0);
+    // bootstrapGlobal still called (re-link)
+    expect(bootstrapGlobal).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("npm");
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5 — pull (clone mode) runs git fetch, rebase then bootstraps
+  // -------------------------------------------------------------------------
+
+  it("pull (clone mode) runs git fetch, rebase then bootstraps", async () => {
+    spawnSync
+      .mockReturnValueOnce({ stdout: "", stderr: "", status: 0 })  // git fetch
+      .mockReturnValueOnce({ stdout: "", stderr: "", status: 0 });  // git rebase
+
+    const source = "/home/user/dotclaude";
+    const result = await syncGlobal("pull", { source });
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["-C", source, "fetch", "origin"],
+      expect.objectContaining({ encoding: "utf8" })
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["-C", source, "rebase", "origin/main"],
+      expect.objectContaining({ encoding: "utf8" })
+    );
+    expect(bootstrapGlobal).toHaveBeenCalledWith(
+      expect.objectContaining({ source })
+    );
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("clone");
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 6 — status (npm mode) reports current and latest version
+  // -------------------------------------------------------------------------
+
+  it("status (npm mode) reports current and latest version", async () => {
+    spawnSync.mockReturnValueOnce({ stdout: "1.5.0\n", stderr: "", status: 0 });
+
+    const result = await syncGlobal("status", {});
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npm",
+      ["view", "@dotclaude/dotclaude", "version"],
+      expect.objectContaining({ encoding: "utf8" })
+    );
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("npm");
+    // summary should mention both installed and latest
+    expect(result.summary).toMatch(/1\.2\.3/);
+    expect(result.summary).toMatch(/1\.5\.0/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 7 — status (clone mode) delegates to git status
+  // -------------------------------------------------------------------------
+
+  it("status (clone mode) delegates to git status", async () => {
+    const gitStatusOutput = " M CLAUDE.md\n";
+    spawnSync.mockReturnValueOnce({ stdout: gitStatusOutput, stderr: "", status: 0 });
+
+    const source = "/home/user/dotclaude";
+    const result = await syncGlobal("status", { source });
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["-C", source, "status", "--short"],
+      expect.objectContaining({ encoding: "utf8" })
+    );
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("clone");
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 8 — push (npm mode) exits with a failure message
+  // -------------------------------------------------------------------------
+
+  it("push (npm mode) exits with a failure message", async () => {
+    const result = await syncGlobal("push", {});
+
+    // No git/npm calls expected
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.mode).toBe("npm");
+    expect(result.summary).toMatch(/clone mode/i);
+  });
+});

--- a/plugins/dotclaude/tests/sync-global.test.mjs
+++ b/plugins/dotclaude/tests/sync-global.test.mjs
@@ -4,7 +4,7 @@
  * Uses vitest with vi.mock / vi.spyOn to intercept spawnSync and bootstrapGlobal.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mock child_process spawnSync before importing the module under test

--- a/plugins/dotclaude/tests/sync-global.test.mjs
+++ b/plugins/dotclaude/tests/sync-global.test.mjs
@@ -236,4 +236,46 @@ describe("syncGlobal", () => {
     const calls = spawnSync.mock.calls.map((c) => c.slice(0, 2));
     expect(calls).not.toContainEqual(["git", ["-C", source, "commit", expect.any(String), expect.any(String)]]);
   });
+
+  // -------------------------------------------------------------------------
+  // Test 11 — pull (npm mode) fails when npm view returns non-zero
+  // -------------------------------------------------------------------------
+
+  it("pull (npm mode) returns ok:false when npm view fails", async () => {
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "network error", status: 1 });
+
+    const result = await syncGlobal("pull", {});
+
+    expect(result.ok).toBe(false);
+    expect(result.mode).toBe("npm");
+    expect(result.summary).toMatch(/npm view failed/i);
+    // npm update must NOT have been called
+    const updateCalls = spawnSync.mock.calls.filter(
+      (call) => call[0] === "npm" && call[1].includes("update")
+    );
+    expect(updateCalls).toHaveLength(0);
+    expect(bootstrapGlobal).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 12 — push (clone mode) aborts when git show fails during secret scan
+  // -------------------------------------------------------------------------
+
+  it("push (clone mode) aborts when git show fails during secret scan", async () => {
+    const source = "/home/user/dotclaude";
+    // git add -A
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "", status: 0 });
+    // git diff --cached --quiet → staged changes
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "", status: 1 });
+    // git diff --cached --name-only
+    spawnSync.mockReturnValueOnce({ stdout: "broken.md\n", stderr: "", status: 0 });
+    // git show :broken.md → fails
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "fatal: path not found", status: 128 });
+
+    const result = await syncGlobal("push", { source });
+
+    expect(result.ok).toBe(false);
+    expect(result.mode).toBe("clone");
+    expect(result.summary).toMatch(/could not read staged file/i);
+  });
 });

--- a/plugins/dotclaude/tests/sync-global.test.mjs
+++ b/plugins/dotclaude/tests/sync-global.test.mjs
@@ -183,4 +183,57 @@ describe("syncGlobal", () => {
     expect(result.mode).toBe("npm");
     expect(result.summary).toMatch(/clone mode/i);
   });
+
+  // -------------------------------------------------------------------------
+  // Test 9 — push (clone mode) happy path
+  // -------------------------------------------------------------------------
+
+  it("push (clone mode) commits and pushes when no secrets detected", async () => {
+    const source = "/home/user/dotclaude";
+    // git add -A
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "", status: 0 });
+    // git diff --cached --quiet → non-zero means there ARE staged changes
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "", status: 1 });
+    // git diff --cached --name-only → returns staged filenames
+    spawnSync.mockReturnValueOnce({ stdout: "CLAUDE.md\n", stderr: "", status: 0 });
+    // git show :CLAUDE.md → clean content (no secrets)
+    spawnSync.mockReturnValueOnce({ stdout: "# CLAUDE\n", stderr: "", status: 0 });
+    // git commit
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "", status: 0 });
+    // git push
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "", status: 0 });
+
+    const result = await syncGlobal("push", { source });
+
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("clone");
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 10 — push (clone mode) aborts when secret detected
+  // -------------------------------------------------------------------------
+
+  it("push (clone mode) aborts when a secret is detected in staged files", async () => {
+    const source = "/home/user/dotclaude";
+    // git add -A
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "", status: 0 });
+    // git diff --cached --quiet → non-zero means staged changes exist
+    spawnSync.mockReturnValueOnce({ stdout: "", stderr: "", status: 1 });
+    // git diff --cached --name-only
+    spawnSync.mockReturnValueOnce({ stdout: "config.js\n", stderr: "", status: 0 });
+    // git show :config.js → contains a secret-shaped value
+    spawnSync.mockReturnValueOnce({
+      stdout: "const API_KEY = 'AKIAIOSFODNN7EXAMPLE123456789012';\n",
+      stderr: "",
+      status: 0,
+    });
+
+    const result = await syncGlobal("push", { source });
+
+    expect(result.ok).toBe(false);
+    expect(result.mode).toBe("clone");
+    // commit and push must NOT have been called
+    const calls = spawnSync.mock.calls.map((c) => c.slice(0, 2));
+    expect(calls).not.toContainEqual(["git", ["-C", source, "commit", expect.any(String), expect.any(String)]]);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `dotclaude bootstrap` and `dotclaude sync` subcommands so consumers of `@dotclaude/dotclaude` can wire up `~/.claude/` and pull updates without running `bootstrap.sh`/`sync.sh` directly.
- Ports `bootstrap.sh` → `bootstrap-global.mjs` and `sync.sh` → `sync-global.mjs` (both with TDD, 18 tests across the two modules, 132 passing total). Supports **npm mode** (default — operates on the installed package) and **clone mode** (`--source <path>` or `DOTCLAUDE_DIR`).
- Wires new entrypoints through the umbrella dispatcher, exports `bootstrapGlobal`/`syncGlobal` from `index.mjs`, adds an informational bootstrap check to `dotclaude-doctor`, and bumps the package to `0.4.0`.

## Test plan

- [x] `npm test` passes (16 files, 134 tests)
- [x] `node plugins/dotclaude/bin/dotclaude.mjs --help` lists `bootstrap` and `sync`
- [x] `node plugins/dotclaude/bin/dotclaude-bootstrap.mjs --version` prints `0.4.0`
- [x] `node plugins/dotclaude/bin/dotclaude-sync.mjs --version` prints `0.4.0`
- [x] `node plugins/dotclaude/bin/dotclaude.mjs bootstrap --version` dispatches through umbrella
- [x] `node plugins/dotclaude/bin/dotclaude-doctor.mjs` reports the new `~/.claude/CLAUDE.md` symlink check
- [x] Secret scan in `sync push` aborts when `AKIA...` / high-entropy keys are staged (covered by `tests/sync-global.test.mjs`)

## Spec ID

cli-bootstrap-command