### PR TITLE
docs: document bootstrap + sync CLI commands in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,9 @@
 >   That wires `commands/`, `skills/`, and this file into `~/.claude/` in one step.
 >   No npm required.
 > - **Want more flexibility:** Install `@dotclaude/dotclaude` for the full governance
->   CLI — `dotclaude doctor`, `dotclaude validate-specs`, `dotclaude check-spec-coverage`,
->   and more. See [README.md](./README.md) or [docs/quickstart.md](./docs/quickstart.md).
+>   CLI — `dotclaude bootstrap`, `dotclaude sync`, `dotclaude doctor`,
+>   `dotclaude validate-specs`, and more. See [README.md](./README.md) or
+>   [docs/quickstart.md](./docs/quickstart.md).
 >
 > **This file is for the bootstrap path.** It gets symlinked into `~/.claude/CLAUDE.md`
 > by `bootstrap.sh` and sets the global rule floor for every Claude Code session.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Claude Code session. To stay current:
 ./sync.sh push          # secret-scan + commit + push
 ```
 
+If you have the CLI installed, you can use it instead of the shell scripts:
+
+```bash
+dotclaude bootstrap             # same as ./bootstrap.sh
+dotclaude sync pull             # same as ./sync.sh pull
+dotclaude sync push             # same as ./sync.sh push
+dotclaude sync status           # show installed vs latest version
+```
+
+Both `bootstrap` and `sync` support `--source <path>` (clone mode) or default
+to the npm package installation (npm mode). Run `dotclaude bootstrap --help`
+or `dotclaude sync --help` for full options.
+
 See [CLAUDE.md](./CLAUDE.md) for the global rules this installs.
 
 ---
@@ -58,7 +71,11 @@ npm install -D @dotclaude/dotclaude
 Then use the umbrella dispatcher or standalone bins interchangeably:
 
 ```bash
-dotclaude doctor                   # self-diagnostic: env, facts, manifest, specs
+dotclaude bootstrap                # set up (or refresh) ~/.claude/ — symlinks commands, skills, CLAUDE.md
+dotclaude sync pull                # pull latest dotclaude version and re-bootstrap
+dotclaude sync push                # secret-scan staged files, commit, and push (clone mode)
+dotclaude sync status              # show installed vs latest version / git status
+dotclaude doctor                   # self-diagnostic: env, facts, manifest, specs, bootstrap
 dotclaude validate-skills          # verify skills manifest checksums + DAG
 dotclaude validate-specs           # audit spec contracts + dependency cycles
 dotclaude check-spec-coverage      # PR gate: protected paths must be spec-backed


### PR DESCRIPTION
## Summary

- `README.md`: adds `dotclaude bootstrap` / `dotclaude sync` as CLI alternatives in the Clone & bootstrap section; adds all four sync subcommands (`pull`, `push`, `status`) and `bootstrap` to the CLI command table.
- `CLAUDE.md`: updates the header blurb to mention `dotclaude bootstrap` and `dotclaude sync` alongside the existing CLI examples.

## Test plan

- [ ] README renders correctly — clone & bootstrap section shows both shell-script and CLI options
- [ ] CLI command table includes `bootstrap` and `sync pull/push/status`
- [ ] CLAUDE.md header blurb lists `dotclaude bootstrap` and `dotclaude sync`
- [ ] `npm test` still passes (no code changes)
- [ ] prettier + markdownlint clean

## No-spec rationale

Documentation-only update. No source files changed, no spec ID required.
