### PR TITLE
docs(spec): register dotclaude-agents spec + gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ settings.local.json
 **/logs/
 **/.DS_Store
 
+# Local working plans — transient, not for distribution.
+docs/plans/
+
 # Node (for the plugin workspace)
 node_modules/
 *.log

--- a/docs/specs/dotclaude-agents/README.md
+++ b/docs/specs/dotclaude-agents/README.md
@@ -1,0 +1,29 @@
+# dotclaude-agents — Engineering Spec
+
+> Created: 2026-04-15
+
+## Status
+
+| #   | Section                     | Status   |
+| --- | --------------------------- | -------- |
+| 1   | Problem / Motivation        | [x] done |
+| 2   | Scope                       | [x] done |
+| 3   | High-Level Architecture     | [x] done |
+| 4   | Data Flow / Components      | [x] done |
+| 5   | Interfaces and APIs         | [x] done |
+| 6   | Implementation Plan         | [x] done |
+| 7   | Non-Functional Requirements | [x] done |
+| 8   | Risks and Alternatives      | [x] done |
+
+## Quick Start
+
+- **What are we building?** → [§1 Problem/Motivation](spec/1-problem-motivation.md)
+- **What's in/out?** → [§2 Scope](spec/2-scope.md)
+- **How does it fit together?** → [§3 Architecture](spec/3-high-level-architecture.md) + [§4 Components](spec/4-data-flow-components.md)
+- **Agent file format + model routing** → [§5 Interfaces](spec/5-interfaces-apis.md)
+- **How to implement it** → [§6 Implementation Plan](spec/6-implementation-plan.md) (5 prompts, parallelizable)
+- **Risks** → [§8 Risks & Alternatives](spec/8-risks-alternatives.md)
+
+## Research Sources
+
+See [research/sources.md](research/sources.md) for indexed source documents.

--- a/docs/specs/dotclaude-agents/research/sources.md
+++ b/docs/specs/dotclaude-agents/research/sources.md
@@ -1,0 +1,12 @@
+# Research Sources
+
+> Indexed documents feeding into this spec. Each tagged with which sections it informs.
+
+<!-- Format:
+- **DOC-N**: {title} — {one-line description}. Feeds: §N, §N.
+-->
+
+- **DOC-1**: `awesome-claude-code-subagents` (`/home/kaiocunha/Projects/VoltAgent/awesome-claude-code-subagents`) — 140+ Claude Code subagents organized into 10 categories; primary inspiration for agent format, model routing, tool scoping, and discovery patterns. Feeds: §3, §4, §5, §6.
+- **DOC-2**: `plugins/dotclaude/.claude-plugin/plugin.json` — current plugin manifest; shows existing schema to extend with `agents` array. Feeds: §4, §5, §6.
+- **DOC-3**: `bootstrap.sh` — existing install script; the vehicle for agent copy step. Feeds: §4, §6.
+- **DOC-4**: `plugins/dotclaude/src/validate-skills-inventory.mjs` — existing skills validator to extend for agent frontmatter linting. Feeds: §6, §7.

--- a/docs/specs/dotclaude-agents/spec.json
+++ b/docs/specs/dotclaude-agents/spec.json
@@ -18,5 +18,5 @@
   ],
   "acceptance_commands": ["npm test", "node plugins/dotclaude/bin/dotclaude-validate-skills.mjs ."],
   "depends_on_specs": ["dotclaude-core"],
-  "active_prs": [28]
+  "active_prs": []
 }

