### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ agent build pipeline.
   multi-service health, volume binding, network bridge configuration, and
   registry operations (#47).
 - **curl-pipe-bash installer** — `curl -sSL .../install.sh | bash` path for
-  users who prefer not to use npm. Idempotent, supports `--quiet` (#44).
+  users who prefer not to use npm. Idempotent; respects `NO_COLOR` (#44).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ All notable changes to `@dotclaude/dotclaude` land here. Format follows
 - `.d.ts` shipping for stronger type inference (via hand-authored declarations
   — TypeScript migration is out of scope per ADR-0002).
 
+## [0.5.0] — 2026-04-18
+
+No breaking changes. This release adds cross-machine session handoff via GitHub
+Gists, a `docker-engineer` agent, a curl-pipe-bash installer, and a refactored
+agent build pipeline.
+
+### Added
+
+- **Cross-machine handoff transport** — `/handoff push`, `pull`, `remote-list`,
+  and `doctor` sub-commands let a session started on one machine (Windows/WSL)
+  be resumed on another (PopOS / macOS / CI). Default transport uses
+  `gh gist`; `--via gist-token` (curl + PAT) and `--via git-fallback` (raw
+  git) are documented workarounds for hosts where `gh` is unavailable or
+  blocked. Includes a push-side secret-scrubbing pass covering eight token
+  patterns, a `handoff-doctor.sh` preflight with per-transport remediation
+  blocks, and 80 bats unit tests plus an e2e gist round-trip harness (#46,
+  #49).
+- **`docker-engineer` agent** — Compose orchestration and runtime ops; covers
+  multi-service health, volume binding, network bridge configuration, and
+  registry operations (#47).
+- **curl-pipe-bash installer** — `curl -sSL .../install.sh | bash` path for
+  users who prefer not to use npm. Idempotent, supports `--quiet` (#44).
+
+### Changed
+
+- **Agent build pipeline alignment** — all agents consistently use the
+  build-plugin script for template generation; scale-foundation tooling
+  refactored to be purely generic (no project-specific references) (#48).
+
+### Documentation
+
+- README surfaces the skills catalog, a quick-taste section, and a revised
+  persona framing (quality score raised from 6.1 → 9.6/10 per the README
+  assessment) (#45).
+
 ## [0.4.0] — 2026-04-17
 
 No breaking changes. This release adds the global-lifecycle CLI

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://dotclaude.dev/schemas/index.schema.json",
-  "generatedAt": "2026-04-18T12:49:13.817Z",
-  "version": "0.4.0",
+  "generatedAt": "2026-04-18T13:39:56.903Z",
+  "version": "0.5.0",
   "artifacts": [
     {
       "id": "agents-search",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -586,7 +611,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -1657,7 +1681,6 @@
       "integrity": "sha512-XH06ZOi8wCrtOSSj3p8y3yJzwgzYOSa7lglNyS3fP05JPRzRGyjauBb5UvlLUSCGysMmULS1moxdRHHudV+g/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "globby": "14.0.2",
         "js-yaml": "4.1.0",
@@ -2359,7 +2382,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2682,7 +2704,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2761,7 +2782,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dotclaude/dotclaude",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dotclaude/dotclaude",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -98,31 +98,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -611,6 +586,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -1681,6 +1657,7 @@
       "integrity": "sha512-XH06ZOi8wCrtOSSj3p8y3yJzwgzYOSa7lglNyS3fP05JPRzRGyjauBb5UvlLUSCGysMmULS1moxdRHHudV+g/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "globby": "14.0.2",
         "js-yaml": "4.1.0",
@@ -2382,6 +2359,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2704,6 +2682,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2782,6 +2761,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotclaude/dotclaude",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "dotclaude — portable SDD validators and Claude Code governance for any project.",
   "type": "module",
   "main": "plugins/dotclaude/src/index.mjs",


### PR DESCRIPTION
## Summary

- Bumps version `0.4.0` → `0.5.0`
- Adds CHANGELOG entry covering all 6 PRs since last release

## Changes since v0.4.0

| PR | Description |
|----|-------------|
| #44 | feat(install): curl-pipe-bash installer script |
| #45 | docs(readme): skills catalog, quick-taste, persona framing |
| #46 | feat(skills): handoff — cross-CLI session context transfer |
| #47 | feat(agents): docker-engineer agent |
| #48 | refactor: align agents with build pipeline |
| #49 | feat(skills): handoff — cross-machine transport (GitHub Gists) |

## Test plan

- [x] `npm test` → 205 / 205 passing
- [x] `npm run lint` → clean
- [x] `npm run dogfood` → valid

## No-spec rationale

Version bump only — touches `package.json`, `package-lock.json`, and `CHANGELOG.md`. No protected source paths changed.