### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and a broad set of provider and IaC agents.
   - Phase 1: schemas + index builder + non-breaking CLI (#34).
   - Phase 2: frontmatter backfill + schema tightening (#36).
   - Phase 3: `dotclaude search`, `dotclaude list`, `dotclaude show`
-    + governance docs + CI gate (#37).
+    - governance docs + CI gate (#37).
   - Phase 4: `build-plugin` script + generated plugin templates (#38).
 - **Slash commands** — generic `/review-pr` (#22) and `/create-inspection`
   (#23), plus strengthened branch-health gates and mandatory test plans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,63 @@ All notable changes to `@dotclaude/dotclaude` land here. Format follows
 - `.d.ts` shipping for stronger type inference (via hand-authored declarations
   — TypeScript migration is out of scope per ADR-0002).
 
+## [0.4.0] — 2026-04-17
+
+No breaking changes. This release adds the global-lifecycle CLI
+(`dotclaude bootstrap`, `dotclaude sync`), first-class agents, the
+taxonomy pipeline (schemas → backfill → search/list/show → build-plugin),
+and a broad set of provider and IaC agents.
+
+### Added
+
+- **Global lifecycle CLI** — `dotclaude bootstrap` (set up or refresh
+  `~/.claude/`) and `dotclaude sync <pull|status|push>` (update an
+  installation). Both are idempotent, support `--json` / `--quiet`
+  / `--no-color`, and are registered as subcommands of the umbrella
+  `dotclaude` dispatcher alongside the taxonomy commands (#29).
+- **First-class agent support** — agents directory, model routing,
+  and discovery wired into the plugin (#28). Ships with 21 agents
+  across generalist, specialist, and veracity tiers (#40):
+  - Kubernetes ecosystem agents + `kubernetes-specialist` skill (#31).
+  - AWS, Azure, GCP provider agents + `*-specialist` skills (#32).
+  - IaC tool agents (Terraform, Terragrunt, Pulumi, Crossplane) +
+    `*-specialist` skills (#33).
+  - Generic veracity harness: `data-scientist`, `compliance-auditor`,
+    and the `veracity-audit` skill (#41).
+- **Taxonomy pipeline** — a four-phase buildout that formalizes the
+  skill/agent metadata layer:
+  - Phase 1: schemas + index builder + non-breaking CLI (#34).
+  - Phase 2: frontmatter backfill + schema tightening (#36).
+  - Phase 3: `dotclaude search`, `dotclaude list`, `dotclaude show`
+    + governance docs + CI gate (#37).
+  - Phase 4: `build-plugin` script + generated plugin templates (#38).
+- **Slash commands** — generic `/review-pr` (#22) and `/create-inspection`
+  (#23), plus strengthened branch-health gates and mandatory test plans
+  in `/review-pr` (#25).
+- **Lint pipeline** — `npm run lint` now wires `prettier` and
+  `markdownlint-cli2` (#18).
+
+### Changed
+
+- README and CLAUDE.md document the two-path usage model
+  (bootstrap vs npm plugin) (#24) and the new `bootstrap` / `sync`
+  subcommands (#30).
+- CLAUDE.md absorbs the Karpathy behavioral guidelines (#26).
+- `dotclaude-agents` spec registered; `.gitignore` cleaned up (#39).
+- Agent spec text updated with tier rationale from audit findings (#42).
+- CI bumps `actions/upload-artifact` 4.6.2 → 7.0.1 (#13).
+
+### Fixed
+
+- `bootstrap` now links `hooks/` into `~/.claude/hooks/` so
+  guard-destructive-git and friends apply globally (#35).
+- Patched `js-yaml` prototype pollution (GHSA-mh29-5h37-fv8m) (#27).
+- Closed 12 open CodeQL alerts around workflow permissions and
+  security (#19).
+- Dogfood workflow now uses `PR_ACTOR` (derived from PR author)
+  instead of the `GITHUB_ACTOR` builtin, restoring correct bot
+  detection (#20, #21).
+
 ## [0.3.0] — 2026-04-14
 
 ### Breaking


### PR DESCRIPTION
## Summary

- Author the `## [0.4.0] — 2026-04-17` CHANGELOG section covering PRs #13, #18–#42. No code changes.
- `package.json` is already at `0.4.0`; the release workflow extracts release notes from the `## [VER]` heading (`release.yml:53`), so without this entry a `v0.4.0` tag would ship empty notes.
- Organized into Added / Changed / Fixed — no breaking changes. Main user-visible features: `dotclaude bootstrap` + `dotclaude sync` CLI, first-class agent support (21 agents across generalist/specialist/veracity tiers), four-phase taxonomy pipeline, `/review-pr` + `/create-inspection` slash commands, `hooks/` linking in bootstrap.

## Test plan

- [x] `npm test` — 194/194 pass locally in worktree.
- [x] `bash plugins/dotclaude/tests/test_validate_settings.sh` — 12/12 pass (mirrors the release workflow gate at `release.yml:36`).
- [x] Verified `package.json` version `0.4.0` matches the intended tag `v0.4.0` (release workflow gate at `release.yml:27–34`).
- [ ] After merge: push `v0.4.0` tag — release workflow publishes to npm with provenance and cuts the GitHub Release from the CHANGELOG section.
- [ ] Verify `npm view @dotclaude/dotclaude versions` shows `0.4.0`.
- [ ] `npm i -g @dotclaude/dotclaude@0.4.0` on workstation; confirm `dotclaude --help` lists `bootstrap` and `sync`.

## Spec ID

dotclaude-core
