### PR TITLE
fix(ci): allow release-please CHANGELOG formatting in lint checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -34,4 +34,5 @@ jobs:
             --max-retries 2 \
             --exclude '^https?://(www\.)?npmjs\.com/' \
             --exclude '^https?://(www\.)?contributor-covenant\.org/' \
+            --exclude '^https?://github\.com/.*/compare/' \
             'docs/**/*.md' '*.md' 'plugins/dotclaude/**/*.md'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -34,5 +34,5 @@ jobs:
             --max-retries 2 \
             --exclude '^https?://(www\.)?npmjs\.com/' \
             --exclude '^https?://(www\.)?contributor-covenant\.org/' \
-            --exclude '^https?://github\.com/.*/compare/' \
+            --exclude '^https?://github\.com/[^/]+/[^/]+/compare/' \
             'docs/**/*.md' '*.md' 'plugins/dotclaude/**/*.md'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,4 +50,4 @@ jobs:
         with: { node-version: "22" }
       # Check only JSON/YAML/MD — the .mjs source is deliberately lightly formatted
       # (see .prettierrc.json); running on .mjs today would churn a lot.
-      - run: npx --yes prettier@3 --check "**/*.{json,yml,yaml,md}" --ignore-path .gitignore --ignore-unknown
+      - run: npx --yes prettier@3 --check "**/*.{json,yml,yaml,md}" --ignore-path .gitignore --ignore-path .prettierignore --ignore-unknown

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,8 @@
 {
   "config": {
     "default": true,
+    "MD004": false,
+    "MD012": { "maximum": 2 },
     "MD013": false,
     "MD024": { "siblings_only": true },
     "MD029": false,

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
## Summary

- Disable markdownlint `MD004` (ul-style) — release-please generates `*` bullets while hand-written CHANGELOG entries use `-`; enforcing consistency is impractical
- Relax `MD012` to allow 2 consecutive blank lines — release-please emits a double blank after version headers
- Add `CHANGELOG.md` to `.prettierignore` — release-please owns its formatting and prettier conflicts with the generated style
- Exclude `github.com/.*/compare/` URLs from lychee — compare URLs in the generated CHANGELOG header are pre-creation 404s; they resolve only after the Release PR is merged and the tag is created

## Test plan

- [x] `npx markdownlint-cli2 "CHANGELOG.md"` passes locally
- [x] `npx prettier@3 --check "**/*.{json,yml,yaml,md}"` passes locally
- [ ] After merge, release-please re-runs → PR #53 CI goes green

## No-spec rationale

Touches `.github/workflows/links.yml` (protected path). This is a narrow CI compatibility fix for release-please's auto-generated CHANGELOG format — no spec required.