### PR TITLE
fix(spec): address all dotclaude-agents audit findings (OPS-3, OPS-4, R-3)

### DIFF
--- a/docs/specs/dotclaude-agents/spec/7-non-functional-requirements.md
+++ b/docs/specs/dotclaude-agents/spec/7-non-functional-requirements.md
@@ -18,8 +18,8 @@
 
 - **OPS-1**: Bootstrap must never overwrite a user-modified agent file. Copy only if the destination does not exist. Users who want updates must delete and re-run. See §6 Prompt 3.
 - **OPS-2**: The `agents` array in `plugin.json` must use relative paths so the plugin works regardless of where the repo is cloned.
-- **OPS-3**: All 8 starter agents must pass `dotclaude-validate-skills` on every CI run. The validate-skills workflow is the enforcement gate.
-- **OPS-4**: Cache file at `~/.claude/cache/agents-catalog.md` must be excluded from version control (already covered by `.gitignore` pattern for `~/.claude/cache/`).
+- **OPS-3**: All starter agents must pass `dotclaude-validate-skills` on every CI run. The validate-skills workflow is the enforcement gate.
+- **OPS-4**: Cache file at `~/.claude/cache/agents-catalog.md` must not be committed. The file lives under `~/.claude/`, which is outside the repo directory and therefore cannot be tracked by this repo's git history.
 
 ## Security
 

--- a/plugins/dotclaude/templates/claude/agents/architect-reviewer.md
+++ b/plugins/dotclaude/templates/claude/agents/architect-reviewer.md
@@ -5,6 +5,7 @@ description: >
   technology choices, or identifying structural anti-patterns. Triggers on:
   "review architecture", "design review", "architecture concerns", "tech stack",
   "coupling", "scalability review", "ADR review".
+  Uses opus — cross-cutting architectural analysis requires deep reasoning across large codebases.
 tools: Read, Grep, Glob
 model: opus
 ---

--- a/plugins/dotclaude/templates/claude/agents/aws-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/aws-engineer.md
@@ -5,6 +5,7 @@ description: >
   integrations. Triggers on: "AWS", "EC2", "ECS", "EKS", "Lambda", "S3",
   "IAM role", "VPC", "RDS", "DynamoDB", "CloudFront", "ALB", "Route53",
   "CloudFormation", "CDK", "API Gateway", "EventBridge", "SQS", "SNS".
+  Uses opus — AWS architecture spans IAM trust, multi-service interactions, and compliance tradeoffs that benefit from deep analysis.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
 ---

--- a/plugins/dotclaude/templates/claude/agents/azure-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/azure-engineer.md
@@ -6,6 +6,7 @@ description: >
   Functions", "Blob Storage", "VNet", "App Gateway", "Front Door", "EntraID",
   "Managed Identity", "ARM template", "Bicep", "Azure DevOps", "ACR",
   "Service Bus", "Logic Apps", "Cosmos DB".
+  Uses opus — Azure spans identity, networking, and multi-subscription governance; deep reasoning reduces costly misconfigurations.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
 ---

--- a/plugins/dotclaude/templates/claude/agents/backend-developer.md
+++ b/plugins/dotclaude/templates/claude/agents/backend-developer.md
@@ -5,6 +5,7 @@ description: >
   background jobs, or infrastructure logic. Triggers on: "build API", "add endpoint",
   "database schema", "backend service", "server-side", "REST", "GraphQL",
   "background job", "migration".
+  Uses sonnet — everyday backend implementation benefits from balanced capability and throughput.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
+++ b/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
@@ -5,6 +5,7 @@ description: >
   git history for a release. Triggers on: "generate changelog", "release notes",
   "what changed", "CHANGELOG", "summarize commits", "release summary",
   "version bump notes".
+  Uses haiku — changelog generation from git history is formulaic and lightweight; fast output benefits release flow.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: haiku
 ---

--- a/plugins/dotclaude/templates/claude/agents/container-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/container-engineer.md
@@ -4,6 +4,7 @@ description: >
   Use when authoring, optimizing, or reviewing container images and build pipelines.
   Triggers on: "Dockerfile", "container image", "multi-stage build", "image size",
   "OCI", "Docker Compose", "container registry", "base image", "layer cache".