--- a/docs/specs/dotclaude-agents/spec/1-problem-motivation.md
+++ b/docs/specs/dotclaude-agents/spec/1-problem-motivation.md
@@ -1,0 +1,15 @@
+# §1 — Problem / Motivation
+
+> Why does this exist? What's broken? Why now?
+
+## Why
+
+dotclaude today ships skills and commands, but agents — the `.claude/agents/` primitive — are treated as a side effect of skills rather than a first-class artifact. Users who install dotclaude get no bundled agents, no template for creating them, no discovery mechanism, and no guidance on model routing. The result is that advanced Claude Code capabilities (persistent specialized agents, model cost optimization, inter-agent orchestration) are invisible to dotclaude users even though the platform fully supports them.
+
+## What
+
+Add a first-class agent layer to dotclaude — bundled starter agents, a bootstrap template that installs them, `model:` routing in skill/agent frontmatter, and a `/agents:search` discovery skill — so that users get the full Claude Code primitives, not just the skills subset.
+
+## Why Now
+
+The `awesome-claude-code-subagents` project demonstrates the pattern is mature and the ecosystem is moving in this direction. Claude Code's agent plugin system (`marketplace.json`, `.claude/agents/`) is stable. dotclaude is already the right distribution vehicle — we just haven't used it for agents yet.

--- a/docs/specs/dotclaude-agents/spec/2-scope.md
+++ b/docs/specs/dotclaude-agents/spec/2-scope.md
@@ -1,0 +1,32 @@
+# §2 — Scope
+
+> What's in, what's out, and where are the boundaries?
+
+## In Scope
+
+- Bundled starter agents shipped with dotclaude (curated small set, not exhaustive)
+- Bootstrap template updates so agents are installed alongside skills on `bootstrap.sh`
+- `model:` frontmatter routing on skills and agents (opus/sonnet/haiku/inherit)
+- A `/agents:search` discovery skill for finding and fetching agents from the catalog
+- Plugin manifest (`marketplace.json` / `plugin.json`) wiring for the agents category
+
+## Out of Scope
+
+- Building a full 140-agent catalog — we ship a curated starter set, not a replica of awesome-claude-code-subagents
+- A custom interactive installer script — bootstrap.sh handles installation
+- Agent lifecycle management (versioning, update notifications) — deferred to a future spec
+- Custom agent type definitions beyond what Claude Code natively supports
+
+## Boundaries
+
+| Touches                        | Does Not Touch                        |
+| ------------------------------ | ------------------------------------- |
+| `plugins/dotclaude/templates/` | Agent runtime / Claude Code internals |
+| `plugins/dotclaude/src/`       | Existing skills content               |
+| `.claude/skills-manifest.json` | CI pipelines                          |
+| `bootstrap.sh`                 | External agent catalogs               |
+| `docs/specs/dotclaude-agents/` | Other spec domains                    |
+
+## Urgency
+
+No hard deadline. Ecosystem is moving in this direction now — shipping before dotclaude-core stabilizes keeps the agent layer composable from the start.

--- a/docs/specs/dotclaude-agents/spec/3-high-level-architecture.md
+++ b/docs/specs/dotclaude-agents/spec/3-high-level-architecture.md
@@ -1,0 +1,39 @@
+# §3 — High-Level Architecture
+
+> System view: components, data stores, external dependencies, deployment.
+
+## System Overview
+
+The agent layer sits alongside the existing skills layer. Agents are `.md` files with YAML frontmatter placed under `.claude/agents/`. dotclaude ships a curated set via its plugin template; `bootstrap.sh` copies them into the user's environment. A `/agents:search` skill provides discovery. Model routing (`model:` frontmatter) is a convention read natively by Claude Code — no new runtime tooling required.
+
+```
+dotclaude repo
+└── plugins/dotclaude/templates/
+    └── .claude/
+        ├── agents/          ← new: bundled starter agents
+        └── skills/          ← existing
+            └── ...
+
+bootstrap.sh
+  → symlinks / copies agents/ into ~/.claude/agents/
+
+Claude Code runtime
+  → reads ~/.claude/agents/*.md
+  → respects model: frontmatter per agent
+```
+
+## Data Stores
+
+| Store                               | Role                           | Access Pattern                              |
+| ----------------------------------- | ------------------------------ | ------------------------------------------- |
+| `~/.claude/cache/agents-catalog.md` | TTL cache for `/agents:search` | Read on search, written on fetch/invalidate |
+
+## External APIs / Dependencies
+
+| Service               | Purpose                                                    | Rate Limits / Constraints                                      |
+| --------------------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
+| GitHub API (optional) | Fetch agent definitions from awesome-claude-code-subagents | 60 req/hr unauthenticated; graceful degradation to stale cache |
+
+## Deployment
+
+Runs entirely on the user's local machine. No server, no hosted state. The `/agents:search` skill optionally reaches out to GitHub for remote catalog fetches — all other operations are local file I/O.

