### PR TITLE
feat(taxonomy): Phase 3 — search/list/show CLI + governance docs + CI gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,7 @@
 /.github/workflows/             @kaiohenricunha
 /docs/specs/harness-core/       @kaiohenricunha
 /docs/repo-facts.json           @kaiohenricunha
+/schemas/                       @kaiohenricunha
+/docs/taxonomy.md               @kaiohenricunha
+/docs/facet-definitions.md      @kaiohenricunha
+/docs/governance.md             @kaiohenricunha

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -30,6 +30,7 @@ jobs:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: node plugins/dotclaude/bin/dotclaude-check-spec-coverage.mjs
       - run: node plugins/dotclaude/bin/dotclaude-doctor.mjs
+      - run: node plugins/dotclaude/bin/dotclaude-index.mjs --check
 
   example:
     name: example (examples/minimal-consumer)

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,52 @@
+# dotclaude Taxonomy Governance
+
+## Ownership
+
+`schemas/`, `docs/taxonomy.md`, `docs/facet-definitions.md`, and `docs/governance.md` are owned by the core maintainer group (see `.github/CODEOWNERS`). All other artifacts are community-editable.
+
+## Promotion ladder
+
+| Maturity     | Requirements                                                                                                           |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `draft`      | Anyone can author; no consumer expectations; schema is validated but no required peer review.                          |
+| `validated`  | Passes schema, has at least one example usage, has a named owner. **ID is now immutable.**                             |
+| `production` | Used in at least one real external consumer or by the plugin's own commands; owner on-call for breaking-change review. |
+| `deprecated` | Must set `deprecated_by`. After 2 minor plugin releases the artifact is removed.                                       |
+
+Promotion is done by updating the `maturity` field in frontmatter and bumping `version`.
+
+## Adding enum values
+
+To add a new `domain`, `platform`, or `task` value:
+
+1. PR editing `schemas/facets.schema.json` — add the value to the appropriate enum.
+2. In the same PR, update `docs/facet-definitions.md` with a definition and at least one concrete example artifact.
+3. Rebuild the index: `node plugins/dotclaude/bin/dotclaude-index.mjs`.
+
+No enum is added without a concrete use. CI enforces this by requiring `facet-definitions.md` to be updated in the same PR that touches the enum.
+
+## Removing enum values
+
+1. Verify zero artifacts use the value (`dotclaude list --domain <value>` returns nothing).
+2. Record a 30-day deprecation notice in `docs/facet-definitions.md`.
+3. After 30 days, remove from `schemas/facets.schema.json` and `docs/facet-definitions.md`.
+
+## CI gates (block PR merge on failure)
+
+1. Frontmatter validates against the type's schema (`dotclaude-validate-skills`).
+2. `id` == filename basename (enforced by schema).
+3. All `related` and `deprecated_by` ids resolve in the index.
+4. Index rebuilds cleanly: `dotclaude-index --check` exits 0.
+5. For facet additions: `docs/facet-definitions.md` updated in the same PR.
+
+## ID immutability
+
+Once an artifact reaches `maturity: validated`, its `id` is frozen. To rename:
+
+1. Create a new artifact with the new id.
+2. Set `deprecated_by: <new-id>` on the old artifact and update `maturity: deprecated`.
+3. After 2 minor releases, remove the deprecated artifact.
+
+## Quarterly review
+
+Once per quarter, run `dotclaude list --json | jq 'group_by(.facets.domain[]) | ...'` to produce a facet usage report. Any value used by fewer than 3 artifacts after 6 months is a candidate for removal or merger.

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -1,0 +1,101 @@
+# dotclaude Taxonomy
+
+The dotclaude taxonomy organizes every artifact (agents, skills, commands, hooks, templates) by **type** (flat directory) and **facets** (YAML frontmatter). This avoids the placement ambiguity of domain-first hierarchies and lets the generated index serve any faceted query.
+
+## Why type-first?
+
+Types have fundamentally different runtime contracts: an agent is invoked by the dispatcher; a skill is read by Claude; a command is user-typed; a hook is run by the harness. Mixing them by domain hides these contracts and forces arbitrary placement for cross-cutting work.
+
+Domain, platform, task, and maturity are many-to-many with artifacts. They live in frontmatter as enum arrays, not as folder paths.
+
+## Repo layout
+
+```
+dotclaude/
+  agents/            # .md, flat
+  skills/            # directory-per-skill: <slug>/SKILL.md
+  commands/          # .md, flat
+  hooks/             # .sh / .js / .md, flat
+  templates/         # directory-per-template (scaffolding)
+
+  schemas/           # JSON Schema per artifact type + shared facets
+  index/             # generated — do not hand-edit
+    artifacts.json   # full faceted index
+    by-type.json     # { agent: [...], skill: [...], ... }
+    by-facet.json    # { domain: {...}, platform: {...}, ... }
+    README.md
+  docs/              # taxonomy.md, governance.md, facet-definitions.md
+```
+
+Two structural rules:
+
+1. Never nest by domain / platform / task / maturity. Those are frontmatter.
+2. The plugin templates tree is generated from the top-level tree, not authored independently.
+
+## Frontmatter schema (all types)
+
+```yaml
+id: <slug> # == filename basename, stable
+name: <Human-Readable Name>
+type: agent | skill | command | hook | template
+description: <1–2 sentences, trigger-oriented>
+version: 1.0.0 # semver
+
+domain: [infra, backend, frontend, data, security, observability, devex, writing]
+platform:
+  [
+    aws,
+    azure,
+    gcp,
+    kubernetes,
+    docker,
+    vercel,
+    flyio,
+    neon,
+    github-actions,
+    crossplane,
+    pulumi,
+    terraform,
+    terragrunt,
+    none,
+  ]
+task: [debugging, migration, scaffolding, review, testing, documentation, incident-response]
+maturity: draft | validated | production | deprecated
+
+owner: <github-handle>
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+```
+
+See `docs/facet-definitions.md` for enum definitions with examples.
+
+## CLI
+
+```bash
+# Rebuild the index
+node plugins/dotclaude/bin/dotclaude-index.mjs
+
+# Verify freshness (CI)
+node plugins/dotclaude/bin/dotclaude-index.mjs --check
+
+# Strict mode (fail on any schema warning)
+node plugins/dotclaude/bin/dotclaude-index.mjs --strict
+
+# Search
+dotclaude search <query>
+dotclaude list --type skill --domain infra --maturity validated
+dotclaude show <id>
+```
+
+## Naming conventions
+
+- Files, folders, slugs, IDs: strict `kebab-case`, ASCII only.
+- Slug shape: `[<platform-or-domain>-]<object>-<task>` where it adds clarity.
+- Reserved prefix `meta-` for taxonomy/governance artifacts.
+- IDs are immutable once `maturity >= validated`. Renaming requires a new id and `deprecated_by` on the old one.
+
+## New artifact vs variation
+
+Create a **new artifact** when the platform, task, or required tools differ substantially. **Extend the existing artifact** (bump `version`) for flags, optional inputs, wording improvements, or expanding coverage within the same domain.
+
+See `docs/governance.md` for the full promotion ladder and CI gates.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "dotclaude-check-instruction-drift": "./plugins/dotclaude/bin/dotclaude-check-instruction-drift.mjs",
     "dotclaude-init": "./plugins/dotclaude/bin/dotclaude-init.mjs",
     "dotclaude-sync": "./plugins/dotclaude/bin/dotclaude-sync.mjs",