+  Uses sonnet — container image optimization is structured and pattern-driven; sonnet provides the right depth without excess cost.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/crossplane-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/crossplane-engineer.md
@@ -5,6 +5,7 @@ description: >
   Kubernetes-native IaC. Triggers on: "Crossplane", "XRD", "Composition",
   "CompositeResource", "Claim", "managed resource", "provider config",
   "ProviderConfig", "composite resource definition", "Crossplane package".
+  Uses sonnet — Crossplane Composition authoring is well-specified; sonnet covers the depth needed.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/deployment-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/deployment-engineer.md
@@ -5,6 +5,7 @@ description: >
   shifting, or rollback procedures. Triggers on: "deployment strategy", "blue/green",
   "canary release", "rolling update", "traffic shifting", "rollback", "release
   coordination", "feature flag", "progressive delivery", "deploy to production".
+  Uses sonnet — deployment strategy execution is structured; sonnet handles the reasoning without over-provisioning cost.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/devops-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/devops-engineer.md
@@ -5,6 +5,7 @@ description: >
   or developer tooling. Triggers on: "CI pipeline", "CD workflow", "GitHub Actions",
   "build automation", "artifact", "release workflow", "environment promotion",
   "pipeline stage", "deploy pipeline", "lint CI".
+  Uses sonnet — CI/CD pipeline work is structured and iterative; sonnet matches the workload.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/documentation-writer.md
+++ b/plugins/dotclaude/templates/claude/agents/documentation-writer.md
@@ -5,6 +5,7 @@ description: >
   onboarding materials, docstrings, or inline docs. Triggers on: "write docs",
   "update README", "API documentation", "document this", "user guide",
   "onboarding guide", "add examples", "explain how".
+  Uses haiku — documentation writing is templated and fast-turnaround; throughput matters more than deep reasoning.
 tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
 model: haiku
 ---

--- a/plugins/dotclaude/templates/claude/agents/frontend-developer.md
+++ b/plugins/dotclaude/templates/claude/agents/frontend-developer.md
@@ -5,6 +5,7 @@ description: >
   state management, or client-side data fetching. Triggers on: "build UI",
   "React component", "frontend", "CSS", "accessibility", "form validation",
   "client-side", "Next.js page", "Tailwind".
+  Uses sonnet — everyday frontend implementation benefits from balanced capability and response speed.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/gcp-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/gcp-engineer.md
@@ -6,6 +6,7 @@ description: >
   "GCE", "Cloud Functions", "Pub/Sub", "GCS", "BigQuery", "Cloud Build",
   "Workload Identity", "Service Account", "VPC", "Cloud Armor", "Cloud CDN",
   "Deployment Manager", "Config Connector".
+  Uses opus — GCP architecture across Workload Identity, VPC networks, and IAM hierarchies requires deep reasoning to avoid security gaps.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
 ---

--- a/plugins/dotclaude/templates/claude/agents/iac-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/iac-engineer.md
@@ -5,6 +5,7 @@ description: >
   state, or handling drift detection. Triggers on: "Terraform", "Pulumi", "OpenTofu",
   "infrastructure as code", "IaC module", "state file", "drift detection", "resource
   graph", "provider", "workspace", "remote state".
+  Uses sonnet — IaC authoring is structured and pattern-driven; sonnet covers the depth needed without excess cost.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/kubernetes-specialist.md
+++ b/plugins/dotclaude/templates/claude/agents/kubernetes-specialist.md
@@ -4,6 +4,7 @@ description: >
   Use when designing, debugging, or reviewing Kubernetes workloads and cluster
   configuration. Triggers on: "kubernetes", "k8s", "pod", "deployment", "cluster",
   "kubectl", "namespace", "ingress", "helm chart", "workload", "node not ready".
+  Uses opus — Kubernetes troubleshooting spans scheduler decisions, network policy semantics, and control-plane interactions; deep reasoning prevents misdiagnosis.
 tools: Read, Grep, Glob, Bash
 model: opus
 ---