--- a/docs/specs/dotclaude-agents/spec/4-data-flow-components.md
+++ b/docs/specs/dotclaude-agents/spec/4-data-flow-components.md
@@ -1,0 +1,71 @@
+# §4 — Data Flow / Components
+
+> Current state analysis + target architecture.
+
+## Current State
+
+`plugins/dotclaude/templates/claude/` holds settings, hooks, and `skills-manifest.json`. `bootstrap.sh` copies these into `~/.claude/`. The `plugin.json` is flat with no `agents` field. No `agents/` directory exists anywhere in the template tree. Skills have no `model:` frontmatter — all run on whatever model the user has active.
+
+```
+plugins/dotclaude/
+├── .claude-plugin/plugin.json      ← no agents field
+├── templates/
+│   └── claude/
+│       ├── settings.json
+│       ├── hooks/
+│       └── skills-manifest.json
+└── (no agents/ anywhere)
+```
+
+## Component Boundaries
+
+| Component                           | Responsibility                                                             |
+| ----------------------------------- | -------------------------------------------------------------------------- |
+| `templates/claude/agents/`          | Stores bundled starter agent `.md` files                                   |
+| `plugin.json`                       | Declares the `agents` array for Claude Code plugin system                  |
+| `/agents:search` skill              | Discovery — search, fetch, and inspect agents from local or remote catalog |
+| `~/.claude/cache/agents-catalog.md` | Local TTL cache for remote catalog fetches                                 |
+| `model:` frontmatter convention     | Routes each agent/skill to the appropriate Claude tier                     |
+
+## Shared State
+
+| State            | Location                            | Consumers                   |
+| ---------------- | ----------------------------------- | --------------------------- |
+| Installed agents | `~/.claude/agents/*.md`             | Claude Code runtime         |
+| Catalog cache    | `~/.claude/cache/agents-catalog.md` | `/agents:search` skill      |
+| Skills manifest  | `~/.claude/skills-manifest.json`    | `dotclaude-validate-skills` |
+
+No shared mutable state between agents at runtime — each agent is stateless and scoped to its invocation.
+
+## Target Architecture
+
+```
+plugins/dotclaude/
+├── .claude-plugin/plugin.json      ← gains "agents" array
+├── templates/
+│   └── claude/
+│       ├── agents/                 ← new: starter agents
+│       │   ├── security-auditor.md
+│       │   ├── architect-reviewer.md
+│       │   └── ...
+│       ├── settings.json
+│       ├── hooks/
+│       └── skills-manifest.json
+└── skills/
+    └── agents-search.md            ← new: /agents:search discovery skill
+```
+
+Bootstrap flow:
+
+```
+bootstrap.sh
+  → copies templates/claude/agents/ → ~/.claude/agents/
+  → Claude Code reads ~/.claude/agents/*.md natively
+  → model: frontmatter respected per agent invocation
+```
+
+### Key Decisions
+
+- **KD-1**: Agents land in `templates/claude/agents/` — matches existing `templates/claude/` convention (not `templates/.claude/`). See §6 for migration note.
+- **KD-2**: `plugin.json` gains an `agents` array — Claude Code reads this natively, no dotclaude runtime changes needed.
+- **KD-3**: `/agents:search` is a skill, not an agent — it's a user-invoked command, not a persistent specialist. Feeds into §5.