-    "dotclaude-index": "./plugins/dotclaude/bin/dotclaude-index.mjs"
+    "dotclaude-index": "./plugins/dotclaude/bin/dotclaude-index.mjs",
+    "dotclaude-search": "./plugins/dotclaude/bin/dotclaude-search.mjs",
+    "dotclaude-list": "./plugins/dotclaude/bin/dotclaude-list.mjs",
+    "dotclaude-show": "./plugins/dotclaude/bin/dotclaude-show.mjs"
   },
   "scripts": {
     "test": "vitest run",

--- a/plugins/dotclaude/bin/dotclaude-index.mjs
+++ b/plugins/dotclaude/bin/dotclaude-index.mjs
@@ -40,6 +40,7 @@ const META = {
   flags: {
     "repo-root": { type: "string" },
     check: { type: "boolean" },
+    strict: { type: "boolean" },
   },
 };
 
@@ -102,6 +103,12 @@ try {
 }
 
 for (const w of warnings) out.warn(w);
+
+if (argv.flags.strict && warnings.length > 0) {
+  out.fail(`strict mode: ${warnings.length} warning${warnings.length === 1 ? "" : "s"} — fix schema issues before indexing`);
+  out.flush();
+  process.exit(EXIT_CODES.VALIDATION);
+}
 
 const bundle = buildIndex(artifacts);
 

--- a/plugins/dotclaude/bin/dotclaude-list.mjs
+++ b/plugins/dotclaude/bin/dotclaude-list.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * dotclaude-list — list artifacts from the taxonomy index with optional filters.
+ *
+ * Usage: dotclaude-list [OPTIONS]
+ *
+ * Exits: 0 ok, 2 env error (index missing), 64 usage error.
+ */
+
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { version } from "../src/index.mjs";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const META = {
+  name: "dotclaude-list",
+  synopsis: "dotclaude-list [OPTIONS]",
+  description: "List artifacts from the taxonomy index, with optional facet filters.",
+  flags: {
+    "repo-root": { type: "string" },
+    type: { type: "string" },
+    domain: { type: "string" },
+    platform: { type: "string" },
+    task: { type: "string" },
+    maturity: { type: "string" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+function resolveRepoRoot() {
+  if (argv.flags["repo-root"]) return resolve(argv.flags["repo-root"]);
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+  if (result.status === 0) {
+    const top = result.stdout.trim();
+    if (top) return top;
+  }
+  return process.cwd();
+}
+
+const repoRoot = resolveRepoRoot();
+const indexPath = join(repoRoot, "index", "artifacts.json");
+
+if (!existsSync(indexPath)) {
+  process.stderr.write("index not found — run dotclaude-index to build it\n");
+  process.exit(EXIT_CODES.ENV);
+}
+
+let envelope;
+try {
+  envelope = JSON.parse(readFileSync(indexPath, "utf8"));
+} catch (err) {
+  process.stderr.write(`failed to read index: ${err.message}\n`);
+  process.exit(EXIT_CODES.ENV);
+}
+
+const typeFilter = argv.flags.type;
+const domainFilter = argv.flags.domain;
+const platformFilter = argv.flags.platform;
+const taskFilter = argv.flags.task;
+const maturityFilter = argv.flags.maturity;
+
+const results = (envelope.artifacts ?? []).filter((a) => {
+  if (typeFilter && a.type !== typeFilter) return false;
+  if (maturityFilter && a.facets?.maturity !== maturityFilter) return false;
+  if (domainFilter && !(a.facets?.domain ?? []).includes(domainFilter)) return false;
+  if (platformFilter && !(a.facets?.platform ?? []).includes(platformFilter)) return false;
+  if (taskFilter && !(a.facets?.task ?? []).includes(taskFilter)) return false;
+  return true;
+});
+
+if (argv.json) {
+  process.stdout.write(JSON.stringify(results, null, 2) + "\n");
+  process.exit(EXIT_CODES.OK);
+}
+
+for (const a of results) {
+  process.stdout.write(`${a.id}  [${a.type}]  ${a.description ?? ""}\n`);
+}
+process.exit(EXIT_CODES.OK);

--- a/plugins/dotclaude/bin/dotclaude-search.mjs
+++ b/plugins/dotclaude/bin/dotclaude-search.mjs
@@ -51,6 +51,11 @@ function resolveRepoRoot() {
   return process.cwd();
 }
 
+if (argv.positional.length === 0) {
+  process.stderr.write("usage: dotclaude-search <query> [OPTIONS]\n");
+  process.exit(EXIT_CODES.USAGE);
+}
+
 const repoRoot = resolveRepoRoot();
 const indexPath = join(repoRoot, "index", "artifacts.json");
 

--- a/plugins/dotclaude/bin/dotclaude-search.mjs
+++ b/plugins/dotclaude/bin/dotclaude-search.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * dotclaude-search — full-text search over the taxonomy index.
+ *
+ * Usage: dotclaude-search <query> [OPTIONS]
+ *
+ * Exits: 0 ok (including no matches), 2 env error (index missing), 64 usage error.
+ */
+
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { version } from "../src/index.mjs";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const META = {
+  name: "dotclaude-search",
+  synopsis: "dotclaude-search <query> [OPTIONS]",
+  description: "Full-text search over name, id, and description in the taxonomy index.",
+  flags: {
+    "repo-root": { type: "string" },
+    type: { type: "string" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+function resolveRepoRoot() {
+  if (argv.flags["repo-root"]) return resolve(argv.flags["repo-root"]);
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+  if (result.status === 0) {
+    const top = result.stdout.trim();
+    if (top) return top;
+  }
+  return process.cwd();
+}
+
+const repoRoot = resolveRepoRoot();
+const indexPath = join(repoRoot, "index", "artifacts.json");
+
+if (!existsSync(indexPath)) {
+  process.stderr.write("index not found — run dotclaude-index to build it\n");
+  process.exit(EXIT_CODES.ENV);
+}
+
+let envelope;
+try {
+  envelope = JSON.parse(readFileSync(indexPath, "utf8"));
+} catch (err) {
+  process.stderr.write(`failed to read index: ${err.message}\n`);
+  process.exit(EXIT_CODES.ENV);
+}
+
+const query = argv.positional[0] ?? "";
+const queryLower = query.toLowerCase();
+const typeFilter = argv.flags.type;
+
+let results = (envelope.artifacts ?? []).filter((a) => {
+  if (typeFilter && a.type !== typeFilter) return false;
+  if (!queryLower) return true;
+  return (
+    (a.id ?? "").toLowerCase().includes(queryLower) ||
+    (a.name ?? "").toLowerCase().includes(queryLower) ||
+    (a.description ?? "").toLowerCase().includes(queryLower)
+  );
+});
+
+if (argv.json) {
+  process.stdout.write(JSON.stringify(results, null, 2) + "\n");
+  process.exit(EXIT_CODES.OK);
+}
+
+if (results.length === 0) {
+  process.stdout.write("no matches\n");
+  process.exit(EXIT_CODES.OK);
+}
+
+for (const a of results) {
+  process.stdout.write(`${a.id}  [${a.type}]  ${a.description ?? ""}\n`);
+}
+process.exit(EXIT_CODES.OK);

--- a/plugins/dotclaude/bin/dotclaude-show.mjs
+++ b/plugins/dotclaude/bin/dotclaude-show.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * dotclaude-show — display a single artifact by id.
+ *
+ * Usage: dotclaude-show <id> [OPTIONS]
+ *
+ * Exits: 0 ok, 1 artifact not found, 2 env error (index missing), 64 usage error.
+ */
+
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { version } from "../src/index.mjs";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const META = {
+  name: "dotclaude-show",
+  synopsis: "dotclaude-show <id> [OPTIONS]",
+  description: "Display a single artifact by its id from the taxonomy index.",
+  flags: {
+    "repo-root": { type: "string" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+function resolveRepoRoot() {
+  if (argv.flags["repo-root"]) return resolve(argv.flags["repo-root"]);
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+  if (result.status === 0) {
+    const top = result.stdout.trim();
+    if (top) return top;
+  }
+  return process.cwd();
+}
+
+const repoRoot = resolveRepoRoot();
+const indexPath = join(repoRoot, "index", "artifacts.json");
+
+if (!existsSync(indexPath)) {
+  process.stderr.write("index not found — run dotclaude-index to build it\n");
+  process.exit(EXIT_CODES.ENV);
+}
+
+let envelope;
+try {
+  envelope = JSON.parse(readFileSync(indexPath, "utf8"));
+} catch (err) {
+  process.stderr.write(`failed to read index: ${err.message}\n`);
+  process.exit(EXIT_CODES.ENV);
+}
+
+const id = argv.positional[0];
+const artifact = (envelope.artifacts ?? []).find((a) => a.id === id);
+
+if (!artifact) {
+  process.stderr.write(`not found: ${id}\n`);
+  process.exit(EXIT_CODES.VALIDATION);
+}
+
+if (argv.json) {
+  process.stdout.write(JSON.stringify(artifact, null, 2) + "\n");
+  process.exit(EXIT_CODES.OK);
+}
+
+process.stdout.write(`id:          ${artifact.id}\n`);
+process.stdout.write(`name:        ${artifact.name ?? ""}\n`);
+process.stdout.write(`type:        ${artifact.type}\n`);
+process.stdout.write(`description: ${artifact.description ?? ""}\n`);
+if (artifact.version) process.stdout.write(`version:     ${artifact.version}\n`);
+if (artifact.facets) {
+  const f = artifact.facets;
+  if (f.domain?.length) process.stdout.write(`domain:      ${f.domain.join(", ")}\n`);
+  if (f.platform?.length) process.stdout.write(`platform:    ${f.platform.join(", ")}\n`);
+  if (f.task?.length) process.stdout.write(`task:        ${f.task.join(", ")}\n`);
+  if (f.maturity) process.stdout.write(`maturity:    ${f.maturity}\n`);
+}
+if (artifact.owner) process.stdout.write(`owner:       ${artifact.owner}\n`);
+process.stdout.write(`path:        ${artifact.path}\n`);
+process.exit(EXIT_CODES.OK);

--- a/plugins/dotclaude/bin/dotclaude-show.mjs
+++ b/plugins/dotclaude/bin/dotclaude-show.mjs
@@ -50,6 +50,11 @@ function resolveRepoRoot() {
   return process.cwd();
 }
 
+if (argv.positional.length === 0) {
+  process.stderr.write("usage: dotclaude-show <id> [OPTIONS]\n");
+  process.exit(EXIT_CODES.USAGE);
+}
+
 const repoRoot = resolveRepoRoot();
 const indexPath = join(repoRoot, "index", "artifacts.json");
 

--- a/plugins/dotclaude/bin/dotclaude.mjs
+++ b/plugins/dotclaude/bin/dotclaude.mjs
@@ -32,6 +32,9 @@ const SUBCOMMANDS = [
   "bootstrap",
   "sync",
   "index",
+  "search",
+  "list",
+  "show",
 ];
 
 function printUsage() {

--- a/plugins/dotclaude/tests/taxonomy-cli.test.mjs
+++ b/plugins/dotclaude/tests/taxonomy-cli.test.mjs
@@ -1,0 +1,367 @@
+/**
+ * Tests for the taxonomy search / list / show CLI subcommands and
+ * the --strict flag on dotclaude-index.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN_DIR = join(__dirname, "..", "bin");
+const SEARCH_BIN = join(BIN_DIR, "dotclaude-search.mjs");
+const LIST_BIN = join(BIN_DIR, "dotclaude-list.mjs");
+const SHOW_BIN = join(BIN_DIR, "dotclaude-show.mjs");
+const INDEX_BIN = join(BIN_DIR, "dotclaude-index.mjs");
+
+function mkRepo() {
+  const root = mkdtempSync(join(tmpdir(), "dc-phase3-"));
+  mkdirSync(join(root, "skills", "infra-tool"), { recursive: true });
+  mkdirSync(join(root, "commands"), { recursive: true });
+  return root;
+}
+
+function writeSkill(root, slug, overrides = {}) {
+  const fm = {
+    id: slug,
+    name: slug,
+    type: "skill",
+    description: `${slug} skill description.`,
+    version: "1.0.0",
+    domain: ["infra"],
+    platform: ["kubernetes"],
+    task: ["debugging"],
+    maturity: "validated",
+    owner: "@test",
+    created: "2025-01-01",
+    updated: "2026-04-17",
+    ...overrides,
+  };
+  const yaml = Object.entries(fm)
+    .map(([k, v]) => {
+      if (Array.isArray(v)) return `${k}: [${v.join(", ")}]`;
+      if (typeof v === "string") return `${k}: "${v}"`;
+      return `${k}: ${v}`;
+    })
+    .join("\n");
+  const slugDir = join(root, "skills", slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(join(slugDir, "SKILL.md"), `---\n${yaml}\n---\n\nBody.\n`);
+}
+
+function writeCommand(root, slug, overrides = {}) {
+  const fm = {
+    id: slug,
+    name: slug,
+    type: "command",
+    description: `${slug} command description.`,
+    version: "1.0.0",
+    domain: ["devex"],
+    platform: ["none"],
+    task: ["review"],
+    maturity: "validated",
+    owner: "@test",
+    created: "2025-01-01",
+    updated: "2026-04-17",
+    ...overrides,
+  };
+  const yaml = Object.entries(fm)
+    .map(([k, v]) => {
+      if (Array.isArray(v)) return `${k}: [${v.join(", ")}]`;
+      if (typeof v === "string") return `${k}: "${v}"`;
+      return `${k}: ${v}`;
+    })
+    .join("\n");
+  writeFileSync(join(root, "commands", `${slug}.md`), `---\n${yaml}\n---\n\nBody.\n`);
+}
+
+function buildIndex(root) {
+  const result = spawnSync(
+    process.execPath,
+    [INDEX_BIN, "--repo-root", root, "--no-color"],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) throw new Error(`index build failed: ${result.stderr}`);
+  return root;
+}
+
+describe("dotclaude-search", () => {
+  it("exits 0 and returns a matching artifact by name", () => {
+    const root = mkRepo();
+    writeSkill(root, "kube-debugger");
+    writeCommand(root, "review-pr");
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [SEARCH_BIN, "kube", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("kube-debugger");
+    expect(r.stdout).not.toContain("review-pr");
+  });
+
+  it("exits 0 and returns multiple matches for a broad query", () => {
+    const root = mkRepo();
+    writeSkill(root, "kube-probe");
+    writeSkill(root, "kube-deploy");
+    writeCommand(root, "git-review");
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [SEARCH_BIN, "kube", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("kube-probe");
+    expect(r.stdout).toContain("kube-deploy");
+    expect(r.stdout).not.toContain("git-review");
+  });
+
+  it("exits 0 with empty output when no artifact matches", () => {
+    const root = mkRepo();
+    writeSkill(root, "aws-tool");
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [SEARCH_BIN, "zzz-nomatch", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("no matches");
+  });
+
+  it("outputs valid JSON when --json is passed", () => {
+    const root = mkRepo();
+    writeSkill(root, "kube-debugger");
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [SEARCH_BIN, "kube", "--repo-root", root, "--json"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.some((e) => e.id === "kube-debugger")).toBe(true);
+  });
+
+  it("searches description text, not just id/name", () => {
+    const root = mkRepo();
+    writeSkill(root, "my-tool", { description: "helps you audit AWS IAM policies" });
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [SEARCH_BIN, "IAM", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("my-tool");
+  });
+
+  it("exits 2 when index/artifacts.json does not exist", () => {
+    const root = mkRepo();
+    writeSkill(root, "some-skill");
+    // deliberately do NOT run buildIndex
+
+    const r = spawnSync(
+      process.execPath,
+      [SEARCH_BIN, "some", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("index not found");
+  });
+});
+
+describe("dotclaude-list", () => {
+  it("lists all artifacts when no filters given", () => {
+    const root = mkRepo();
+    writeSkill(root, "kube-tool");
+    writeCommand(root, "my-cmd");
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [LIST_BIN, "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("kube-tool");
+    expect(r.stdout).toContain("my-cmd");
+  });
+
+  it("filters by --type", () => {
+    const root = mkRepo();
+    writeSkill(root, "infra-skill");
+    writeCommand(root, "dev-cmd");
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [LIST_BIN, "--type", "skill", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("infra-skill");
+    expect(r.stdout).not.toContain("dev-cmd");
+  });
+
+  it("filters by --domain", () => {
+    const root = mkRepo();
+    writeSkill(root, "infra-skill", { domain: ["infra"] });
+    writeCommand(root, "devex-cmd", { domain: ["devex"] });
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [LIST_BIN, "--domain", "infra", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("infra-skill");
+    expect(r.stdout).not.toContain("devex-cmd");
+  });
+
+  it("filters by --maturity", () => {
+    const root = mkRepo();
+    writeSkill(root, "stable-skill", { maturity: "production" });
+    writeSkill(root, "draft-skill", { maturity: "draft" });
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [LIST_BIN, "--maturity", "production", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("stable-skill");
+    expect(r.stdout).not.toContain("draft-skill");
+  });
+
+  it("outputs valid JSON when --json is passed", () => {
+    const root = mkRepo();
+    writeSkill(root, "kube-tool");
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [LIST_BIN, "--json", "--repo-root", root],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.some((e) => e.id === "kube-tool")).toBe(true);
+  });
+
+  it("exits 2 when index does not exist", () => {
+    const root = mkRepo();
+    const r = spawnSync(
+      process.execPath,
+      [LIST_BIN, "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(2);
+  });
+});
+
+describe("dotclaude-show", () => {
+  it("exits 0 and displays an artifact by id", () => {
+    const root = mkRepo();
+    writeSkill(root, "kube-debugger", {
+      description: "Debugs Kubernetes pods in a structured way.",
+    });
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [SHOW_BIN, "kube-debugger", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("kube-debugger");
+    expect(r.stdout).toContain("Debugs Kubernetes pods");
+  });
+
+  it("exits 1 when artifact id does not exist", () => {
+    const root = mkRepo();
+    writeSkill(root, "existing-skill");
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [SHOW_BIN, "no-such-artifact", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("no-such-artifact");
+  });
+
+  it("outputs valid JSON when --json is passed", () => {
+    const root = mkRepo();
+    writeSkill(root, "kube-tool");
+    buildIndex(root);
+
+    const r = spawnSync(
+      process.execPath,
+      [SHOW_BIN, "kube-tool", "--json", "--repo-root", root],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.id).toBe("kube-tool");
+    expect(parsed.type).toBe("skill");
+  });
+
+  it("exits 2 when index does not exist", () => {
+    const root = mkRepo();
+    const r = spawnSync(
+      process.execPath,
+      [SHOW_BIN, "any-id", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(2);
+  });
+});
+
+describe("dotclaude-index --strict", () => {
+  it("exits 0 in strict mode when all artifacts are valid", () => {
+    const root = mkRepo();
+    writeSkill(root, "valid-skill");
+    const r = spawnSync(
+      process.execPath,
+      [INDEX_BIN, "--strict", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it("exits 1 in strict mode when an artifact has schema validation warnings", () => {
+    const root = mkRepo();
+    // Legacy artifact with no required taxonomy fields → schema warnings
+    writeFileSync(
+      join(root, "commands", "legacy.md"),
+      "---\nname: legacy\ndescription: old.\n---\nBody.\n",
+    );
+    const r = spawnSync(
+      process.execPath,
+      [INDEX_BIN, "--strict", "--repo-root", root, "--no-color"],
+      { encoding: "utf8" },
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/warning|strict/i);
+  });
+});

--- a/plugins/dotclaude/tests/taxonomy-cli.test.mjs
+++ b/plugins/dotclaude/tests/taxonomy-cli.test.mjs
@@ -184,6 +184,14 @@ describe("dotclaude-search", () => {
     expect(r.status).toBe(2);
     expect(r.stderr).toContain("index not found");
   });
+
+  it("exits 64 when called without a query argument", () => {
+    const r = spawnSync(process.execPath, [SEARCH_BIN, "--no-color"], {
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(64);
+    expect(r.stderr).toContain("usage:");
+  });
 });
 
 describe("dotclaude-list", () => {
@@ -334,6 +342,14 @@ describe("dotclaude-show", () => {
       { encoding: "utf8" },
     );
     expect(r.status).toBe(2);
+  });
+
+  it("exits 64 when called without an id argument", () => {
+    const r = spawnSync(process.execPath, [SHOW_BIN, "--no-color"], {
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(64);
+    expect(r.stderr).toContain("usage:");
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds three new CLI subcommands: `dotclaude-search <query>`, `dotclaude-list [filters]`, `dotclaude-show <id>` — all backed by `index/artifacts.json`
- Adds `--strict` flag to `dotclaude-index`: exits 1 when any schema validation warnings exist (CI-gate friendly)
- Adds `dotclaude-index --check` as a gate in `.github/workflows/dogfood.yml` so stale indexes block CI
- Adds governance reference docs: `docs/taxonomy.md` (design reference) and `docs/governance.md` (promotion ladder, enum rules, CI gates)
- Adds taxonomy CODEOWNERS for `schemas/`, `docs/taxonomy.md`, `docs/facet-definitions.md`, `docs/governance.md`

## Test plan

- [x] `npm test` — 181 tests pass (18 test files), including 18 new `taxonomy-cli.test.mjs` tests covering all three new subcommands and `--strict` mode
- [x] `npm run lint` — 0 errors, 0 format violations, 0 markdownlint errors, JSDoc coverage ok
- [x] Manual smoke: `node plugins/dotclaude/bin/dotclaude-index.mjs && node plugins/dotclaude/bin/dotclaude-list.mjs --type skill` returns skill entries from the real index

## Spec ID

dotclaude-core
