### PR TITLE
fix(ci): fix release-please config section names and tag format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
   "changelog-sections": [
-    { "type": "feat", "section": "### Added" },
-    { "type": "fix", "section": "### Fixed" },
-    { "type": "perf", "section": "### Performance" },
-    { "type": "refactor", "section": "### Changed" },
-    { "type": "docs", "section": "### Documentation" },
+    { "type": "feat", "section": "Added" },
+    { "type": "fix", "section": "Fixed" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "refactor", "section": "Changed" },
+    { "type": "docs", "section": "Documentation" },
     { "type": "chore", "hidden": true },
     { "type": "style", "hidden": true },
     { "type": "test", "hidden": true },


### PR DESCRIPTION
## Summary

- Removes `### ` prefix from `changelog-sections` section names — release-please adds `### ` automatically, so the plain text (`Added`, not `### Added`) is correct
- Adds `"include-component-in-tag": false` so release-please uses the existing `v*.*.*` tag format (`v0.5.0`) instead of `dotclaude-v0.5.0` (which didn't exist), enabling it to correctly scope the changelog to commits since `v0.5.0`

Both bugs were visible in the first generated Release PR (#53): `### ### Added` headings and the full commit history since the beginning of the repo instead of just since `v0.5.0`.

## No-spec rationale

Config-only fix for the release automation added in #52. No source code or protected paths changed.

## Test plan

- [ ] Merge this PR; release-please re-runs on main and updates PR #53 with correct `### Added` headings and only the two `feat` commits since `v0.5.0`