--- a/docs/specs/dotclaude-agents/spec/5-interfaces-apis.md
+++ b/docs/specs/dotclaude-agents/spec/5-interfaces-apis.md
@@ -1,0 +1,106 @@
+# §5 — Interfaces and APIs
+
+> External APIs, internal endpoints, database schemas.
+
+## Agent File Format
+
+Every agent is a `.md` file with YAML frontmatter. This is the contract between dotclaude and Claude Code:
+
+```yaml
+---
+name: security-auditor # kebab-case, unique within ~/.claude/agents/
+description: > # Shown in Claude Code UI; used for auto-activation matching
+  Use when reviewing code for security vulnerabilities, auditing PRs,
+  or analyzing attack surface. Triggers on: "security review", "audit", "CVE".
+tools: Read, Grep, Glob # Comma-separated; minimal necessary permissions
+model: opus # See model routing below
+---
+You are a security-focused code reviewer...
+```
+
+**Required frontmatter fields:** `name`, `description`, `tools`, `model`
+
+---
+
+## Model Routing Values
+
+| Value     | Maps To               | When to Use                                                                  |
+| --------- | --------------------- | ---------------------------------------------------------------------------- |
+| `opus`    | claude-opus-4-6       | Deep reasoning — security audits, architecture review, complex orchestration |
+| `sonnet`  | claude-sonnet-4-6     | Everyday coding — feature work, bug fixes, refactors                         |
+| `haiku`   | claude-haiku-4-5      | Lightweight tasks — docs, formatting, quick lookups                          |
+| `inherit` | Caller's active model | When the agent should flex with the user's session model                     |
+
+**Starter agent tier assignments:**
+
+| Agent                   | Model    | Rationale                                             |
+| ----------------------- | -------- | ----------------------------------------------------- |
+| `security-auditor`      | `opus`   | High-stakes analysis; false negatives are costly      |
+| `architect-reviewer`    | `opus`   | Deep cross-cutting reasoning across large codebases   |
+| `workflow-orchestrator` | `opus`   | Coordinates other agents; reasoning quality compounds |
+| `backend-developer`     | `sonnet` | Everyday implementation work                          |
+| `frontend-developer`    | `sonnet` | Everyday implementation work                          |
+| `test-engineer`         | `sonnet` | Test writing is structured but not cheap              |
+| `documentation-writer`  | `haiku`  | Formulaic; low reasoning demand                       |
+| `changelog-assistant`   | `haiku`  | Git log summarization; lightweight                    |
+
+---
+
+## `/agents:search` Skill Commands
+
+The discovery skill exposes four sub-commands:
+
+### `search <query>`
+
+- Case-insensitive substring match against agent names and descriptions
+- Searches local `~/.claude/agents/` first, then remote catalog (if cache warm)
+- Returns a table: `Name | Model | Tools | Description`
+
+### `fetch <name>`
+
+- Retrieves full agent definition (frontmatter + body)
+- Offers: save to `~/.claude/agents/`, customize before saving, or just inspect
+
+### `list`
+
+- Lists all installed agents in `~/.claude/agents/` with one-line descriptions
+- Groups by model tier (opus / sonnet / haiku / inherit)
+
+### `invalidate [--fetch]`
+
+- Clears `~/.claude/cache/agents-catalog.md`
+- `--fetch` immediately re-populates from GitHub before returning
+
+---
+
+## `plugin.json` Schema Changes
+
+Current:
+
+```json
+{
+  "name": "harness",
+  "description": "...",
+  "author": { ... }
+}
+```
+
+Target — add `agents` array:
+
+```json
+{
+  "name": "harness",
+  "description": "...",
+  "author": { ... },
+  "agents": [
+    "./templates/claude/agents/security-auditor.md",
+    "./templates/claude/agents/architect-reviewer.md",
+    "./templates/claude/agents/backend-developer.md",
+    "./templates/claude/agents/frontend-developer.md",
+    "./templates/claude/agents/test-engineer.md",
+    "./templates/claude/agents/documentation-writer.md",
+    "./templates/claude/agents/workflow-orchestrator.md",
+    "./templates/claude/agents/changelog-assistant.md"
+  ]
+}
+```

