### PR TITLE
feat(agents): add AWS, Azure, GCP provider agents and specialist skills

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-16T12:52:16.625Z",
+  "generatedAt": "2026-04-16T13:02:59.879Z",
   "skills": [
     {
       "name": "audit-and-fix",

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -127,6 +127,27 @@
       "checksum": "sha256:bfad56ceca2a109b8464828840ff5c4b36bd0109fa87d4c3c1058db15f58025a",
       "dependencies": [],
       "lastValidated": "2026-04-16"
+    },
+    {
+      "name": "aws-specialist",
+      "path": ".claude/skills/aws-specialist/SKILL.md",
+      "checksum": "sha256:7dc6acbc8782427fa8623bb00cabb2d6da385db6bfc35d343ba29812466b42e8",
+      "dependencies": [],
+      "lastValidated": "2026-04-16"
+    },
+    {
+      "name": "azure-specialist",
+      "path": ".claude/skills/azure-specialist/SKILL.md",
+      "checksum": "sha256:4406593cba0dda73e5aecdfb7bb13c4c7a86fd11620793453528a0bbf2524e0e",
+      "dependencies": [],
+      "lastValidated": "2026-04-16"
+    },
+    {
+      "name": "gcp-specialist",
+      "path": ".claude/skills/gcp-specialist/SKILL.md",
+      "checksum": "sha256:95e1392a2f7ba74576f8d4a721882b0d2d2fbfa06b8fd24dd4b0029c2688a83e",
+      "dependencies": [],
+      "lastValidated": "2026-04-16"
     }
   ]
 }

--- a/plugins/dotclaude/templates/claude/agents/aws-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/aws-engineer.md
@@ -1,0 +1,46 @@
+---
+name: aws-engineer
+description: >
+  Use when designing, debugging, or reviewing AWS workloads and service
+  integrations. Triggers on: "AWS", "EC2", "ECS", "EKS", "Lambda", "S3",
+  "IAM role", "VPC", "RDS", "DynamoDB", "CloudFront", "ALB", "Route53",
+  "CloudFormation", "CDK", "API Gateway", "EventBridge", "SQS", "SNS".
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: opus
+---
+
+You are a senior AWS engineer with production experience across compute, networking, storage, IAM, and serverless. You reason about AWS architecture in terms of account boundaries, regional isolation, IAM trust relationships, and service quotas — not service marketing names.
+
+## AWS Expertise
+
+- Compute: EC2 (instance families, Spot, Savings Plans), ECS (Fargate vs EC2 launch type), EKS (managed node groups, Fargate profiles, IRSA)
+- Serverless: Lambda (cold starts, concurrency, layers, destinations), API Gateway (REST vs HTTP vs WebSocket), EventBridge, Step Functions, SQS, SNS
+- Storage and data: S3 (storage classes, lifecycle, bucket policies vs ACLs), EBS, EFS, RDS (engine selection, read replicas, parameter groups), DynamoDB (partition keys, GSIs, on-demand vs provisioned)
+- Networking: VPC design (public/private/isolated subnets), Transit Gateway, PrivateLink, ALB/NLB/CLB trade-offs, Route53 (routing policies, health checks), CloudFront (behaviors, OAC)
+- IAM: least-privilege policies, permission boundaries, SCPs, role-assumption chains, resource-based vs identity-based policies
+- Observability: CloudWatch (Metrics, Logs Insights, Alarms), X-Ray, Container Insights
+- IaC: CloudFormation (stack sets, change sets, drift), CDK (constructs, aspects, synth output review)
+
+## Working Approach
+
+1. **Read before writing.** Inspect existing CloudFormation/CDK/Terraform and IAM policies before proposing changes. AWS drift is cheap to cause and expensive to diagnose.
+2. **Think in accounts and regions.** Multi-account boundaries are the strongest isolation primitive. Cross-account access is IAM, not network.
+3. **Cite service quotas.** Many production incidents trace to silent quota limits (EIPs per region, Lambda concurrent executions, VPC endpoints). Verify the quota before recommending scale-out.
+4. **Prefer managed over self-managed.** RDS over EC2-hosted Postgres. Fargate over EC2 launch type for stateless workloads. Justify any self-managed choice.
+5. **Least-privilege IAM by default.** Start with deny-all. Add allow statements with resource ARNs and condition keys. Wildcards in production IAM are findings.
+6. **Verify with the AWS CLI.** `aws sts get-caller-identity`, `aws configure list`, and dry-run flags (`--dry-run`, `--no-execute-changeset`) ground claims in actual account state.
+
+## Constraints
+
+- Never apply changes to a live AWS account without explicit user instruction and a preceding dry-run/change-set preview.
+- Never recommend `*` in IAM actions or resources without explaining the scope expansion.
+- Cite `file:line` or resource ARN for every finding.
+- When account state is unavailable, scope advice to IaC files only and say so.
+
+## Collaboration
+
+- Hand off container image concerns to `container-engineer`.
+- Route EKS/Kubernetes workload design to `kubernetes-specialist`.
+- Coordinate multi-cloud trade-offs with `azure-engineer` or `gcp-engineer`.
+- Route Terraform/CDK-shared patterns to `iac-engineer`; Terragrunt-specific to `terragrunt-engineer`.
+- Escalate security posture review to `security-engineer`.

--- a/plugins/dotclaude/templates/claude/agents/aws-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/aws-engineer.md
@@ -42,5 +42,5 @@ You are a senior AWS engineer with production experience across compute, network
 - Hand off container image concerns to `container-engineer`.
 - Route EKS/Kubernetes workload design to `kubernetes-specialist`.
 - Coordinate multi-cloud trade-offs with `azure-engineer` or `gcp-engineer`.
-- Route Terraform/CDK-shared patterns to `iac-engineer`; Terragrunt-specific to `terragrunt-engineer`.
+- Route Terraform/CDK-shared patterns to `iac-engineer`; Terragrunt-specific to `terragrunt-engineer` if available in your repo.
 - Escalate security posture review to `security-engineer`.

--- a/plugins/dotclaude/templates/claude/agents/azure-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/azure-engineer.md
@@ -43,6 +43,6 @@ You are a senior Azure engineer with production experience across compute, ident
 - Hand off container image concerns to `container-engineer`.
 - Route AKS/Kubernetes workload design to `kubernetes-specialist`.
 - Coordinate multi-cloud trade-offs with `aws-engineer` or `gcp-engineer`.
-- Route Terraform-shared patterns to `iac-engineer`; Terragrunt-specific to `terragrunt-engineer`.
+- Route Terraform-shared patterns to `iac-engineer`; Terragrunt-specific to `terragrunt-engineer` if available in your repo.
 - Coordinate Azure DevOps CI/CD with `devops-engineer`; deployment strategies with `deployment-engineer`.
 - Escalate security posture review to `security-engineer`.

--- a/plugins/dotclaude/templates/claude/agents/azure-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/azure-engineer.md
@@ -1,0 +1,48 @@
+---
+name: azure-engineer
+description: >
+  Use when designing, debugging, or reviewing Azure workloads and service
+  integrations. Triggers on: "Azure", "AKS", "ACI", "App Service", "Azure
+  Functions", "Blob Storage", "VNet", "App Gateway", "Front Door", "EntraID",
+  "Managed Identity", "ARM template", "Bicep", "Azure DevOps", "ACR",
+  "Service Bus", "Logic Apps", "Cosmos DB".
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: opus
+---
+
+You are a senior Azure engineer with production experience across compute, identity, networking, and data services. You reason about Azure in terms of subscriptions, resource groups, Managed Identity scopes, and regional pairs — not marketing tiers.
+
+## Azure Expertise
+
+- Compute: AKS (node pools, Virtual Nodes, Azure CNI vs kubenet), ACI, Virtual Machines (VM sizes, Spot, availability sets/zones), App Service (plans, slots, WEBSITE\_\* settings)
+- Serverless: Azure Functions (consumption vs premium vs dedicated), Logic Apps (standard vs consumption), Service Bus (queues vs topics, sessions), Event Grid, Event Hubs
+- Storage and data: Blob Storage (hot/cool/archive, lifecycle, access tiers), Azure Files (SMB vs NFS), Cosmos DB (consistency levels, partition keys, RU/s), Azure SQL (vCore vs DTU, elastic pools)
+- Networking: VNet peering vs VWAN hub-spoke, Application Gateway (WAF, path rules), Front Door (Standard vs Premium, caching), Private Endpoints vs Service Endpoints, NSG vs Azure Firewall
+- Identity: EntraID (formerly Azure AD) app registrations, Managed Identity (system vs user-assigned), role-assignment scopes, conditional access, PIM
+- DevOps: Azure DevOps (Pipelines, Repos, Artifacts), ACR (geo-replication, content trust, tasks)
+- IaC: ARM templates, Bicep (modules, loops, what-if), Terraform (AzureRM provider, `azapi` for preview services)
+
+## Working Approach
+
+1. **Read before writing.** Inspect Bicep/ARM/Terraform and role assignments before proposing changes. Azure drift often hides in implicit role inheritance.
+2. **Think in management groups and subscriptions.** Policy and cost boundaries live here. Resource groups are deployment units, not security boundaries.
+3. **Managed Identity over service principal secrets.** Any workload inside Azure with identity needs should use Managed Identity. Service principal secrets are a smell.
+4. **Prefer Bicep over ARM for new work.** ARM is the lower level; Bicep compiles to ARM and is vastly more readable. CDK for Terraform is viable when cross-cloud is required.
+5. **Preview with `what-if`.** `az deployment group what-if` before every deployment. For Bicep, the build output (`bicep build`) shows the compiled ARM — review it.
+6. **Region pairs matter.** Some services (paired storage replication, disaster recovery) depend on Azure's region-pair concept. Check pair geography before designing DR.
+
+## Constraints
+
+- Never apply changes to a live Azure subscription without explicit user instruction and a preceding `what-if` preview.
+- Never recommend using service principal client secrets when Managed Identity is an option.
+- Cite `file:line` or resource ID for every finding.
+- When subscription state is unavailable, scope advice to IaC files only and say so.
+
+## Collaboration
+
+- Hand off container image concerns to `container-engineer`.
+- Route AKS/Kubernetes workload design to `kubernetes-specialist`.
+- Coordinate multi-cloud trade-offs with `aws-engineer` or `gcp-engineer`.
+- Route Terraform-shared patterns to `iac-engineer`; Terragrunt-specific to `terragrunt-engineer`.
+- Coordinate Azure DevOps CI/CD with `devops-engineer`; deployment strategies with `deployment-engineer`.
+- Escalate security posture review to `security-engineer`.

--- a/plugins/dotclaude/templates/claude/agents/gcp-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/gcp-engineer.md
@@ -1,0 +1,48 @@
+---
+name: gcp-engineer
+description: >
+  Use when designing, debugging, or reviewing Google Cloud workloads and
+  service integrations. Triggers on: "GCP", "Google Cloud", "GKE", "Cloud Run",
+  "GCE", "Cloud Functions", "Pub/Sub", "GCS", "BigQuery", "Cloud Build",
+  "Workload Identity", "Service Account", "VPC", "Cloud Armor", "Cloud CDN",
+  "Deployment Manager", "Config Connector".
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: opus
+---
+
+You are a senior Google Cloud engineer with production experience across compute, data, networking, and identity. You reason about GCP in terms of projects, Workload Identity, VPC networks, and IAM hierarchies — not product names in isolation.
+
+## GCP Expertise
+
+- Compute: GKE (Autopilot vs Standard, node pools, Workload Identity), Cloud Run (services vs jobs, concurrency, min instances), GCE (machine families, custom types, MIGs, spot)
+- Serverless: Cloud Functions (v1 vs v2 / Cloud Run under the hood), Pub/Sub (push vs pull, dead-letter, ordering keys), Cloud Tasks, Eventarc, Workflows
+- Storage and data: GCS (storage classes, lifecycle, uniform vs fine-grained ACLs), Filestore, BigQuery (slots vs on-demand, partitioning, clustering), Cloud SQL, Spanner, Firestore
+- Networking: VPC (auto vs custom mode), Shared VPC, VPC peering, Private Google Access, Cloud Load Balancing (global vs regional), Cloud Armor (WAF, Adaptive Protection), Cloud CDN
+- Identity: IAM (primitive vs predefined vs custom roles), Service Accounts (impersonation, key-less via Workload Identity Federation), Organization Policies, VPC Service Controls
+- Observability: Cloud Monitoring, Cloud Logging (sinks, exclusions, log buckets), Cloud Trace, Error Reporting
+- IaC: Deployment Manager (legacy), Config Connector (GCP resources as Kubernetes objects), Terraform (Google + Google-Beta providers), Pulumi
+
+## Working Approach
+
+1. **Read before writing.** Inspect Terraform/Config Connector/Deployment Manager and IAM bindings before proposing changes. Hierarchical IAM inheritance obscures effective permissions.
+2. **Think in projects.** Projects are the primary quota, billing, and security boundary. Folders group projects; organizations root the hierarchy.
+3. **Workload Identity over service account keys.** Any workload in GCP should use Workload Identity (GKE) or Workload Identity Federation (outside GCP). Downloaded service account keys are a finding.
+4. **Prefer Autopilot for new GKE clusters.** Cost, security defaults, and node management are better unless Standard's flexibility is demonstrably required.
+5. **Region and multi-region matter.** GCS multi-region is geo-replicated; BigQuery datasets are regional by default. Verify location before reasoning about latency or compliance.
+6. **Dry-run with `gcloud`.** `--dry-run`, `--impersonate-service-account`, `gcloud projects get-iam-policy` ground changes in actual project state.
+
+## Constraints
+
+- Never apply changes to a live GCP project without explicit user instruction and a preceding `terraform plan` or `gcloud ... --dry-run`.
+- Never recommend downloading service account keys when Workload Identity is an option.
+- Cite `file:line` or resource self-link for every finding.
+- When project state is unavailable, scope advice to IaC files only and say so.
+
+## Collaboration
+
+- Hand off container image concerns to `container-engineer`.
+- Route GKE/Kubernetes workload design to `kubernetes-specialist`.
+- Coordinate multi-cloud trade-offs with `aws-engineer` or `azure-engineer`.
+- Route Terraform-shared patterns to `iac-engineer`; Terragrunt-specific to `terragrunt-engineer`; Config Connector/Crossplane to `crossplane-engineer`.
+- Coordinate Cloud Build CI/CD with `devops-engineer`; deployment strategies with `deployment-engineer`.
+- Escalate security posture review to `security-engineer`.

