### PR TITLE
feat(skills): handoff — cross-CLI session context transfer

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-18T00:36:26.834Z",
+  "generatedAt": "2026-04-18T00:42:01.849Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:bc03efac7bfc70c324b4410b7794f14a0547a0e242d1b1f897769c2c6ba60a96",
+      "checksum": "sha256:5d3273585152d3bf8cddb7dbf7681dd3e6c0a7c61ad1b807365aa77983c4868f",
       "dependencies": [],
       "lastValidated": "2026-04-18"
     }

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,188 +1,195 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-17T12:38:08.896Z",
+  "generatedAt": "2026-04-18T00:22:03.249Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
       "checksum": "sha256:f7a8fa0598d7925de95ed3829ea677a2df58fa3db93e9ff290944bb686fad7d7",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
       "checksum": "sha256:cf3ac020cd3ce7d8fc11dbf4f5f5a2ffa5e1d6443e60cd10179b564bd77894cc",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
       "checksum": "sha256:fdb8f057e6a1d553183c69d03ebb89aea896d4fadd03d8087789ac0ac59490f7",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
       "checksum": "sha256:cf987369294337fff90fc62e1d73d235d35055055dc8e4fbfb33a492f7cd38b5",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
       "checksum": "sha256:50573c4199f27083286fdbc3760b2f684105b4a6df39b7cb47094d7c0e5327f7",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
       "checksum": "sha256:3f7b90b69172e29cdcf66713f2708f9741003d05cc12cf9d81ff79ff9c5b692c",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
       "checksum": "sha256:d8f898a09ce979e92838db9537c452d0b3ed4d4fec8d1d4409defefe93e94650",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:170cdf18695a83727c335d9a6570fe7e6997a98436626bdb36d83e409aa75cd4",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
       "checksum": "sha256:6ffc091e9bd421798c5b7990f21d095563d69c59c3e2bd10d35b554b3ec225d9",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
       "checksum": "sha256:d0bc84f956c0ee8c176cf76a79374e8defb0bd2487c8340a2e2a1d9e04d8a1cc",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
       "checksum": "sha256:52e610b195a43fdd460106c1bdf56b32803cb86d163a4303274773ea3900bf79",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2dc1c4213ab6650d685e7b2243ddda91fce2ceba224ca3da3951afeb37d12946",
       "dependencies": [],