--- a/plugins/dotclaude/templates/claude/agents/platform-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/platform-engineer.md
@@ -5,6 +5,7 @@ description: >
   tooling, or environment parity. Triggers on: "developer platform", "internal tooling",
   "golden path", "paved road", "developer experience", "self-service", "environment parity",
   "platform team", "scaffolding", "service catalog".
+  Uses opus — platform design decisions compound over time; deep reasoning prevents golden-path choices that become maintenance burdens.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: opus
 ---

--- a/plugins/dotclaude/templates/claude/agents/pulumi-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/pulumi-engineer.md
@@ -5,6 +5,7 @@ description: >
   API. Triggers on: "Pulumi", "pulumi up", "pulumi stack", "ComponentResource",
   "Pulumi ESC", "Automation API", "pulumi.Config", "pulumi new", "stack
   reference", "StackReference".
+  Uses sonnet — Pulumi stack work is code-first and structured; sonnet matches the task depth.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/security-auditor.md
+++ b/plugins/dotclaude/templates/claude/agents/security-auditor.md
@@ -5,6 +5,7 @@ description: >
   assessing secrets exposure, or evaluating compliance posture. Triggers on:
   "audit security", "find vulnerabilities", "check secrets", "OWASP review",
   "security scan", "CVE", "threat model".
+  Uses opus — security analysis requires thorough reasoning; false negatives have high downstream cost.
 tools: Read, Grep, Glob
 model: opus
 ---

--- a/plugins/dotclaude/templates/claude/agents/security-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/security-engineer.md
@@ -5,6 +5,7 @@ description: >
   managing secrets, or assessing supply-chain risks. Triggers on: "infrastructure
   hardening", "network policy", "secrets management", "RBAC", "admission controller",
   "mTLS", "supply chain", "image signing", "privilege escalation", "security posture".
+  Uses opus — infrastructure hardening and privilege analysis require deep reasoning; a missed vector has high downstream cost.
 tools: Read, Grep, Glob, Bash
 model: opus
 ---

--- a/plugins/dotclaude/templates/claude/agents/terragrunt-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/terragrunt-engineer.md
@@ -5,6 +5,7 @@ description: >
   multi-environment root-module hierarchies. Triggers on: "Terragrunt",
   "terragrunt.hcl", "run-all", "DRY Terraform", "dependency block",
   "env hierarchy", "root module", "terragrunt hooks", "generate block".
+  Uses sonnet — Terragrunt DRY patterns are well-specified; sonnet handles the reasoning without over-provisioning cost.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/test-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/test-engineer.md
@@ -5,6 +5,7 @@ description: >
   up test infrastructure. Triggers on: "write tests", "add test coverage",
   "fix flaky test", "integration test", "test suite", "coverage report",
   "missing tests", "test CI".
+  Uses sonnet — test design benefits from reasoning about edge cases and failure modes; sonnet balances depth and speed.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: sonnet
 ---

--- a/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
+++ b/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
@@ -5,6 +5,7 @@ description: >
   parallel workstreams, or planning and delegating complex implementation efforts.
   Triggers on: "orchestrate", "coordinate agents", "parallel tasks", "multi-step plan",
   "delegate work", "break down", "dispatch subagents".
+  Uses opus — orchestration quality compounds across delegated agents; poor decomposition cascades into downstream failures.
 tools: Read, Bash, Glob, Grep
 model: opus
 ---


### PR DESCRIPTION
## Summary

- **OPS-3**: Remove hardcoded count "8" → "All starter agents" (`spec/7-non-functional-requirements.md:21`) — 21 agents now installed
- **OPS-4**: Correct false `.gitignore` claim → explain cache lives outside the repo directory and cannot be committed (`spec/7-non-functional-requirements.md:22`)
- **R-3**: Add model-tier rationale sentence to every agent's `description:` block (21 files) — makes cost/model choices visible to users at a glance

## Test plan

- [x] `npm test` — 194 tests pass (0 failures)
- [x] `node plugins/dotclaude/bin/dotclaude-validate-skills.mjs .` — `✓ manifest valid  ✓ agents valid (no errors)`
- [x] Spot-checked security-auditor (opus), backend-developer (sonnet), changelog-assistant (haiku) for correct rationale text

## Spec ID

dotclaude-agents