--- a/plugins/dotclaude/templates/claude/agents/gcp-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/gcp-engineer.md
@@ -43,6 +43,6 @@ You are a senior Google Cloud engineer with production experience across compute
 - Hand off container image concerns to `container-engineer`.
 - Route GKE/Kubernetes workload design to `kubernetes-specialist`.
 - Coordinate multi-cloud trade-offs with `aws-engineer` or `azure-engineer`.
-- Route Terraform-shared patterns to `iac-engineer`; Terragrunt-specific to `terragrunt-engineer`; Config Connector/Crossplane to `crossplane-engineer`.
+- Route Terraform-shared patterns to `iac-engineer`; Terragrunt-specific to `terragrunt-engineer` if available in your repo; Config Connector/Crossplane to `crossplane-engineer` if available in your repo.
 - Coordinate Cloud Build CI/CD with `devops-engineer`; deployment strategies with `deployment-engineer`.
 - Escalate security posture review to `security-engineer`.

--- a/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
+++ b/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
@@ -38,6 +38,9 @@ You are a senior workflow orchestrator responsible for decomposing complex tasks
 | `deployment-engineer`   | Deployment strategies, rollback, traffic shifting    |
 | `iac-engineer`          | IaC modules (Terraform/Pulumi), state management     |
 | `security-engineer`     | Infrastructure hardening, network policies, secrets  |
+| `aws-engineer`          | AWS services, IAM, VPC, CloudFormation/CDK           |
+| `azure-engineer`        | Azure services, EntraID, Bicep/ARM, Managed Identity |
+| `gcp-engineer`          | GCP services, IAM, Workload Identity, Terraform      |
 
 ## Working Approach
 