--- a/docs/specs/dotclaude-agents/spec/6-implementation-plan.md
+++ b/docs/specs/dotclaude-agents/spec/6-implementation-plan.md
@@ -1,0 +1,177 @@
+# §6 — Implementation Plan
+
+> Phases, workstreams, prompts, tests, migrations, rollback.
+
+## 6.1 Phased Rollout
+
+| Phase | Work                                                         | Depends On                        |
+| ----- | ------------------------------------------------------------ | --------------------------------- |
+| 1     | Add `model:` frontmatter to all existing skills              | Nothing — fully independent       |
+| 2     | Author starter agents in `templates/claude/agents/`          | Nothing — independent of Phase 1  |
+| 3     | Update `plugin.json` with `agents` array                     | Phase 2 (agents must exist first) |
+| 4     | Update `bootstrap.sh` to copy agents                         | Phase 2                           |
+| 5     | Add `/agents:search` skill                                   | Phase 2 (needs agents to search)  |
+| 6     | Update `dotclaude-validate-skills` to lint agent frontmatter | Phase 2                           |
+
+Phases 1 and 2 are fully parallelizable.
+
+## 6.2 Workstream Breakdown
+
+### Workstream A — Model routing (Phase 1)
+
+- Audit all skills in `skills/` for appropriate model tier
+- Add `model:` to each frontmatter
+- No runtime changes; Claude Code reads it natively
+- Interface contract: `model: opus | sonnet | haiku | inherit`
+
+### Workstream B — Starter agents (Phase 2)
+
+- Create `plugins/dotclaude/templates/claude/agents/`
+- Author 8 starter agents (see §5 for list and tier assignments)
+- Each must pass frontmatter validation: `name`, `description`, `tools`, `model`
+
+### Workstream C — Plugin manifest + bootstrap (Phases 3–4, depends on B)
+
+- Add `agents` array to `plugins/dotclaude/.claude-plugin/plugin.json`
+- Update `bootstrap.sh` to copy `templates/claude/agents/` → `~/.claude/agents/` (skip if file exists — OPS-1)
+
+### Workstream D — Discovery skill (Phase 5, depends on B)
+
+- Author `skills/agents-search.md` with `search`, `fetch`, `list`, `invalidate` commands
+- Implement 12h TTL cache at `~/.claude/cache/agents-catalog.md`
+- Graceful degradation to stale cache on network failure (REL-1)
+
+### Workstream E — Validator update (Phase 6, depends on B)
+
+- Extend `dotclaude-validate-skills` to also lint `~/.claude/agents/*.md`
+- Required fields: `name`, `description`, `tools`, `model`
+- Valid model values: `opus`, `sonnet`, `haiku`, `inherit`
+
+## 6.3 Prompt Sequence
+
+### Prompt 1 — Model routing pass (Workstream A)
+
+```
+Read first:
+- plugins/dotclaude/templates/claude/skills-manifest.json
+- skills/ (glob all .md files, read frontmatter)
+- docs/specs/dotclaude-agents/spec/5-interfaces-apis.md (model routing table)
+
+Task: Add `model:` frontmatter to every skill .md file under skills/.
+Use the tier assignment table in §5 as guidance:
+- opus: security-review, spec, validate-spec, create-audit, audit-and-fix, ground-first
+- haiku: changelog, markdown, simplify
+- sonnet: everything else
+- inherit: skills that orchestrate other skills (dispatching-parallel-agents, executing-plans)
+
+Failing test first:
+- test: skills missing model: frontmatter → dotclaude-validate-skills exits non-zero
+```
+
+### Prompt 2 — Starter agents (Workstream B)
+
+```
+Read first:
+- plugins/dotclaude/templates/claude/agents/ (create this directory)
+- docs/specs/dotclaude-agents/spec/5-interfaces-apis.md (agent file format + tier table)
+- /home/kaiocunha/Projects/VoltAgent/awesome-claude-code-subagents/categories/01-core-development/ (reference)
+- /home/kaiocunha/Projects/VoltAgent/awesome-claude-code-subagents/categories/04-quality-security/ (reference)
+
+Task: Author the 8 starter agents listed in §5. Follow the agent file format exactly.
+Keep descriptions specific enough for auto-activation matching.
+Scope tools to minimum necessary per agent type (see §5 tool scoping table from DOC-1).
+
+Failing test first:
+- test: each agent file has all required frontmatter fields → pass
+- test: model value is one of opus/sonnet/haiku/inherit → pass
+```
+
+### Prompt 3 — Plugin manifest + bootstrap (Workstream C)
+
+```
+Read first:
+- plugins/dotclaude/.claude-plugin/plugin.json
+- bootstrap.sh
+- plugins/dotclaude/templates/claude/agents/ (must exist from Prompt 2)
+- plugins/dotclaude/tests/bats/bootstrap.bats
+
+Task:
+1. Add "agents" array to plugin.json pointing to all 8 agent files
+2. Update bootstrap.sh to copy templates/claude/agents/ → ~/.claude/agents/
+   - Skip copy if destination file already exists (OPS-1: never overwrite user edits)
+   - Log each agent installed
+
+Failing test first:
+- test (bats): bootstrap.sh installs agents to ~/.claude/agents/
+- test (bats): bootstrap.sh skips existing agent files (idempotent)
+```
+
+### Prompt 4 — `/agents:search` skill (Workstream D)
+
+```
+Read first:
+- skills/dependabot-sweep.md (reference for skill structure)
+- skills/changelog.md (reference for haiku-tier skill)
+- docs/specs/dotclaude-agents/spec/5-interfaces-apis.md (command interface)
+- /home/kaiocunha/Projects/VoltAgent/awesome-claude-code-subagents/tools/subagent-catalog/ (reference)
+
+Task: Author skills/agents-search.md implementing the four sub-commands from §5.
+Cache logic: check ~/.claude/cache/agents-catalog.md mtime; if > 12h or missing, fetch.
+Fallback: if fetch fails, use stale cache and warn.
+
+Failing test first:
+- test: /agents:search list returns installed agents
+- test: /agents:search invalidate clears cache file
+```
+
+### Prompt 5 — Validator update (Workstream E)
+
+```
+Read first:
+- plugins/dotclaude/src/validate-skills-inventory.mjs
+- plugins/dotclaude/tests/validate-skills-inventory.test.mjs
+- plugins/dotclaude/bin/dotclaude-validate-skills.mjs
+- docs/specs/dotclaude-agents/spec/5-interfaces-apis.md (required fields + valid model values)
+
+Task: Extend validate-skills-inventory to also validate agent files under .claude/agents/.
+Required fields: name, description, tools, model.
+Valid model values: opus, sonnet, haiku, inherit.
+Emit clear error messages citing file:line for each violation.
+
+Failing test first:
+- test: agent missing model: → non-zero exit + error message
+- test: agent with model: invalid → non-zero exit + error message
+- test: valid agent → passes
+```
+
+## 6.4 Testing Strategy
+
+| Unit                       | UNIT                                         | INTEGRATION                                      | POST-DEPLOY                                |
+| -------------------------- | -------------------------------------------- | ------------------------------------------------ | ------------------------------------------ |
+| Model routing frontmatter  | Validate all skills have valid model: value  | `dotclaude-validate-skills` exits 0 on full repo | Spot-check one skill invocation per tier   |
+| Starter agents             | Each agent has required fields + valid model | `dotclaude-validate-skills` passes on agents/    | Claude Code surfaces agents in UI          |
+| `plugin.json` agents array | JSON schema check                            | `claude plugin install` picks up agents          | Agents appear in fresh install             |
+| `bootstrap.sh` agent copy  | Bats: installs agents; skips existing        | End-to-end bootstrap on clean $HOME              | `ls ~/.claude/agents/` post-bootstrap      |
+| `/agents:search` skill     | Cache TTL logic; fallback on network failure | Search returns installed agents                  | `search security` returns security-auditor |
+| Validator extension        | Missing/invalid fields → non-zero exit       | CI validate-skills step catches bad agents       | PR with bad agent file fails CI            |
+
+## 6.5 Migration Sequence
+
+All steps are additive — no existing behavior changes until bootstrap.sh is run by the user.
+
+1. Add `model:` to skill frontmatter (read-only metadata; no behavior change for existing users)
+2. Create `templates/claude/agents/` with starter agents (new directory; no conflict)
+3. Update `plugin.json` with `agents` array (additive field; ignored by older Claude Code versions)
+4. Update `bootstrap.sh` — new agent copy step runs only on fresh files (skips existing)
+5. Ship `/agents:search` skill (new file; no conflict with existing skills)
+6. Update validator — new checks apply only to agent files; existing skill checks unchanged
+
+## 6.6 Rollback Plan
+
+| Scenario                                            | Action                                  | Notes                                               |
+| --------------------------------------------------- | --------------------------------------- | --------------------------------------------------- |
+| Bundled agent causes problems                       | Delete `~/.claude/agents/<name>.md`     | Per-agent; no global rollback needed                |
+| `plugin.json` agents array breaks older Claude Code | Remove `agents` field from plugin.json  | Additive field; shouldn't break, but safe to revert |
+| bootstrap.sh agent copy step breaks bootstrap       | Remove the copy block from bootstrap.sh | Agents directory still exists; no data loss         |
+| `/agents:search` skill is buggy                     | Delete `skills/agents-search.md`        | Standalone file; no dependencies                    |
+| Validator rejects valid agents                      | Revert validator change                 | Previous version in git; `git revert` the commit    |