-      "lastValidated": "2026-04-17"
+      "lastValidated": "2026-04-18"
+    },
+    {
+      "name": "handoff",
+      "path": ".claude/skills/handoff/SKILL.md",
+      "checksum": "sha256:adfde8b42087e73804bd8545f52e519e02dfa342430f9649579628420b0b1628",
+      "dependencies": [],
+      "lastValidated": "2026-04-18"
     }
   ]
 }

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-18T00:22:03.249Z",
+  "generatedAt": "2026-04-18T00:36:26.834Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:adfde8b42087e73804bd8545f52e519e02dfa342430f9649579628420b0b1628",
+      "checksum": "sha256:bc03efac7bfc70c324b4410b7794f14a0547a0e242d1b1f897769c2c6ba60a96",
       "dependencies": [],
       "lastValidated": "2026-04-18"
     }

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotclaude.dev/schemas/index.schema.json",
-  "generatedAt": "2026-04-17T14:17:29.874Z",
+  "generatedAt": "2026-04-18T00:36:26.760Z",
   "version": "0.4.0",
   "artifacts": [
     {
@@ -10,9 +10,15 @@
       "name": "agents-search",
       "description": "Discover, search, and manage Claude Code agents. Use when you want to find available agents, list installed agents, or refresh the agent catalog. Triggers on: \"search agents\", \"list agents\", \"find agent\", \"what agents\", \"agent catalog\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -25,9 +31,16 @@
       "name": "audit-and-fix",
       "description": "Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to \"audit and fix\" or kicks off an overnight cleanup run.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -40,9 +53,16 @@
       "name": "aws-specialist",
       "description": "Deep-dive AWS architecture review, debugging, and service design. Use for structured investigations of AWS-specific issues, cost or IAM audits, and multi-service design reviews. Triggers on: \"AWS audit\", \"AWS design review\", \"IAM review\", \"cost audit AWS\", \"review my VPC\", \"AWS troubleshooting\", \"Lambda deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["aws"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "aws"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -55,9 +75,16 @@
       "name": "azure-specialist",
       "description": "Deep-dive Azure architecture review, debugging, and service design. Use for structured investigations of Azure-specific issues, identity or cost audits, and multi-service design reviews. Triggers on: \"Azure audit\", \"Azure design review\", \"EntraID review\", \"Managed Identity debug\", \"review my Azure\", \"Azure troubleshooting\", \"AKS deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["azure"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "azure"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -70,9 +97,15 @@
       "name": "changelog",
       "description": "Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -85,9 +118,16 @@
       "name": "create-assessment",
       "description": "Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -100,9 +140,16 @@
       "name": "create-audit",
       "description": "Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -115,9 +162,16 @@
       "name": "create-inspection",
       "description": "Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -130,9 +184,17 @@
       "name": "crossplane-specialist",
       "description": "Deep-dive Crossplane platform review: XRD design, Composition correctness, provider config audit, managed resource health, and GitOps integration. Use for structured investigations of stuck Claims, composition pipeline bugs, and credential injection patterns. Triggers on: \"Crossplane audit\", \"XRD review\", \"Composition debug\", \"stuck Claim\", \"managed resource stuck\", \"provider config review\", \"Crossplane GitOps\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["crossplane", "kubernetes"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "crossplane",
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -145,9 +207,16 @@
       "name": "dependabot-sweep",
       "description": "Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.\n",
       "facets": {
-        "domain": ["devex", "security"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex",
+          "security"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -160,9 +229,16 @@
       "name": "detect-flaky",
       "description": "Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["testing", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "testing",
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -175,9 +251,16 @@
       "name": "fix-with-evidence",
       "description": "Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -190,9 +273,16 @@
       "name": "gcp-specialist",
       "description": "Deep-dive Google Cloud architecture review, debugging, and service design. Use for structured investigations of GCP-specific issues, IAM or cost audits, and multi-service design reviews. Triggers on: \"GCP audit\", \"GCP design review\", \"Workload Identity debug\", \"IAM review GCP\", \"review my GKE\", \"GCP troubleshooting\", \"Cloud Run deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["gcp"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "gcp"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -205,9 +295,15 @@
       "name": "git",
       "description": "Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -220,10 +316,39 @@
       "name": "ground-first",
       "description": "Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
+    },
+    {
+      "id": "handoff",
+      "type": "skill",
+      "path": "skills/handoff/SKILL.md",
+      "name": "handoff",
+      "description": "Transfer conversation context between agentic CLIs (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI). Reads a source session transcript by UUID and produces either an inline summary or a paste-ready handoff digest for another agent. Use when switching agents mid-task or recovering context. Triggers on: \"handoff\", \"transfer context\", \"continue in codex\", \"continue in claude\", \"continue in copilot\", \"switch to codex\", \"switch to claude\", \"what was that session about\", \"claude --resume\", \"copilot --resume\", \"codex resume\", \"find the session where\", \"search sessions\", \"which session did I\".\n",
+      "facets": {
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation",
+          "debugging"
+        ],
+        "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha"
@@ -235,9 +360,16 @@
       "name": "kubernetes-specialist",
       "description": "Deep-dive Kubernetes troubleshooting, workload design, and cluster health review. Use when you need a structured investigation of a cluster issue, a design review of Kubernetes manifests, or a health audit of a namespace or workload. Triggers on: \"debug kubernetes\", \"why is my pod\", \"review my manifests\", \"cluster health\", \"kubernetes design review\", \"k8s audit\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["kubernetes"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -250,9 +382,16 @@
       "name": "markdown",
       "description": "Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.\n",
       "facets": {
-        "domain": ["devex", "writing"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex",
+          "writing"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -265,9 +404,16 @@
       "name": "merge-pr",
       "description": "Merge a pull request only after full local verification, with a data-regression gate for PRs touching data/calibration/rankings.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -280,9 +426,16 @@
       "name": "pulumi-specialist",
       "description": "Deep-dive Pulumi stack review, component design, Automation API audit, and secrets management. Use for structured investigations of Pulumi stack drift, ComponentResource coupling, ESC configuration, and Automation API workflows. Triggers on: \"Pulumi audit\", \"stack review\", \"Automation API review\", \"ComponentResource design\", \"ESC audit\", \"Pulumi secrets\", \"Pulumi testing\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["pulumi"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "pulumi"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -295,9 +448,15 @@
       "name": "review-pr",
       "description": "Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -310,9 +469,16 @@
       "name": "security-review",
       "description": "Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.\n",
       "facets": {
-        "domain": ["devex", "security"],
-        "platform": ["none"],
-        "task": ["review"],
+        "domain": [
+          "devex",
+          "security"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -325,9 +491,15 @@
       "name": "spec",
       "description": "Create structured engineering specs through interactive pairing. Use when the user wants to create a spec, design doc, technical specification, architecture document, RFC, or engineering plan. Triggers on \"let's spec this out\", \"create a spec\", \"design doc\", \"write a technical plan\", \"plan the architecture\". Works for greenfield and brownfield projects. Outputs to docs/specs/.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -340,9 +512,16 @@
       "name": "terraform-specialist",
       "description": "Deep-dive Terraform architecture review, module design, state management, and migration. Use for structured investigations of Terraform workspaces, provider configuration, module coupling, import workflows, and test coverage. Triggers on: \"Terraform audit\", \"module review\", \"state management\", \"Terraform import\", \"workspace design\", \"provider config review\", \"Terraform testing\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terraform"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -355,9 +534,17 @@
       "name": "terragrunt-specialist",
       "description": "Deep-dive Terragrunt hierarchy review, DRY pattern audits, and run-all orchestration analysis. Use for structured investigations of multi-environment Terragrunt layouts, dependency graphs, remote state config, and hook correctness. Triggers on: \"Terragrunt audit\", \"run-all review\", \"dependency block\", \"DRY pattern review\", \"env hierarchy audit\", \"mock_outputs\", \"terragrunt hooks\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terraform", "terragrunt"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform",
+          "terragrunt"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -370,9 +557,16 @@
       "name": "validate-spec",
       "description": "Audit an already-implemented spec against the codebase. Walks each constraint (ARCH-N, PERF-N, KD-N, etc.) and acceptance criterion, grounds findings in file:line evidence, runs the spec.json acceptance_commands, and writes a single audit doc to docs/audits/. Use whenever the user asks to \"validate a spec\", \"audit a spec\", \"check if spec is implemented\", \"verify the spec is done\", \"is this spec really done\", or otherwise wants closure on spec-driven work. Read-only against the spec — produces an audit, never modifies the spec itself.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -385,9 +579,16 @@
       "name": "veracity-audit",
       "description": "Audit a data pipeline for Veracity and Value. Dispatches data-scientist, compliance-auditor, and data-engineer agents with project context injected at dispatch time. All source paths are supplied via flags — no defaults, no project assumptions. Subcommands: audit (full pipeline walk), score-check (scoring math only), gate-check (gate coverage only), source-trace <label> (single source end-to-end). Invoke when: \"audit pipeline\", \"veracity check\", \"scoring math correct?\", \"check gates\", \"trace source\", \"verify quality gates\", \"formula correct?\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -10,15 +10,9 @@
       "name": "agents-search",
       "description": "Discover, search, and manage Claude Code agents. Use when you want to find available agents, list installed agents, or refresh the agent catalog. Triggers on: \"search agents\", \"list agents\", \"find agent\", \"what agents\", \"agent catalog\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -31,16 +25,9 @@
       "name": "audit-and-fix",
       "description": "Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to \"audit and fix\" or kicks off an overnight cleanup run.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -53,16 +40,9 @@
       "name": "aws-specialist",
       "description": "Deep-dive AWS architecture review, debugging, and service design. Use for structured investigations of AWS-specific issues, cost or IAM audits, and multi-service design reviews. Triggers on: \"AWS audit\", \"AWS design review\", \"IAM review\", \"cost audit AWS\", \"review my VPC\", \"AWS troubleshooting\", \"Lambda deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "aws"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["aws"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -75,16 +55,9 @@
       "name": "azure-specialist",
       "description": "Deep-dive Azure architecture review, debugging, and service design. Use for structured investigations of Azure-specific issues, identity or cost audits, and multi-service design reviews. Triggers on: \"Azure audit\", \"Azure design review\", \"EntraID review\", \"Managed Identity debug\", \"review my Azure\", \"Azure troubleshooting\", \"AKS deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "azure"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["azure"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -97,15 +70,9 @@
       "name": "changelog",
       "description": "Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -118,16 +85,9 @@
       "name": "create-assessment",
       "description": "Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -140,16 +100,9 @@
       "name": "create-audit",
       "description": "Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -162,16 +115,9 @@
       "name": "create-inspection",
       "description": "Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -184,17 +130,9 @@
       "name": "crossplane-specialist",
       "description": "Deep-dive Crossplane platform review: XRD design, Composition correctness, provider config audit, managed resource health, and GitOps integration. Use for structured investigations of stuck Claims, composition pipeline bugs, and credential injection patterns. Triggers on: \"Crossplane audit\", \"XRD review\", \"Composition debug\", \"stuck Claim\", \"managed resource stuck\", \"provider config review\", \"Crossplane GitOps\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "crossplane",
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["crossplane", "kubernetes"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -207,16 +145,9 @@
       "name": "dependabot-sweep",
       "description": "Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "security"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex", "security"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -229,16 +160,9 @@
       "name": "detect-flaky",
       "description": "Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "testing",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["testing", "debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -251,16 +175,9 @@
       "name": "fix-with-evidence",
       "description": "Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -273,16 +190,9 @@
       "name": "gcp-specialist",
       "description": "Deep-dive Google Cloud architecture review, debugging, and service design. Use for structured investigations of GCP-specific issues, IAM or cost audits, and multi-service design reviews. Triggers on: \"GCP audit\", \"GCP design review\", \"Workload Identity debug\", \"IAM review GCP\", \"review my GKE\", \"GCP troubleshooting\", \"Cloud Run deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "gcp"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["gcp"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -295,15 +205,9 @@
       "name": "git",
       "description": "Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -316,16 +220,9 @@
       "name": "ground-first",
       "description": "Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -338,16 +235,9 @@
       "name": "handoff",
       "description": "Transfer conversation context between agentic CLIs (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI). Reads a source session transcript by UUID and produces either an inline summary or a paste-ready handoff digest for another agent. Use when switching agents mid-task or recovering context. Triggers on: \"handoff\", \"transfer context\", \"continue in codex\", \"continue in claude\", \"continue in copilot\", \"switch to codex\", \"switch to claude\", \"what was that session about\", \"claude --resume\", \"copilot --resume\", \"codex resume\", \"find the session where\", \"search sessions\", \"which session did I\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -360,16 +250,9 @@
       "name": "kubernetes-specialist",
       "description": "Deep-dive Kubernetes troubleshooting, workload design, and cluster health review. Use when you need a structured investigation of a cluster issue, a design review of Kubernetes manifests, or a health audit of a namespace or workload. Triggers on: \"debug kubernetes\", \"why is my pod\", \"review my manifests\", \"cluster health\", \"kubernetes design review\", \"k8s audit\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["kubernetes"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -382,16 +265,9 @@
       "name": "markdown",
       "description": "Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "writing"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex", "writing"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -404,16 +280,9 @@
       "name": "merge-pr",
       "description": "Merge a pull request only after full local verification, with a data-regression gate for PRs touching data/calibration/rankings.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -426,16 +295,9 @@
       "name": "pulumi-specialist",
       "description": "Deep-dive Pulumi stack review, component design, Automation API audit, and secrets management. Use for structured investigations of Pulumi stack drift, ComponentResource coupling, ESC configuration, and Automation API workflows. Triggers on: \"Pulumi audit\", \"stack review\", \"Automation API review\", \"ComponentResource design\", \"ESC audit\", \"Pulumi secrets\", \"Pulumi testing\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "pulumi"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["pulumi"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -448,15 +310,9 @@
       "name": "review-pr",
       "description": "Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -469,16 +325,9 @@
       "name": "security-review",
       "description": "Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "security"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex", "security"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -491,15 +340,9 @@
       "name": "spec",
       "description": "Create structured engineering specs through interactive pairing. Use when the user wants to create a spec, design doc, technical specification, architecture document, RFC, or engineering plan. Triggers on \"let's spec this out\", \"create a spec\", \"design doc\", \"write a technical plan\", \"plan the architecture\". Works for greenfield and brownfield projects. Outputs to docs/specs/.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -512,16 +355,9 @@
       "name": "terraform-specialist",
       "description": "Deep-dive Terraform architecture review, module design, state management, and migration. Use for structured investigations of Terraform workspaces, provider configuration, module coupling, import workflows, and test coverage. Triggers on: \"Terraform audit\", \"module review\", \"state management\", \"Terraform import\", \"workspace design\", \"provider config review\", \"Terraform testing\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -534,17 +370,9 @@
       "name": "terragrunt-specialist",
       "description": "Deep-dive Terragrunt hierarchy review, DRY pattern audits, and run-all orchestration analysis. Use for structured investigations of multi-environment Terragrunt layouts, dependency graphs, remote state config, and hook correctness. Triggers on: \"Terragrunt audit\", \"run-all review\", \"dependency block\", \"DRY pattern review\", \"env hierarchy audit\", \"mock_outputs\", \"terragrunt hooks\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform",
-          "terragrunt"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform", "terragrunt"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -557,16 +385,9 @@
       "name": "validate-spec",
       "description": "Audit an already-implemented spec against the codebase. Walks each constraint (ARCH-N, PERF-N, KD-N, etc.) and acceptance criterion, grounds findings in file:line evidence, runs the spec.json acceptance_commands, and writes a single audit doc to docs/audits/. Use whenever the user asks to \"validate a spec\", \"audit a spec\", \"check if spec is implemented\", \"verify the spec is done\", \"is this spec really done\", or otherwise wants closure on spec-driven work. Read-only against the spec — produces an audit, never modifies the spec itself.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -579,16 +400,9 @@
       "name": "veracity-audit",
       "description": "Audit a data pipeline for Veracity and Value. Dispatches data-scientist, compliance-auditor, and data-engineer agents with project context injected at dispatch time. All source paths are supplied via flags — no defaults, no project assumptions. Subcommands: audit (full pipeline walk), score-check (scoring math only), gate-check (gate coverage only), source-trace <label> (single source end-to-end). Invoke when: \"audit pipeline\", \"veracity check\", \"scoring math correct?\", \"check gates\", \"trace source\", \"verify quality gates\", \"formula correct?\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "draft"
       },
       "version": "1.0.0",

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -12,6 +12,7 @@
       "fix-with-evidence",
       "git",
       "ground-first",
+      "handoff",
       "markdown",
       "merge-pr",
       "review-pr",
@@ -30,8 +31,13 @@
       "terraform-specialist",
       "terragrunt-specialist"
     ],
-    "security": ["dependabot-sweep", "security-review"],
-    "writing": ["markdown"]
+    "security": [
+      "dependabot-sweep",
+      "security-review"
+    ],
+    "writing": [
+      "markdown"
+    ]
   },
   "platform": {
     "none": [
@@ -45,21 +51,44 @@
       "fix-with-evidence",
       "git",
       "ground-first",
+      "handoff",
       "markdown",
       "security-review",
       "spec",
       "validate-spec",
       "veracity-audit"
     ],
-    "aws": ["aws-specialist"],
-    "azure": ["azure-specialist"],
-    "crossplane": ["crossplane-specialist"],
-    "kubernetes": ["crossplane-specialist", "kubernetes-specialist"],
-    "github-actions": ["dependabot-sweep", "merge-pr", "review-pr"],
-    "gcp": ["gcp-specialist"],
-    "pulumi": ["pulumi-specialist"],
-    "terraform": ["terraform-specialist", "terragrunt-specialist"],
-    "terragrunt": ["terragrunt-specialist"]
+    "aws": [
+      "aws-specialist"
+    ],
+    "azure": [
+      "azure-specialist"
+    ],
+    "crossplane": [
+      "crossplane-specialist"
+    ],
+    "kubernetes": [
+      "crossplane-specialist",
+      "kubernetes-specialist"
+    ],
+    "github-actions": [
+      "dependabot-sweep",
+      "merge-pr",
+      "review-pr"
+    ],
+    "gcp": [
+      "gcp-specialist"
+    ],
+    "pulumi": [
+      "pulumi-specialist"
+    ],
+    "terraform": [
+      "terraform-specialist",
+      "terragrunt-specialist"
+    ],
+    "terragrunt": [
+      "terragrunt-specialist"
+    ]
   },
   "task": {
     "debugging": [
@@ -73,6 +102,7 @@
       "fix-with-evidence",
       "gcp-specialist",
       "ground-first",
+      "handoff",
       "kubernetes-specialist",
       "pulumi-specialist",
       "terraform-specialist",
@@ -104,10 +134,17 @@
       "create-assessment",
       "create-audit",
       "create-inspection",
+      "handoff",
       "markdown",
       "spec"
     ],
-    "testing": ["detect-flaky", "fix-with-evidence", "merge-pr", "validate-spec", "veracity-audit"]
+    "testing": [
+      "detect-flaky",
+      "fix-with-evidence",
+      "merge-pr",
+      "validate-spec",
+      "veracity-audit"
+    ]
   },
   "maturity": {
     "validated": [
@@ -137,6 +174,9 @@
       "terragrunt-specialist",
       "validate-spec"
     ],
-    "draft": ["veracity-audit"]
+    "draft": [
+      "handoff",
+      "veracity-audit"
+    ]
   }
 }

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -31,13 +31,8 @@
       "terraform-specialist",
       "terragrunt-specialist"
     ],
-    "security": [
-      "dependabot-sweep",
-      "security-review"
-    ],
-    "writing": [
-      "markdown"
-    ]
+    "security": ["dependabot-sweep", "security-review"],
+    "writing": ["markdown"]
   },
   "platform": {
     "none": [
@@ -58,37 +53,15 @@
       "validate-spec",
       "veracity-audit"
     ],
-    "aws": [
-      "aws-specialist"
-    ],
-    "azure": [
-      "azure-specialist"
-    ],
-    "crossplane": [
-      "crossplane-specialist"
-    ],
-    "kubernetes": [
-      "crossplane-specialist",
-      "kubernetes-specialist"
-    ],
-    "github-actions": [
-      "dependabot-sweep",
-      "merge-pr",
-      "review-pr"
-    ],
-    "gcp": [
-      "gcp-specialist"
-    ],
-    "pulumi": [
-      "pulumi-specialist"
-    ],
-    "terraform": [
-      "terraform-specialist",
-      "terragrunt-specialist"
-    ],
-    "terragrunt": [
-      "terragrunt-specialist"
-    ]
+    "aws": ["aws-specialist"],
+    "azure": ["azure-specialist"],
+    "crossplane": ["crossplane-specialist"],
+    "kubernetes": ["crossplane-specialist", "kubernetes-specialist"],
+    "github-actions": ["dependabot-sweep", "merge-pr", "review-pr"],
+    "gcp": ["gcp-specialist"],
+    "pulumi": ["pulumi-specialist"],
+    "terraform": ["terraform-specialist", "terragrunt-specialist"],
+    "terragrunt": ["terragrunt-specialist"]
   },
   "task": {
     "debugging": [
@@ -138,13 +111,7 @@
       "markdown",
       "spec"
     ],
-    "testing": [
-      "detect-flaky",
-      "fix-with-evidence",
-      "merge-pr",
-      "validate-spec",
-      "veracity-audit"
-    ]
+    "testing": ["detect-flaky", "fix-with-evidence", "merge-pr", "validate-spec", "veracity-audit"]
   },
   "maturity": {
     "validated": [
@@ -174,9 +141,6 @@
       "terragrunt-specialist",
       "validate-spec"
     ],
-    "draft": [
-      "handoff",
-      "veracity-audit"
-    ]
+    "draft": ["handoff", "veracity-audit"]
   }
 }

--- a/index/by-type.json
+++ b/index/by-type.json
@@ -6,6 +6,7 @@
     "azure-specialist",
     "crossplane-specialist",
     "gcp-specialist",
+    "handoff",
     "kubernetes-specialist",
     "pulumi-specialist",
     "spec",

--- a/plugins/dotclaude/templates/claude/skills-manifest.json
+++ b/plugins/dotclaude/templates/claude/skills-manifest.json
@@ -108,6 +108,13 @@
       "lastValidated": null
     },
     {
+      "name": "handoff",
+      "path": ".claude/skills/handoff/SKILL.md",
+      "checksum": "",
+      "dependencies": [],
+      "lastValidated": null
+    },
+    {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "",

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -59,7 +59,7 @@ without explicit sub-command, run `describe` by default:
 - Literal resume-command fragments: `claude --resume <uuid>`,
   `copilot --resume=<uuid>`, `codex resume <uuid>`.
 - Natural-language: "what was that session about", "continue in
-  <cli>", "switch to <cli>", "handoff".
+  \<cli\>", "switch to \<cli\>", "handoff".
 
 Extract `<cli>` and `<uuid>` from the user message. If either is missing,
 ask a single clarifying question before proceeding.
@@ -193,7 +193,7 @@ on the chosen row.
    - `cwd` (from session meta using the per-CLI filter)
    - `mtime` (from `stat`)
    - snippet — prefer the first user-prompt match; else first
-     assistant match. Prefix with `user: ` or `asst: `. Truncate to 80
+     assistant match. Prefix with "user: " or "asst: ". Truncate to 80
      chars with `…`.
 6. Sort by `mtime` desc. Truncate to `--limit` (default 20).
 7. Render:

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -1,0 +1,246 @@
+---
+id: handoff
+name: handoff
+type: skill
+version: 1.0.0
+domain: [devex]
+platform: [none]
+task: [documentation, debugging]
+maturity: draft
+description: >
+  Transfer conversation context between agentic CLIs (Claude Code, GitHub
+  Copilot CLI, OpenAI Codex CLI). Reads a source session transcript by UUID
+  and produces either an inline summary or a paste-ready handoff digest for
+  another agent. Use when switching agents mid-task or recovering context.
+  Triggers on: "handoff", "transfer context", "continue in codex",
+  "continue in claude", "continue in copilot", "switch to codex",
+  "switch to claude", "what was that session about",
+  "claude --resume", "copilot --resume", "codex resume",
+  "find the session where", "search sessions", "which session did I".
+argument-hint: "<sub-cmd> [<source-cli>] <uuid|latest|query> [--to <target-cli>] [--cli <cli>]"
+tools: Glob, Read, Grep, Bash, Write
+effort: medium
+model: sonnet
+---
+
+# Handoff — Cross-CLI Session Context Transfer
+
+Locate a session transcript from one agentic CLI and hand its context to
+another. Supports three source CLIs (`claude`, `copilot`, `codex`) and
+the same three as targets. The skill never invokes a different CLI
+itself — it produces a summary or a paste-ready block the user drops
+into the target agent.
+
+## Arguments
+
+- `$0` — sub-command: `describe`, `digest`, `file`, `list`, or `search`.
+  If not provided and the skill is auto-triggered, default to `describe`.
+- `$1` — positional varies by sub-command:
+  - `describe` / `digest` / `file` / `list` → source CLI
+    (`claude`, `copilot`, `codex`).
+  - `search` → the query string (regex).
+- `$2` — session identifier: a UUID or the literal `latest`. Required for
+  `describe`, `digest`, `file`. Ignored for `list` and `search`.
+- `--to <target-cli>` — optional; tunes the digest voice for the target
+  agent. Defaults to `claude` since that is the most common consumer in
+  this repo.
+- `--cli <cli>` — `search` only; restrict the scan to one CLI.
+- `--since <ISO>` — `search` only; skip sessions older than this date.
+  Default: 30 days ago.
+- `--limit <N>` — `search` only; max rows in the hit table. Default: 20.
+
+---
+
+## Auto-trigger contract
+
+When the user message matches any of these patterns and the skill fires
+without explicit sub-command, run `describe` by default:
+
+- Literal resume-command fragments: `claude --resume <uuid>`,
+  `copilot --resume=<uuid>`, `codex resume <uuid>`.
+- Natural-language: "what was that session about", "continue in
+  <cli>", "switch to <cli>", "handoff".
+
+Extract `<cli>` and `<uuid>` from the user message. If either is missing,
+ask a single clarifying question before proceeding.
+
+---
+
+## Sub-Commands
+
+### `describe <cli> <uuid|latest>`
+
+Print an inline 2–4 sentence summary of the session plus the verbatim
+user prompts. Use when the user asks "what was that about" and nothing
+more.
+
+**Steps:**
+
+1. Resolve the session file. Load the per-CLI reference:
+   - `claude` → `references/claude-code.md`
+   - `copilot` → `references/copilot.md`
+   - `codex` → `references/codex.md`
+2. Apply the `latest` resolver if the identifier is `latest`, otherwise
+   locate the file by UUID using the path pattern in that reference.
+3. If no file is found, output exactly:
+
+   ```
+   No <cli> session found for '<identifier>'
+   ```
+
+   and stop.
+
+4. Run the per-CLI `jq` filters from the reference to extract:
+   - session meta (cwd, model, timestamp)
+   - all user turns, verbatim, in order
+   - all assistant turns (kept in memory for summary only; do not print)
+5. Render the output as:
+
+   ```markdown
+   **<cli>** `<short-uuid>` — `<cwd>` — <started-at>
+
+   **User prompts:**
+
+   - <prompt 1>
+   - <prompt 2>
+
+   **Summary:** <2–4 sentences of what the session was about>
+   ```
+
+### `digest <cli> <uuid|latest> [--to <target-cli>]`
+
+Print a paste-ready handoff block. Use when the user wants to carry the
+context into a different agent.
+
+**Steps:**
+
+1. Run steps 1–4 from `describe`.
+2. Build the normalized digest described in
+   `references/digest-schema.md`.
+3. Print the digest wrapped in a single `<handoff>...</handoff>` block
+   so the target agent can recognize and ingest it as one unit. Do not
+   print any commentary before or after the block.
+
+### `file <cli> <uuid|latest> [--to <target-cli>]`
+
+Same as `digest`, but also write the rendered markdown to
+`docs/handoffs/<YYYY-MM-DD>-<cli>-<short-uuid>.md` using `Write`. The
+`<handoff>` block goes at the top of the file; a human-readable summary
+follows. Print only the written path to stdout.
+
+If `docs/handoffs/` does not exist in the current repo, fall back to
+`~/.claude/handoffs/`. Do not create `docs/handoffs/` outside of a git
+repo.
+
+### `list <cli>`
+
+List sessions for the given CLI, newest first.
+
+**Steps:**
+
+1. Enumerate sessions using the per-CLI path pattern.
+2. For each session, extract the short UUID (first 8 chars), mtime, and
+   session meta cwd.
+3. Render as a table:
+
+   ```markdown
+   | UUID (short) | cwd | last modified |
+   | ------------ | --- | ------------- |
+   ```
+
+4. If no sessions found, output:
+
+   ```
+   No <cli> sessions found
+   ```
+
+### `search <query> [--cli <cli>] [--since <ISO>] [--limit <N>]`
+
+Scan transcripts across one or all CLIs for a substring/regex match and
+return a ranked list of candidate sessions. Use when you remember what a
+session was about but not its UUID. Chain into `describe <cli> <uuid>`
+on the chosen row.
+
+**Steps:**
+
+1. Resolve the search roots. If `--cli` is given, use only the matching
+   root; otherwise scan all three:
+   - `claude` → `~/.claude/projects/`
+   - `copilot` → `~/.copilot/session-state/`
+   - `codex` → `~/.codex/sessions/`
+2. Compute the `--since` cutoff. Default: 30 days ago. Use
+   `find <root> -name '<pattern>' -newermt "<cutoff>"` to pre-filter by
+   mtime. Per-CLI patterns:
+   - claude: `*.jsonl` under `~/.claude/projects/*/`
+   - copilot: `events.jsonl` under `~/.copilot/session-state/*/`
+   - codex: `rollout-*.jsonl` under `~/.codex/sessions/*/*/*/`
+3. **Raw pass (fast filter).** Run
+   `rg -l -i --no-messages -e '<query>' <file-list>` to get the
+   candidate-file list. This hits JSON-escaped content too; that's
+   fine — it's a superset we refine in the next step.
+4. **Clean pass (snippet extraction).** For each candidate file, apply
+   the CLI's user+assistant `jq` filter from the corresponding reference
+   in `references/` (see `claude-code.md`, `copilot.md`, `codex.md`),
+   then `rg -i -m 1 -C 0 '<query>'` over the extracted text so the full
+   matching line is available for snippet construction. If the clean
+   pass yields no hit, **drop the file** — the raw match was in
+   tool-use payloads or metadata (almost always noise). For codex, drop
+   any snippet whose source turn is an `<environment_context>` block.
+5. For each surviving candidate, extract:
+   - `cli` (inferred from root)
+   - short UUID (first 8 chars; for claude/codex parse from filename,
+     for copilot parse from the parent dir name)
+   - `cwd` (from session meta using the per-CLI filter)
+   - `mtime` (from `stat`)
+   - snippet — prefer the first user-prompt match; else first
+     assistant match. Prefix with `user: ` or `asst: `. Truncate to 80
+     chars with `…`.
+6. Sort by `mtime` desc. Truncate to `--limit` (default 20).
+7. Render:
+
+   ```markdown
+   | CLI     | Short UUID | cwd         | Last modified    | Match                      |
+   | ------- | ---------- | ----------- | ---------------- | -------------------------- |
+   | copilot | 1be89762   | /home/kaioh | 2026-04-17 20:21 | user: "copilot --resume=…" |
+
+   Drill in with `/handoff describe <cli> <uuid>`.
+   ```
+
+8. If no candidates survive, output exactly:
+
+   ```
+   No sessions matching '<query>'
+   ```
+
+**Query-handling rules:**
+
+- `<query>` is passed to `rg` as a regex. Shell-special characters the
+  user typed verbatim should be single-quoted when shelling out.
+- Case-insensitive by default (`-i`). The caller can opt out with an
+  explicit `(?-i)` inline flag in the regex.
+- Do not expand `~` inside the query — only inside the root paths.
+
+---
+
+## Error handling
+
+- Unknown sub-command → print usage line and stop.
+- Unknown source CLI → print the three supported values and stop.
+- Malformed UUID → treat as a literal and let the resolver return
+  "not found" rather than guessing.
+- Missing `jq` on PATH → fall back to reading the JSONL with `Read` and
+  parsing in-memory. Note the fallback only in human-readable output
+  modes (`describe`, `list`, `search`). Do not emit any extra stdout for
+  `digest`; for `file`, stdout must remain path-only — if a fallback
+  note is needed, place it in the written markdown body after the
+  `<handoff>` block.
+
+## Out of scope
+
+- Invoking the target CLI directly. The skill prints, the user pastes.
+- Secret redaction. The caller is responsible for not passing sensitive
+  transcripts through `file` or `search` output.
+- Fuzzy or semantic search. `search` is substring/regex only. If a user
+  wants semantic retrieval, direct them to the raw transcripts.
+- Persistent indexing. Grep-at-query-time is fast enough for local
+  session volumes; revisit only if p95 exceeds ~2s.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
@@ -1,0 +1,128 @@
+# Claude Code — session transcript reference
+
+Claude Code stores one JSONL file per session under a per-project
+directory derived from the session's cwd.
+
+## Path layout
+
+```
+~/.claude/projects/<project-slug>/<session-id>.jsonl
+```
+
+- `<project-slug>` — the session cwd with `/` replaced by `-` and the
+  leading `/` preserved (e.g. `/home/kaioh/projects/kaiohenricunha/dotclaude`
+  → `-home-kaioh-projects-kaiohenricunha-dotclaude`).
+- `<session-id>` — a UUID v4. Matches the value a user passes to
+  `claude --resume <uuid>`.
+
+## Locating a session
+
+**By UUID** — the project slug is not known up front, so search across all
+project dirs:
+
+```bash
+find ~/.claude/projects -maxdepth 2 -type f -name '<uuid>.jsonl' 2>/dev/null
+```
+
+**Latest** — newest `.jsonl` across all project dirs by mtime (GNU/BSD
+portable):
+
+```bash
+find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl' 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
+  | sort -rn | head -1 | awk '{print $2}'
+```
+
+**List** — all sessions grouped by project, newest first:
+
+```bash
+find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl' 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
+  | sort -rn
+```
+
+## Record schema
+
+JSONL, one record per line. Relevant top-level types:
+
+- `user` — user message, content in `.message.content`
+- `assistant` — model message, content in `.message.content`
+- `system` — environment/system-reminder records
+- `attachment`, `pr-link`, `file-history-snapshot` — ancillary
+
+Every record carries `sessionId`, `cwd`, and `version`.
+
+### Extract session metadata
+
+```bash
+jq -r 'select(.cwd) | {cwd, sessionId, version}' <file> | head -1
+```
+
+## Extraction filters
+
+### User prompts (verbatim, in order)
+
+`.message.content` is an array of content blocks. Text lives in blocks
+with `type == "text"`:
+
+```bash
+jq -r 'select(.type == "user") | .message.content
+  | if type == "string" then . else (map(select(.type == "text") | .text) | join("\n")) end' <file>
+```
+
+### Assistant turns (text only)
+
+```bash
+jq -r 'select(.type == "assistant") | .message.content
+  | (map(select(.type == "text") | .text) | join("\n"))' <file>
+```
+
+### Tool calls the assistant made
+
+```bash
+jq -c 'select(.type == "assistant") | .message.content
+  | map(select(.type == "tool_use") | {name, input})' <file>
+```
+
+### Files the session touched
+
+Scan tool-use inputs for absolute paths:
+
+```bash
+jq -r 'select(.type == "assistant") | .message.content[]
+  | select(.type == "tool_use")
+  | .input | (.file_path // .path // empty)' <file> | sort -u
+```
+
+## Content search (clean pass)
+
+For `/handoff search`, raw `rg` over the JSONL gives a superset — JSON
+escapes and system-reminder boilerplate match noisily. Re-filter by
+extracting user+assistant text first:
+
+```bash
+jq -r '
+  select((.type == "user" or .type == "assistant") and (.isSidechain | not))
+  | .type as $role
+  | .message.content
+  | if type == "string" then "\($role):\t\(.)"
+    else empty end,
+    ( if type == "array" then
+        (map(select(.type == "text") | .text) | join("\n"))
+          | select(length > 0)
+          | "\($role):\t\(.)"
+      else empty end )
+' <file> | rg -i -m 1 '<query>'
+```
+
+## Notes
+
+- The first few records of a session are `summary`, `system`, or an
+  initial environment `system-reminder`. User prompts usually start
+  from record 2 onward.
+- `isSidechain: true` records come from sub-agents (the `Agent` tool).
+  Filter them out if you only want the top-level conversation:
+  add `and (.isSidechain | not)` to the filter. The search clean-pass
+  already does this.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
@@ -1,0 +1,148 @@
+# OpenAI Codex CLI — session transcript reference
+
+Codex CLI stores one JSONL "rollout" file per session under a
+date-partitioned tree. The UUID is the same value passed to
+`codex resume <uuid>`.
+
+## Path layout
+
+```
+~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<uuid>.jsonl
+```
+
+Examples:
+
+```
+~/.codex/sessions/2026/04/17/rollout-2026-04-17T20-20-43-019d9dbf-27e3-7661-b189-9ced5a55bd2f.jsonl
+```
+
+## Locating a session
+
+**By UUID** — search recursively (the date path is not known up front):
+
+```bash
+find ~/.codex/sessions -type f -name "rollout-*-<uuid>.jsonl" 2>/dev/null
+```
+
+**Latest** — newest rollout by mtime (GNU/BSD portable):
+
+```bash
+find ~/.codex/sessions -type f -name 'rollout-*.jsonl' 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
+  | sort -rn | head -1 | awk '{print $2}'
+```
+
+**List** — all rollouts newest first, with session metadata:
+
+```bash
+find ~/.codex/sessions -type f -name 'rollout-*.jsonl' 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
+  | sort -rn
+```
+
+## Record schema
+
+Each record has `timestamp`, `type`, `payload`.
+
+Relevant `type` values:
+
+- `session_meta` — one per session, first record; carries cwd, cli
+  version, model provider, and base instructions
+- `event_msg` — lifecycle events (task_started, response_generated, etc.)
+  keyed by `.payload.type`
+- `response_item` — actual conversation turns, keyed by
+  `.payload.type` (typically `message`) and `.payload.role`
+- `turn_context` — per-turn configuration
+
+## Extraction filters
+
+### Session metadata
+
+```bash
+jq -c 'select(.type == "session_meta") | .payload
+  | {id, cwd, cli_version, model_provider, timestamp}' <file> | head -1
+```
+
+`payload.base_instructions.text` holds the full system prompt. Do not
+inline it in the digest — it is large and rarely useful to a target
+agent.
+
+### User prompts
+
+```bash
+jq -r 'select(.type == "response_item"
+             and .payload.type == "message"
+             and .payload.role == "user")
+       | .payload.content[0].text' <file>
+```
+
+The first user record is usually an `<environment_context>` block.
+Filter it out when rendering prompts for humans:
+
+```bash
+jq -r 'select(.type == "response_item"
+             and .payload.type == "message"
+             and .payload.role == "user")
+       | .payload.content[0].text
+       | select(test("^<environment_context>") | not)' <file>
+```
+
+### Assistant turns
+
+```bash
+jq -r 'select(.type == "response_item"
+             and .payload.type == "message"
+             and .payload.role == "assistant")
+       | .payload.content[0].text' <file>
+```
+
+### Tool calls
+
+Codex emits tool calls as `response_item` records with a non-`message`
+payload type:
+
+```bash
+jq -c 'select(.type == "response_item" and .payload.type != "message")
+       | .payload | {type, name, arguments}' <file>
+```
+
+### Task lifecycle
+
+```bash
+jq -c 'select(.type == "event_msg") | .payload | {type, turn_id}' <file>
+```
+
+## Content search (clean pass)
+
+For `/handoff search`, raw `rg` over rollouts matches inside
+`base_instructions.text` (the entire Codex system prompt, ~10k chars)
+and tool-call payloads. Always extract clean turn text first:
+
+```bash
+jq -r '
+  select(.type == "response_item"
+         and .payload.type == "message"
+         and (.payload.role == "user" or .payload.role == "assistant"))
+  | .payload.role as $r
+  | .payload.content[0].text
+  | select(test("^<environment_context>") | not)
+  | "\($r):\t" + .
+' <file> | rg -i -m 1 '<query>'
+```
+
+The `<environment_context>` filter is important: every Codex session's
+first user turn is an auto-generated block with cwd/shell/timezone, and
+searching for common words like `bash` or a username matches every
+session without it.
+
+## Notes
+
+- Codex sessions routinely exceed 100k lines because tool-call output
+  is logged inline. For the `describe` sub-command, truncate the
+  assistant transcript to the last ~20 turns before summarizing.
+- `payload.content` is always an array. `content[0].text` is the
+  common case but probe with `content | length` before trusting it.
+- `cwd` in `session_meta` is the cwd at session start; if the user ran
+  `cd` mid-session, later `event_msg` records reflect the updated cwd.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/copilot.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/copilot.md
@@ -1,0 +1,133 @@
+# GitHub Copilot CLI — session transcript reference
+
+Copilot CLI stores one directory per session under
+`~/.copilot/session-state/`, keyed by UUID. The UUID is the same value
+passed to `copilot --resume=<uuid>`.
+
+## Path layout
+
+```
+~/.copilot/session-state/<uuid>/
+  events.jsonl      # the full event stream (messages, tool calls, hooks)
+  workspace.yaml    # session workspace metadata
+  checkpoints/      # snapshots taken at checkpoints
+  files/            # file payloads the session attached
+  research/         # research artifacts produced mid-session
+```
+
+## Locating a session
+
+**By UUID** — direct path:
+
+```
+~/.copilot/session-state/<uuid>/events.jsonl
+```
+
+**Latest** — newest session dir by mtime of its `events.jsonl` (GNU/BSD
+portable):
+
+```bash
+find ~/.copilot/session-state -maxdepth 2 -name events.jsonl 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
+  | sort -rn | head -1 | awk '{print $2}'
+```
+
+**List** — all sessions newest first:
+
+```bash
+find ~/.copilot/session-state -maxdepth 2 -name events.jsonl 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
+  | sort -rn
+```
+
+## Event schema
+
+Each record has `type`, `id`, `parentId`, `timestamp`, `data`.
+
+Relevant `type` values:
+
+- `session.start`, `session.resume`, `session.shutdown`
+- `session.model_change`
+- `user.message` — user prompt; content in `.data.content`
+- `assistant.message` — model response; content in `.data` (varies)
+- `assistant.turn_start`, `assistant.turn_end`
+- `tool.execution_start`, `tool.execution_complete`
+- `hook.start`, `hook.end`
+- `system.message`
+
+## Extraction filters
+
+### Session metadata (cwd, model)
+
+```bash
+jq -r 'select(.type == "session.start") | .data | {cwd, model, sessionId}' <file> | head -1
+```
+
+If `session.start` lacks `cwd`, fall back to the sibling
+`workspace.yaml` in the session dir — it carries `cwd:` as a top-level
+key.
+
+### User prompts
+
+```bash
+jq -r 'select(.type == "user.message") | .data.content' <file>
+```
+
+Note: `.data.transformedContent` wraps the prompt with system-reminder
+boilerplate. Always prefer `.data.content` for the clean user text.
+
+### Assistant turns
+
+```bash
+jq -r 'select(.type == "assistant.message") | .data' <file>
+```
+
+The `.data` object varies by Copilot version. Probe with:
+
+```bash
+jq 'select(.type == "assistant.message") | .data | keys' <file> | head -1
+```
+
+Current versions use `.data.text` or `.data.content` for the
+user-visible response.
+
+### Tool calls
+
+```bash
+jq -c 'select(.type == "tool.execution_start") | .data | {tool, input}' <file>
+```
+
+### Model transitions
+
+```bash
+jq -c 'select(.type == "session.model_change") | .data' <file>
+```
+
+## Content search (clean pass)
+
+For `/handoff search`, raw `rg` matches JSON escapes and
+`transformedContent` boilerplate. Extract clean text first:
+
+```bash
+jq -r '
+  if .type == "user.message" then "user:\t" + (.data.content // "")
+  elif .type == "assistant.message" then
+    "asst:\t" + (.data.text // .data.content // (.data | tostring))
+  else empty end
+' <file> | rg -i -m 1 '<query>'
+```
+
+Do not search `.data.transformedContent` — it wraps the raw prompt with
+system-reminder boilerplate and produces false positives.
+
+## Notes
+
+- Copilot sessions can span multiple model changes in one transcript;
+  the digest should note the model(s) used, not just the first one.
+- The `research/` sibling dir often holds the most important context
+  (extracted facts, code-walkthrough notes). Mention its presence in
+  the digest if non-empty.
+- `checkpoints/` entries can be sizable; do not inline them into the
+  digest — reference the path only.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/digest-schema.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/digest-schema.md
@@ -1,0 +1,132 @@
+# Handoff digest — common schema and rendering
+
+The digest is the normalized payload the skill hands to the target
+agent. It is CLI-agnostic: a Claude transcript and a Codex transcript
+should produce the same shape.
+
+## Fields
+
+```yaml
+origin:
+  cli: claude | copilot | codex
+  session_id: <full-uuid>
+  short_id: <first-8-chars-of-uuid>
+  cwd: <absolute-path>
+  model: <model-id-or-list>
+  started_at: <ISO-8601>
+  turn_count: <int> # user turns only
+summary: |
+  2–4 sentences, plain English, describing what the session was about
+  and where it left off. No CLI-specific jargon.
+user_prompts:
+  - <verbatim prompt 1>
+  - <verbatim prompt 2>
+key_findings:
+  - <single-sentence claim the assistant established>
+  - ...
+artifacts:
+  files_touched:
+    - <absolute path>
+  commands_run:
+    - <non-read-only shell command>
+next_step_suggestion: |
+  One sentence the target agent should pick up from.
+```
+
+## Rendering: `<handoff>` block (for `digest` and `file` sub-commands)
+
+```markdown
+<handoff origin="<cli>" session="<short-id>" cwd="<cwd>">
+
+**Summary.** <summary prose>
+
+**User prompts (verbatim, in order).**
+
+1. <prompt 1>
+2. <prompt 2>
+
+**Key findings.**
+
+- <finding 1>
+- <finding 2>
+
+**Artifacts.**
+
+- Files touched: <path1>, <path2>
+- Commands run: `<cmd1>`, `<cmd2>`
+
+**Next step.** <next_step_suggestion>
+
+</handoff>
+```
+
+The `<handoff>` tag is intentional: target agents can detect it
+reliably and distinguish digest content from surrounding commentary.
+
+## Rendering: `describe` sub-command (terse inline summary)
+
+```markdown
+**<cli>** `<short-id>` — `<cwd>` — <started-at>
+
+**User prompts.**
+
+- <prompt 1>
+- <prompt 2>
+
+**Summary.** <2–4 sentence summary>
+```
+
+No `<handoff>` wrapper. No key findings, artifacts, or next step —
+those belong in `digest`/`file`.
+
+## Rendering: `file` sub-command (markdown doc)
+
+```markdown
+# Handoff: <origin.cli> → <target.cli>
+
+_Generated: <ISO-timestamp>_
+_Origin session: `<full-uuid>` (cwd: `<cwd>`)_
+
+<handoff origin="..." session="..." cwd="...">
+... (same block as digest) ...
+</handoff>
+
+---
+
+## Full user prompt log
+
+1. <prompt 1>
+
+<!-- etc -->
+
+## Notes
+
+- Prompts 1–N verbatim; assistant responses summarized above.
+- Source transcript: `<absolute path to jsonl>`
+```
+
+File path: `docs/handoffs/<YYYY-MM-DD>-<origin.cli>-<short-id>.md` when
+a `docs/` directory exists at the repo root, else
+`~/.claude/handoffs/<YYYY-MM-DD>-<origin.cli>-<short-id>.md`.
+
+## Target-CLI tuning (the `--to` flag)
+
+The only field that changes with `--to` is `next_step_suggestion`:
+
+- `--to claude` — phrase the next step as an imperative Claude can
+  follow directly ("Continue the refactor by editing …").
+- `--to codex` — include explicit filepaths and a concrete sub-task,
+  since Codex prefers task-shaped inputs.
+- `--to copilot` — phrase as a question or "help me with …" since
+  Copilot pairs with the user.
+
+All other fields are identical regardless of target.
+
+## Size bounds
+
+- `summary`: ≤ 400 characters.
+- `key_findings`: ≤ 5 bullets.
+- `user_prompts`: cap at the last 10 prompts if the session has more;
+  note the truncation in `summary`.
+- `files_touched`: ≤ 20 paths; dedupe; prefer ones the assistant
+  wrote/edited over ones it merely read.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -103,6 +103,7 @@ more.
    **<cli>** `<short-uuid>` — `<cwd>` — <started-at>
 
    **User prompts:**
+
    - <prompt 1>
    - <prompt 2>
 
@@ -183,8 +184,9 @@ on the chosen row.
 4. **Clean pass (snippet extraction).** For each candidate file, apply
    the CLI's user+assistant `jq` filter from the corresponding reference
    in `references/` (see `claude-code.md`, `copilot.md`, `codex.md`),
-   then `rg -i -m 1 -o -C 0 '<query>'` over the extracted text. If the
-   clean pass yields no hit, **drop the file** — the raw match was in
+   then `rg -i -m 1 -C 0 '<query>'` over the extracted text so the full
+   matching line is available for snippet construction. If the clean
+   pass yields no hit, **drop the file** — the raw match was in
    tool-use payloads or metadata (almost always noise). For codex, drop
    any snippet whose source turn is an `<environment_context>` block.
 5. For each surviving candidate, extract:
@@ -200,9 +202,9 @@ on the chosen row.
 7. Render:
 
    ```markdown
-   | CLI     | Short UUID | cwd                          | Last modified      | Match               |
-   | ------- | ---------- | ---------------------------- | ------------------ | ------------------- |
-   | copilot | 1be89762   | /home/kaioh                  | 2026-04-17 20:21   | user: "copilot --resume=…" |
+   | CLI     | Short UUID | cwd         | Last modified    | Match                      |
+   | ------- | ---------- | ----------- | ---------------- | -------------------------- |
+   | copilot | 1be89762   | /home/kaioh | 2026-04-17 20:21 | user: "copilot --resume=…" |
 
    Drill in with `/handoff describe <cli> <uuid>`.
    ```
@@ -230,7 +232,11 @@ on the chosen row.
 - Malformed UUID → treat as a literal and let the resolver return
   "not found" rather than guessing.
 - Missing `jq` on PATH → fall back to reading the JSONL with `Read` and
-  parsing in-memory; note the fallback in output.
+  parsing in-memory. Note the fallback only in human-readable output
+  modes (`describe`, `list`, `search`). Do not emit any extra stdout for
+  `digest`; for `file`, stdout must remain path-only — if a fallback
+  note is needed, place it in the written markdown body after the
+  `<handoff>` block.
 
 ## Out of scope
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,169 @@
+---
+id: handoff
+name: handoff
+type: skill
+version: 1.0.0
+domain: [devex]
+platform: [none]
+task: [documentation, debugging]
+maturity: experimental
+owner: "@kaiohenricunha"
+created: 2026-04-17
+updated: 2026-04-17
+description: >
+  Transfer conversation context between agentic CLIs (Claude Code, GitHub
+  Copilot CLI, OpenAI Codex CLI). Reads a source session transcript by UUID
+  and produces either an inline summary or a paste-ready handoff digest for
+  another agent. Use when switching agents mid-task or recovering context.
+  Triggers on: "handoff", "transfer context", "continue in codex",
+  "continue in claude", "continue in copilot", "switch to codex",
+  "switch to claude", "what was that session about",
+  "claude --resume", "copilot --resume", "codex resume".
+argument-hint: "<sub-cmd> <source-cli> <uuid|latest> [--to <target-cli>]"
+tools: Glob, Read, Grep, Bash, Write
+effort: medium
+model: sonnet
+---
+
+# Handoff — Cross-CLI Session Context Transfer
+
+Locate a session transcript from one agentic CLI and hand its context to
+another. Supports three source CLIs (`claude`, `copilot`, `codex`) and
+the same three as targets. The skill never invokes a different CLI
+itself — it produces a summary or a paste-ready block the user drops
+into the target agent.
+
+## Arguments
+
+- `$0` — sub-command: `describe`, `digest`, `file`, or `list`. If not
+  provided and the skill is auto-triggered, default to `describe`.
+- `$1` — source CLI: `claude`, `copilot`, `codex`. Required for all
+  sub-commands.
+- `$2` — session identifier: a UUID or the literal `latest`. Required for
+  `describe`, `digest`, `file`. Ignored for `list`.
+- `--to <target-cli>` — optional; tunes the digest voice for the target
+  agent. Defaults to `claude` since that is the most common consumer in
+  this repo.
+
+---
+
+## Auto-trigger contract
+
+When the user message matches any of these patterns and the skill fires
+without explicit sub-command, run `describe` by default:
+
+- Literal resume-command fragments: `claude --resume <uuid>`,
+  `copilot --resume=<uuid>`, `codex resume <uuid>`.
+- Natural-language: "what was that session about", "continue in
+  <cli>", "switch to <cli>", "handoff".
+
+Extract `<cli>` and `<uuid>` from the user message. If either is missing,
+ask a single clarifying question before proceeding.
+
+---
+
+## Sub-Commands
+
+### `describe <cli> <uuid|latest>`
+
+Print an inline 2–4 sentence summary of the session plus the verbatim
+user prompts. Use when the user asks "what was that about" and nothing
+more.
+
+**Steps:**
+
+1. Resolve the session file. Load the per-CLI reference:
+   - `claude` → `references/claude-code.md`
+   - `copilot` → `references/copilot.md`
+   - `codex` → `references/codex.md`
+2. Apply the `latest` resolver if the identifier is `latest`, otherwise
+   locate the file by UUID using the path pattern in that reference.
+3. If no file is found, output exactly:
+
+   ```
+   No <cli> session found for '<identifier>'
+   ```
+
+   and stop.
+
+4. Run the per-CLI `jq` filters from the reference to extract:
+   - session meta (cwd, model, timestamp)
+   - all user turns, verbatim, in order
+   - all assistant turns (kept in memory for summary only; do not print)
+5. Render the output as:
+
+   ```markdown
+   **<cli>** `<short-uuid>` — `<cwd>` — <started-at>
+
+   **User prompts:**
+   - <prompt 1>
+   - <prompt 2>
+
+   **Summary:** <2–4 sentences of what the session was about>
+   ```
+
+### `digest <cli> <uuid|latest> [--to <target-cli>]`
+
+Print a paste-ready handoff block. Use when the user wants to carry the
+context into a different agent.
+
+**Steps:**
+
+1. Run steps 1–4 from `describe`.
+2. Build the normalized digest described in
+   `references/digest-schema.md`.
+3. Print the digest wrapped in a single `<handoff>...</handoff>` block
+   so the target agent can recognize and ingest it as one unit. Do not
+   print any commentary before or after the block.
+
+### `file <cli> <uuid|latest> [--to <target-cli>]`
+
+Same as `digest`, but also write the rendered markdown to
+`docs/handoffs/<YYYY-MM-DD>-<cli>-<short-uuid>.md` using `Write`. The
+`<handoff>` block goes at the top of the file; a human-readable summary
+follows. Print only the written path to stdout.
+
+If `docs/handoffs/` does not exist in the current repo, fall back to
+`~/.claude/handoffs/`. Do not create `docs/handoffs/` outside of a git
+repo.
+
+### `list <cli>`
+
+List sessions for the given CLI, newest first.
+
+**Steps:**
+
+1. Enumerate sessions using the per-CLI path pattern.
+2. For each session, extract the short UUID (first 8 chars), mtime, and
+   session meta cwd.
+3. Render as a table:
+
+   ```markdown
+   | UUID (short) | cwd | last modified |
+   | ------------ | --- | ------------- |
+   ```
+
+4. If no sessions found, output:
+
+   ```
+   No <cli> sessions found
+   ```
+
+---
+
+## Error handling
+
+- Unknown sub-command → print usage line and stop.
+- Unknown source CLI → print the three supported values and stop.
+- Malformed UUID → treat as a literal and let the resolver return
+  "not found" rather than guessing.
+- Missing `jq` on PATH → fall back to reading the JSONL with `Read` and
+  parsing in-memory; note the fallback in output.
+
+## Out of scope
+
+- Invoking the target CLI directly. The skill prints, the user pastes.
+- Secret redaction. The caller is responsible for not passing sensitive
+  transcripts through `file`.
+- Content-based session search (e.g. "find the session where I worked
+  on foo"). Identifier must be UUID or `latest`.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -18,8 +18,9 @@ description: >
   Triggers on: "handoff", "transfer context", "continue in codex",
   "continue in claude", "continue in copilot", "switch to codex",
   "switch to claude", "what was that session about",
-  "claude --resume", "copilot --resume", "codex resume".
-argument-hint: "<sub-cmd> <source-cli> <uuid|latest> [--to <target-cli>]"
+  "claude --resume", "copilot --resume", "codex resume",
+  "find the session where", "search sessions", "which session did I".
+argument-hint: "<sub-cmd> [<source-cli>] <uuid|latest|query> [--to <target-cli>] [--cli <cli>]"
 tools: Glob, Read, Grep, Bash, Write
 effort: medium
 model: sonnet
@@ -35,15 +36,21 @@ into the target agent.
 
 ## Arguments
 
-- `$0` — sub-command: `describe`, `digest`, `file`, or `list`. If not
-  provided and the skill is auto-triggered, default to `describe`.
-- `$1` — source CLI: `claude`, `copilot`, `codex`. Required for all
-  sub-commands.
+- `$0` — sub-command: `describe`, `digest`, `file`, `list`, or `search`.
+  If not provided and the skill is auto-triggered, default to `describe`.
+- `$1` — positional varies by sub-command:
+  - `describe` / `digest` / `file` / `list` → source CLI
+    (`claude`, `copilot`, `codex`).
+  - `search` → the query string (regex).
 - `$2` — session identifier: a UUID or the literal `latest`. Required for
-  `describe`, `digest`, `file`. Ignored for `list`.
+  `describe`, `digest`, `file`. Ignored for `list` and `search`.
 - `--to <target-cli>` — optional; tunes the digest voice for the target
   agent. Defaults to `claude` since that is the most common consumer in
   this repo.
+- `--cli <cli>` — `search` only; restrict the scan to one CLI.
+- `--since <ISO>` — `search` only; skip sessions older than this date.
+  Default: 30 days ago.
+- `--limit <N>` — `search` only; max rows in the hit table. Default: 20.
 
 ---
 
@@ -149,6 +156,71 @@ List sessions for the given CLI, newest first.
    No <cli> sessions found
    ```
 
+### `search <query> [--cli <cli>] [--since <ISO>] [--limit <N>]`
+
+Scan transcripts across one or all CLIs for a substring/regex match and
+return a ranked list of candidate sessions. Use when you remember what a
+session was about but not its UUID. Chain into `describe <cli> <uuid>`
+on the chosen row.
+
+**Steps:**
+
+1. Resolve the search roots. If `--cli` is given, use only the matching
+   root; otherwise scan all three:
+   - `claude` → `~/.claude/projects/`
+   - `copilot` → `~/.copilot/session-state/`
+   - `codex` → `~/.codex/sessions/`
+2. Compute the `--since` cutoff. Default: 30 days ago. Use
+   `find <root> -name '<pattern>' -newermt "<cutoff>"` to pre-filter by
+   mtime. Per-CLI patterns:
+   - claude: `*.jsonl` under `~/.claude/projects/*/`
+   - copilot: `events.jsonl` under `~/.copilot/session-state/*/`
+   - codex: `rollout-*.jsonl` under `~/.codex/sessions/*/*/*/`
+3. **Raw pass (fast filter).** Run
+   `rg -l -i --no-messages -e '<query>' <file-list>` to get the
+   candidate-file list. This hits JSON-escaped content too; that's
+   fine — it's a superset we refine in the next step.
+4. **Clean pass (snippet extraction).** For each candidate file, apply
+   the CLI's user+assistant `jq` filter from the corresponding reference
+   in `references/` (see `claude-code.md`, `copilot.md`, `codex.md`),
+   then `rg -i -m 1 -o -C 0 '<query>'` over the extracted text. If the
+   clean pass yields no hit, **drop the file** — the raw match was in
+   tool-use payloads or metadata (almost always noise). For codex, drop
+   any snippet whose source turn is an `<environment_context>` block.
+5. For each surviving candidate, extract:
+   - `cli` (inferred from root)
+   - short UUID (first 8 chars; for claude/codex parse from filename,
+     for copilot parse from the parent dir name)
+   - `cwd` (from session meta using the per-CLI filter)
+   - `mtime` (from `stat`)
+   - snippet — prefer the first user-prompt match; else first
+     assistant match. Prefix with `user: ` or `asst: `. Truncate to 80
+     chars with `…`.
+6. Sort by `mtime` desc. Truncate to `--limit` (default 20).
+7. Render:
+
+   ```markdown
+   | CLI     | Short UUID | cwd                          | Last modified      | Match               |
+   | ------- | ---------- | ---------------------------- | ------------------ | ------------------- |
+   | copilot | 1be89762   | /home/kaioh                  | 2026-04-17 20:21   | user: "copilot --resume=…" |
+
+   Drill in with `/handoff describe <cli> <uuid>`.
+   ```
+
+8. If no candidates survive, output exactly:
+
+   ```
+   No sessions matching '<query>'
+   ```
+
+**Query-handling rules:**
+
+- `<query>` is passed to `rg` as a regex. Shell-special characters the
+  user typed verbatim should be single-quoted when shelling out.
+- Case-insensitive by default (`-i`). The caller can opt out with an
+  explicit `(?-i)` inline flag in the regex.
+- Do not expand `~` inside the query — only inside the root paths.
+
 ---
 
 ## Error handling
@@ -164,6 +236,8 @@ List sessions for the given CLI, newest first.
 
 - Invoking the target CLI directly. The skill prints, the user pastes.
 - Secret redaction. The caller is responsible for not passing sensitive
-  transcripts through `file`.
-- Content-based session search (e.g. "find the session where I worked
-  on foo"). Identifier must be UUID or `latest`.
+  transcripts through `file` or `search` output.
+- Fuzzy or semantic search. `search` is substring/regex only. If a user
+  wants semantic retrieval, direct them to the raw transcripts.
+- Persistent indexing. Grep-at-query-time is fast enough for local
+  session volumes; revisit only if p95 exceeds ~2s.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -6,7 +6,7 @@ version: 1.0.0
 domain: [devex]
 platform: [none]
 task: [documentation, debugging]
-maturity: experimental
+maturity: draft
 owner: "@kaiohenricunha"
 created: 2026-04-17
 updated: 2026-04-17

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -62,7 +62,7 @@ without explicit sub-command, run `describe` by default:
 - Literal resume-command fragments: `claude --resume <uuid>`,
   `copilot --resume=<uuid>`, `codex resume <uuid>`.
 - Natural-language: "what was that session about", "continue in
-  <cli>", "switch to <cli>", "handoff".
+  \<cli\>", "switch to \<cli\>", "handoff".
 
 Extract `<cli>` and `<uuid>` from the user message. If either is missing,
 ask a single clarifying question before proceeding.
@@ -196,7 +196,7 @@ on the chosen row.
    - `cwd` (from session meta using the per-CLI filter)
    - `mtime` (from `stat`)
    - snippet — prefer the first user-prompt match; else first
-     assistant match. Prefix with `user: ` or `asst: `. Truncate to 80
+     assistant match. Prefix with "user: " or "asst: ". Truncate to 80
      chars with `…`.
 6. Sort by `mtime` desc. Truncate to `--limit` (default 20).
 7. Render:

--- a/skills/handoff/references/claude-code.md
+++ b/skills/handoff/references/claude-code.md
@@ -24,17 +24,22 @@ project dirs:
 find ~/.claude/projects -maxdepth 2 -type f -name '<uuid>.jsonl' 2>/dev/null
 ```
 
-**Latest** — newest `.jsonl` across all project dirs by mtime:
+**Latest** — newest `.jsonl` across all project dirs by mtime (GNU/BSD
+portable):
 
 ```bash
-find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl' 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
   | sort -rn | head -1 | awk '{print $2}'
 ```
 
 **List** — all sessions grouped by project, newest first:
 
 ```bash
-find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl' 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
   | sort -rn
 ```
 
@@ -100,25 +105,15 @@ extracting user+assistant text first:
 ```bash
 jq -r '
   select((.type == "user" or .type == "assistant") and (.isSidechain | not))
+  | .type as $role
   | .message.content
-  | if type == "string" then "\(.type)\t\(.)" end // empty,
+  | if type == "string" then "\($role):\t\(.)"
+    else empty end,
     ( if type == "array" then
         (map(select(.type == "text") | .text) | join("\n"))
-          | if length > 0 then "\(input_filename)\t\(.)" end
+          | select(length > 0)
+          | "\($role):\t\(.)"
       else empty end )
-' <file> | rg -i -m 1 '<query>' && echo <file>
-```
-
-A simpler working form (role-prefixed lines, pipe to `rg`):
-
-```bash
-jq -r '
-  select((.type == "user" or .type == "assistant") and (.isSidechain | not))
-  | "\(.type):\t" +
-    ( .message.content
-      | if type == "string" then .
-        else (map(select(.type == "text") | .text) | join("\n"))
-        end )
 ' <file> | rg -i -m 1 '<query>'
 ```
 

--- a/skills/handoff/references/claude-code.md
+++ b/skills/handoff/references/claude-code.md
@@ -91,6 +91,37 @@ jq -r 'select(.type == "assistant") | .message.content[]
   | .input | (.file_path // .path // empty)' <file> | sort -u
 ```
 
+## Content search (clean pass)
+
+For `/handoff search`, raw `rg` over the JSONL gives a superset — JSON
+escapes and system-reminder boilerplate match noisily. Re-filter by
+extracting user+assistant text first:
+
+```bash
+jq -r '
+  select((.type == "user" or .type == "assistant") and (.isSidechain | not))
+  | .message.content
+  | if type == "string" then "\(.type)\t\(.)" end // empty,
+    ( if type == "array" then
+        (map(select(.type == "text") | .text) | join("\n"))
+          | if length > 0 then "\(input_filename)\t\(.)" end
+      else empty end )
+' <file> | rg -i -m 1 '<query>' && echo <file>
+```
+
+A simpler working form (role-prefixed lines, pipe to `rg`):
+
+```bash
+jq -r '
+  select((.type == "user" or .type == "assistant") and (.isSidechain | not))
+  | "\(.type):\t" +
+    ( .message.content
+      | if type == "string" then .
+        else (map(select(.type == "text") | .text) | join("\n"))
+        end )
+' <file> | rg -i -m 1 '<query>'
+```
+
 ## Notes
 
 - The first few records of a session are `summary`, `system`, or an
@@ -98,4 +129,5 @@ jq -r 'select(.type == "assistant") | .message.content[]
   from record 2 onward.
 - `isSidechain: true` records come from sub-agents (the `Agent` tool).
   Filter them out if you only want the top-level conversation:
-  add `and (.isSidechain | not)` to the filter.
+  add `and (.isSidechain | not)` to the filter. The search clean-pass
+  already does this.

--- a/skills/handoff/references/claude-code.md
+++ b/skills/handoff/references/claude-code.md
@@ -1,0 +1,101 @@
+# Claude Code — session transcript reference
+
+Claude Code stores one JSONL file per session under a per-project
+directory derived from the session's cwd.
+
+## Path layout
+
+```
+~/.claude/projects/<project-slug>/<session-id>.jsonl
+```
+
+- `<project-slug>` — the session cwd with `/` replaced by `-` and the
+  leading `/` preserved (e.g. `/home/kaioh/projects/kaiohenricunha/dotclaude`
+  → `-home-kaioh-projects-kaiohenricunha-dotclaude`).
+- `<session-id>` — a UUID v4. Matches the value a user passes to
+  `claude --resume <uuid>`.
+
+## Locating a session
+
+**By UUID** — the project slug is not known up front, so search across all
+project dirs:
+
+```bash
+find ~/.claude/projects -maxdepth 2 -type f -name '<uuid>.jsonl' 2>/dev/null
+```
+
+**Latest** — newest `.jsonl` across all project dirs by mtime:
+
+```bash
+find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+  | sort -rn | head -1 | awk '{print $2}'
+```
+
+**List** — all sessions grouped by project, newest first:
+
+```bash
+find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+  | sort -rn
+```
+
+## Record schema
+
+JSONL, one record per line. Relevant top-level types:
+
+- `user` — user message, content in `.message.content`
+- `assistant` — model message, content in `.message.content`
+- `system` — environment/system-reminder records
+- `attachment`, `pr-link`, `file-history-snapshot` — ancillary
+
+Every record carries `sessionId`, `cwd`, and `version`.
+
+### Extract session metadata
+
+```bash
+jq -r 'select(.cwd) | {cwd, sessionId, version}' <file> | head -1
+```
+
+## Extraction filters
+
+### User prompts (verbatim, in order)
+
+`.message.content` is an array of content blocks. Text lives in blocks
+with `type == "text"`:
+
+```bash
+jq -r 'select(.type == "user") | .message.content
+  | if type == "string" then . else (map(select(.type == "text") | .text) | join("\n")) end' <file>
+```
+
+### Assistant turns (text only)
+
+```bash
+jq -r 'select(.type == "assistant") | .message.content
+  | (map(select(.type == "text") | .text) | join("\n"))' <file>
+```
+
+### Tool calls the assistant made
+
+```bash
+jq -c 'select(.type == "assistant") | .message.content
+  | map(select(.type == "tool_use") | {name, input})' <file>
+```
+
+### Files the session touched
+
+Scan tool-use inputs for absolute paths:
+
+```bash
+jq -r 'select(.type == "assistant") | .message.content[]
+  | select(.type == "tool_use")
+  | .input | (.file_path // .path // empty)' <file> | sort -u
+```
+
+## Notes
+
+- The first few records of a session are `summary`, `system`, or an
+  initial environment `system-reminder`. User prompts usually start
+  from record 2 onward.
+- `isSidechain: true` records come from sub-agents (the `Agent` tool).
+  Filter them out if you only want the top-level conversation:
+  add `and (.isSidechain | not)` to the filter.

--- a/skills/handoff/references/codex.md
+++ b/skills/handoff/references/codex.md
@@ -110,6 +110,29 @@ jq -c 'select(.type == "response_item" and .payload.type != "message")
 jq -c 'select(.type == "event_msg") | .payload | {type, turn_id}' <file>
 ```
 
+## Content search (clean pass)
+
+For `/handoff search`, raw `rg` over rollouts matches inside
+`base_instructions.text` (the entire Codex system prompt, ~10k chars)
+and tool-call payloads. Always extract clean turn text first:
+
+```bash
+jq -r '
+  select(.type == "response_item"
+         and .payload.type == "message"
+         and (.payload.role == "user" or .payload.role == "assistant"))
+  | .payload.role as $r
+  | .payload.content[0].text
+  | select(test("^<environment_context>") | not)
+  | "\($r):\t" + .
+' <file> | rg -i -m 1 '<query>'
+```
+
+The `<environment_context>` filter is important: every Codex session's
+first user turn is an auto-generated block with cwd/shell/timezone, and
+searching for common words like `bash` or a username matches every
+session without it.
+
 ## Notes
 
 - Codex sessions routinely exceed 100k lines because tool-call output

--- a/skills/handoff/references/codex.md
+++ b/skills/handoff/references/codex.md
@@ -1,0 +1,121 @@
+# OpenAI Codex CLI — session transcript reference
+
+Codex CLI stores one JSONL "rollout" file per session under a
+date-partitioned tree. The UUID is the same value passed to
+`codex resume <uuid>`.
+
+## Path layout
+
+```
+~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<uuid>.jsonl
+```
+
+Examples:
+
+```
+~/.codex/sessions/2026/04/17/rollout-2026-04-17T20-20-43-019d9dbf-27e3-7661-b189-9ced5a55bd2f.jsonl
+```
+
+## Locating a session
+
+**By UUID** — search recursively (the date path is not known up front):
+
+```bash
+find ~/.codex/sessions -type f -name "rollout-*-<uuid>.jsonl" 2>/dev/null
+```
+
+**Latest** — newest rollout by mtime:
+
+```bash
+find ~/.codex/sessions -type f -name 'rollout-*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+  | sort -rn | head -1 | awk '{print $2}'
+```
+
+**List** — all rollouts newest first, with session metadata:
+
+```bash
+find ~/.codex/sessions -type f -name 'rollout-*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+  | sort -rn
+```
+
+## Record schema
+
+Each record has `timestamp`, `type`, `payload`.
+
+Relevant `type` values:
+
+- `session_meta` — one per session, first record; carries cwd, cli
+  version, model provider, and base instructions
+- `event_msg` — lifecycle events (task_started, response_generated, etc.)
+  keyed by `.payload.type`
+- `response_item` — actual conversation turns, keyed by
+  `.payload.type` (typically `message`) and `.payload.role`
+- `turn_context` — per-turn configuration
+
+## Extraction filters
+
+### Session metadata
+
+```bash
+jq -c 'select(.type == "session_meta") | .payload
+  | {id, cwd, cli_version, model_provider, timestamp}' <file> | head -1
+```
+
+`payload.base_instructions.text` holds the full system prompt. Do not
+inline it in the digest — it is large and rarely useful to a target
+agent.
+
+### User prompts
+
+```bash
+jq -r 'select(.type == "response_item"
+             and .payload.type == "message"
+             and .payload.role == "user")
+       | .payload.content[0].text' <file>
+```
+
+The first user record is usually an `<environment_context>` block.
+Filter it out when rendering prompts for humans:
+
+```bash
+jq -r 'select(.type == "response_item"
+             and .payload.type == "message"
+             and .payload.role == "user")
+       | .payload.content[0].text
+       | select(test("^<environment_context>") | not)' <file>
+```
+
+### Assistant turns
+
+```bash
+jq -r 'select(.type == "response_item"
+             and .payload.type == "message"
+             and .payload.role == "assistant")
+       | .payload.content[0].text' <file>
+```
+
+### Tool calls
+
+Codex emits tool calls as `response_item` records with a non-`message`
+payload type:
+
+```bash
+jq -c 'select(.type == "response_item" and .payload.type != "message")
+       | .payload | {type, name, arguments}' <file>
+```
+
+### Task lifecycle
+
+```bash
+jq -c 'select(.type == "event_msg") | .payload | {type, turn_id}' <file>
+```
+
+## Notes
+
+- Codex sessions routinely exceed 100k lines because tool-call output
+  is logged inline. For the `describe` sub-command, truncate the
+  assistant transcript to the last ~20 turns before summarizing.
+- `payload.content` is always an array. `content[0].text` is the
+  common case but probe with `content | length` before trusting it.
+- `cwd` in `session_meta` is the cwd at session start; if the user ran
+  `cd` mid-session, later `event_msg` records reflect the updated cwd.

--- a/skills/handoff/references/codex.md
+++ b/skills/handoff/references/codex.md
@@ -24,17 +24,21 @@ Examples:
 find ~/.codex/sessions -type f -name "rollout-*-<uuid>.jsonl" 2>/dev/null
 ```
 
-**Latest** — newest rollout by mtime:
+**Latest** — newest rollout by mtime (GNU/BSD portable):
 
 ```bash
-find ~/.codex/sessions -type f -name 'rollout-*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+find ~/.codex/sessions -type f -name 'rollout-*.jsonl' 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
   | sort -rn | head -1 | awk '{print $2}'
 ```
 
 **List** — all rollouts newest first, with session metadata:
 
 ```bash
-find ~/.codex/sessions -type f -name 'rollout-*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+find ~/.codex/sessions -type f -name 'rollout-*.jsonl' 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
   | sort -rn
 ```
 

--- a/skills/handoff/references/copilot.md
+++ b/skills/handoff/references/copilot.md
@@ -23,17 +23,22 @@ passed to `copilot --resume=<uuid>`.
 ~/.copilot/session-state/<uuid>/events.jsonl
 ```
 
-**Latest** — newest session dir by mtime of its `events.jsonl`:
+**Latest** — newest session dir by mtime of its `events.jsonl` (GNU/BSD
+portable):
 
 ```bash
-find ~/.copilot/session-state -maxdepth 2 -name events.jsonl -printf '%T@ %p\n' 2>/dev/null \
+find ~/.copilot/session-state -maxdepth 2 -name events.jsonl 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
   | sort -rn | head -1 | awk '{print $2}'
 ```
 
 **List** — all sessions newest first:
 
 ```bash
-find ~/.copilot/session-state -maxdepth 2 -name events.jsonl -printf '%T@ %p\n' 2>/dev/null \
+find ~/.copilot/session-state -maxdepth 2 -name events.jsonl 2>/dev/null \
+  | xargs -I{} sh -c \
+    'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
   | sort -rn
 ```
 

--- a/skills/handoff/references/copilot.md
+++ b/skills/handoff/references/copilot.md
@@ -1,0 +1,111 @@
+# GitHub Copilot CLI — session transcript reference
+
+Copilot CLI stores one directory per session under
+`~/.copilot/session-state/`, keyed by UUID. The UUID is the same value
+passed to `copilot --resume=<uuid>`.
+
+## Path layout
+
+```
+~/.copilot/session-state/<uuid>/
+  events.jsonl      # the full event stream (messages, tool calls, hooks)
+  workspace.yaml    # session workspace metadata
+  checkpoints/      # snapshots taken at checkpoints
+  files/            # file payloads the session attached
+  research/         # research artifacts produced mid-session
+```
+
+## Locating a session
+
+**By UUID** — direct path:
+
+```
+~/.copilot/session-state/<uuid>/events.jsonl
+```
+
+**Latest** — newest session dir by mtime of its `events.jsonl`:
+
+```bash
+find ~/.copilot/session-state -maxdepth 2 -name events.jsonl -printf '%T@ %p\n' 2>/dev/null \
+  | sort -rn | head -1 | awk '{print $2}'
+```
+
+**List** — all sessions newest first:
+
+```bash
+find ~/.copilot/session-state -maxdepth 2 -name events.jsonl -printf '%T@ %p\n' 2>/dev/null \
+  | sort -rn
+```
+
+## Event schema
+
+Each record has `type`, `id`, `parentId`, `timestamp`, `data`.
+
+Relevant `type` values:
+
+- `session.start`, `session.resume`, `session.shutdown`
+- `session.model_change`
+- `user.message` — user prompt; content in `.data.content`
+- `assistant.message` — model response; content in `.data` (varies)
+- `assistant.turn_start`, `assistant.turn_end`
+- `tool.execution_start`, `tool.execution_complete`
+- `hook.start`, `hook.end`
+- `system.message`
+
+## Extraction filters
+
+### Session metadata (cwd, model)
+
+```bash
+jq -r 'select(.type == "session.start") | .data | {cwd, model, sessionId}' <file> | head -1
+```
+
+If `session.start` lacks `cwd`, fall back to the sibling
+`workspace.yaml` in the session dir — it carries `cwd:` as a top-level
+key.
+
+### User prompts
+
+```bash
+jq -r 'select(.type == "user.message") | .data.content' <file>
+```
+
+Note: `.data.transformedContent` wraps the prompt with system-reminder
+boilerplate. Always prefer `.data.content` for the clean user text.
+
+### Assistant turns
+
+```bash
+jq -r 'select(.type == "assistant.message") | .data' <file>
+```
+
+The `.data` object varies by Copilot version. Probe with:
+
+```bash
+jq 'select(.type == "assistant.message") | .data | keys' <file> | head -1
+```
+
+Current versions use `.data.text` or `.data.content` for the
+user-visible response.
+
+### Tool calls
+
+```bash
+jq -c 'select(.type == "tool.execution_start") | .data | {tool, input}' <file>
+```
+
+### Model transitions
+
+```bash
+jq -c 'select(.type == "session.model_change") | .data' <file>
+```
+
+## Notes
+
+- Copilot sessions can span multiple model changes in one transcript;
+  the digest should note the model(s) used, not just the first one.
+- The `research/` sibling dir often holds the most important context
+  (extracted facts, code-walkthrough notes). Mention its presence in
+  the digest if non-empty.
+- `checkpoints/` entries can be sizable; do not inline them into the
+  digest — reference the path only.

--- a/skills/handoff/references/copilot.md
+++ b/skills/handoff/references/copilot.md
@@ -100,6 +100,23 @@ jq -c 'select(.type == "tool.execution_start") | .data | {tool, input}' <file>
 jq -c 'select(.type == "session.model_change") | .data' <file>
 ```
 
+## Content search (clean pass)
+
+For `/handoff search`, raw `rg` matches JSON escapes and
+`transformedContent` boilerplate. Extract clean text first:
+
+```bash
+jq -r '
+  if .type == "user.message" then "user:\t" + (.data.content // "")
+  elif .type == "assistant.message" then
+    "asst:\t" + (.data.text // .data.content // (.data | tostring))
+  else empty end
+' <file> | rg -i -m 1 '<query>'
+```
+
+Do not search `.data.transformedContent` — it wraps the raw prompt with
+system-reminder boilerplate and produces false positives.
+
 ## Notes
 
 - Copilot sessions can span multiple model changes in one transcript;

--- a/skills/handoff/references/digest-schema.md
+++ b/skills/handoff/references/digest-schema.md
@@ -14,7 +14,7 @@ origin:
   cwd: <absolute-path>
   model: <model-id-or-list>
   started_at: <ISO-8601>
-  turn_count: <int>           # user turns only
+  turn_count: <int> # user turns only
 summary: |
   2–4 sentences, plain English, describing what the session was about
   and where it left off. No CLI-specific jargon.
@@ -41,14 +41,17 @@ next_step_suggestion: |
 **Summary.** <summary prose>
 
 **User prompts (verbatim, in order).**
+
 1. <prompt 1>
 2. <prompt 2>
 
 **Key findings.**
+
 - <finding 1>
 - <finding 2>
 
 **Artifacts.**
+
 - Files touched: <path1>, <path2>
 - Commands run: `<cmd1>`, `<cmd2>`
 
@@ -66,6 +69,7 @@ reliably and distinguish digest content from surrounding commentary.
 **<cli>** `<short-id>` — `<cwd>` — <started-at>
 
 **User prompts.**
+
 - <prompt 1>
 - <prompt 2>
 

--- a/skills/handoff/references/digest-schema.md
+++ b/skills/handoff/references/digest-schema.md
@@ -1,0 +1,128 @@
+# Handoff digest — common schema and rendering
+
+The digest is the normalized payload the skill hands to the target
+agent. It is CLI-agnostic: a Claude transcript and a Codex transcript
+should produce the same shape.
+
+## Fields
+
+```yaml
+origin:
+  cli: claude | copilot | codex
+  session_id: <full-uuid>
+  short_id: <first-8-chars-of-uuid>
+  cwd: <absolute-path>
+  model: <model-id-or-list>
+  started_at: <ISO-8601>
+  turn_count: <int>           # user turns only
+summary: |
+  2–4 sentences, plain English, describing what the session was about
+  and where it left off. No CLI-specific jargon.
+user_prompts:
+  - <verbatim prompt 1>
+  - <verbatim prompt 2>
+key_findings:
+  - <single-sentence claim the assistant established>
+  - ...
+artifacts:
+  files_touched:
+    - <absolute path>
+  commands_run:
+    - <non-read-only shell command>
+next_step_suggestion: |
+  One sentence the target agent should pick up from.
+```
+
+## Rendering: `<handoff>` block (for `digest` and `file` sub-commands)
+
+```markdown
+<handoff origin="<cli>" session="<short-id>" cwd="<cwd>">
+
+**Summary.** <summary prose>
+
+**User prompts (verbatim, in order).**
+1. <prompt 1>
+2. <prompt 2>
+
+**Key findings.**
+- <finding 1>
+- <finding 2>
+
+**Artifacts.**
+- Files touched: <path1>, <path2>
+- Commands run: `<cmd1>`, `<cmd2>`
+
+**Next step.** <next_step_suggestion>
+
+</handoff>
+```
+
+The `<handoff>` tag is intentional: target agents can detect it
+reliably and distinguish digest content from surrounding commentary.
+
+## Rendering: `describe` sub-command (terse inline summary)
+
+```markdown
+**<cli>** `<short-id>` — `<cwd>` — <started-at>
+
+**User prompts.**
+- <prompt 1>
+- <prompt 2>
+
+**Summary.** <2–4 sentence summary>
+```
+
+No `<handoff>` wrapper. No key findings, artifacts, or next step —
+those belong in `digest`/`file`.
+
+## Rendering: `file` sub-command (markdown doc)
+
+```markdown
+# Handoff: <origin.cli> → <target.cli>
+
+_Generated: <ISO-timestamp>_
+_Origin session: `<full-uuid>` (cwd: `<cwd>`)_
+
+<handoff origin="..." session="..." cwd="...">
+... (same block as digest) ...
+</handoff>
+
+---
+
+## Full user prompt log
+
+1. <prompt 1>
+
+<!-- etc -->
+
+## Notes
+
+- Prompts 1–N verbatim; assistant responses summarized above.
+- Source transcript: `<absolute path to jsonl>`
+```
+
+File path: `docs/handoffs/<YYYY-MM-DD>-<origin.cli>-<short-id>.md` when
+a `docs/` directory exists at the repo root, else
+`~/.claude/handoffs/<YYYY-MM-DD>-<origin.cli>-<short-id>.md`.
+
+## Target-CLI tuning (the `--to` flag)
+
+The only field that changes with `--to` is `next_step_suggestion`:
+
+- `--to claude` — phrase the next step as an imperative Claude can
+  follow directly ("Continue the refactor by editing …").
+- `--to codex` — include explicit filepaths and a concrete sub-task,
+  since Codex prefers task-shaped inputs.
+- `--to copilot` — phrase as a question or "help me with …" since
+  Copilot pairs with the user.
+
+All other fields are identical regardless of target.
+
+## Size bounds
+
+- `summary`: ≤ 400 characters.
+- `key_findings`: ≤ 5 bullets.
+- `user_prompts`: cap at the last 10 prompts if the session has more;
+  note the truncation in `summary`.
+- `files_touched`: ≤ 20 paths; dedupe; prefer ones the assistant
+  wrote/edited over ones it merely read.


### PR DESCRIPTION
## Summary

- New `skills/handoff/` skill for transferring session context across Claude Code, GitHub Copilot CLI, and OpenAI Codex CLI — finds a transcript by UUID (or `latest`) and produces either an inline summary or a paste-ready `<handoff>` block for a target agent.
- Five sub-commands: `describe`, `digest`, `file`, `list`, `search`. Per-CLI path layouts and `jq` filters live in `references/*.md` so the skill never re-derives them.
- Dual activation: `/handoff` slash command and description-based auto-trigger on phrases like `claude --resume <uuid>`, `copilot --resume=<uuid>`, `codex resume <uuid>`, "continue in codex", "find the session where".

## Test plan

- [x] `/handoff describe copilot 1be89762-b820-4ad9-872c-0bef30bb8e26` — returns the session where the user asked about a Claude session and follow-up on discovery steps.
- [x] `/handoff describe codex 019d9dbf-27e3-7661-b189-9ced5a55bd2f` — returns the nested-meta session summary.
- [x] `/handoff describe claude latest` — resolves to the newest `.jsonl` across all `~/.claude/projects/*` dirs.
- [ ] `/handoff digest codex 019d9dbf-27e3-7661-b189-9ced5a55bd2f --to claude` — prints a single `<handoff>` block with no commentary; paste into a fresh Claude session and confirm it can answer "what were you working on?" without reading raw jsonl.
- [ ] `/handoff file copilot 1be89762-b820-4ad9-872c-0bef30bb8e26 --to codex` — writes `docs/handoffs/2026-04-17-copilot-1be89762.md`; first block in the file is `<handoff>`.
- [ ] `/handoff list copilot` — enumerates every UUID in `~/.copilot/session-state/` sorted by mtime desc.
- [x] `/handoff search "copilot --resume"` — returns the two sessions on disk that contain that phrase verbatim.
- [ ] `[x] `/handoff search "resume[-= ][0-9a-f]{8}"` — regex match hits all three resume-command fragments; confirms clean-pass strips `<environment_context>` noise from Codex.
- [ ] `/handoff search "nonexistent-xyz-token"` — prints exactly `No sessions matching 'nonexistent-xyz-token'`.
- [ ] Auto-trigger: open a fresh session, paste `copilot --resume=1be89762-b820-4ad9-872c-0bef30bb8e26` alone, no other instruction. The skill should fire from the description match and default to `describe`.

## No-spec rationale

This PR adds a new self-contained skill under `skills/handoff/`. `skills/` is not on the protected-paths list in CLAUDE.md (`docs/repo-facts.json`), and no existing spec covers cross-CLI session handoff. If the skill graduates from `maturity: experimental` to `validated`, a follow-up PR will add a proper spec under `docs/specs/` and backfill a Spec ID.