--- a/plugins/dotclaude/tests/init-harness-scaffold.test.mjs
+++ b/plugins/dotclaude/tests/init-harness-scaffold.test.mjs
@@ -35,6 +35,8 @@ describe("scaffoldHarness", () => {
 
     const expected = [
       ".claude/agents/architect-reviewer.md",
+      ".claude/agents/aws-engineer.md",
+      ".claude/agents/azure-engineer.md",
       ".claude/agents/backend-developer.md",
       ".claude/agents/changelog-assistant.md",
       ".claude/agents/container-engineer.md",
@@ -42,6 +44,7 @@ describe("scaffoldHarness", () => {
       ".claude/agents/devops-engineer.md",
       ".claude/agents/documentation-writer.md",
       ".claude/agents/frontend-developer.md",
+      ".claude/agents/gcp-engineer.md",
       ".claude/agents/iac-engineer.md",
       ".claude/agents/kubernetes-specialist.md",
       ".claude/agents/platform-engineer.md",

--- a/skills/aws-specialist/SKILL.md
+++ b/skills/aws-specialist/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: aws-specialist
+description: >
+  Deep-dive AWS architecture review, debugging, and service design. Use for
+  structured investigations of AWS-specific issues, cost or IAM audits, and
+  multi-service design reviews. Triggers on: "AWS audit", "AWS design review",
+  "IAM review", "cost audit AWS", "review my VPC", "AWS troubleshooting",
+  "Lambda deep-dive".
+argument-hint: "<account context, service, or problem description>"
+tools: Read, Grep, Glob, Bash
+effort: max
+model: opus
+---
+
+# AWS Specialist
+
+Structured investigation for AWS workloads. Five phases: gather context,
+diagnose, design, recommend, verify.
+
+## Arguments
+
+- `$0` — account context, service scope, or problem description. Required.
+
+---
+
+## Phase 1: Context Gathering
+
+1. Identify the account(s), region(s), and services in scope.
+2. Glob for IaC in the working directory: `**/*.tf`, `**/*.yaml` (SAM/CloudFormation), `**/cdk.json`, `**/template.yaml`.
+3. If AWS CLI access is available:
+   ```bash
+   aws sts get-caller-identity
+   aws configure list
+   ```
+4. Note the service scope (e.g. "EKS cluster + VPC + IAM" vs "Lambda + API Gateway + DynamoDB"). Scope commands to the relevant resource types.
+
+---
+
+## Phase 2: Diagnosis
+
+**Compute / containers:**
+
+```bash
+aws ec2 describe-instances --filters Name=instance-state-name,Values=running
+aws ecs list-services --cluster <name>
+aws eks describe-cluster --name <name>
+```
+
+**IAM / identity:**
+
+```bash
+aws iam list-policies --scope Local
+aws iam get-role --role-name <role>
+aws iam simulate-principal-policy --policy-source-arn <arn> --action-names <action>
+```
+
+**Networking:**
+
+```bash
+aws ec2 describe-vpcs
+aws ec2 describe-route-tables
+aws ec2 describe-security-groups
+```
+
+**Serverless / events:**
+
+```bash
+aws lambda list-functions
+aws lambda get-function-configuration --function-name <name>
+aws apigateway get-rest-apis
+```
+
+**Cost / quotas:**
+
+```bash
+aws service-quotas list-service-quotas --service-code ec2
+aws ce get-cost-and-usage --time-period Start=<>,End=<> --granularity DAILY --metrics UnblendedCost
+```
+
+---
+
+## Phase 3: Design / Root-Cause Analysis
+
+Map symptoms to causes:
+
+| Symptom                 | Common Causes                                          | Check                                             |
+| ----------------------- | ------------------------------------------------------ | ------------------------------------------------- |
+| 5xx from ALB            | Unhealthy targets, timeout mismatch, HTTP/S misrouting | Target group health, ALB access logs              |
+| Lambda throttled        | Reserved concurrency, account-wide limit               | `aws lambda get-function-concurrency`             |
+| EKS pod IAM fails       | Missing IRSA, ServiceAccount annotation                | OIDC provider + trust policy on role              |
+| S3 AccessDenied         | Bucket policy, SCP, VPC endpoint policy                | Use `aws s3api get-bucket-policy` + IAM simulator |
+| RDS CPU spike           | Missing indexes, connection storm, runaway query       | Performance Insights, slow query log              |
+| CloudFront caching miss | Incorrect cache key, missing `Cache-Control`           | Check behaviors + origin headers                  |
+
+Cite resource ARN or `file:line` for every finding.
+
+---
+
+## Phase 4: Recommendations
+
+Output findings in priority order:
+
+```
+[CRITICAL] <title>
+Resource: <ARN or file:line>
+Issue: <one sentence>
+Evidence: <CLI output or code snippet>
+Fix: <specific change, with IaC diff if applicable>
+Trade-off: <alternative and its downside, if meaningful>
+```
+
+- Order: CRITICAL → WARNING → INFO.
+- For IaC fixes, show the exact Terraform/CDK/CloudFormation diff.
+- Reference relevant docs in `references/` where applicable.
+
+---
+
+## Phase 5: Verification
+
+After fixes are applied:
+
+1. Re-run the diagnostic command that surfaced the issue.
+2. For IAM changes: `aws iam simulate-principal-policy` with the exact action and resource.
+3. For networking changes: `aws ec2 describe-route-tables` or VPC Reachability Analyzer.
+4. For serverless changes: invoke a test event via `aws lambda invoke` or API Gateway test console.
+5. Check CloudWatch metrics and alarms — no new alarms should be triggering.
+
+---
+
+## Reference Docs
+
+Consult `references/` for decision guides:
+
+| File               | When to use                                    |
+| ------------------ | ---------------------------------------------- |
+| `compute.md`       | EC2, ECS, EKS selection and sizing             |
+| `serverless.md`    | Lambda, API Gateway, EventBridge, SQS, SNS     |
+| `storage.md`       | S3, EBS, EFS, RDS, DynamoDB                    |
+| `networking.md`    | VPC, ALB/NLB, Route53, CloudFront, PrivateLink |
+| `iam.md`           | Policies, roles, SCPs, permission boundaries   |
+| `observability.md` | CloudWatch, X-Ray, Container Insights          |
+| `iac-patterns.md`  | CloudFormation, CDK, SAM patterns              |

--- a/skills/aws-specialist/references/compute.md
+++ b/skills/aws-specialist/references/compute.md
@@ -1,0 +1,51 @@
+# AWS Compute
+
+## Key Concepts
+
+- **EC2** — virtual machines. Choose instance family by workload (compute/memory/storage/network optimized). Spot for interruptible, Savings Plans for steady-state.
+- **ECS** — AWS-native container orchestration. Fargate (serverless) vs EC2 launch type (you manage nodes).
+- **EKS** — managed Kubernetes. Managed node groups (EC2) vs Fargate profiles. IRSA (IAM Roles for Service Accounts) for pod identity.
+- **Auto Scaling** — EC2 Auto Scaling Groups with launch templates; ECS service autoscaling on CloudWatch metrics; EKS Cluster Autoscaler or Karpenter.
+
+## Common Patterns
+
+```hcl
+# Fargate task — no node management
+resource "aws_ecs_task_definition" "app" {
+  family                   = "my-app"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+  container_definitions    = jsonencode([{ ... }])
+}
+```
+
+```hcl
+# EKS IRSA — pod assumes IAM role via OIDC
+resource "aws_iam_role" "pod_role" {
+  name = "eks-pod-role"
+  assume_role_policy = data.aws_iam_policy_document.irsa.json
+}
+
+# ServiceAccount annotation: eks.amazonaws.com/role-arn
+```
+
+## Checklist
+
+- [ ] EC2 instance families match workload profile (not default `t3.medium` for production databases).
+- [ ] Spot instances used only for interruption-tolerant workloads; mixed with On-Demand via ASG mixed instances policy.
+- [ ] ECS tasks use `awsvpc` network mode (task-level ENI) for production — `bridge` leaks ports between tasks.
+- [ ] EKS pod identity uses IRSA, not node instance profile.
+- [ ] EKS cluster autoscaler OR Karpenter — not both.
+- [ ] Managed node group release channel pinned or automated.
+
+## Gotchas
+
+- Fargate cold starts (task startup) are seconds, not milliseconds — unsuitable for sub-second latency triggers.
+- `t3`/`t4g` burstable instances accumulate CPU credits. Production workloads that exceed baseline get throttled silently; use `unlimited` mode or non-burstable.
+- EKS Fargate profiles require subnets with private connectivity — public subnets are rejected.
+- IRSA requires the OIDC provider to be registered with IAM once per cluster; missing registration fails silently with 403.
+- ECS Service `minimumHealthyPercent: 100` + `maximumPercent: 100` blocks rolling deploys (no headroom to start new tasks).

--- a/skills/aws-specialist/references/iac-patterns.md
+++ b/skills/aws-specialist/references/iac-patterns.md
@@ -1,0 +1,62 @@
+# AWS IaC Patterns
+
+## Key Concepts
+
+- **CloudFormation** — JSON/YAML declarative IaC. AWS-native; supports StackSets (multi-account/region), ChangeSets (preview), drift detection.
+- **CDK** — imperative IaC in TypeScript/Python/Java/Go/C#. Compiles to CloudFormation via `cdk synth`. Constructs encapsulate patterns.
+- **SAM** — Serverless Application Model. CloudFormation superset for Lambda + API Gateway + DynamoDB shortcuts.
+- **Terraform** — third-party, multi-cloud. `aws` and `awscc` providers (the latter auto-generated from CloudFormation schema).
+
+## Common Patterns
+
+```yaml
+# CloudFormation ChangeSet preview before apply
+# aws cloudformation create-change-set --stack-name app --template-body file://template.yaml --change-set-name preview
+# aws cloudformation describe-change-set --stack-name app --change-set-name preview
+# aws cloudformation execute-change-set --stack-name app --change-set-name preview
+```
+
+```typescript
+// CDK: use L2 constructs, not L1 (Cfn*)
+const bucket = new s3.Bucket(this, "Data", {
+  encryption: s3.BucketEncryption.S3_MANAGED,
+  blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+  lifecycleRules: [
+    {
+      transitions: [
+        { storageClass: s3.StorageClass.INFREQUENT_ACCESS, transitionAfter: Duration.days(30) },
+      ],
+    },
+  ],
+  removalPolicy: RemovalPolicy.RETAIN, // never default to DESTROY for stateful resources
+});
+```
+
+```hcl
+# Terraform + AWS provider with assume_role per environment
+provider "aws" {
+  region = "us-east-1"
+  assume_role {
+    role_arn     = "arn:aws:iam::${var.account_id}:role/TerraformDeploy"
+    session_name = "terraform-${var.env}"
+  }
+}
+```
+
+## Checklist
+
+- [ ] All stateful resources (S3, RDS, DynamoDB) have `DeletionPolicy: Retain` (CloudFormation) or `removalPolicy: RETAIN` (CDK).
+- [ ] ChangeSet or `terraform plan` review is gated on every production deploy (not auto-applied).
+- [ ] CloudFormation stack drift detection scheduled weekly.
+- [ ] CDK `cdk diff` output committed to PR description or comment for reviewer inspection.
+- [ ] State backends (Terraform) use S3 + DynamoDB lock; state encryption + versioning on.
+- [ ] No hardcoded account IDs or ARNs — use variables or data sources.
+
+## Gotchas
+
+- CloudFormation rollback on failure can leave orphaned resources (Lambda versions, ENIs in VPC) that block retry — manually clean up or import.
+- CDK construct updates can generate large diffs on version bumps. Review `cdk diff` carefully after `npm update`.
+- Terraform `aws_s3_bucket_*` resources split in provider v4+: config that worked before needs migration to `aws_s3_bucket_policy`, `aws_s3_bucket_versioning`, etc.
+- SAM `Transform: AWS::Serverless-2016-10-31` expands at deploy time — template in git is not the deployed template. Use `sam package` for exact rendered CFN.
+- CDK `cdk destroy` removes stacks, but bucket/table deletion needs `RemovalPolicy.DESTROY` or `autoDeleteObjects: true` (for S3) — otherwise deletion fails with non-empty errors.
+- Multi-account CDK: the `env` prop is per-stack and must be set; otherwise `cdk synth` uses the current CLI profile's account.

--- a/skills/aws-specialist/references/iam.md
+++ b/skills/aws-specialist/references/iam.md
@@ -5,7 +5,7 @@
 - **Identity-based policies** — attached to users, groups, roles. Define what the principal can do.
 - **Resource-based policies** — attached to resources (S3 buckets, SQS queues, Lambda). Define who can access the resource.
 - **Permission boundaries** — cap the maximum permissions a role/user can have, regardless of attached policies.
-- **Service Control Policies (SCPs)** — Organization-level policies. Deny-only at the top-level, override nothing, apply to all principals in an account.
+- **Service Control Policies (SCPs)** — Organization-level guardrails that define the maximum permissions principals in an account can have. Can contain both Allow and Deny statements, but do not grant permissions by themselves.
 - **Role chaining** — assume role A, then assume role B from A. Each assumption has a max session duration.
 - **IRSA (IAM Roles for Service Accounts)** — EKS pod identity via OIDC provider trust.
 

--- a/skills/aws-specialist/references/iam.md
+++ b/skills/aws-specialist/references/iam.md
@@ -1,0 +1,56 @@
+# AWS IAM
+
+## Key Concepts
+
+- **Identity-based policies** — attached to users, groups, roles. Define what the principal can do.
+- **Resource-based policies** — attached to resources (S3 buckets, SQS queues, Lambda). Define who can access the resource.
+- **Permission boundaries** — cap the maximum permissions a role/user can have, regardless of attached policies.
+- **Service Control Policies (SCPs)** — Organization-level policies. Deny-only at the top-level, override nothing, apply to all principals in an account.
+- **Role chaining** — assume role A, then assume role B from A. Each assumption has a max session duration.
+- **IRSA (IAM Roles for Service Accounts)** — EKS pod identity via OIDC provider trust.
+
+## Common Patterns
+
+```hcl
+# Least-privilege role with resource ARN + condition
+data "aws_iam_policy_document" "s3_read" {
+  statement {
+    effect = "Allow"
+    actions = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::my-bucket/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceVpce"
+      values   = ["vpce-xxxxx"]
+    }
+  }
+}
+```
+
+```hcl
+# Permission boundary: cap what developer-created roles can do
+resource "aws_iam_role" "developer_role" {
+  name                 = "app-role"
+  assume_role_policy   = data.aws_iam_policy_document.assume.json
+  permissions_boundary = aws_iam_policy.developer_boundary.arn
+}
+```
+
+## Checklist
+
+- [ ] No `*` in Action or Resource in production policies (except read-only documentation actions).
+- [ ] All roles use assumable-by principals that are as narrow as possible (specific service, specific account).
+- [ ] Cross-account role trust policies include `sts:ExternalId` condition.
+- [ ] MFA required for human user policies (via `aws:MultiFactorAuthPresent` condition).
+- [ ] Root account has MFA and no access keys.
+- [ ] SCPs set in the organization to block risky actions (disabling CloudTrail, leaving the organization).
+- [ ] Access Analyzer enabled to flag resources accessible from outside the account/organization.
+
+## Gotchas
+
+- `NotAction` / `NotResource` is dangerous — it allows everything EXCEPT the listed items, easy to write permissive-by-accident.
+- Policy evaluation: explicit Deny wins, then SCP (if any), then permission boundary (if any), then identity + resource policies combined. A missing SCP allow is a deny.
+- IRSA requires both: OIDC provider registered in IAM, AND ServiceAccount has the `eks.amazonaws.com/role-arn` annotation.
+- AssumeRole doesn't propagate session tags automatically — need `sts:TagSession` permission and explicit tag passing.
+- Condition keys differ by service. `aws:PrincipalArn` is global; `s3:x-amz-acl` is S3-specific. Wrong key silently fails (doesn't match, evaluates false).
+- Role sessions expire; long-running processes must refresh credentials. SDK default providers handle this, custom signing does not.

--- a/skills/aws-specialist/references/networking.md
+++ b/skills/aws-specialist/references/networking.md
@@ -1,0 +1,66 @@
+# AWS Networking
+
+## Key Concepts
+
+- **VPC** — isolated virtual network. Subnets are AZ-scoped. Route tables + NAT/IGW control egress. Default VPC is permissive — don't use for production.
+- **ALB / NLB / CLB** — Application (L7, path/host routing), Network (L4, TCP/UDP + static IP), Classic (legacy).
+- **Route53** — managed DNS. Routing policies: simple, weighted, latency, geolocation, failover, multi-value.
+- **CloudFront** — global CDN. Behaviors match by path pattern; origin access control (OAC) replaces legacy OAI for S3.
+- **PrivateLink / VPC Endpoints** — private connectivity to AWS services (gateway endpoints for S3/DynamoDB; interface endpoints for others).
+- **Transit Gateway** — hub-and-spoke connecting multiple VPCs + on-prem.
+
+## Common Patterns
+
+```hcl
+# VPC with public + private + isolated subnets across AZs
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+  name   = "app"
+  cidr   = "10.0.0.0/16"
+
+  azs              = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  public_subnets   = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
+  private_subnets  = ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
+  isolated_subnets = ["10.0.20.0/24", "10.0.21.0/24", "10.0.22.0/24"]
+
+  enable_nat_gateway     = true
+  single_nat_gateway     = false   # one per AZ for HA
+  enable_dns_hostnames   = true
+  enable_dns_support     = true
+}
+```
+
+```hcl
+# ALB with HTTPS redirect + target group health check
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate.app.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+```
+
+## Checklist
+
+- [ ] VPC has at least 3 AZs (availability + AZ-rebalancing tolerance).
+- [ ] Single NAT Gateway only in dev — production uses one NAT per AZ.
+- [ ] Security groups: default-deny inbound, reference other SGs (not CIDRs) for intra-VPC traffic.
+- [ ] NACLs used only for subnet-level coarse controls; application-level rules belong in SGs.
+- [ ] ALB/NLB access logs enabled to S3 for production.
+- [ ] CloudFront uses OAC (not legacy OAI) for S3 origins.
+- [ ] VPC endpoints (interface/gateway) used for private AWS service access to avoid NAT costs.
+
+## Gotchas
+
+- NAT Gateway bandwidth is per-gateway — a single gateway caps all egress from a subnet's AZ. Provision per-AZ for production.
+- Security group rule limits are per-SG (60 inbound + 60 outbound by default) and per-ENI (total rules). Request limit increases early.
+- Route53 DNS propagation isn't instant; TTL controls client-side caching. `alias` records to AWS resources follow the target's TTL, not yours.
+- CloudFront price class affects edge distribution — `PriceClass_100` excludes non-US/EU edges.
+- VPC peering is non-transitive: A↔B and B↔C does NOT imply A↔C. Use Transit Gateway for mesh.
+- Gateway endpoints (S3, DynamoDB) are free; interface endpoints cost per hour per AZ + per GB.

--- a/skills/aws-specialist/references/observability.md
+++ b/skills/aws-specialist/references/observability.md
@@ -1,0 +1,57 @@
+# AWS Observability
+
+## Key Concepts
+
+- **CloudWatch Metrics** — namespace/dimension-based time-series. 1-minute granularity standard, 1-second for detailed monitoring ($).
+- **CloudWatch Logs** — log streams organized into log groups. Query with Logs Insights (subset of SQL).
+- **CloudWatch Alarms** — trigger on metric thresholds. SNS target for paging, Lambda for auto-remediation.
+- **X-Ray** — distributed tracing. Instrument SDK per language; service map shows call graph.
+- **Container Insights** — CloudWatch addon for ECS/EKS with pre-built dashboards and detailed metrics.
+- **CloudTrail** — API call audit log. Required for security; enable in all regions.
+
+## Common Patterns
+
+```hcl
+# Metric filter + alarm from application log
+resource "aws_cloudwatch_log_metric_filter" "errors" {
+  name           = "error-count"
+  log_group_name = aws_cloudwatch_log_group.app.name
+  pattern        = "{ $.level = \"error\" }"
+  metric_transformation {
+    name      = "AppErrors"
+    namespace = "MyApp"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "errors" {
+  alarm_name          = "app-error-spike"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "AppErrors"
+  namespace           = "MyApp"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 10
+  alarm_actions       = [aws_sns_topic.oncall.arn]
+}
+```
+
+## Checklist
+
+- [ ] Log group retention set (not "Never Expire" for production — cost risk).
+- [ ] Structured JSON logs (for Logs Insights `$.field` queries).
+- [ ] CloudTrail enabled in all regions + logs encrypted + log file validation on.
+- [ ] Alarms use `evaluation_periods > 1` to avoid flapping.
+- [ ] Container Insights enabled on all production ECS/EKS clusters.
+- [ ] X-Ray sampling rate tuned — 100% sampling is expensive, 5% is standard for production.
+- [ ] CloudWatch dashboards scoped per service; no "god dashboard" with 100 widgets.
+
+## Gotchas
+
+- CloudWatch metric publishing has a 1-minute delay — alarms can't detect sub-minute spikes without detailed monitoring ($).
+- Logs Insights query costs are per-GB scanned. Narrow time ranges and log groups before running wide filters.
+- Metric filters process logs as they arrive, charging per delivered log byte. High-volume logs with many filters become expensive.
+- Custom metrics via `PutMetricData` are billed per metric per month. Tagging every request with a custom dimension explodes cardinality.
+- X-Ray trace retention is 30 days max — can't use it for long-term analysis.
+- CloudTrail "data events" (S3/Lambda data plane) are off by default and extra-cost; "management events" are on by default and free for single-region.

--- a/skills/aws-specialist/references/serverless.md
+++ b/skills/aws-specialist/references/serverless.md
@@ -1,0 +1,59 @@
+# AWS Serverless
+
+## Key Concepts
+
+- **Lambda** — function-as-a-service. Cold starts on first invocation or after scale-down. Concurrency is account-wide unless reserved.
+- **API Gateway** — REST (legacy, feature-rich), HTTP (cheaper, faster, less feature), WebSocket (stateful connections).
+- **EventBridge** — event bus with pattern-matching rules. Replacement for CloudWatch Events.
+- **Step Functions** — state machine orchestration. Standard (long-running, exactly-once) vs Express (short, at-least-once).
+- **SQS / SNS** — queue (pull, durable) vs pub/sub (push, fan-out).
+
+## Common Patterns
+
+```hcl
+# Lambda with reserved concurrency
+resource "aws_lambda_function" "api" {
+  function_name    = "my-api"
+  handler          = "index.handler"
+  runtime          = "nodejs20.x"  # use the project's Node runtime
+  memory_size      = 512
+  timeout          = 30
+  reserved_concurrent_executions = 50
+  environment {
+    variables = { LOG_LEVEL = "info" }
+  }
+}
+```
+
+```hcl
+# API Gateway HTTP + Lambda integration
+resource "aws_apigatewayv2_api" "http" {
+  name          = "my-api"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id             = aws_apigatewayv2_api.http.id
+  integration_type   = "AWS_PROXY"
+  integration_uri    = aws_lambda_function.api.invoke_arn
+  payload_format_version = "2.0"
+}
+```
+
+## Checklist
+
+- [ ] Lambda timeout < API Gateway timeout (29 seconds for HTTP API, else client hits 504 before Lambda knows).
+- [ ] Reserved concurrency set for production-critical functions to prevent starvation by other workloads.
+- [ ] Dead-letter queue (DLQ) or destination configured for async invocations.
+- [ ] CloudWatch Logs retention set (default is forever = unbounded cost).
+- [ ] SQS queue has a DLQ with `maxReceiveCount`.
+- [ ] EventBridge rule targets have retry and DLQ configured.
+
+## Gotchas
+
+- Lambda cold starts multiply with VPC attachment + large deployment packages — use layers and provisioned concurrency for latency-sensitive paths.
+- `reserved_concurrent_executions = 0` is a kill switch — it disables the function entirely, not "unlimited".
+- API Gateway REST caches are regional, not global. Use CloudFront in front of API Gateway for cache distribution.
+- SQS visibility timeout must exceed the slowest consumer processing time, else messages get redelivered while still in-flight.
+- Step Functions Standard pricing per state transition; tight loops become expensive. Use Express for high-throughput short workflows.
+- EventBridge default bus collects CloudTrail events — don't attach expensive targets without filtering, or you'll pay per event.

--- a/skills/aws-specialist/references/storage.md
+++ b/skills/aws-specialist/references/storage.md
@@ -1,0 +1,71 @@
+# AWS Storage
+
+## Key Concepts
+
+- **S3** — object storage. Storage classes (Standard, IA, Intelligent-Tiering, Glacier). Bucket policies + IAM + Access Points + Block Public Access overlap.
+- **EBS** — block storage for EC2. gp3 for general purpose, io2 for high-IOPS, st1/sc1 for throughput/cold.
+- **EFS** — shared NFS filesystem. Standard (multi-AZ) vs One Zone. Provisioned vs Bursting throughput.
+- **RDS** — managed relational DB. Engine choice (PostgreSQL/MySQL/MariaDB/Oracle/SQL Server/Aurora). Read replicas cross-region for DR.
+- **DynamoDB** — managed key-value/document. Partition key + sort key. GSIs for alternate access patterns. On-demand vs Provisioned capacity.
+
+## Common Patterns
+
+```hcl
+# S3 with lifecycle + encryption + block public access
+resource "aws_s3_bucket" "data" {
+  bucket = "my-app-data"
+}
+
+resource "aws_s3_bucket_public_access_block" "data" {
+  bucket                  = aws_s3_bucket.data.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+  rule {
+    apply_server_side_encryption_by_default { sse_algorithm = "AES256" }
+  }
+}
+```
+
+```hcl
+# DynamoDB with GSI
+resource "aws_dynamodb_table" "items" {
+  name           = "items"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "pk"
+  range_key      = "sk"
+  attribute { name = "pk"; type = "S" }
+  attribute { name = "sk"; type = "S" }
+  attribute { name = "gsi1pk"; type = "S" }
+
+  global_secondary_index {
+    name            = "gsi1"
+    hash_key        = "gsi1pk"
+    projection_type = "ALL"
+  }
+}
+```
+
+## Checklist
+
+- [ ] S3 buckets have Block Public Access enabled at bucket level (default on new buckets, verify for imported).
+- [ ] S3 default encryption set (SSE-S3 minimum, SSE-KMS for compliance).
+- [ ] S3 lifecycle rules transition old objects to IA/Glacier and expire incomplete multipart uploads.
+- [ ] EBS volumes encrypted by default (account-level setting).
+- [ ] RDS has automated backups, multi-AZ for production, Performance Insights enabled.
+- [ ] DynamoDB uses PAY_PER_REQUEST for spiky workloads, Provisioned + auto-scaling for predictable.
+- [ ] Point-in-time recovery enabled on DynamoDB tables with production data.
+
+## Gotchas
+
+- S3 bucket names are global — a deleted bucket name is reusable, but not immediately. Plan for name-squatting risk in public scenarios.
+- `aws s3 cp` recursively with `--exclude` before `--include` is the opposite order of most tools; get it wrong and you copy nothing.
+- EFS throughput mode "Bursting" runs out of credits under sustained load; switch to Elastic or Provisioned for steady workloads.
+- RDS minor version auto-upgrades happen during maintenance windows — production DBs should pin minor version and upgrade deliberately.
+- DynamoDB "hot partition" is the #1 performance issue. Partition key cardinality must spread load evenly; monotonic keys (timestamps) concentrate writes.
+- S3 Intelligent-Tiering has a monitoring fee per object — cost-effective only for objects > 128 KB.

--- a/skills/azure-specialist/SKILL.md
+++ b/skills/azure-specialist/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: azure-specialist
+description: >
+  Deep-dive Azure architecture review, debugging, and service design. Use for
+  structured investigations of Azure-specific issues, identity or cost audits,
+  and multi-service design reviews. Triggers on: "Azure audit", "Azure design
+  review", "EntraID review", "Managed Identity debug", "review my Azure",
+  "Azure troubleshooting", "AKS deep-dive".
+argument-hint: "<subscription context, service, or problem description>"
+tools: Read, Grep, Glob, Bash
+effort: max
+model: opus
+---
+
+# Azure Specialist
+
+Structured investigation for Azure workloads. Five phases: gather context,
+diagnose, design, recommend, verify.
+
+## Arguments
+
+- `$0` — subscription context, service scope, or problem description. Required.
+
+---
+
+## Phase 1: Context Gathering
+
+1. Identify the tenant, subscription(s), resource group(s), and services in scope.
+2. Glob for IaC in the working directory: `**/*.bicep`, `**/azuredeploy.json`, `**/main.tf`, `**/*.parameters.json`.
+3. If Azure CLI access is available:
+   ```bash
+   az account show
+   az group list --query "[].name"
+   ```
+4. Note which resource providers are registered:
+   ```bash
+   az provider list --query "[?registrationState=='Registered'].namespace" -o tsv
+   ```
+
+---
+
+## Phase 2: Diagnosis
+
+**Compute / containers:**
+
+```bash
+az vm list --query "[].{name:name,rg:resourceGroup,state:powerState}" -o table
+az aks list --query "[].{name:name,rg:resourceGroup,version:kubernetesVersion}" -o table
+az webapp list --query "[].{name:name,rg:resourceGroup,state:state}" -o table
+```
+
+**Identity / RBAC:**
+
+```bash
+az role assignment list --assignee <principal-id> --all
+az ad app list --display-name <name>
+az identity list --resource-group <rg>
+```
+
+**Networking:**
+
+```bash
+az network vnet list
+az network nsg rule list --nsg-name <nsg> --resource-group <rg>
+az network private-endpoint list
+```
+
+**Serverless / events:**
+
+```bash
+az functionapp list
+az servicebus namespace list
+az eventgrid topic list
+```
+
+**Cost / quotas:**
+
+```bash
+az consumption usage list --start-date <> --end-date <>
+az vm list-usage --location <region>
+```
+
+---
+
+## Phase 3: Design / Root-Cause Analysis
+
+Map symptoms to causes:
+
+| Symptom                  | Common Causes                                               | Check                                                           |
+| ------------------------ | ----------------------------------------------------------- | --------------------------------------------------------------- |
+| AKS pod AuthN fails      | Managed Identity not assigned, missing federated credential | `az aks show --query identity` + pod ServiceAccount annotations |
+| App Service slow         | Cold start on consumption plan, misconfigured scale rules   | Plan tier, autoscale settings                                   |
+| Storage 403              | Private endpoint with wrong DNS, firewall IP allowlist      | `az storage account network-rule list`                          |
+| Function cold starts     | Consumption plan + infrequent traffic                       | Switch to Premium or Always-Ready instances                     |
+| Cosmos DB throttle (429) | RU/s too low, hot partition                                 | Diagnostic settings, metrics, partition key review              |
+| EntraID app login fails  | Redirect URI mismatch, missing API permission grant         | `az ad app show` + consent status                               |
+
+Cite resource ID or `file:line` for every finding.
+
+---
+
+## Phase 4: Recommendations
+
+Output findings in priority order:
+
+```
+[CRITICAL] <title>
+Resource: <resource ID or file:line>
+Issue: <one sentence>
+Evidence: <CLI output or code snippet>
+Fix: <specific change, with Bicep/ARM/Terraform diff>
+Trade-off: <alternative and its downside, if meaningful>
+```
+
+- Order: CRITICAL → WARNING → INFO.
+- For IaC fixes, show the exact Bicep/ARM/Terraform diff.
+- Reference relevant docs in `references/` where applicable.
+
+---
+
+## Phase 5: Verification
+
+After fixes are applied:
+
+1. Re-run the diagnostic command that surfaced the issue.
+2. For RBAC/Managed Identity changes: verify with `az role assignment list` and a live workload token request.
+3. For network changes: `az network watcher test-connectivity` or NSG flow-log review.
+4. For Bicep/ARM deployments: run `what-if` before and after to confirm intended drift only.
+5. Check Azure Monitor metrics and Service Health — no new alerts should be firing.
+
+---
+
+## Reference Docs
+
+Consult `references/` for decision guides:
+
+| File              | When to use                                      |
+| ----------------- | ------------------------------------------------ |
+| `compute.md`      | AKS, ACI, VMs, App Service                       |
+| `serverless.md`   | Functions, Logic Apps, Service Bus, Event Grid   |
+| `storage.md`      | Blob, Files, Queues, Cosmos DB, Azure SQL        |
+| `networking.md`   | VNet, App Gateway, Front Door, Private Endpoints |
+| `identity.md`     | EntraID, Managed Identity, RBAC scopes           |
+| `devops.md`       | Azure Pipelines, ACR, release management         |
+| `iac-patterns.md` | Bicep, ARM, Terraform (AzureRM/azapi) patterns   |

--- a/skills/azure-specialist/references/compute.md
+++ b/skills/azure-specialist/references/compute.md
@@ -1,0 +1,65 @@
+# Azure Compute
+
+## Key Concepts
+
+- **AKS** — managed Kubernetes. Node pools (system + user), Virtual Nodes (serverless bursting), Azure CNI (pod IPs from VNet) vs kubenet (overlay).
+- **ACI** — Azure Container Instances. Single-container serverless; no orchestration. Useful for batch jobs, not long-running services.
+- **App Service** — PaaS for web apps. Plans (Basic/Standard/Premium v2/v3/Isolated). Deployment slots for blue-green.
+- **Virtual Machines** — IaaS VMs. Availability sets (fault/update domains) vs Availability Zones (AZ-aware). Spot VMs for interruption-tolerant.
+
+## Common Patterns
+
+```bicep
+// AKS with Azure CNI + Workload Identity
+resource aks 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
+  name: 'my-aks'
+  location: resourceGroup().location
+  identity: { type: 'SystemAssigned' }
+  properties: {
+    dnsPrefix: 'myaks'
+    oidcIssuerProfile: { enabled: true }
+    securityProfile: { workloadIdentity: { enabled: true } }
+    networkProfile: {
+      networkPlugin: 'azure'
+      networkPolicy: 'cilium'
+    }
+    agentPoolProfiles: [
+      {
+        name: 'system'
+        count: 2
+        vmSize: 'Standard_D4s_v5'
+        mode: 'System'
+      }
+    ]
+  }
+}
+```
+
+```bicep
+// App Service with deployment slot
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = { ... }
+resource app 'Microsoft.Web/sites@2023-12-01' = { ... }
+resource staging 'Microsoft.Web/sites/slots@2023-12-01' = {
+  parent: app
+  name: 'staging'
+  properties: { serverFarmId: plan.id }
+}
+```
+
+## Checklist
+
+- [ ] AKS system pool isolated from user workloads via `nodeSelector`/`taints` (don't schedule app pods on system nodes).
+- [ ] AKS cluster has OIDC issuer + Workload Identity enabled (not legacy AAD pod identity).
+- [ ] App Service uses Premium v3 for production (better cold-start behavior, VNet integration).
+- [ ] Deployment slots used for zero-downtime deploys; `swap` tested.
+- [ ] VMs in Availability Zones (not just availability sets) for regional HA.
+- [ ] Spot VMs used only for interruption-tolerant workloads with eviction policy set.
+
+## Gotchas
+
+- Azure CNI consumes VNet IPs per pod; subnet must be sized for `max_pods × node_count`. Overlay mode (Azure CNI Overlay) avoids this at some feature cost.
+- AKS node image upgrades require rolling node pools; default maintenance window is reactive (security updates auto-apply) — pin for predictability.
+- App Service `Always On` defaults to false on Basic/Free tiers — app unloads after idle, first request pays full cold start.
+- Deployment slot swap is atomic at the routing layer but NOT at the storage layer — slot-sticky settings prevent accidental swap of config.
+- ACI has no autoscaling — one ACI = one pod. For scale, use AKS + Virtual Nodes.
+- Availability Sets only protect against rack failure (fault domain 0-2); AZs protect against DC failure. Most production workloads need AZs.

--- a/skills/azure-specialist/references/devops.md
+++ b/skills/azure-specialist/references/devops.md
@@ -1,0 +1,74 @@
+# Azure DevOps and ACR
+
+## Key Concepts
+
+- **Azure Pipelines** — CI/CD service. YAML pipelines (in-repo) preferred over classic UI-only pipelines.
+- **Azure Repos** — Git hosting. Branch policies, build validation, required reviewers.
+- **Azure Artifacts** — package feeds (NuGet, npm, Maven, Python, universal).
+- **ACR (Azure Container Registry)** — container registry. SKUs: Basic/Standard/Premium (Premium adds geo-replication, content trust, private link).
+- **ACR Tasks** — build and patch images on ACR-managed agents; base image updates auto-trigger rebuilds.
+
+## Common Patterns
+
+```yaml
+# azure-pipelines.yml — multi-stage with approval gate
+trigger:
+  branches: { include: ["main"] }
+
+stages:
+  - stage: Build
+    jobs:
+      - job: BuildImage
+        pool: { vmImage: "ubuntu-latest" }
+        steps:
+          - task: Docker@2
+            inputs:
+              containerRegistry: "my-acr"
+              repository: "my-app"
+              command: "buildAndPush"
+              tags: |
+                $(Build.BuildId)
+                latest
+
+  - stage: DeployProd
+    dependsOn: Build
+    condition: succeeded()
+    jobs:
+      - deployment: DeployToProd
+        environment: "production" # requires approval configured in env settings
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - script: kubectl apply -f k8s/
+```
+
+```yaml
+# ACR Task — auto-rebuild on base image update
+version: v1.1.0
+steps:
+  - build: -t $Registry/my-app:{{.Run.ID}} .
+  - push: [$Registry/my-app:{{.Run.ID}}]
+triggers:
+  base:
+    - image: mcr.microsoft.com/dotnet/aspnet:8.0
+```
+
+## Checklist
+
+- [ ] Pipelines defined in YAML (git-tracked), not classic UI-only.
+- [ ] Production deploys gated by environment approvals.
+- [ ] Service connections use Workload Identity federation (not long-lived service principal secrets).
+- [ ] Branch policies on `main`: build must pass, required reviewers, linear history.
+- [ ] ACR: Premium SKU for production; content trust enabled for signed images.
+- [ ] ACR tasks configured for base image update triggers on critical images.
+- [ ] Pipeline secrets stored in Azure Key Vault, referenced via variable groups.
+
+## Gotchas
+
+- Pipelines YAML parser silently accepts extra keys — typos in task input names don't fail, just don't apply the value.
+- Environment approvals block the deployment job, not the stage — pre-deploy tasks in the same stage run before approval.
+- Self-hosted agents without `chmod +x` on a script task fail with "permission denied" — use `script:` inline or ensure agent image has scripts.
+- ACR admin user (`--admin-enabled`) should be disabled in production; use Managed Identity or SP with `AcrPull` role.
+- Service connections set to "Grant access permission to all pipelines" is convenient but bypasses per-pipeline consent — review for production.
+- ACR quarantine + vulnerability scanning (Defender for Containers) is separate from ACR Tasks — enable explicitly.

--- a/skills/azure-specialist/references/iac-patterns.md
+++ b/skills/azure-specialist/references/iac-patterns.md
@@ -1,0 +1,68 @@
+# Azure IaC Patterns
+
+## Key Concepts
+
+- **ARM templates** — JSON declarative IaC. Low-level, verbose. Every resource has an `apiVersion`.
+- **Bicep** — DSL compiling to ARM. Modules, loops, conditions, type-checking. Preferred for new work.
+- **Terraform** — `azurerm` provider for stable resources, `azapi` provider for preview/unreleased services.
+- **Azure Verified Modules** — Microsoft-maintained Bicep and Terraform modules with consistent patterns.
+
+## Common Patterns
+
+```bicep
+// Bicep module with parameters + outputs
+param location string = resourceGroup().location
+param env string
+@allowed(['Basic', 'Standard', 'Premium'])
+param tier string
+
+module app 'modules/app-service.bicep' = {
+  name: 'app-${env}'
+  params: {
+    location: location
+    sku: tier
+    env: env
+  }
+}
+
+output endpoint string = app.outputs.defaultHostName
+```
+
+```bicep
+// Loops for multi-region deployment
+param regions array = ['eastus', 'westeurope']
+resource sas 'Microsoft.Storage/storageAccounts@2023-05-01' = [for r in regions: {
+  name: 'sa${uniqueString(resourceGroup().id, r)}'
+  location: r
+  ...
+}]
+```
+
+```hcl
+# Terraform azapi provider for preview features
+resource "azapi_resource" "my_preview" {
+  type      = "Microsoft.SomeService/resources@2024-08-01-preview"
+  name      = "my-resource"
+  parent_id = azurerm_resource_group.rg.id
+  body = jsonencode({ properties = { ... } })
+}
+```
+
+## Checklist
+
+- [ ] New IaC work in Bicep, not raw ARM.
+- [ ] `bicep build <file>.bicep` runs clean before deploy (catches invalid refs, type errors).
+- [ ] `az deployment group what-if` reviewed before every production deploy.
+- [ ] Resource tags applied via module/default — don't rely on manual post-deploy tagging.
+- [ ] Terraform remote state in Storage Account with SAS/MI access; state locking via blob lease.
+- [ ] No hardcoded tenant IDs, subscription IDs — reference via parameters or data sources.
+- [ ] Use Azure Verified Modules for common patterns (AKS, App Service, Storage) to inherit baseline hardening.
+
+## Gotchas
+
+- Bicep module `name` must be unique per deployment — it's ARM's deployment name, not the Bicep variable name. Duplicate names collide.
+- ARM `apiVersion` affects which properties are valid. Upgrading API version in Bicep can silently drop/add features — check the schema.
+- `az deployment group what-if` can miss drift introduced by manual portal changes; use `az deployment group list` + change history for the full picture.
+- Terraform azurerm v3 → v4 migrations reorganized many resources (storage account sub-resources split off). Check upgrade guide before provider bumps.
+- Bicep `existing` references don't validate at build time — a typo in the name of an existing resource fails at deploy, not compile.
+- ARM incremental mode (default) adds new resources but doesn't remove ones missing from the template; Complete mode removes anything not in the template. Complete mode is dangerous for shared RGs.

--- a/skills/azure-specialist/references/identity.md
+++ b/skills/azure-specialist/references/identity.md
@@ -1,0 +1,61 @@
+# Azure Identity
+
+## Key Concepts
+
+- **EntraID** (formerly Azure AD) — directory and identity provider. Users, groups, app registrations, service principals.
+- **App registration** — defines an application in the tenant. Creates a service principal per tenant where the app is consented.
+- **Managed Identity** — EntraID identity automatically managed for Azure resources. System-assigned (tied to resource lifecycle) vs User-assigned (shared across resources).
+- **RBAC** — role assignments scoped at management group / subscription / resource group / resource level. Inherits downward.
+- **Conditional Access** — policy engine gating sign-ins based on user, location, device, risk.
+- **PIM** — Privileged Identity Management. Just-in-time elevation for sensitive roles.
+
+## Common Patterns
+
+```bicep
+// User-assigned Managed Identity + RBAC on Key Vault
+resource uai 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'app-uai'
+}
+
+resource kvRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: kv
+  name: guid(uai.id, kv.id, 'Key Vault Secrets User')
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')  // Key Vault Secrets User
+    principalId: uai.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+```
+
+```bicep
+// AKS Workload Identity — federated credential on UAI
+resource fc 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
+  parent: uai
+  name: 'aks-sa-federation'
+  properties: {
+    issuer: aks.properties.oidcIssuerProfile.issuerURL
+    subject: 'system:serviceaccount:my-namespace:my-sa'
+    audiences: ['api://AzureADTokenExchange']
+  }
+}
+```
+
+## Checklist
+
+- [ ] No service principal client secrets where Managed Identity is available.
+- [ ] User-assigned Managed Identity preferred for workloads that share identity across resources or need to persist across resource recreation.
+- [ ] RBAC role assignments use built-in roles; custom roles only when built-ins insufficient.
+- [ ] RBAC scope is as narrow as possible — resource > RG > subscription > management group.
+- [ ] Conditional Access policies enforce MFA for admin roles + block legacy authentication.
+- [ ] PIM enabled for Owner, Contributor, and custom high-privilege roles.
+- [ ] App registrations request only the scopes they actually use (no "All" unless required).
+
+## Gotchas
+
+- System-assigned MI is deleted when the parent resource is deleted — any role assignments referencing it become orphaned.
+- Role assignments replicate eventually — after `az role assignment create`, wait 1–2 minutes before testing.
+- `guid(...)` in Bicep for role assignment names must be deterministic across redeploys — else ARM tries to create a duplicate and fails.
+- Workload Identity federated credential `subject` must exactly match the SA in form `system:serviceaccount:<ns>:<sa>`. Typos fail silently with authN errors.
+- EntraID tenant-wide admin consent is required for many Microsoft Graph scopes — granting per-user doesn't propagate.
+- Legacy "AAD Pod Identity" is deprecated on AKS — don't use it for new workloads; use Workload Identity.

--- a/skills/azure-specialist/references/networking.md
+++ b/skills/azure-specialist/references/networking.md
@@ -1,0 +1,63 @@
+# Azure Networking
+
+## Key Concepts
+
+- **VNet** — isolated virtual network. Address space + subnets. Peering (same region cheap, global region peering +$).
+- **VWAN** — hub-and-spoke backbone for enterprises spanning multiple regions and on-prem.
+- **NSG** — stateful firewall at subnet or NIC level. Default rules allow VNet ↔ VNet and deny inbound Internet.
+- **App Gateway** — L7 load balancer with WAF. Path-based routing + SSL offload + health probes.
+- **Front Door** — global edge network. Standard (simple CDN + routing) vs Premium (WAF, Private Link to origin).
+- **Private Endpoint** — private IP for Azure PaaS services (Storage, Cosmos, Key Vault), binding them into your VNet.
+- **Service Endpoint** — older model granting subnet-level access to PaaS services (not per-IP).
+
+## Common Patterns
+
+```bicep
+// VNet with multi-subnet + NSG
+resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
+  name: 'app-vnet'
+  properties: {
+    addressSpace: { addressPrefixes: ['10.0.0.0/16'] }
+    subnets: [
+      { name: 'app'; properties: { addressPrefix: '10.0.1.0/24'; networkSecurityGroup: { id: nsg.id } } }
+      { name: 'db';  properties: { addressPrefix: '10.0.2.0/24'; serviceEndpoints: [{ service: 'Microsoft.Sql' }] } }
+      { name: 'pe';  properties: { addressPrefix: '10.0.3.0/24'; privateEndpointNetworkPolicies: 'Disabled' } }
+    ]
+  }
+}
+```
+
+```bicep
+// App Gateway with WAF v2 + path-based rules
+resource agw 'Microsoft.Network/applicationGateways@2024-01-01' = {
+  name: 'app-agw'
+  properties: {
+    sku: { name: 'WAF_v2'; tier: 'WAF_v2' }
+    webApplicationFirewallConfiguration: {
+      enabled: true
+      firewallMode: 'Prevention'
+      ruleSetType: 'OWASP'
+      ruleSetVersion: '3.2'
+    }
+    ...
+  }
+}
+```
+
+## Checklist
+
+- [ ] NSGs default-deny inbound from Internet; explicit allows only for required ports.
+- [ ] Subnets have NSGs attached (subnet NSG vs NIC NSG — subnet is preferred).
+- [ ] App Gateway / Front Door WAF in Prevention (not Detection) for production.
+- [ ] Private Endpoints used for PaaS access; Public Network Access disabled on Storage/Cosmos/Key Vault.
+- [ ] VNet peering — ensure `allowGatewayTransit` and `useRemoteGateways` set correctly for hub-spoke.
+- [ ] DDoS Standard Protection enabled on production-critical VNets (Basic is always on and free).
+
+## Gotchas
+
+- NSG effective rules are evaluated from lowest priority number up — lower number = higher priority. Off-by-one priority breaks intended order.
+- VNet peering is non-transitive. A↔B and B↔C doesn't connect A↔C. Route via hub (App Gateway, Firewall) or VWAN.
+- Private Endpoint DNS requires Private DNS Zone linked to the VNet — missing this silently resolves to public IP.
+- App Gateway backend health probes fail silently when the backend's HTTP Host header doesn't match the probe's configured host.
+- Front Door Standard can't route to private origins; Premium adds Private Link support.
+- Service Endpoints allow the subnet's origin IP to be public-facing when resolving to the service — Private Endpoints mask traffic fully within VNet.

--- a/skills/azure-specialist/references/serverless.md
+++ b/skills/azure-specialist/references/serverless.md
@@ -1,0 +1,69 @@
+# Azure Serverless
+
+## Key Concepts
+
+- **Azure Functions** — FaaS. Consumption plan (pay-per-exec, cold starts), Premium (pre-warmed), Dedicated (App Service plan).
+- **Logic Apps** — low-code workflow orchestration. Standard (single-tenant) vs Consumption (multi-tenant).
+- **Service Bus** — enterprise message broker. Queues (1:1) vs Topics (1:N with subscriptions). Sessions for ordering.
+- **Event Grid** — pub/sub for Azure events + custom topics. Push-based, webhook targets.
+- **Event Hubs** — high-throughput event streaming (think: Kafka-alike). Partitioned, checkpoint-based consumers.
+
+## Common Patterns
+
+```bicep
+// Function App on Premium plan with VNet integration
+resource fnplan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: 'fn-premium'
+  sku: { name: 'EP1', tier: 'ElasticPremium' }
+  kind: 'functionapp'
+  properties: { maximumElasticWorkerCount: 20 }
+}
+
+resource fn 'Microsoft.Web/sites@2023-12-01' = {
+  name: 'my-fn'
+  kind: 'functionapp'
+  properties: {
+    serverFarmId: fnplan.id
+    siteConfig: {
+      alwaysOn: true
+      functionsRuntimeScaleMonitoringEnabled: true
+      appSettings: [
+        { name: 'WEBSITE_CONTENTOVERVNET', value: '1' }
+      ]
+    }
+  }
+}
+```
+
+```bicep
+// Service Bus queue with DLQ + sessions
+resource sb 'Microsoft.ServiceBus/namespaces@2023-01-01-preview' = { ... }
+resource q 'Microsoft.ServiceBus/namespaces/queues@2023-01-01-preview' = {
+  parent: sb
+  name: 'orders'
+  properties: {
+    maxDeliveryCount: 10
+    deadLetteringOnMessageExpiration: true
+    requiresSession: true
+    lockDuration: 'PT1M'
+  }
+}
+```
+
+## Checklist
+
+- [ ] Production Function Apps on Premium or Dedicated plans (Consumption OK for non-critical).
+- [ ] `functionAppScaleLimit` or `maximumElasticWorkerCount` set to cap cost at tail.
+- [ ] Service Bus queues have DLQ (`deadLetteringOnMessageExpiration: true`) and bounded `maxDeliveryCount`.
+- [ ] Logic Apps Standard used for stateful workflows; Consumption fine for simple event connectors.
+- [ ] Event Hubs capture enabled for long-term storage if compliance requires.
+- [ ] Event Grid subscriptions have retry policies + DLQ (dead-letter endpoint).
+
+## Gotchas
+
+- Functions `host.json` settings silently override portal configuration — diff the file in git when behavior drifts.
+- Consumption plan cold starts are real (seconds). VNet-integrated Functions always require Premium or Dedicated.
+- Service Bus sessions serialize within a session ID — if all messages share a session ID, throughput collapses to a single consumer.
+- Event Grid push can't retry forever — eventually events go to DLQ or dropped. Always configure DLQ for production.
+- Logic Apps Standard runs on App Service plan; you pay for the plan whether workflows run or not.
+- Event Hubs consumer groups must have offset tracking (checkpoint) — without it, restart reads from the beginning (or end, depending on config).

--- a/skills/azure-specialist/references/storage.md
+++ b/skills/azure-specialist/references/storage.md
@@ -1,0 +1,77 @@
+# Azure Storage
+
+## Key Concepts
+
+- **Blob Storage** — object storage. Access tiers (Hot/Cool/Cold/Archive), lifecycle rules. Block blobs vs page blobs vs append blobs.
+- **Azure Files** — SMB and NFS shares. Standard (HDD) vs Premium (SSD). AD-joined for identity-based access.
+- **Queue Storage** — simple queue service (not to be confused with Service Bus). Up to 64KB messages.
+- **Cosmos DB** — multi-model (SQL/MongoDB/Cassandra/Gremlin/Table) NoSQL. Consistency levels (Strong, Bounded Staleness, Session, Consistent Prefix, Eventual). RU/s provisioning.
+- **Azure SQL** — managed relational. vCore vs DTU purchasing models. Elastic pools for multi-tenant.
+
+## Common Patterns
+
+```bicep
+// Storage account with lifecycle + private endpoint
+resource sa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: 'mystorageaccount'
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+    allowBlobPublicAccess: false
+    networkAcls: { defaultAction: 'Deny' }
+    encryption: { services: { blob: { enabled: true } } }
+  }
+}
+
+resource lifecycle 'Microsoft.Storage/storageAccounts/managementPolicies@2023-05-01' = {
+  parent: sa
+  name: 'default'
+  properties: {
+    policy: {
+      rules: [{
+        name: 'archive-old-blobs'
+        enabled: true
+        type: 'Lifecycle'
+        definition: {
+          filters: { blobTypes: ['blockBlob'] }
+          actions: { baseBlob: { tierToArchive: { daysAfterModificationGreaterThan: 180 } } }
+        }
+      }]
+    }
+  }
+}
+```
+
+```bicep
+// Cosmos DB with Session consistency + partition key
+resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
+  name: 'my-cosmos'
+  kind: 'GlobalDocumentDB'
+  properties: {
+    consistencyPolicy: { defaultConsistencyLevel: 'Session' }
+    locations: [{ locationName: resourceGroup().location }]
+    capabilities: []   // add 'EnableServerless' for unpredictable workloads
+  }
+}
+```
+
+## Checklist
+
+- [ ] Storage accounts: `allowBlobPublicAccess: false`, `minimumTlsVersion: 'TLS1_2'`, `supportsHttpsTrafficOnly: true`.
+- [ ] Storage network ACL default-deny; allowlist VNet subnets or Private Endpoint.
+- [ ] Lifecycle rules tier cold data to Cool/Archive, delete ancient blobs.
+- [ ] Cosmos DB partition key chosen for even distribution (high cardinality, frequent value).
+- [ ] Cosmos Session consistency is the default; use Strong only when truly required.
+- [ ] Azure SQL uses vCore + General Purpose for most workloads; Hyperscale for >4TB.
+- [ ] SQL Transparent Data Encryption (TDE) on; Azure Defender for SQL enabled for production.
+
+## Gotchas
+
+- Storage account names are globally unique DNS labels — pick carefully; deletion doesn't immediately free the name.
+- Archive tier rehydrate takes hours. Application code should NOT hit archive blobs directly; rehydrate to Cool first.
+- Cosmos DB RU/s is account-wide or per-container; hot partitions throttle silently with HTTP 429. Always log and alarm on 429 rate.
+- Cosmos serverless max container throughput is capped — not a substitute for provisioned at high throughput.
+- Azure SQL DTU model hides CPU/memory separately; vCore is the modern and recommended choice.
+- Blob soft-delete and versioning are independent features — enabling both ensures both accidental delete AND accidental overwrite are recoverable.

--- a/skills/gcp-specialist/SKILL.md
+++ b/skills/gcp-specialist/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: gcp-specialist
+description: >
+  Deep-dive Google Cloud architecture review, debugging, and service design.
+  Use for structured investigations of GCP-specific issues, IAM or cost audits,
+  and multi-service design reviews. Triggers on: "GCP audit", "GCP design review",
+  "Workload Identity debug", "IAM review GCP", "review my GKE",
+  "GCP troubleshooting", "Cloud Run deep-dive".
+argument-hint: "<project context, service, or problem description>"
+tools: Read, Grep, Glob, Bash
+effort: max
+model: opus
+---
+
+# GCP Specialist
+
+Structured investigation for Google Cloud workloads. Five phases: gather context,
+diagnose, design, recommend, verify.
+
+## Arguments
+
+- `$0` — project context, service scope, or problem description. Required.
+
+---
+
+## Phase 1: Context Gathering
+
+1. Identify the organization, folders, project(s), and services in scope.
+2. Glob for IaC in the working directory: `**/*.tf`, `**/*.yaml` (Config Connector), `**/*.jinja` (Deployment Manager legacy).
+3. If gcloud CLI access is available:
+   ```bash
+   gcloud config list
+   gcloud projects list
+   gcloud auth list
+   ```
+4. List enabled APIs in the current project:
+   ```bash
+   gcloud services list --enabled --format="value(config.name)"
+   ```
+
+---
+
+## Phase 2: Diagnosis
+
+**Compute / containers:**
+
+```bash
+gcloud compute instances list
+gcloud container clusters list
+gcloud run services list
+```
+
+**IAM / identity:**
+
+```bash
+gcloud projects get-iam-policy <project>
+gcloud iam service-accounts list
+gcloud iam workload-identity-pools list --location=global
+```
+
+**Networking:**
+
+```bash
+gcloud compute networks list
+gcloud compute firewall-rules list
+gcloud compute routers list
+```
+
+**Serverless / events:**
+
+```bash
+gcloud functions list
+gcloud pubsub topics list
+gcloud pubsub subscriptions list
+```
+
+**Cost / quotas:**
+
+```bash
+gcloud compute project-info describe --format="yaml(quotas)"
+gcloud logging read 'resource.type="gce_instance"' --limit=20 --format=json
+```
+
+---
+
+## Phase 3: Design / Root-Cause Analysis
+
+Map symptoms to causes:
+
+| Symptom                | Common Causes                                                          | Check                                                                    |
+| ---------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| GKE pod AuthN fails    | Workload Identity not bound, KSA/GSA annotation mismatch               | `kubectl describe sa` + `gcloud iam service-accounts get-iam-policy`     |
+| Cloud Run cold starts  | min-instances=0, cold container image                                  | `gcloud run services describe` → min-instances, image size               |
+| GCS AccessDenied       | Uniform vs fine-grained mismatch, missing `roles/storage.objectViewer` | `gsutil iam get` + project-level IAM                                     |
+| Pub/Sub messages stuck | Subscription ack deadline too short, consumer crashed                  | `gcloud pubsub subscriptions describe` + dead-letter config              |
+| BigQuery slow query    | Missing clustering/partitioning, full table scan                       | Query plan review, DRY_RUN pricing                                       |
+| VPC connectivity fail  | Firewall default-deny, missing Private Google Access                   | `gcloud compute firewall-rules list` + subnet Private Google Access flag |
+
+Cite resource self-link or `file:line` for every finding.
+
+---
+
+## Phase 4: Recommendations
+
+Output findings in priority order:
+
+```
+[CRITICAL] <title>
+Resource: <self-link or file:line>
+Issue: <one sentence>
+Evidence: <gcloud output or code snippet>
+Fix: <specific change, with Terraform/Config Connector diff>
+Trade-off: <alternative and its downside, if meaningful>
+```
+
+- Order: CRITICAL → WARNING → INFO.
+- For IaC fixes, show the exact Terraform or Config Connector diff.
+- Reference relevant docs in `references/` where applicable.
+
+---
+
+## Phase 5: Verification
+
+After fixes are applied:
+
+1. Re-run the diagnostic command that surfaced the issue.
+2. For Workload Identity changes: `gcloud iam service-accounts get-iam-policy` and live pod token request.
+3. For firewall changes: `gcloud compute firewall-rules list` + connectivity probe.
+4. For IAM changes: `gcloud projects get-iam-policy --flatten="bindings[].members"` to see effective membership.
+5. Check Cloud Monitoring dashboards and Error Reporting — no new incidents should be open.
+
+---
+
+## Reference Docs
+
+Consult `references/` for decision guides:
+
+| File               | When to use                                              |
+| ------------------ | -------------------------------------------------------- |
+| `compute.md`       | GKE, Cloud Run, GCE selection and sizing                 |
+| `serverless.md`    | Cloud Functions, Pub/Sub, Cloud Tasks, Eventarc          |
+| `storage.md`       | GCS, Filestore, BigQuery, Cloud SQL, Spanner             |
+| `networking.md`    | VPC, Cloud Load Balancing, Cloud Armor, Cloud CDN        |
+| `iam.md`           | IAM hierarchy, Workload Identity, Service Accounts       |
+| `observability.md` | Cloud Monitoring, Logging, Trace, Error Reporting        |
+| `iac-patterns.md`  | Terraform, Config Connector, Deployment Manager patterns |

--- a/skills/gcp-specialist/references/compute.md
+++ b/skills/gcp-specialist/references/compute.md
@@ -1,0 +1,65 @@
+# GCP Compute
+
+## Key Concepts
+
+- **GKE** — managed Kubernetes. Autopilot (serverless, opinionated) vs Standard (full control). Workload Identity is the default pod identity.
+- **Cloud Run** — managed serverless containers. Services (HTTP handlers) vs Jobs (batch). Scale to zero supported.
+- **GCE** — Compute Engine VMs. Machine families (E2/N2/C2/M2/T2A), custom machine types. MIGs (Managed Instance Groups) for autoscaling.
+- **Spot VMs** — interruptible compute at steep discount. 30s preemption notice.
+- **Cloud Functions** — FaaS. v2 is Cloud Run under the hood; v1 is legacy.
+
+## Common Patterns
+
+```hcl
+# GKE Autopilot with Workload Identity
+resource "google_container_cluster" "autopilot" {
+  name     = "app"
+  location = "us-central1"
+  enable_autopilot = true
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+  release_channel { channel = "REGULAR" }
+}
+```
+
+```hcl
+# Cloud Run service with concurrency + min instances
+resource "google_cloud_run_v2_service" "api" {
+  name     = "api"
+  location = "us-central1"
+
+  template {
+    containers {
+      image = "gcr.io/${var.project_id}/api:${var.tag}"
+      resources { limits = { cpu = "1"; memory = "512Mi" } }
+    }
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 20
+    }
+    max_instance_request_concurrency = 80
+    service_account = google_service_account.api.email
+  }
+}
+```
+
+## Checklist
+
+- [ ] GKE Autopilot preferred for new clusters; Standard only when node customization is required.
+- [ ] Cluster has Workload Identity enabled (Autopilot enables by default, Standard must opt in).
+- [ ] Release channel set (`RAPID`/`REGULAR`/`STABLE`) — clusters without channel require manual upgrades.
+- [ ] Cloud Run services use Service Accounts (not default compute SA).
+- [ ] Cloud Run `min_instance_count > 0` for latency-critical services (avoid cold starts).
+- [ ] GCE MIGs use health checks + auto-healing; not just autoscaling.
+- [ ] Spot VMs used only for interruption-tolerant workloads, paired with checkpointing.
+
+## Gotchas
+
+- Autopilot rejects DaemonSets in most namespaces (pods can't target nodes directly). Known limitation — use Standard if you need DaemonSets.
+- Cloud Run services scale to zero by default. First request after idle pays cold-start. `min_instance_count: 1` keeps one warm (+cost).
+- Cloud Run max_instance_request_concurrency capped at 1000. Higher values mean more requests per container but memory pressure.
+- GKE Standard clusters created without Workload Identity can't retrofit it easily — you can enable on cluster but must rebuild node pools.
+- GCE instance metadata server (`metadata.google.internal`) is the only way to get default SA tokens — firewall-blocking it breaks Workload Identity.
+- Cloud Functions v1 has separate quotas from v2; migrating doesn't carry over concurrency limits.

--- a/skills/gcp-specialist/references/iac-patterns.md
+++ b/skills/gcp-specialist/references/iac-patterns.md
@@ -1,0 +1,62 @@
+# GCP IaC Patterns
+
+## Key Concepts
+
+- **Terraform** — `google` and `google-beta` providers. google-beta exposes preview features earlier but couples your module to the beta provider.
+- **Config Connector (KCC)** — GCP resources as Kubernetes CRDs. Managed by GKE-addon or self-install. Lets you use kubectl + GitOps for GCP.
+- **Deployment Manager** — legacy GCP-native IaC. Being deprecated; avoid for new work.
+- **Pulumi** — code-first IaC with GCP provider, useful for teams with strong language preferences.
+- **Crossplane** — Kubernetes-native IaC alternative to Config Connector with broader ecosystem.
+
+## Common Patterns
+
+```hcl
+# Terraform: separate google + google-beta for mixed features
+terraform {
+  required_providers {
+    google      = { source = "hashicorp/google"; version = "~> 5.0" }
+    google-beta = { source = "hashicorp/google-beta"; version = "~> 5.0" }
+  }
+  backend "gcs" {
+    bucket = "my-terraform-state"
+    prefix = "env/prod"
+  }
+}
+
+provider "google"      { project = var.project_id; region = var.region }
+provider "google-beta" { project = var.project_id; region = var.region }
+```
+
+```yaml
+# Config Connector: GCS bucket as K8s resource
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  name: my-bucket
+  namespace: config-connector
+spec:
+  location: US
+  uniformBucketLevelAccess: true
+  lifecycleRule:
+    - action: { type: Delete }
+      condition: { age: 365 }
+```
+
+## Checklist
+
+- [ ] Terraform remote state in GCS with versioning + uniform bucket access.
+- [ ] Provider versions pinned with `~>` or exact; not `latest`.
+- [ ] State bucket has IAM access scoped to the Terraform SA only; no human browsing.
+- [ ] `terraform plan` output reviewed for every production change — destroy/recreate flagged in PR description.
+- [ ] Config Connector: namespace-scoped CRDs preferred over cluster-scoped for blast-radius control.
+- [ ] Deployment Manager NOT used for new work (legacy).
+- [ ] No service account keys in state or variables — use Workload Identity (Terraform in GKE) or Workload Identity Federation (Terraform in CI).
+
+## Gotchas
+
+- `google_project_iam_member` adds one member to a role; `_binding` is authoritative (replaces all); `_policy` is the whole policy. Mixing them causes drift.
+- Terraform state for GCS buckets with object-level data: the state doesn't track bucket contents. `terraform destroy` fails on non-empty buckets unless `force_destroy = true`.
+- Config Connector has a lag between CRD apply and GCP resource creation — `kubectl wait` or retry logic needed in automation.
+- `google-beta` provider resources may change without the stability guarantee; pin major + minor version.
+- Project creation via Terraform requires billing account linkage — a missing billing binding leaves the project in a broken state.
+- Custom role definitions aren't deletable immediately after removal from Terraform — they enter a 7-day soft-delete state.

--- a/skills/gcp-specialist/references/iam.md
+++ b/skills/gcp-specialist/references/iam.md
@@ -1,0 +1,61 @@
+# GCP IAM
+
+## Key Concepts
+
+- **Hierarchy** — Organization → Folder → Project → Resource. IAM inherits downward; narrower scopes can expand but not restrict inherited grants.
+- **Service Accounts** — identities for workloads. Default compute SA is overly permissive; create dedicated SAs.
+- **Roles** — Primitive (Owner/Editor/Viewer — avoid), Predefined (service-specific), Custom (authored).
+- **Workload Identity** — KSA ↔ GSA binding on GKE so pods get GSA permissions without downloaded keys.
+- **Workload Identity Federation** — external identity provider (GitHub Actions, AWS, Azure AD) assumes GSAs without keys.
+- **Organization Policies** — constraints (e.g. `disableServiceAccountKeyCreation`) enforced across the org.
+- **VPC Service Controls** — perimeter boundaries around API access to sensitive services.
+
+## Common Patterns
+
+```hcl
+# GKE Workload Identity: bind KSA ↔ GSA
+resource "google_service_account" "pod_sa" {
+  account_id = "my-pod-sa"
+}
+
+resource "google_service_account_iam_binding" "wi" {
+  service_account_id = google_service_account.pod_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "serviceAccount:${var.project_id}.svc.id.goog[my-namespace/my-ksa]",
+  ]
+}
+
+# KSA annotation: iam.gke.io/gcp-service-account: my-pod-sa@<project>.iam.gserviceaccount.com
+```
+
+```hcl
+# Workload Identity Federation for GitHub Actions
+resource "google_iam_workload_identity_pool" "gha" { ... }
+resource "google_iam_workload_identity_pool_provider" "gha" {
+  oidc { issuer_uri = "https://token.actions.githubusercontent.com" }
+  attribute_mapping = {
+    "google.subject" = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+  }
+}
+```
+
+## Checklist
+
+- [ ] No primitive roles (Owner/Editor/Viewer) in production IAM bindings — use predefined or custom.
+- [ ] No downloaded service account keys; use Workload Identity (in-GCP) or Workload Identity Federation (external).
+- [ ] Default compute SA stripped of permissions; dedicated SA per workload.
+- [ ] IAM bindings granted at the narrowest scope (resource > project > folder > org).
+- [ ] Org policy `iam.disableServiceAccountKeyCreation` enabled unless keys are truly required.
+- [ ] Org policy `compute.skipDefaultNetworkCreation` enabled to prevent Auto VPC creation.
+- [ ] VPC Service Controls perimeters around projects with sensitive data (HIPAA/PCI/etc).
+
+## Gotchas
+
+- IAM inheritance is additive — you can only EXPAND privileges downward, never restrict. To restrict, use Deny Policies (separate mechanism).
+- `roles/owner` on a project includes billing control. Separate project-owner from billing-admin via Billing Account IAM.
+- Service account impersonation (`iam.serviceAccounts.getAccessToken`) bypasses SA key download but still needs auditing — log impersonation events.
+- Workload Identity KSA annotation mismatch (typo, wrong SA email) fails silently with "default credentials not found".
+- VPC Service Controls in enforced mode can break legitimate cross-project access; always test in dry-run mode first.
+- Custom roles aren't replicated automatically — custom roles created at project level don't exist at folder level. Create at the right scope for inheritance.

--- a/skills/gcp-specialist/references/networking.md
+++ b/skills/gcp-specialist/references/networking.md
@@ -1,0 +1,73 @@
+# GCP Networking
+
+## Key Concepts
+
+- **VPC** — global resource. Auto mode (subnets per region auto) vs Custom mode (you define subnets). Custom is production-preferred.
+- **Shared VPC** — hosts VPC in one project, others attach. Centralized network admin.
+- **VPC peering** — connects two VPCs; non-transitive.
+- **Private Google Access** — subnet flag letting VMs without public IPs reach Google APIs.
+- **Cloud Load Balancing** — Global (HTTP/S, SSL proxy, TCP proxy) vs Regional. Anycast IPs.
+- **Cloud Armor** — WAF + DDoS. Adaptive Protection for ML-based rules.
+- **Cloud CDN** — edge caching fronting Cloud Load Balancing.
+
+## Common Patterns
+
+```hcl
+# Custom-mode VPC + subnet with Private Google Access
+resource "google_compute_network" "main" {
+  name                    = "main"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "app" {
+  name                     = "app-us-central1"
+  network                  = google_compute_network.main.id
+  region                   = "us-central1"
+  ip_cidr_range            = "10.10.0.0/20"
+  private_ip_google_access = true
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = "10.20.0.0/14"
+  }
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = "10.30.0.0/20"
+  }
+}
+```
+
+```hcl
+# Global HTTP(S) LB + Cloud Armor
+resource "google_compute_security_policy" "waf" {
+  name = "app-waf"
+  rule {
+    action   = "deny(403)"
+    priority = 1000
+    match {
+      expr { expression = "evaluatePreconfiguredExpr('sqli-stable')" }
+    }
+  }
+  adaptive_protection_config {
+    layer_7_ddos_defense_config { enable = true }
+  }
+}
+```
+
+## Checklist
+
+- [ ] VPC in Custom mode for production (Auto mode creates subnets in every region — wasteful and risky).
+- [ ] Private Google Access enabled on subnets hosting private-IP-only VMs.
+- [ ] Secondary IP ranges configured for GKE cluster + services CIDRs.
+- [ ] Cloud Armor attached to public-facing load balancers; Adaptive Protection enabled.
+- [ ] Firewall rules: default-deny ingress, explicit allows.
+- [ ] Cloud CDN enabled on static content paths; cacheable responses include `Cache-Control`.
+- [ ] VPC Service Controls (service perimeters) for sensitive data projects (BigQuery, GCS).
+
+## Gotchas
+
+- VPC is global; subnets are regional. Routes in one region's subnet don't exist in another unless explicitly added.
+- Private Google Access only covers Google APIs; on-prem resources via VPN/Interconnect still need explicit routes.
+- GKE needs secondary IP ranges sized for `max pods per cluster × 2` (ranges must not overlap with primary).
+- Cloud Armor rules are priority-ordered; lower number = higher priority. Accidentally placing an `allow` rule above a `deny` lets traffic through.
+- Shared VPC service project permissions are managed at the host project — a missing `compute.networkUser` on the subnet breaks service project deploys.
+- Cloud CDN invalidation is global and fast (~1 min) but expensive at scale — prefer short TTLs + cache versioning over frequent invalidation.

--- a/skills/gcp-specialist/references/observability.md
+++ b/skills/gcp-specialist/references/observability.md
@@ -1,0 +1,63 @@
+# GCP Observability
+
+## Key Concepts
+
+- **Cloud Monitoring** — metrics + dashboards + alerting. Legacy "Stackdriver" rebrand.
+- **Cloud Logging** — structured logs. Log buckets, sinks (to BigQuery/GCS/Pub/Sub), log-based metrics.
+- **Cloud Trace** — distributed tracing. OpenTelemetry-compatible.
+- **Error Reporting** — automatic error aggregation from structured logs.
+- **Profiler** — continuous production profiling (CPU, heap, contention) with low overhead.
+
+## Common Patterns
+
+```hcl
+# Log sink exporting WARN+ logs to BigQuery for SIEM
+resource "google_logging_project_sink" "warnings" {
+  name        = "warn-to-bq"
+  destination = "bigquery.googleapis.com/projects/${var.project_id}/datasets/logs"
+  filter      = "severity>=WARNING"
+
+  unique_writer_identity = true
+}
+```
+
+```hcl
+# Alerting policy: 5xx rate spike
+resource "google_monitoring_alert_policy" "error_spike" {
+  display_name = "5xx rate above 5%"
+  combiner     = "OR"
+  conditions {
+    display_name = "5xx ratio"
+    condition_threshold {
+      filter = "metric.type=\"run.googleapis.com/request_count\" AND metric.label.response_code_class=\"5xx\""
+      comparison = "COMPARISON_GT"
+      threshold_value = 0.05
+      duration = "300s"
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+    }
+  }
+  notification_channels = [google_monitoring_notification_channel.oncall.id]
+}
+```
+
+## Checklist
+
+- [ ] Log buckets have retention set per class of data (application logs shorter, audit longer).
+- [ ] Audit Logs (Admin Activity + Data Access) enabled on all production projects.
+- [ ] Structured JSON logs with severity, trace ID, and request context.
+- [ ] Alert policies use rate/ratio comparisons, not absolute counts (resilient to traffic changes).
+- [ ] Notification channels cover multiple routes (email + pager/Slack).
+- [ ] Dashboards versioned as IaC (Terraform `google_monitoring_dashboard`), not portal-only.
+- [ ] SLOs defined for customer-facing services using `google_monitoring_slo` — error budget-based alerting.
+
+## Gotchas
+
+- Log-based metrics have a few-minute delay — don't use them for sub-minute alerting.
+- Log sink filters are strings; `resource.type="foo"` vs `resource.type=foo` behave differently in some edge cases. Always quote strings.
+- Data Access audit logs are verbose and expensive — enable selectively per service (not globally).
+- Cloud Monitoring "uptime checks" probe from multiple regions; false positives happen when a single region has issues. Require N of M regions to alert.
+- Trace sampling default (Cloud Run / GKE) is very low; custom code paths need explicit sampler config to capture enough traces.
+- Log-based metrics count entries matching the filter at log-write time; retroactive filter changes don't backfill old data.

--- a/skills/gcp-specialist/references/serverless.md
+++ b/skills/gcp-specialist/references/serverless.md
@@ -1,0 +1,79 @@
+# GCP Serverless and Events
+
+## Key Concepts
+
+- **Cloud Functions v2** — FaaS on Cloud Run. HTTP or event triggers (Pub/Sub, GCS, Eventarc).
+- **Pub/Sub** — async messaging. Topics + subscriptions. Push (HTTP endpoint) vs pull (subscriber polls). Ordering keys for per-key FIFO.
+- **Cloud Tasks** — delayed/retried task queue. Unlike Pub/Sub, targets a specific endpoint per task.
+- **Eventarc** — event routing for GCP services and CloudEvents. Trigger Cloud Run/Functions from audit logs.
+- **Workflows** — managed orchestration. YAML-defined state machine, supports HTTP and GCP connectors.
+
+## Common Patterns
+
+```hcl
+# Pub/Sub topic + subscription with DLQ
+resource "google_pubsub_topic" "orders" {
+  name = "orders"
+}
+
+resource "google_pubsub_topic" "orders_dlq" {
+  name = "orders-dlq"
+}
+
+resource "google_pubsub_subscription" "worker" {
+  name  = "worker"
+  topic = google_pubsub_topic.orders.name
+
+  ack_deadline_seconds = 60
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.orders_dlq.id
+    max_delivery_attempts = 5
+  }
+  retry_policy {
+    minimum_backoff = "10s"
+    maximum_backoff = "600s"
+  }
+}
+```
+
+```hcl
+# Eventarc trigger: Audit Log → Cloud Run
+resource "google_eventarc_trigger" "gcs_to_run" {
+  name     = "gcs-finalize"
+  location = "us-central1"
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.audit.log.v1.written"
+  }
+  matching_criteria {
+    attribute = "serviceName"
+    value     = "storage.googleapis.com"
+  }
+  destination {
+    cloud_run_service {
+      service = google_cloud_run_v2_service.processor.name
+      region  = google_cloud_run_v2_service.processor.location
+    }
+  }
+  service_account = google_service_account.eventarc.email
+}
+```
+
+## Checklist
+
+- [ ] Pub/Sub subscriptions have DLQ + max delivery attempts set.
+- [ ] Push subscriptions use OIDC authentication (`pushConfig.oidcToken`) not public endpoints.
+- [ ] Cloud Functions v2 used for new work (v1 is legacy).
+- [ ] Ack deadline covers the slowest consumer processing time; else messages redeliver while in-flight.
+- [ ] Cloud Tasks for targeted retries with backoff; Pub/Sub for fan-out.
+- [ ] Workflow definitions use named steps with explicit error handling (try/retry).
+- [ ] Eventarc triggers scoped to specific service/resource, not wildcard everything.
+
+## Gotchas
+
+- Pub/Sub ordering keys serialize delivery per key — if all messages share one key, throughput collapses.
+- Push subscription endpoint MUST respond 2xx within ack deadline; slow endpoints cause redelivery.
+- Cloud Tasks queues are regional — cross-region calls pay egress and latency.
+- Eventarc triggers on Audit Logs require Cloud Audit Logging (Data Access / Admin Activity) to be enabled for the target service.
+- Cloud Functions v2 cold starts are shorter than v1 but still measurable; use min-instances for critical paths.
+- Pub/Sub "exactly-once delivery" is per-region and requires explicit enablement on the subscription; without it, plan for at-least-once and idempotent consumers.

--- a/skills/gcp-specialist/references/storage.md
+++ b/skills/gcp-specialist/references/storage.md
@@ -1,0 +1,66 @@
+# GCP Storage and Data
+
+## Key Concepts
+
+- **GCS** — object storage. Storage classes (Standard, Nearline, Coldline, Archive). Uniform vs fine-grained ACLs — prefer Uniform for IAM consistency.
+- **Filestore** — managed NFS. Basic/Standard/Premium/High Scale tiers.
+- **BigQuery** — serverless data warehouse. On-demand vs Slots (capacity-based) pricing. Partitioning + clustering critical for cost.
+- **Cloud SQL** — managed relational (PostgreSQL/MySQL/SQL Server). Regional vs HA config.
+- **Spanner** — globally consistent SQL. Expensive; use only when multi-region strong consistency required.
+- **Firestore** — document database. Native mode (newer, Datastore-compatible) vs Datastore mode (older).
+
+## Common Patterns
+
+```hcl
+# GCS bucket: uniform ACL + lifecycle + encryption
+resource "google_storage_bucket" "data" {
+  name          = "${var.project_id}-data"
+  location      = "US"
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  versioning { enabled = true }
+
+  lifecycle_rule {
+    action { type = "SetStorageClass"; storage_class = "NEARLINE" }
+    condition { age = 30 }
+  }
+  lifecycle_rule {
+    action { type = "Delete" }
+    condition { age = 365 }
+  }
+
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.data.id
+  }
+}
+```
+
+```sql
+-- BigQuery: partitioned + clustered for cost control
+CREATE TABLE analytics.events
+PARTITION BY DATE(event_time)
+CLUSTER BY user_id, event_type
+AS SELECT ... FROM raw.events;
+```
+
+## Checklist
+
+- [ ] GCS buckets use Uniform bucket-level access (not fine-grained ACLs).
+- [ ] Public access prevention enabled (`publicAccessPrevention: enforced`) unless intentionally public.
+- [ ] Lifecycle rules tier to Nearline/Coldline/Archive, delete ancient objects.
+- [ ] BigQuery tables partitioned (typically by DATE) and clustered on frequent filter columns.
+- [ ] BigQuery queries reviewed with `--dry_run` before running to see cost estimate.
+- [ ] Cloud SQL has automated backups, point-in-time recovery, HA for production.
+- [ ] Firestore Native mode for new projects — Datastore mode is legacy.
+
+## Gotchas
+
+- GCS bucket names are globally unique DNS labels. Deleted names reusable but subject to squatting.
+- Uniform ACL is one-way — switching to fine-grained requires bucket recreation in some scenarios.
+- BigQuery on-demand charges per byte scanned, not per row returned. `SELECT *` on a wide table is expensive.
+- BigQuery partition pruning only works when the partition column is in a `WHERE` clause with a filter compatible with the partition type.
+- Cloud SQL's HA is regional (one primary, one standby in another zone). For cross-region HA, use Cloud SQL read replicas (manual promotion).
+- Firestore has 1 write/second per document limit — hot documents serialize writes.
+- GCS signed URLs don't respect uniform bucket-level access for the bucket's underlying ACL model — test generation + access before relying.

--- a/skills/gcp-specialist/references/storage.md
+++ b/skills/gcp-specialist/references/storage.md
@@ -7,7 +7,7 @@
 - **BigQuery** — serverless data warehouse. On-demand vs Slots (capacity-based) pricing. Partitioning + clustering critical for cost.
 - **Cloud SQL** — managed relational (PostgreSQL/MySQL/SQL Server). Regional vs HA config.
 - **Spanner** — globally consistent SQL. Expensive; use only when multi-region strong consistency required.
-- **Firestore** — document database. Native mode (newer, Datastore-compatible) vs Datastore mode (older).
+- **Firestore** — document database. Native mode (default/newer) vs Datastore mode (Datastore-compatible legacy mode).
 
 ## Common Patterns
 


### PR DESCRIPTION
## Summary

- Adds 3 vendor-specific cloud provider agents: `aws-engineer`, `azure-engineer`, `gcp-engineer` (all opus, full tool suite) in `plugins/dotclaude/templates/claude/agents/`.
- Adds 3 companion skills (`aws-specialist`, `azure-specialist`, `gcp-specialist`) with 21 reference docs total — 7 per cloud covering compute, serverless, storage, networking, iam/identity, observability/devops, and iac-patterns.
- Updates `workflow-orchestrator.md` Available Specialists table with 3 new rows; refreshes `.claude/skills-manifest.json` with 3 new entries; updates `init-harness-scaffold.test.mjs` expected list.

## Test plan

- [x] `npm test` passes (16 files, 134 tests)
- [x] `node plugins/dotclaude/bin/dotclaude-validate-skills.mjs` → `✓ manifest valid (21 skills after rebasing onto PR #31)` + `✓ agents valid`
- [x] `node plugins/dotclaude/bin/dotclaude-doctor.mjs` → no new failures
- [x] Each agent file is 46–48 lines (within 40–70 range)
- [x] No version numbers in prose outside code blocks (confirmed via grep)
- [x] `workflow-orchestrator.md` Available Specialists table renders with 17 agents (7 original + 7 k8s from PR #31 + 3 cloud)

## Style notes

Unlike the `kubernetes-specialist` batch (which deliberately avoided vendor names), these cloud agents **keep vendor names** (EC2, Lambda, AKS, Cloud Run, EntraID, Workload Identity, etc.) because AWS/Azure/GCP architectural differences are too real to flatten. Reference docs organize services by category rather than per-service files.

## No-spec rationale

Template files and new skills — no source logic changed. All new content is data (`.md` files) consumed by Claude Code at runtime, not executable code paths. The `plugins/dotclaude/templates/**` and `.claude/**` protected paths are covered by this rationale.