--- a/docs/specs/dotclaude-agents/spec/7-non-functional-requirements.md
+++ b/docs/specs/dotclaude-agents/spec/7-non-functional-requirements.md
@@ -1,0 +1,28 @@
+# §7 — Non-Functional Requirements
+
+> Performance, reliability, operational, security constraints.
+
+## Performance
+
+- **PERF-1**: `/agents:search list` (local only) must complete in < 1s on a cold shell. No network calls for local operations.
+- **PERF-2**: Remote catalog fetch (GitHub API) uses a 12-hour TTL cache. Stale-cache reads are < 100ms.
+- **PERF-3**: `model:` frontmatter resolution adds no measurable latency — Claude Code reads it natively at agent load time.
+
+## Reliability
+
+- **REL-1**: `/agents:search` must degrade gracefully on GitHub API failure — fall back to stale cache and surface a warning, never hard-fail. See §6 Workstream D.
+- **REL-2**: `bootstrap.sh` agent installation must be idempotent — re-running bootstrap on an existing install must not corrupt or overwrite user-modified agent files. See OPS-1.
+- **REL-3**: Validator failures must be actionable — every error must cite the file and field that failed, not just exit non-zero silently.
+
+## Operational
+
+- **OPS-1**: Bootstrap must never overwrite a user-modified agent file. Copy only if the destination does not exist. Users who want updates must delete and re-run. See §6 Prompt 3.
+- **OPS-2**: The `agents` array in `plugin.json` must use relative paths so the plugin works regardless of where the repo is cloned.
+- **OPS-3**: All 8 starter agents must pass `dotclaude-validate-skills` on every CI run. The validate-skills workflow is the enforcement gate.
+- **OPS-4**: Cache file at `~/.claude/cache/agents-catalog.md` must be excluded from version control (already covered by `.gitignore` pattern for `~/.claude/cache/`).
+
+## Security
+
+- **SEC-1**: Agent `.md` files must not contain secrets, tokens, or credentials. The validator must check for common patterns (e.g., `ghp_`, `sk-`, `AKIA`) and reject on match.
+- **SEC-2**: The `tools:` field must be the minimum necessary for the agent's role. Reviewer/auditor agents must not have `Write` or `Edit`. Enforced by validator lint rule.
+- **SEC-3**: Remote catalog fetches in `/agents:search` must use HTTPS only. No HTTP fallback.

