### PR TITLE
feat(install): add curl-pipe-bash installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ spec-driven-development governance into consumer repos.
 | What you want                                     | How                                                                                              |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | Skills & commands library wired into `~/.claude/` | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required                         |
-| Spec-governance CLI for your own repos            | **[Install the CLI](#install-the-cli)** — `curl -fsSL …/install.sh \| bash` (Node ≥ 20 required) |
+| Spec-governance CLI for your own repos            | **[Install the CLI](#install-the-cli)** — see install section (Node ≥ 20 required)               |
 
 Both paths are independent. You can use one or both.
 
@@ -79,8 +79,8 @@ The one-liner installs the package globally and runs `dotclaude bootstrap` to
 wire `~/.claude/` automatically. To pin a version or skip the bootstrap step:
 
 ```bash
-DOTCLAUDE_VERSION=0.4.0 curl -fsSL https://raw.githubusercontent.com/kaiohenricunha/dotclaude/main/install.sh | bash
-DOTCLAUDE_SKIP_BOOTSTRAP=1 curl -fsSL https://raw.githubusercontent.com/kaiohenricunha/dotclaude/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kaiohenricunha/dotclaude/main/install.sh | DOTCLAUDE_VERSION=0.4.0 bash
+curl -fsSL https://raw.githubusercontent.com/kaiohenricunha/dotclaude/main/install.sh | DOTCLAUDE_SKIP_BOOTSTRAP=1 bash
 ```
 
 Then use the umbrella dispatcher or standalone bins interchangeably:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ spec-driven-development governance into consumer repos.
 
 ## TL;DR — pick your path
 
-| What you want                                     | How                                                                       |
-| ------------------------------------------------- | ------------------------------------------------------------------------- |
-| Skills & commands library wired into `~/.claude/` | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required  |
-| Spec-governance CLI for your own repos            | **[Install the CLI](#install-the-cli)** — `npm i -g @dotclaude/dotclaude` |
+| What you want                                     | How                                                                                              |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Skills & commands library wired into `~/.claude/` | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required                         |
+| Spec-governance CLI for your own repos            | **[Install the CLI](#install-the-cli)** — `curl -fsSL …/install.sh \| bash` (Node ≥ 20 required) |
 
 Both paths are independent. You can use one or both.
 
@@ -61,11 +61,26 @@ Need spec-governance gates, CI integration, drift detection, or programmatic
 validation in your own projects? Install the CLI:
 
 ```bash
+# One-liner (requires Node ≥ 20)
+curl -fsSL https://raw.githubusercontent.com/kaiohenricunha/dotclaude/main/install.sh | bash
+```
+
+Or install manually:
+
+```bash
 # Global — use dotclaude anywhere
 npm install -g @dotclaude/dotclaude
 
 # Per-project — pin it to a repo (useful for CI)
 npm install -D @dotclaude/dotclaude
+```
+
+The one-liner installs the package globally and runs `dotclaude bootstrap` to
+wire `~/.claude/` automatically. To pin a version or skip the bootstrap step:
+
+```bash
+DOTCLAUDE_VERSION=0.4.0 curl -fsSL https://raw.githubusercontent.com/kaiohenricunha/dotclaude/main/install.sh | bash
+DOTCLAUDE_SKIP_BOOTSTRAP=1 curl -fsSL https://raw.githubusercontent.com/kaiohenricunha/dotclaude/main/install.sh | bash
 ```
 
 Then use the umbrella dispatcher or standalone bins interchangeably:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ spec-driven-development governance into consumer repos.
 
 ## TL;DR — pick your path
 
-| What you want                                     | How                                                                                              |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Skills & commands library wired into `~/.claude/` | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required                         |
-| Spec-governance CLI for your own repos            | **[Install the CLI](#install-the-cli)** — see install section (Node ≥ 20 required)               |
+| What you want                                     | How                                                                                |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Skills & commands library wired into `~/.claude/` | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required           |
+| Spec-governance CLI for your own repos            | **[Install the CLI](#install-the-cli)** — see install section (Node ≥ 20 required) |
 
 Both paths are independent. You can use one or both.
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Env overrides
+DOTCLAUDE_VERSION="${DOTCLAUDE_VERSION:-latest}"
+DOTCLAUDE_SKIP_BOOTSTRAP="${DOTCLAUDE_SKIP_BOOTSTRAP:-}"
+
+# Color helpers (suppressed when NO_COLOR is set or stdout is not a TTY)
+if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; RESET='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BOLD=''; RESET=''
+fi
+
+info()  { printf '%b==>%b %s\n' "$GREEN" "$RESET" "$*"; }
+warn()  { printf '%bwarn:%b %s\n' "$YELLOW" "$RESET" "$*" >&2; }
+error() { printf '%berror:%b %s\n' "$RED" "$RESET" "$*" >&2; exit 1; }
+
+# ── 1. Prerequisites ──────────────────────────────────────────────────────────
+
+if ! command -v node >/dev/null 2>&1; then
+  error "Node.js is required but not found. Install Node >= 20 from https://nodejs.org"
+fi
+
+node_version=$(node --version)
+node_major="${node_version%%.*}"
+node_major="${node_major#v}"
+if [[ "$node_major" -lt 20 ]]; then
+  error "Node >= 20 required (found ${node_version}). Upgrade at https://nodejs.org"
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  error "npm is required but not found. It ships with Node — try reinstalling Node from https://nodejs.org"
+fi
+
+# ── 2. Install ────────────────────────────────────────────────────────────────
+
+info "Installing @dotclaude/dotclaude@${DOTCLAUDE_VERSION} ..."
+npm install -g "@dotclaude/dotclaude@${DOTCLAUDE_VERSION}"
+
+# ── 3. Bootstrap ~/.claude/ ───────────────────────────────────────────────────
+
+if [[ -z "$DOTCLAUDE_SKIP_BOOTSTRAP" ]]; then
+  info "Running dotclaude bootstrap ..."
+  if ! dotclaude bootstrap; then
+    warn "bootstrap step failed — run 'dotclaude doctor' to diagnose"
+  fi
+fi
+
+# ── 4. Doctor ─────────────────────────────────────────────────────────────────
+
+info "Running dotclaude doctor ..."
+dotclaude doctor || true   # non-zero is informational, not fatal
+
+# ── 5. Done ───────────────────────────────────────────────────────────────────
+
+printf '\n%bdotclaude installed successfully.%b\n' "$BOLD" "$RESET"
+printf '  %bdotclaude --help%b   see all commands\n' "$GREEN" "$RESET"
+printf '  %bdotclaude doctor%b   re-run diagnostics any time\n\n' "$GREEN" "$RESET"

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,20 @@ fi
 info "Installing @dotclaude/dotclaude@${DOTCLAUDE_VERSION} ..."
 npm install -g "@dotclaude/dotclaude@${DOTCLAUDE_VERSION}"
 
+npm_prefix="$(npm prefix -g 2>/dev/null || true)"
+npm_bin_dir=""
+if [[ -n "$npm_prefix" ]]; then
+  npm_bin_dir="${npm_prefix%/}/bin"
+fi
+
+if ! command -v dotclaude >/dev/null 2>&1; then
+  if [[ -n "$npm_bin_dir" ]]; then
+    error "'dotclaude' was installed but is not on your PATH. Add '${npm_bin_dir}' to PATH and re-run. For example: export PATH=\"${npm_bin_dir}:\$PATH\""
+  else
+    error "'dotclaude' was installed but is not on your PATH. Add npm's global bin directory to PATH and re-run."
+  fi
+fi
+
 # ── 3. Bootstrap ~/.claude/ ───────────────────────────────────────────────────
 
 if [[ -z "$DOTCLAUDE_SKIP_BOOTSTRAP" ]]; then


### PR DESCRIPTION
## Summary

- Adds `install.sh` to the repo root: a shellcheck-clean curl-pipe-bash installer that checks Node ≥ 20, runs `npm install -g @dotclaude/dotclaude`, bootstraps `~/.claude/`, and verifies with `dotclaude doctor`
- Supports `DOTCLAUDE_VERSION` and `DOTCLAUDE_SKIP_BOOTSTRAP` env overrides; respects `NO_COLOR`
- Updates `README.md` to surface the curl one-liner as the primary CLI install path

## Test plan

- [ ] `bash -x install.sh` on a machine with Node ≥ 20 — full install completes, `dotclaude --version` works
- [ ] `DOTCLAUDE_VERSION=0.4.0 bash install.sh` — installs pinned version
- [ ] `DOTCLAUDE_SKIP_BOOTSTRAP=1 bash install.sh` — skips bootstrap step, doctor still runs
- [x] Node < 20: script exits with clear error message
- [x] Node missing: script exits with install URL
- [ ] `NO_COLOR=1 bash install.sh` — no ANSI escape codes in output
- [x] `shellcheck install.sh` — clean (no warnings)

## No-spec rationale

`README.md` is a protected path but this change is a docs/install improvement, not a spec-governed feature — no architectural decisions or spec contracts are introduced.