--- a/docs/specs/dotclaude-agents/spec/8-risks-alternatives.md
+++ b/docs/specs/dotclaude-agents/spec/8-risks-alternatives.md
@@ -1,0 +1,27 @@
+# §8 — Risks and Alternatives
+
+> Known risks with mitigations, rejected approaches with reasoning.
+
+## Risks
+
+| ID  | Risk                                                                                              | Likelihood | Impact | Mitigation                                                                                                                                      |
+| --- | ------------------------------------------------------------------------------------------------- | ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| R-1 | Claude Code changes the `.claude/agents/` spec or frontmatter contract, breaking installed agents | Low        | High   | Pin to documented Claude Code behavior; monitor release notes. Agent files are plain markdown — degradation is graceful (ignored, not crashed). |
+| R-2 | `bootstrap.sh` agent copy overwrites user-customized agents on re-run                             | Medium     | High   | OPS-1: skip copy if destination exists. Document the behavior explicitly in bootstrap output.                                                   |
+| R-3 | `model: opus` agents surprise users with higher token costs                                       | Medium     | Medium | Document tier rationale in each agent's description. Default borderline agents to `sonnet`, not `opus`.                                         |
+| R-4 | Starter agent set becomes stale as Claude Code evolves                                            | Medium     | Low    | Agents are plain markdown — users can edit freely. Staleness is visible and self-correcting.                                                    |
+| R-5 | GitHub API rate limit blocks `/agents:search fetch` in CI or headless contexts                    | Low        | Low    | REL-1: fall back to stale cache. Remote fetch is optional, not required.                                                                        |
+
+## Rejected Alternatives
+
+- **A-1: Ship a full 140-agent catalog (mirroring awesome-claude-code-subagents)**
+  Rejected because the maintenance burden would be enormous and the value is unclear — most agents would go unused by most users. A curated starter set of 8 high-value agents is the right scope. Users who want the full catalog can install awesome-claude-code-subagents directly via `/agents:search fetch`.
+
+- **A-2: Build a custom interactive installer script (like awesome-claude-code-subagents' `install-agents.sh`)**
+  Rejected because `bootstrap.sh` is already the installation vehicle for dotclaude. Adding a second installer creates a confusing split. The right answer is to extend bootstrap, not add a parallel path.
+
+- **A-3: Store agents under `templates/.claude/agents/` (with the dot)**
+  Rejected in favor of `templates/claude/agents/` (without the dot) to match the existing convention in this repo — `templates/claude/` already holds `settings.json`, `hooks/`, and `skills-manifest.json`. Consistency beats pedantry. See KD-1.
+
+- **A-4: Make `/agents:search` an agent (not a skill)**
+  Rejected because discovery is a user-invoked command, not a persistent specialist. It has no domain expertise — it's plumbing. Skills are the right primitive for commands; agents are the right primitive for specialists. See KD-3.


### PR DESCRIPTION
## Summary

- Register `docs/specs/dotclaude-agents/` — 8-section engineering spec for first-class agent support in dotclaude (problem, scope, architecture, data flow, interfaces §5, implementation plan §6, NFRs, risks).
- Clear `active_prs` in spec.json (PR #28 was the implementing PR and is already merged).
- Add `docs/plans/` to `.gitignore` to keep transient local planning docs out of the repo.

## Test plan

- [x] `npm test` — 194 tests pass
- [x] `npm run lint` — markdownlint + prettier clean on all 156 docs

## No-spec rationale

This commit IS the spec registration; a `Spec ID` would be circular.
