### PR TITLE
docs: close v0.4-v0.5 coverage gaps + automate version stamps

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -32,6 +32,8 @@ jobs:
       - run: node plugins/dotclaude/bin/dotclaude-doctor.mjs
       - run: node plugins/dotclaude/bin/dotclaude-index.mjs --check
       - run: node scripts/build-plugin.mjs --check
+      - name: docs version stamps match package.json
+        run: node scripts/stamp-doc-versions.mjs --check
 
   example:
     name: example (examples/minimal-consumer)

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ settings.local.json
 # Local working plans — transient, not for distribution.
 docs/plans/
 
+# Articles — written locally, published elsewhere, not versioned here.
+docs/articles/
+
+# Assessment docs — graded locally, not for distribution.
+docs/assessments/
+
 # Node (for the plugin workspace)
 node_modules/
 *.log

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -9,6 +9,7 @@
     "MD031": false,
     "MD033": { "allowed_elements": ["details", "summary", "kbd", "br", "sub", "sup", "previous", "current_status", "value"] },
     "MD036": false,
+    "MD060": false,
     "MD040": false,
     "MD041": false
   },

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -8,6 +8,7 @@
     "MD029": false,
     "MD031": false,
     "MD033": { "allowed_elements": ["details", "summary", "kbd", "br", "sub", "sup", "previous", "current_status", "value"] },
+    "MD036": false,
     "MD040": false,
     "MD041": false
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,11 +42,35 @@ npx dotclaude-doctor         # self-diagnostic
      plugins/dotclaude/templates/githooks/pre-commit
    node scripts/check-jsdoc-coverage.mjs plugins/dotclaude/src
    npm run dogfood
+   npm run docs:stamp-check   # verify docs/*.md version stamps match package.json
    ```
 4. **Follow spec discipline.** Every PR touching a protected path (see
    `docs/repo-facts.json`) needs `Spec ID: dotclaude-core` or a
    `## No-spec rationale` section in its body. If you're adding a new
    subsystem, run `/spec` first to produce the design doc in `docs/specs/`.
+
+## Releasing a new version
+
+1. Bump `version` in `package.json` (semver — patch/minor/major as appropriate).
+2. Run `npm run docs:stamp` to rewrite `_Last updated: vX.Y.Z_` stamps across all
+   `docs/*.md` files to the new version. Never edit stamps by hand.
+3. Add a `## [X.Y.Z] — YYYY-MM-DD` block to `CHANGELOG.md`.
+4. Run the full local gate above to confirm everything is green.
+5. Open a PR with title `chore(release): vX.Y.Z` and body:
+   ```
+   ## Summary
+   - Bumps package version to X.Y.Z
+   - Updates doc version stamps via `npm run docs:stamp`
+   - Updates CHANGELOG.md
+
+   ## Test plan
+   - [ ] Full test suite green (`npm test`)
+   - [ ] `npm run docs:stamp-check` exits 0
+   - [ ] `npm run dogfood` exits 0
+
+   ## No-spec rationale
+   Release mechanics — no new protected paths or subsystem changes.
+   ```
 
 ## Commit + PR conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ npx dotclaude-doctor         # self-diagnostic
 3. Add a `## [X.Y.Z] — YYYY-MM-DD` block to `CHANGELOG.md`.
 4. Run the full local gate above to confirm everything is green.
 5. Open a PR with title `chore(release): vX.Y.Z` and body:
+
    ```
    ## Summary
    - Bumps package version to X.Y.Z

--- a/README.md
+++ b/README.md
@@ -68,60 +68,60 @@ or `dotclaude sync --help` for full options.
 
 **Cloud, IaC & Container specialists** — activate automatically when you mention the relevant technology:
 
-| Skill / Agent                                                          | Triggers on                                     | What it does                                                           |
-| ---------------------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
-| [`aws-specialist`](skills/aws-specialist/SKILL.md)                     | "AWS", "IAM role", "Lambda", "ECS", "S3"…       | Deep-dive AWS architecture review, IAM audits, multi-service debugging |
-| [`azure-specialist`](skills/azure-specialist/SKILL.md)                 | "Azure", "AKS", "Managed Identity", "Bicep"…    | Azure workload review, identity audits, ARM/Bicep guidance             |
-| [`gcp-specialist`](skills/gcp-specialist/SKILL.md)                     | "GCP", "GKE", "Cloud Run", "Workload Identity"… | GCP architecture review, IAM hierarchy, serverless guidance            |
-| [`kubernetes-specialist`](skills/kubernetes-specialist/SKILL.md)       | "kubernetes", "k8s", "pod", "helm chart"…       | Cluster troubleshooting, workload design, network policy review        |
-| [`crossplane-specialist`](skills/crossplane-specialist/SKILL.md)       | "Crossplane", "XRD", "Composition", "Claim"…    | XRD design, Composition correctness, provider config audit             |
-| [`terraform-specialist`](skills/terraform-specialist/SKILL.md)         | "Terraform", "state file", "IaC module"…        | Module design, state management, workspace review                      |
-| [`terragrunt-specialist`](skills/terragrunt-specialist/SKILL.md)       | "Terragrunt", "run-all", "DRY Terraform"…       | DRY hierarchy review, dependency graph, env layout                     |
-| [`pulumi-specialist`](skills/pulumi-specialist/SKILL.md)               | "Pulumi", "ComponentResource", "stack"…         | Stack review, Automation API audit, secrets management                 |
-| [`docker-engineer`](agents/docker-engineer.md)                         | "docker compose", "docker exec", "container logs", "docker stats"… | Multi-service Compose orchestration, runtime container ops, supply chain analysis |
+| Skill / Agent                                                    | Triggers on                                                        | What it does                                                                      |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| [`aws-specialist`](skills/aws-specialist/SKILL.md)               | "AWS", "IAM role", "Lambda", "ECS", "S3"…                          | Deep-dive AWS architecture review, IAM audits, multi-service debugging            |
+| [`azure-specialist`](skills/azure-specialist/SKILL.md)           | "Azure", "AKS", "Managed Identity", "Bicep"…                       | Azure workload review, identity audits, ARM/Bicep guidance                        |
+| [`gcp-specialist`](skills/gcp-specialist/SKILL.md)               | "GCP", "GKE", "Cloud Run", "Workload Identity"…                    | GCP architecture review, IAM hierarchy, serverless guidance                       |
+| [`kubernetes-specialist`](skills/kubernetes-specialist/SKILL.md) | "kubernetes", "k8s", "pod", "helm chart"…                          | Cluster troubleshooting, workload design, network policy review                   |
+| [`crossplane-specialist`](skills/crossplane-specialist/SKILL.md) | "Crossplane", "XRD", "Composition", "Claim"…                       | XRD design, Composition correctness, provider config audit                        |
+| [`terraform-specialist`](skills/terraform-specialist/SKILL.md)   | "Terraform", "state file", "IaC module"…                           | Module design, state management, workspace review                                 |
+| [`terragrunt-specialist`](skills/terragrunt-specialist/SKILL.md) | "Terragrunt", "run-all", "DRY Terraform"…                          | DRY hierarchy review, dependency graph, env layout                                |
+| [`pulumi-specialist`](skills/pulumi-specialist/SKILL.md)         | "Pulumi", "ComponentResource", "stack"…                            | Stack review, Automation API audit, secrets management                            |
+| [`docker-engineer`](agents/docker-engineer.md)                   | "docker compose", "docker exec", "container logs", "docker stats"… | Multi-service Compose orchestration, runtime container ops, supply chain analysis |
 
 **Engineering workflow** — slash commands:
 
-| Command                                              | Invoke                         | What it does                                                                                                      |
-| ---------------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| [`git`](commands/git.md)                             | `/git`                         | Conventional commits, PR creation, branch naming                                                                  |
-| [`changelog`](commands/changelog.md)                 | `/changelog`                   | Generate changelog entry from git history                                                                         |
-| [`merge-pr`](commands/merge-pr.md)                   | `/merge-pr <N>`                | Full local verification gate before merge                                                                         |
-| [`pre-pr`](commands/pre-pr.md) ¹                     | `/pre-pr [base-branch]`        | Quality gate before opening a PR: simplify, security-review, test suite                                           |
-| [`review-pr`](commands/review-pr.md)                 | `/review-pr <N>`               | Fetch comments, apply fixes, resolve threads                                                                      |
-| [`review-prs`](commands/review-prs.md) ¹             | `/review-prs <N1> [N2 N3 ...]` | Batch-review multiple PRs in parallel with one sub-agent per PR                                                   |
-| [`audit-and-fix`](commands/audit-and-fix.md)         | `/audit-and-fix <domain>`      | Audit → cluster findings → spawn parallel fix PRs                                                                 |
-| [`dependabot-sweep`](commands/dependabot-sweep.md)   | `/dependabot-sweep`            | Batch-triage all open Dependabot PRs                                                                              |
-| [`handoff`](skills/handoff/SKILL.md)                 | `/handoff <sub-command>`       | Transfer session context between AI agents (Claude Code, Copilot CLI, Codex) and across machines via GitHub Gists |
+| Command                                            | Invoke                         | What it does                                                                                                      |
+| -------------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| [`git`](commands/git.md)                           | `/git`                         | Conventional commits, PR creation, branch naming                                                                  |
+| [`changelog`](commands/changelog.md)               | `/changelog`                   | Generate changelog entry from git history                                                                         |
+| [`merge-pr`](commands/merge-pr.md)                 | `/merge-pr <N>`                | Full local verification gate before merge                                                                         |
+| [`pre-pr`](commands/pre-pr.md) ¹                   | `/pre-pr [base-branch]`        | Quality gate before opening a PR: simplify, security-review, test suite                                           |
+| [`review-pr`](commands/review-pr.md)               | `/review-pr <N>`               | Fetch comments, apply fixes, resolve threads                                                                      |
+| [`review-prs`](commands/review-prs.md) ¹           | `/review-prs <N1> [N2 N3 ...]` | Batch-review multiple PRs in parallel with one sub-agent per PR                                                   |
+| [`audit-and-fix`](commands/audit-and-fix.md)       | `/audit-and-fix <domain>`      | Audit → cluster findings → spawn parallel fix PRs                                                                 |
+| [`dependabot-sweep`](commands/dependabot-sweep.md) | `/dependabot-sweep`            | Batch-triage all open Dependabot PRs                                                                              |
+| [`handoff`](skills/handoff/SKILL.md)               | `/handoff <sub-command>`       | Transfer session context between AI agents (Claude Code, Copilot CLI, Codex) and across machines via GitHub Gists |
 
 > ¹ `maturity: draft` — functional but not yet tested across all project types.
 
 **Debugging & quality:**
 
-| Command                                                  | Invoke                       | What it does                                   |
-| -------------------------------------------------------- | ---------------------------- | ---------------------------------------------- |
-| [`ground-first`](commands/ground-first.md)               | `/ground-first <subject>`    | Code-grounded analysis before any edit         |
-| [`fix-with-evidence`](commands/fix-with-evidence.md)     | `/fix-with-evidence <issue>` | Reproduce → Fix → Verify → PR loop             |
-| [`detect-flaky`](commands/detect-flaky.md)               | `/detect-flaky <test-cmd>`   | Find and fix flaky tests by repeated execution |
-| [`security-review`](commands/security-review.md)         | `/security-review`           | Scan changed files for OWASP vulnerabilities   |
+| Command                                              | Invoke                       | What it does                                   |
+| ---------------------------------------------------- | ---------------------------- | ---------------------------------------------- |
+| [`ground-first`](commands/ground-first.md)           | `/ground-first <subject>`    | Code-grounded analysis before any edit         |
+| [`fix-with-evidence`](commands/fix-with-evidence.md) | `/fix-with-evidence <issue>` | Reproduce → Fix → Verify → PR loop             |
+| [`detect-flaky`](commands/detect-flaky.md)           | `/detect-flaky <test-cmd>`   | Find and fix flaky tests by repeated execution |
+| [`security-review`](commands/security-review.md)     | `/security-review`           | Scan changed files for OWASP vulnerabilities   |
 
 **Analysis & documentation:**
 
-| Command                                                    | Invoke                         | What it does                                              |
-| ---------------------------------------------------------- | ------------------------------ | --------------------------------------------------------- |
-| [`create-audit`](commands/create-audit.md)                 | `/create-audit <subject>`      | Evidence-based audit doc → `docs/audits/`                 |
-| [`create-inspection`](commands/create-inspection.md)       | `/create-inspection <problem>` | Investigate and surface fix options → `docs/inspections/` |
-| [`create-assessment`](commands/create-assessment.md)       | `/create-assessment <target>`  | 0–10 graded assessment doc → `docs/assessments/`          |
-| [`markdown`](commands/markdown.md)                         | `/markdown <path>`             | Fix markdown formatting and structure                     |
+| Command                                              | Invoke                         | What it does                                              |
+| ---------------------------------------------------- | ------------------------------ | --------------------------------------------------------- |
+| [`create-audit`](commands/create-audit.md)           | `/create-audit <subject>`      | Evidence-based audit doc → `docs/audits/`                 |
+| [`create-inspection`](commands/create-inspection.md) | `/create-inspection <problem>` | Investigate and surface fix options → `docs/inspections/` |
+| [`create-assessment`](commands/create-assessment.md) | `/create-assessment <target>`  | 0–10 graded assessment doc → `docs/assessments/`          |
+| [`markdown`](commands/markdown.md)                   | `/markdown <path>`             | Fix markdown formatting and structure                     |
 
 **Spec & governance:**
 
-| Command / Skill                                          | Invoke                                                                                                                                | What it does                                    |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| [`spec`](skills/spec/SKILL.md)                           | `/spec <id> "<title>"`                                                                                                                | Interactive spec authoring → `docs/specs/`      |
-| [`validate-spec`](skills/validate-spec/SKILL.md)         | `/validate-spec <id>`                                                                                                                 | Audit an implemented spec against the codebase  |
-| [`agents-search`](skills/agents-search/SKILL.md)         | `/agents-search list`                                                                                                                 | Discover, search, and manage Claude Code agents |
-| [`veracity-audit`](skills/veracity-audit/SKILL.md)       | `/veracity-audit audit --config <config> --quality-config <quality-config> --pipeline-dir <pipeline-dir> --scoring-dir <scoring-dir>` | Audit a data pipeline for veracity and value    |
+| Command / Skill                                    | Invoke                                                                                                                                | What it does                                    |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| [`spec`](skills/spec/SKILL.md)                     | `/spec <id> "<title>"`                                                                                                                | Interactive spec authoring → `docs/specs/`      |
+| [`validate-spec`](skills/validate-spec/SKILL.md)   | `/validate-spec <id>`                                                                                                                 | Audit an implemented spec against the codebase  |
+| [`agents-search`](skills/agents-search/SKILL.md)   | `/agents-search list`                                                                                                                 | Discover, search, and manage Claude Code agents |
+| [`veracity-audit`](skills/veracity-audit/SKILL.md) | `/veracity-audit audit --config <config> --quality-config <quality-config> --pipeline-dir <pipeline-dir> --scoring-dir <scoring-dir>` | Audit a data pipeline for veracity and value    |
 
 See [CLAUDE.md](./CLAUDE.md) for the global rules this installs.
 

--- a/README.md
+++ b/README.md
@@ -64,61 +64,64 @@ or `dotclaude sync --help` for full options.
 
 ### What you get
 
-26 skills and commands are wired into every Claude Code session:
+30 skills and commands are wired into every Claude Code session:
 
-**Cloud & IaC specialists** — activate automatically when you mention the relevant technology:
+**Cloud, IaC & Container specialists** — activate automatically when you mention the relevant technology:
 
-| Skill                   | Triggers on                                     | What it does                                                           |
-| ----------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
-| `aws-specialist`        | "AWS", "IAM role", "Lambda", "ECS", "S3"…       | Deep-dive AWS architecture review, IAM audits, multi-service debugging |
-| `azure-specialist`      | "Azure", "AKS", "Managed Identity", "Bicep"…    | Azure workload review, identity audits, ARM/Bicep guidance             |
-| `gcp-specialist`        | "GCP", "GKE", "Cloud Run", "Workload Identity"… | GCP architecture review, IAM hierarchy, serverless guidance            |
-| `kubernetes-specialist` | "kubernetes", "k8s", "pod", "helm chart"…       | Cluster troubleshooting, workload design, network policy review        |
-| `crossplane-specialist` | "Crossplane", "XRD", "Composition", "Claim"…    | XRD design, Composition correctness, provider config audit             |
-| `terraform-specialist`  | "Terraform", "state file", "IaC module"…        | Module design, state management, workspace review                      |
-| `terragrunt-specialist` | "Terragrunt", "run-all", "DRY Terraform"…       | DRY hierarchy review, dependency graph, env layout                     |
-| `pulumi-specialist`     | "Pulumi", "ComponentResource", "stack"…         | Stack review, Automation API audit, secrets management                 |
+| Skill / Agent                                                          | Triggers on                                     | What it does                                                           |
+| ---------------------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
+| [`aws-specialist`](skills/aws-specialist/SKILL.md)                     | "AWS", "IAM role", "Lambda", "ECS", "S3"…       | Deep-dive AWS architecture review, IAM audits, multi-service debugging |
+| [`azure-specialist`](skills/azure-specialist/SKILL.md)                 | "Azure", "AKS", "Managed Identity", "Bicep"…    | Azure workload review, identity audits, ARM/Bicep guidance             |
+| [`gcp-specialist`](skills/gcp-specialist/SKILL.md)                     | "GCP", "GKE", "Cloud Run", "Workload Identity"… | GCP architecture review, IAM hierarchy, serverless guidance            |
+| [`kubernetes-specialist`](skills/kubernetes-specialist/SKILL.md)       | "kubernetes", "k8s", "pod", "helm chart"…       | Cluster troubleshooting, workload design, network policy review        |
+| [`crossplane-specialist`](skills/crossplane-specialist/SKILL.md)       | "Crossplane", "XRD", "Composition", "Claim"…    | XRD design, Composition correctness, provider config audit             |
+| [`terraform-specialist`](skills/terraform-specialist/SKILL.md)         | "Terraform", "state file", "IaC module"…        | Module design, state management, workspace review                      |
+| [`terragrunt-specialist`](skills/terragrunt-specialist/SKILL.md)       | "Terragrunt", "run-all", "DRY Terraform"…       | DRY hierarchy review, dependency graph, env layout                     |
+| [`pulumi-specialist`](skills/pulumi-specialist/SKILL.md)               | "Pulumi", "ComponentResource", "stack"…         | Stack review, Automation API audit, secrets management                 |
+| [`docker-engineer`](agents/docker-engineer.md)                         | "docker compose", "docker exec", "container logs", "docker stats"… | Multi-service Compose orchestration, runtime container ops, supply chain analysis |
 
 **Engineering workflow** — slash commands:
 
-| Command            | Invoke                         | What it does                                                                                                      |
-| ------------------ | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `git`              | `/git`                         | Conventional commits, PR creation, branch naming                                                                  |
-| `changelog`        | `/changelog`                   | Generate changelog entry from git history                                                                         |
-| `merge-pr`         | `/merge-pr <N>`                | Full local verification gate before merge                                                                         |
-| `pre-pr`           | `/pre-pr [base-branch]`        | Quality gate before opening a PR: simplify, security-review, test suite                                           |
-| `review-pr`        | `/review-pr <N>`               | Fetch comments, apply fixes, resolve threads                                                                      |
-| `review-prs`       | `/review-prs <N1> [N2 N3 ...]` | Batch-review multiple PRs in parallel with one sub-agent per PR                                                   |
-| `audit-and-fix`    | `/audit-and-fix <domain>`      | Audit → cluster findings → spawn parallel fix PRs                                                                 |
-| `dependabot-sweep` | `/dependabot-sweep`            | Batch-triage all open Dependabot PRs                                                                              |
-| `handoff`          | `/handoff <sub-command>`       | Transfer session context between AI agents (Claude Code, Copilot CLI, Codex) and across machines via GitHub Gists |
+| Command                                              | Invoke                         | What it does                                                                                                      |
+| ---------------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| [`git`](commands/git.md)                             | `/git`                         | Conventional commits, PR creation, branch naming                                                                  |
+| [`changelog`](commands/changelog.md)                 | `/changelog`                   | Generate changelog entry from git history                                                                         |
+| [`merge-pr`](commands/merge-pr.md)                   | `/merge-pr <N>`                | Full local verification gate before merge                                                                         |
+| [`pre-pr`](commands/pre-pr.md) ¹                     | `/pre-pr [base-branch]`        | Quality gate before opening a PR: simplify, security-review, test suite                                           |
+| [`review-pr`](commands/review-pr.md)                 | `/review-pr <N>`               | Fetch comments, apply fixes, resolve threads                                                                      |
+| [`review-prs`](commands/review-prs.md) ¹             | `/review-prs <N1> [N2 N3 ...]` | Batch-review multiple PRs in parallel with one sub-agent per PR                                                   |
+| [`audit-and-fix`](commands/audit-and-fix.md)         | `/audit-and-fix <domain>`      | Audit → cluster findings → spawn parallel fix PRs                                                                 |
+| [`dependabot-sweep`](commands/dependabot-sweep.md)   | `/dependabot-sweep`            | Batch-triage all open Dependabot PRs                                                                              |
+| [`handoff`](skills/handoff/SKILL.md)                 | `/handoff <sub-command>`       | Transfer session context between AI agents (Claude Code, Copilot CLI, Codex) and across machines via GitHub Gists |
+
+> ¹ `maturity: draft` — functional but not yet tested across all project types.
 
 **Debugging & quality:**
 
-| Command             | Invoke                       | What it does                                   |
-| ------------------- | ---------------------------- | ---------------------------------------------- |
-| `ground-first`      | `/ground-first <subject>`    | Code-grounded analysis before any edit         |
-| `fix-with-evidence` | `/fix-with-evidence <issue>` | Reproduce → Fix → Verify → PR loop             |
-| `detect-flaky`      | `/detect-flaky <test-cmd>`   | Find and fix flaky tests by repeated execution |
-| `security-review`   | `/security-review`           | Scan changed files for OWASP vulnerabilities   |
+| Command                                                  | Invoke                       | What it does                                   |
+| -------------------------------------------------------- | ---------------------------- | ---------------------------------------------- |
+| [`ground-first`](commands/ground-first.md)               | `/ground-first <subject>`    | Code-grounded analysis before any edit         |
+| [`fix-with-evidence`](commands/fix-with-evidence.md)     | `/fix-with-evidence <issue>` | Reproduce → Fix → Verify → PR loop             |
+| [`detect-flaky`](commands/detect-flaky.md)               | `/detect-flaky <test-cmd>`   | Find and fix flaky tests by repeated execution |
+| [`security-review`](commands/security-review.md)         | `/security-review`           | Scan changed files for OWASP vulnerabilities   |
 
 **Analysis & documentation:**
 
-| Command             | Invoke                         | What it does                                              |
-| ------------------- | ------------------------------ | --------------------------------------------------------- |
-| `create-audit`      | `/create-audit <subject>`      | Evidence-based audit doc → `docs/audits/`                 |
-| `create-inspection` | `/create-inspection <problem>` | Investigate and surface fix options → `docs/inspections/` |
-| `create-assessment` | `/create-assessment <target>`  | 0–10 graded assessment doc → `docs/assessments/`          |
-| `markdown`          | `/markdown <path>`             | Fix markdown formatting and structure                     |
+| Command                                                    | Invoke                         | What it does                                              |
+| ---------------------------------------------------------- | ------------------------------ | --------------------------------------------------------- |
+| [`create-audit`](commands/create-audit.md)                 | `/create-audit <subject>`      | Evidence-based audit doc → `docs/audits/`                 |
+| [`create-inspection`](commands/create-inspection.md)       | `/create-inspection <problem>` | Investigate and surface fix options → `docs/inspections/` |
+| [`create-assessment`](commands/create-assessment.md)       | `/create-assessment <target>`  | 0–10 graded assessment doc → `docs/assessments/`          |
+| [`markdown`](commands/markdown.md)                         | `/markdown <path>`             | Fix markdown formatting and structure                     |
 
 **Spec & governance:**
 
-| Command / Skill  | Invoke                                                                                                                                | What it does                                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `spec`           | `/spec <id> "<title>"`                                                                                                                | Interactive spec authoring → `docs/specs/`      |
-| `validate-spec`  | `/validate-spec <id>`                                                                                                                 | Audit an implemented spec against the codebase  |
-| `agents-search`  | `/agents-search list`                                                                                                                 | Discover, search, and manage Claude Code agents |
-| `veracity-audit` | `/veracity-audit audit --config <config> --quality-config <quality-config> --pipeline-dir <pipeline-dir> --scoring-dir <scoring-dir>` | Audit a data pipeline for veracity and value    |
+| Command / Skill                                          | Invoke                                                                                                                                | What it does                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| [`spec`](skills/spec/SKILL.md)                           | `/spec <id> "<title>"`                                                                                                                | Interactive spec authoring → `docs/specs/`      |
+| [`validate-spec`](skills/validate-spec/SKILL.md)         | `/validate-spec <id>`                                                                                                                 | Audit an implemented spec against the codebase  |
+| [`agents-search`](skills/agents-search/SKILL.md)         | `/agents-search list`                                                                                                                 | Discover, search, and manage Claude Code agents |
+| [`veracity-audit`](skills/veracity-audit/SKILL.md)       | `/veracity-audit audit --config <config> --quality-config <quality-config> --pipeline-dir <pipeline-dir> --scoring-dir <scoring-dir>` | Audit a data pipeline for veracity and value    |
 
 See [CLAUDE.md](./CLAUDE.md) for the global rules this installs.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,5 +1,7 @@
 # Node API reference
 
+_Last updated: v0.5.0_
+
 The public contract lives at `plugins/dotclaude/src/index.mjs` — import from
 the package root, not deep paths:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Architecture
 
+_Last updated: v0.5.0_
+
 ## Layers
 
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,8 @@
 # CLI reference
 
-Every bin honors the **harness-wide flag set** in addition to its own:
+_Last updated: v0.5.0_
+
+Every bin honors the **dotclaude-wide flag set** in addition to its own:
 
 | Flag                    | Shape | Behavior                                                                           |
 | ----------------------- | ----- | ---------------------------------------------------------------------------------- |
@@ -24,6 +26,7 @@ Every bin honors the **harness-wide flag set** in addition to its own:
 **The umbrella `dotclaude`** forwards to each `dotclaude-<sub>` bin:
 
 ```
+# Governance validators
 dotclaude validate-specs [OPTIONS]
 dotclaude validate-skills [OPTIONS]
 dotclaude check-spec-coverage [OPTIONS]
@@ -31,6 +34,16 @@ dotclaude check-instruction-drift [OPTIONS]
 dotclaude detect-drift [OPTIONS]
 dotclaude doctor [OPTIONS]
 dotclaude init [OPTIONS]
+
+# Installation lifecycle (added v0.4.0)
+dotclaude bootstrap [OPTIONS]
+dotclaude sync <pull|push|status> [OPTIONS]
+
+# Taxonomy discovery (added v0.4.0)
+dotclaude index [OPTIONS]
+dotclaude search <query> [OPTIONS]
+dotclaude list [OPTIONS]
+dotclaude show <id> [OPTIONS]
 ```
 
 Each subcommand also exists standalone — `npx dotclaude-doctor` and
@@ -180,3 +193,157 @@ bash plugins/dotclaude/scripts/validate-settings.sh --json <path>
 ```
 
 `--json` emits `{events:[{check,category,status,message}], counts:{fail,warn}}`.
+
+---
+
+## `dotclaude-bootstrap` _(added v0.4.0)_
+
+Set up or refresh `~/.claude/` by symlinking `commands/`, `skills/`, and
+`CLAUDE.md` from the dotclaude source, and copying agent templates into
+`~/.claude/agents/`. Idempotent — safe to re-run after pulling new commits.
+Pre-existing real files (not symlinks) are backed up to `<name>.bak-<timestamp>`.
+
+> **Platform note:** Windows is not supported (symlinks require elevated
+> permissions). Use WSL or run `bootstrap.sh` from Git Bash instead.
+
+| Flag               | Default      |                                                  |
+| ------------------ | ------------ | ------------------------------------------------ |
+| `--source <path>`  | npm install  | Path to a local dotclaude git clone (clone mode) |
+| `--target <dir>`   | `~/.claude`  | Override destination directory                   |
+| `--quiet`          | false        | Suppress per-file progress; print summary only   |
+
+**Typical invocations:**
+
+```bash
+dotclaude bootstrap
+dotclaude bootstrap --source ~/projects/dotclaude   # clone mode
+dotclaude bootstrap --quiet
+```
+
+**Returns** a summary with counts: `{linked, skipped, backed_up}`.
+
+---
+
+## `dotclaude-sync` _(added v0.4.0)_
+
+Pull, push, or check status for a dotclaude installation. Works in two modes:
+**npm mode** (default — installed globally via npm) or **clone mode** (local
+git checkout, activated with `--source`).
+
+| Flag              | Default     |                                          |
+| ----------------- | ----------- | ---------------------------------------- |
+| `--source <path>` | npm install | Path to a local dotclaude git clone      |
+| `--quiet`         | false       | Suppress per-file progress               |
+
+**Subcommands:**
+
+| Subcommand | Description |
+|------------|-------------|
+| `pull` | npm mode: fetch latest from registry and re-bootstrap. Clone mode: `git fetch` + `git rebase origin/main` + re-bootstrap. Defaults to `pull` if no subcommand given. |
+| `push` | Clone mode only: secret-scan staged files, commit, and push to origin. Set `HARNESS_SYNC_SKIP_SECRET_SCAN=1` to bypass the scan. |
+| `status` | npm mode: print current version. Clone mode: `git status --short`. |
+
+**Typical invocations:**
+
+```bash
+dotclaude sync pull            # update to latest
+dotclaude sync status          # check installed version
+dotclaude sync push            # commit + push local changes (clone mode)
+```
+
+---
+
+## `dotclaude-index` _(added v0.4.0)_
+
+Rebuild the taxonomy index (`index/artifacts.json`, `index/by-type.json`,
+`index/by-facet.json`) from authored artifacts in `agents/`, `skills/`,
+`commands/`, `hooks/`, and `templates/`. Required before `search`, `list`,
+and `show` can operate.
+
+| Flag                 | Default          |                                              |
+| -------------------- | ---------------- | -------------------------------------------- |
+| `--repo-root <path>` | resolved via git | Override repo root                           |
+| `--check`            | false            | Verify index is fresh without writing (CI)   |
+| `--strict`           | false            | Fail on schema validation warnings           |
+
+**Typical invocations:**
+
+```bash
+dotclaude index                    # rebuild
+dotclaude index --check            # CI freshness gate — exit 1 if stale
+dotclaude index --strict           # fail on any warning
+```
+
+**Emitted codes** (when `--check` fails): `INDEX_STALE`.
+
+---
+
+## `dotclaude-search` _(added v0.4.0)_
+
+Full-text search over the taxonomy index by name, id, and description.
+Requires `dotclaude index` to have been run at least once.
+
+| Flag                 | Default          |                                              |
+| -------------------- | ---------------- | -------------------------------------------- |
+| `--repo-root <path>` | resolved via git | Override repo root                           |
+| `--type <type>`      | —                | Filter to one artifact type (agent, skill, command, …) |
+
+**Typical invocations:**
+
+```bash
+dotclaude search kubernetes
+dotclaude search "IaC module" --type skill
+dotclaude search aws --json | jq -r '.[] | .id'
+```
+
+Searches are case-insensitive. Exit 2 if the index is missing.
+
+---
+
+## `dotclaude-list` _(added v0.4.0)_
+
+List all artifacts from the taxonomy index with optional facet filters.
+Requires `dotclaude index` to have been run at least once.
+
+| Flag                    | Default          |                              |
+| ----------------------- | ---------------- | ---------------------------- |
+| `--repo-root <path>`    | resolved via git | Override repo root           |
+| `--type <type>`         | —                | Filter by artifact type      |
+| `--domain <domain>`     | —                | Filter by domain facet       |
+| `--platform <platform>` | —                | Filter by platform facet     |
+| `--task <task>`         | —                | Filter by task facet         |
+| `--maturity <maturity>` | —                | Filter by maturity level     |
+
+All filters are optional; omitting them lists everything. Multiple filters
+combine with AND logic.
+
+**Typical invocations:**
+
+```bash
+dotclaude list
+dotclaude list --type command
+dotclaude list --domain devex --maturity validated
+dotclaude list --json | jq -r '.[].id'
+```
+
+---
+
+## `dotclaude-show` _(added v0.4.0)_
+
+Display detailed metadata for a single artifact by its id. When a skill and
+agent share an id, use `--type` to disambiguate.
+
+| Flag                 | Default          |                                              |
+| -------------------- | ---------------- | -------------------------------------------- |
+| `--repo-root <path>` | resolved via git | Override repo root                           |
+| `--type <type>`      | —                | Force type when multiple artifacts share an id |
+
+**Typical invocations:**
+
+```bash
+dotclaude show aws-specialist
+dotclaude show review-pr --type command
+dotclaude show pre-pr --json
+```
+
+Exit 1 if the artifact is not found. Exit 2 if the index is missing.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -239,7 +239,7 @@ git checkout, activated with `--source`).
 
 | Subcommand | Description |
 |------------|-------------|
-| `pull` | npm mode: fetch latest from registry and re-bootstrap. Clone mode: `git fetch` + `git rebase origin/main` + re-bootstrap. Defaults to `pull` if no subcommand given. |
+| `pull` | npm mode: fetch latest from registry and re-bootstrap. Clone mode: `git fetch` + `git rebase origin/main` + re-bootstrap. |
 | `push` | Clone mode only: secret-scan staged files, commit, and push to origin. Set `HARNESS_SYNC_SKIP_SECRET_SCAN=1` to bypass the scan. |
 | `status` | npm mode: print current version. Clone mode: `git status --short`. |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -206,11 +206,11 @@ Pre-existing real files (not symlinks) are backed up to `<name>.bak-<timestamp>`
 > **Platform note:** Windows is not supported (symlinks require elevated
 > permissions). Use WSL or run `bootstrap.sh` from Git Bash instead.
 
-| Flag               | Default      |                                                  |
-| ------------------ | ------------ | ------------------------------------------------ |
-| `--source <path>`  | npm install  | Path to a local dotclaude git clone (clone mode) |
-| `--target <dir>`   | `~/.claude`  | Override destination directory                   |
-| `--quiet`          | false        | Suppress per-file progress; print summary only   |
+| Flag              | Default     |                                                  |
+| ----------------- | ----------- | ------------------------------------------------ |
+| `--source <path>` | npm install | Path to a local dotclaude git clone (clone mode) |
+| `--target <dir>`  | `~/.claude` | Override destination directory                   |
+| `--quiet`         | false       | Suppress per-file progress; print summary only   |
 
 **Typical invocations:**
 
@@ -230,18 +230,18 @@ Pull, push, or check status for a dotclaude installation. Works in two modes:
 **npm mode** (default — installed globally via npm) or **clone mode** (local
 git checkout, activated with `--source`).
 
-| Flag              | Default     |                                          |
-| ----------------- | ----------- | ---------------------------------------- |
-| `--source <path>` | npm install | Path to a local dotclaude git clone      |
-| `--quiet`         | false       | Suppress per-file progress               |
+| Flag              | Default     |                                     |
+| ----------------- | ----------- | ----------------------------------- |
+| `--source <path>` | npm install | Path to a local dotclaude git clone |
+| `--quiet`         | false       | Suppress per-file progress          |
 
 **Subcommands:**
 
-| Subcommand | Description |
-|------------|-------------|
-| `pull` | npm mode: fetch latest from registry and re-bootstrap. Clone mode: `git fetch` + `git rebase origin/main` + re-bootstrap. |
-| `push` | Clone mode only: secret-scan staged files, commit, and push to origin. Set `HARNESS_SYNC_SKIP_SECRET_SCAN=1` to bypass the scan. |
-| `status` | npm mode: print current version. Clone mode: `git status --short`. |
+| Subcommand | Description                                                                                                                      |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `pull`     | npm mode: fetch latest from registry and re-bootstrap. Clone mode: `git fetch` + `git rebase origin/main` + re-bootstrap.        |
+| `push`     | Clone mode only: secret-scan staged files, commit, and push to origin. Set `HARNESS_SYNC_SKIP_SECRET_SCAN=1` to bypass the scan. |
+| `status`   | npm mode: print current version. Clone mode: `git status --short`.                                                               |
 
 **Typical invocations:**
 
@@ -260,11 +260,11 @@ Rebuild the taxonomy index (`index/artifacts.json`, `index/by-type.json`,
 `commands/`, `hooks/`, and `templates/`. Required before `search`, `list`,
 and `show` can operate.
 
-| Flag                 | Default          |                                              |
-| -------------------- | ---------------- | -------------------------------------------- |
-| `--repo-root <path>` | resolved via git | Override repo root                           |
-| `--check`            | false            | Verify index is fresh without writing (CI)   |
-| `--strict`           | false            | Fail on schema validation warnings           |
+| Flag                 | Default          |                                            |
+| -------------------- | ---------------- | ------------------------------------------ |
+| `--repo-root <path>` | resolved via git | Override repo root                         |
+| `--check`            | false            | Verify index is fresh without writing (CI) |
+| `--strict`           | false            | Fail on schema validation warnings         |
 
 **Typical invocations:**
 
@@ -283,9 +283,9 @@ dotclaude index --strict           # fail on any warning
 Full-text search over the taxonomy index by name, id, and description.
 Requires `dotclaude index` to have been run at least once.
 
-| Flag                 | Default          |                                              |
-| -------------------- | ---------------- | -------------------------------------------- |
-| `--repo-root <path>` | resolved via git | Override repo root                           |
+| Flag                 | Default          |                                                        |
+| -------------------- | ---------------- | ------------------------------------------------------ |
+| `--repo-root <path>` | resolved via git | Override repo root                                     |
 | `--type <type>`      | —                | Filter to one artifact type (agent, skill, command, …) |
 
 **Typical invocations:**
@@ -305,14 +305,14 @@ Searches are case-insensitive. Exit 2 if the index is missing.
 List all artifacts from the taxonomy index with optional facet filters.
 Requires `dotclaude index` to have been run at least once.
 
-| Flag                    | Default          |                              |
-| ----------------------- | ---------------- | ---------------------------- |
-| `--repo-root <path>`    | resolved via git | Override repo root           |
-| `--type <type>`         | —                | Filter by artifact type      |
-| `--domain <domain>`     | —                | Filter by domain facet       |
-| `--platform <platform>` | —                | Filter by platform facet     |
-| `--task <task>`         | —                | Filter by task facet         |
-| `--maturity <maturity>` | —                | Filter by maturity level     |
+| Flag                    | Default          |                          |
+| ----------------------- | ---------------- | ------------------------ |
+| `--repo-root <path>`    | resolved via git | Override repo root       |
+| `--type <type>`         | —                | Filter by artifact type  |
+| `--domain <domain>`     | —                | Filter by domain facet   |
+| `--platform <platform>` | —                | Filter by platform facet |
+| `--task <task>`         | —                | Filter by task facet     |
+| `--maturity <maturity>` | —                | Filter by maturity level |
 
 All filters are optional; omitting them lists everything. Multiple filters
 combine with AND logic.
@@ -333,9 +333,9 @@ dotclaude list --json | jq -r '.[].id'
 Display detailed metadata for a single artifact by its id. When a skill and
 agent share an id, use `--type` to disambiguate.
 
-| Flag                 | Default          |                                              |
-| -------------------- | ---------------- | -------------------------------------------- |
-| `--repo-root <path>` | resolved via git | Override repo root                           |
+| Flag                 | Default          |                                                |
+| -------------------- | ---------------- | ---------------------------------------------- |
+| `--repo-root <path>` | resolved via git | Override repo root                             |
 | `--type <type>`      | —                | Force type when multiple artifacts share an id |
 
 **Typical invocations:**

--- a/docs/dotfile-quickstart.md
+++ b/docs/dotfile-quickstart.md
@@ -160,13 +160,13 @@ after a pull the new version is live — but the running session cached the old 
 
 ## What gets symlinked
 
-| `~/.claude/` path        | Source                                       |
-| ------------------------ | -------------------------------------------- |
-| `CLAUDE.md`              | `CLAUDE.md` (global rules for all sessions)  |
-| `commands/*.md`          | `commands/*.md` (all slash commands)         |
-| `skills/*/`              | `skills/*/` (all skill directories)          |
-| `hooks/*.sh`             | `plugins/dotclaude/hooks/*.sh`               |
-| `agents/*.md` (copied)   | `plugins/dotclaude/templates/claude/agents/` |
+| `~/.claude/` path      | Source                                       |
+| ---------------------- | -------------------------------------------- |
+| `CLAUDE.md`            | `CLAUDE.md` (global rules for all sessions)  |
+| `commands/*.md`        | `commands/*.md` (all slash commands)         |
+| `skills/*/`            | `skills/*/` (all skill directories)          |
+| `hooks/*.sh`           | `plugins/dotclaude/hooks/*.sh`               |
+| `agents/*.md` (copied) | `plugins/dotclaude/templates/claude/agents/` |
 
 > Agents are **copied**, not symlinked — Claude Code resolves agent paths at startup
 > and needs real files, not symlinks, on some platforms.

--- a/docs/dotfile-quickstart.md
+++ b/docs/dotfile-quickstart.md
@@ -1,5 +1,7 @@
 # Dotfile quickstart — skills & commands in every Claude Code session
 
+_Last updated: v0.5.0_
+
 Bootstrap dotclaude into `~/.claude/` in under 30 seconds. No npm, no Node required.
 
 **Who this is for:** anyone who wants `/pre-pr`, `/dependabot-sweep`, `/review-prs`,
@@ -15,8 +17,9 @@ git clone https://github.com/kaiohenricunha/dotclaude.git ~/projects/dotclaude
 cd ~/projects/dotclaude
 ```
 
-> **Windows:** symlinks require elevated permissions. Use WSL or Git Bash, or install
-> via npm and run `dotclaude bootstrap` instead (see [quickstart.md](./quickstart.md)).
+> **Windows:** symlinks require elevated permissions. Use WSL (where the CLI works),
+> or run `./bootstrap.sh` from Git Bash instead of using `dotclaude bootstrap`
+> natively on Windows.
 
 ## 2. Bootstrap
 

--- a/docs/dotfile-quickstart.md
+++ b/docs/dotfile-quickstart.md
@@ -1,0 +1,177 @@
+# Dotfile quickstart — skills & commands in every Claude Code session
+
+Bootstrap dotclaude into `~/.claude/` in under 30 seconds. No npm, no Node required.
+
+**Who this is for:** anyone who wants `/pre-pr`, `/dependabot-sweep`, `/review-prs`,
+cloud/IaC specialists, and the full commands library available in every project they
+open in Claude Code. You manage it like any dotfile — pull to update, push to sync.
+
+---
+
+## 1. Clone
+
+```bash
+git clone https://github.com/kaiohenricunha/dotclaude.git ~/projects/dotclaude
+cd ~/projects/dotclaude
+```
+
+> **Windows:** symlinks require elevated permissions. Use WSL or Git Bash, or install
+> via npm and run `dotclaude bootstrap` instead (see [quickstart.md](./quickstart.md)).
+
+## 2. Bootstrap
+
+```bash
+./bootstrap.sh
+```
+
+This symlinks `commands/`, `skills/`, and `CLAUDE.md` into `~/.claude/`, and copies
+agent templates into `~/.claude/agents/`. Idempotent — safe to re-run anytime.
+
+Expected output:
+
+```
+✓ CLAUDE.md
+✓ commands/git.md
+✓ commands/pre-pr.md
+...
+✓ skills/aws-specialist/
+...
+bootstrap complete — 29 items linked, 0 skipped, 0 backed up
+Run 'dotclaude-doctor' to verify the install.
+```
+
+Pre-existing real files (not symlinks) are backed up to `<name>.bak-<timestamp>` before
+being replaced.
+
+## 3. Verify
+
+If `dotclaude` is on your PATH (it is if you installed via npm globally):
+
+```bash
+dotclaude-doctor
+```
+
+Otherwise, open any repo in Claude Code and type:
+
+```
+/git
+```
+
+If Claude Code loads the skill and starts the git workflow, the bootstrap worked.
+
+## 4. Try your first command
+
+Open any repo in Claude Code. The full library is now available:
+
+```
+# Read code before touching it — always grounded
+/ground-first <subject>
+
+# Fix a bug with a full evidence loop
+/fix-with-evidence <issue>
+
+# Gate your PR before opening it
+/pre-pr
+
+# Batch-triage all open Dependabot PRs
+/dependabot-sweep
+
+# Transfer your session to another machine or AI
+/handoff push claude latest
+```
+
+Cloud/IaC specialists activate automatically — just mention the technology:
+
+```
+Review the IAM policies in this repo.
+# → aws-specialist activates automatically
+
+Help me debug this Kubernetes pod restart loop.
+# → kubernetes-specialist activates automatically
+```
+
+## 5. Stay current
+
+```bash
+# Pull latest dotclaude and re-bootstrap ~/.claude/ in one command
+./sync.sh pull
+# or, if dotclaude is on PATH:
+dotclaude sync pull
+```
+
+Check what version you're on:
+
+```bash
+./sync.sh status
+# or:
+dotclaude sync status
+```
+
+## 6. Push your customizations (optional)
+
+If you've edited commands or skills locally and want to push them back:
+
+```bash
+./sync.sh push
+# or:
+dotclaude sync push
+```
+
+The push runs a secret scan before committing — it refuses files containing
+`*_KEY`/`*_TOKEN`/`*_SECRET` patterns or AWS keys. Set
+`HARNESS_SYNC_SKIP_SECRET_SCAN=1` to bypass if needed.
+
+---
+
+## Troubleshooting
+
+**A skill or command isn't available in Claude Code.**
+
+Check that the symlink exists:
+
+```bash
+ls -la ~/.claude/commands/pre-pr.md
+ls -la ~/.claude/skills/aws-specialist/
+```
+
+If missing, re-run `./bootstrap.sh`. If the symlink exists but the skill isn't loading,
+restart the Claude Code session (`/clear` or quit and reopen).
+
+**`bootstrap.sh` says "backed up N files".**
+
+That's expected on first run if you had existing files in `~/.claude/`. The originals
+are preserved as `<name>.bak-<timestamp>`. Review them before deleting.
+
+**You see `command not found: dotclaude-doctor`.**
+
+`dotclaude-doctor` is part of the npm package, not the bootstrap path. It's optional.
+To get it: `npm install -g @dotclaude/dotclaude`. Or just open Claude Code and verify
+the commands load by trying `/git` or `/ground-first`.
+
+**A skill was updated upstream but your session still runs the old version.**
+
+Run `./sync.sh pull` then restart the Claude Code session. Skills are symlinked, so
+after a pull the new version is live — but the running session cached the old one.
+
+---
+
+## What gets symlinked
+
+| `~/.claude/` path        | Source                                       |
+| ------------------------ | -------------------------------------------- |
+| `CLAUDE.md`              | `CLAUDE.md` (global rules for all sessions)  |
+| `commands/*.md`          | `commands/*.md` (all slash commands)         |
+| `skills/*/`              | `skills/*/` (all skill directories)          |
+| `hooks/*.sh`             | `plugins/dotclaude/hooks/*.sh`               |
+| `agents/*.md` (copied)   | `plugins/dotclaude/templates/claude/agents/` |
+
+> Agents are **copied**, not symlinked — Claude Code resolves agent paths at startup
+> and needs real files, not symlinks, on some platforms.
+
+---
+
+## Next
+
+- [docs/index.md](./index.md) — full docs nav
+- [CLAUDE.md](../CLAUDE.md) — the global rules installed by bootstrap
+- [cli-reference.md](./cli-reference.md) — `dotclaude bootstrap`, `sync`, and all CLI subcommands

--- a/docs/facet-definitions.md
+++ b/docs/facet-definitions.md
@@ -1,5 +1,7 @@
 # Facet Definitions
 
+_Last updated: v0.5.0_
+
 Canonical definitions for every enum value in `schemas/facets.schema.json`.
 When adding a new value, update this file in the same PR and include one
 example artifact that uses it (governance rule).

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,5 +1,7 @@
 # dotclaude Taxonomy Governance
 
+_Last updated: v0.5.0_
+
 ## Ownership
 
 `schemas/`, `docs/taxonomy.md`, `docs/facet-definitions.md`, and `docs/governance.md` are owned by the core maintainer group (see `.github/CODEOWNERS`). All other artifacts are community-editable.

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -12,16 +12,16 @@ machines. Nine sub-commands, three transports, one scrubbed digest.
 
 ## When to use it
 
-| Situation                                                | Sub-command                    |
-| -------------------------------------------------------- | ------------------------------ |
-| Continue a Claude Code session in Codex                  | `digest` → paste-in            |
-| Pick up the same work on a different laptop              | `push` (machine A) → `pull` (machine B) |
-| Persist the handoff to a markdown file for later         | `file`                         |
-| Inspect a session's purpose without loading it           | `describe`                     |
-| Find an old session by topic                             | `search "k8s networking"`      |
-| List recent sessions                                     | `list claude`                  |
-| Check what's waiting for you on the transport            | `remote-list`                  |
-| Diagnose why `push`/`pull` isn't working                 | `doctor`                       |
+| Situation                                        | Sub-command                             |
+| ------------------------------------------------ | --------------------------------------- |
+| Continue a Claude Code session in Codex          | `digest` → paste-in                     |
+| Pick up the same work on a different laptop      | `push` (machine A) → `pull` (machine B) |
+| Persist the handoff to a markdown file for later | `file`                                  |
+| Inspect a session's purpose without loading it   | `describe`                              |
+| Find an old session by topic                     | `search "k8s networking"`               |
+| List recent sessions                             | `list claude`                           |
+| Check what's waiting for you on the transport    | `remote-list`                           |
+| Diagnose why `push`/`pull` isn't working         | `doctor`                                |
 
 ---
 
@@ -34,6 +34,7 @@ machines. Nine sub-commands, three transports, one scrubbed digest.
 ```
 
 This:
+
 1. Loads the most recent Claude Code session transcript.
 2. Runs a secret-scrubbing pass (eight token patterns — bearer, AWS key, etc.).
 3. Voices the digest for the target agent (Codex in this case).
@@ -54,11 +55,11 @@ digest, and lists any follow-up prompts.
 
 Three transports, picked with `--via`:
 
-| Transport       | Flag                   | Requirements                                                      | When to use                         |
-| --------------- | ---------------------- | ----------------------------------------------------------------- | ----------------------------------- |
-| GitHub (default)| `--via github`         | `gh` CLI on PATH, authenticated with `gist` scope                 | Default — works on most hosts       |
-| Token-based     | `--via gist-token`     | `curl` + `DOTCLAUDE_GH_TOKEN` PAT with `gist` scope                | Hosts where `gh` isn't installable  |
-| Raw git         | `--via git-fallback`   | `git` + `DOTCLAUDE_HANDOFF_REPO` pointing at a private repo       | Corporate hosts where GitHub API is blocked |
+| Transport        | Flag                 | Requirements                                                | When to use                                 |
+| ---------------- | -------------------- | ----------------------------------------------------------- | ------------------------------------------- |
+| GitHub (default) | `--via github`       | `gh` CLI on PATH, authenticated with `gist` scope           | Default — works on most hosts               |
+| Token-based      | `--via gist-token`   | `curl` + `DOTCLAUDE_GH_TOKEN` PAT with `gist` scope         | Hosts where `gh` isn't installable          |
+| Raw git          | `--via git-fallback` | `git` + `DOTCLAUDE_HANDOFF_REPO` pointing at a private repo | Corporate hosts where GitHub API is blocked |
 
 Run `/handoff doctor --via <transport>` to verify prerequisites and get a
 platform-specific remediation block.
@@ -67,17 +68,17 @@ platform-specific remediation block.
 
 ## Sub-commands at a glance
 
-| Sub-command       | Positional args         | Flags                                           |
-| ----------------- | ----------------------- | ----------------------------------------------- |
-| `describe`        | `<cli> <uuid\|latest>`  | `--to`                                          |
-| `digest`          | `<cli> <uuid\|latest>`  | `--to`                                          |
-| `file`            | `<cli> <uuid\|latest>`  | `--to`                                          |
-| `list`            | `<cli>`                 | `--limit`, `--since`                            |
-| `search`          | `<query>`               | `--cli`, `--limit`, `--since`                   |
-| `push`            | `<cli> <uuid\|latest>`  | `--to`, `--via`, `--include-transcript`, `--tag`|
-| `pull`            | `<handle\|latest>`      | `--to`, `--via`, `--from-file`                  |
-| `remote-list`     | —                       | `--via`, `--limit`, `--since`                   |
-| `doctor`          | —                       | `--via`                                         |
+| Sub-command   | Positional args        | Flags                                            |
+| ------------- | ---------------------- | ------------------------------------------------ |
+| `describe`    | `<cli> <uuid\|latest>` | `--to`                                           |
+| `digest`      | `<cli> <uuid\|latest>` | `--to`                                           |
+| `file`        | `<cli> <uuid\|latest>` | `--to`                                           |
+| `list`        | `<cli>`                | `--limit`, `--since`                             |
+| `search`      | `<query>`              | `--cli`, `--limit`, `--since`                    |
+| `push`        | `<cli> <uuid\|latest>` | `--to`, `--via`, `--include-transcript`, `--tag` |
+| `pull`        | `<handle\|latest>`     | `--to`, `--via`, `--from-file`                   |
+| `remote-list` | —                      | `--via`, `--limit`, `--since`                    |
+| `doctor`      | —                      | `--via`                                          |
 
 Full argument semantics live in [`skills/handoff/SKILL.md`](../skills/handoff/SKILL.md).
 

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -1,0 +1,137 @@
+# Handoff guide — cross-CLI, cross-machine session transfer
+
+_Last updated: v0.5.0_
+
+> **Added in v0.5.0.** Full skill reference: [`skills/handoff/SKILL.md`](../skills/handoff/SKILL.md).
+
+The `/handoff` skill moves live session context from one agentic CLI to another —
+Claude Code, GitHub Copilot CLI, OpenAI Codex CLI — on the same machine or across
+machines. Nine sub-commands, three transports, one scrubbed digest.
+
+---
+
+## When to use it
+
+| Situation                                                | Sub-command                    |
+| -------------------------------------------------------- | ------------------------------ |
+| Continue a Claude Code session in Codex                  | `digest` → paste-in            |
+| Pick up the same work on a different laptop              | `push` (machine A) → `pull` (machine B) |
+| Persist the handoff to a markdown file for later         | `file`                         |
+| Inspect a session's purpose without loading it           | `describe`                     |
+| Find an old session by topic                             | `search "k8s networking"`      |
+| List recent sessions                                     | `list claude`                  |
+| Check what's waiting for you on the transport            | `remote-list`                  |
+| Diagnose why `push`/`pull` isn't working                 | `doctor`                       |
+
+---
+
+## Quick start — machine-to-machine handoff
+
+**On machine A** (Windows/WSL, inside a Claude Code session):
+
+```
+/handoff push claude latest --to codex --tag "finishing auth refactor"
+```
+
+This:
+1. Loads the most recent Claude Code session transcript.
+2. Runs a secret-scrubbing pass (eight token patterns — bearer, AWS key, etc.).
+3. Voices the digest for the target agent (Codex in this case).
+4. Uploads as a private GitHub Gist via `gh gist`.
+
+**On machine B** (Linux/macOS, inside Codex CLI):
+
+```
+/handoff pull latest --to codex
+```
+
+This pulls the most recent handoff addressed to Codex, prints the paste-ready
+digest, and lists any follow-up prompts.
+
+---
+
+## Transports
+
+Three transports, picked with `--via`:
+
+| Transport       | Flag                   | Requirements                                                      | When to use                         |
+| --------------- | ---------------------- | ----------------------------------------------------------------- | ----------------------------------- |
+| GitHub (default)| `--via github`         | `gh` CLI on PATH, authenticated with `gist` scope                 | Default — works on most hosts       |
+| Token-based     | `--via gist-token`     | `curl` + `DOTCLAUDE_GH_TOKEN` PAT with `gist` scope                | Hosts where `gh` isn't installable  |
+| Raw git         | `--via git-fallback`   | `git` + `DOTCLAUDE_HANDOFF_REPO` pointing at a private repo       | Corporate hosts where GitHub API is blocked |
+
+Run `/handoff doctor --via <transport>` to verify prerequisites and get a
+platform-specific remediation block.
+
+---
+
+## Sub-commands at a glance
+
+| Sub-command       | Positional args         | Flags                                           |
+| ----------------- | ----------------------- | ----------------------------------------------- |
+| `describe`        | `<cli> <uuid\|latest>`  | `--to`                                          |
+| `digest`          | `<cli> <uuid\|latest>`  | `--to`                                          |
+| `file`            | `<cli> <uuid\|latest>`  | `--to`                                          |
+| `list`            | `<cli>`                 | `--limit`, `--since`                            |
+| `search`          | `<query>`               | `--cli`, `--limit`, `--since`                   |
+| `push`            | `<cli> <uuid\|latest>`  | `--to`, `--via`, `--include-transcript`, `--tag`|
+| `pull`            | `<handle\|latest>`      | `--to`, `--via`, `--from-file`                  |
+| `remote-list`     | —                       | `--via`, `--limit`, `--since`                   |
+| `doctor`          | —                       | `--via`                                         |
+
+Full argument semantics live in [`skills/handoff/SKILL.md`](../skills/handoff/SKILL.md).
+
+---
+
+## Common patterns
+
+**Persist important context as a markdown file:**
+
+```
+/handoff file claude latest --to claude
+# writes to docs/handoffs/<date>-<topic>.md
+```
+
+**Recover context after `/clear`:**
+
+```
+/handoff search "auth middleware" --cli claude --since 2026-04-01
+/handoff describe claude <uuid-from-search>
+```
+
+**Scheduled remote handoff** (e.g. running as a /loop or cron):
+
+```
+/handoff push claude latest --to claude --via github --tag "nightly checkpoint"
+```
+
+---
+
+## Secrets & privacy
+
+- **Push-side scrubbing**: eight secret patterns (AWS access keys, bearer tokens,
+  `*_KEY`/`*_TOKEN`/`*_SECRET` with 20+ char values, PAT prefixes) are stripped
+  before upload.
+- **Gists are private by default** (`gh gist create` without `--public`). Do not
+  add `--public`.
+- **`--include-transcript` is opt-in** — uploading raw turns increases secret
+  leakage blast radius. Off by default.
+- The skill never invokes another CLI itself — it produces the digest and hands
+  you a paste-ready block. This is deliberate: it keeps the transfer auditable
+  and prevents unintended cross-session execution.
+
+---
+
+## Troubleshooting
+
+See [troubleshooting.md — skills & commands](./troubleshooting.md#skills--commands-dotfile-users).
+For transport-specific failures, start with:
+
+```
+/handoff doctor --via github
+/handoff doctor --via gist-token
+/handoff doctor --via git-fallback
+```
+
+Each prints a platform-specific remediation block with the exact commands to fix
+the failure mode it detected.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,15 +9,15 @@ validator, and a destructive-git PreToolUse hook.
 
 ## Start here
 
-| If you are…                                       | Read                                                                               |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Setting up skills & commands in `~/.claude/`      | [dotfile-quickstart.md](./dotfile-quickstart.md) — 30 seconds, no npm required    |
-| A consumer evaluating the plugin                  | [quickstart.md](./quickstart.md) — 5 minutes from install to first green validator |
-| Integrating the library in CI                     | [cli-reference.md](./cli-reference.md) and the `--json` payload examples           |
-| Importing the Node API                            | [api-reference.md](./api-reference.md)                                             |
-| Debugging a validator failure                     | [troubleshooting.md](./troubleshooting.md) (indexed by `ERROR_CODES`)              |
-| Upgrading or forking                              | [upgrade-guide.md](./upgrade-guide.md)                                             |
-| Contributing                                      | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                           |
+| If you are…                                  | Read                                                                               |
+| -------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Setting up skills & commands in `~/.claude/` | [dotfile-quickstart.md](./dotfile-quickstart.md) — 30 seconds, no npm required     |
+| A consumer evaluating the plugin             | [quickstart.md](./quickstart.md) — 5 minutes from install to first green validator |
+| Integrating the library in CI                | [cli-reference.md](./cli-reference.md) and the `--json` payload examples           |
+| Importing the Node API                       | [api-reference.md](./api-reference.md)                                             |
+| Debugging a validator failure                | [troubleshooting.md](./troubleshooting.md) (indexed by `ERROR_CODES`)              |
+| Upgrading or forking                         | [upgrade-guide.md](./upgrade-guide.md)                                             |
+| Contributing                                 | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                           |
 
 ## Deeper references
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,25 +1,29 @@
 # `@dotclaude/dotclaude` — docs
 
-The harness is a portable npm package + Claude Code plugin that bootstraps
+_Last updated: v0.5.0_
+
+dotclaude is a portable npm package + Claude Code plugin that bootstraps
 spec-driven-development governance into consumer repos. It ships a
 zero-dependency Node API, an umbrella CLI, a gold-standard shell settings
 validator, and a destructive-git PreToolUse hook.
 
 ## Start here
 
-| If you are…                      | Read                                                                               |
-| -------------------------------- | ---------------------------------------------------------------------------------- |
-| A consumer evaluating the plugin | [quickstart.md](./quickstart.md) — 5 minutes from install to first green validator |
-| Integrating the library in CI    | [cli-reference.md](./cli-reference.md) and the `--json` payload examples           |
-| Importing the Node API           | [api-reference.md](./api-reference.md)                                             |
-| Debugging a validator failure    | [troubleshooting.md](./troubleshooting.md) (indexed by `ERROR_CODES`)              |
-| Upgrading or forking             | [upgrade-guide.md](./upgrade-guide.md)                                             |
-| Contributing                     | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                           |
+| If you are…                                       | Read                                                                               |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Setting up skills & commands in `~/.claude/`      | [dotfile-quickstart.md](./dotfile-quickstart.md) — 30 seconds, no npm required    |
+| A consumer evaluating the plugin                  | [quickstart.md](./quickstart.md) — 5 minutes from install to first green validator |
+| Integrating the library in CI                     | [cli-reference.md](./cli-reference.md) and the `--json` payload examples           |
+| Importing the Node API                            | [api-reference.md](./api-reference.md)                                             |
+| Debugging a validator failure                     | [troubleshooting.md](./troubleshooting.md) (indexed by `ERROR_CODES`)              |
+| Upgrading or forking                              | [upgrade-guide.md](./upgrade-guide.md)                                             |
+| Contributing                                      | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                           |
 
 ## Deeper references
 
 - [architecture.md](./architecture.md) — layer diagram + PR-time coverage check sequence
 - [personas.md](./personas.md) — consumer vs dotfile user vs contributor entry-point matrix
+- [handoff-guide.md](./handoff-guide.md) — cross-CLI, cross-machine session transfer (v0.5.0+)
 - [adr/](./adr/) — architectural decision records (one per load-bearing decision)
 - [specs/dotclaude-core/](./specs/dotclaude-core/) — the canonical spec this repo governs itself with
 
@@ -27,7 +31,7 @@ validator, and a destructive-git PreToolUse hook.
 
 - **Structured-error contract.** Every validator emits `ValidationError`
   instances with stable `.code` values (see [troubleshooting.md](./troubleshooting.md)).
-- **Umbrella CLI + standalone bins.** `harness validate-specs` or
+- **Umbrella CLI + standalone bins.** `dotclaude validate-specs` or
   `dotclaude-validate-specs` — both exist, same behavior.
 - **Universal flags.** `--help`, `--version`, `--json`, `--verbose`,
   `--no-color` on every bin.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,5 +1,7 @@
 # Personas — who reads which file
 
+_Last updated: v0.5.0_
+
 This repo is a dual-purpose checkout. Three distinct audiences consume
 parts of it. Pick yours, then follow the "Start here" column.
 
@@ -7,7 +9,7 @@ parts of it. Pick yours, then follow the "Start here" column.
 | ----------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------- |
 | **Consumer** — installing the plugin to govern your own repo      | Install, scaffold, run validators, wire CI                 | [quickstart.md](./quickstart.md) → [cli-reference.md](./cli-reference.md) |
 | **Library user** — importing the Node API into your own tooling   | Import, typed signatures, error codes                      | [api-reference.md](./api-reference.md)                                    |
-| **Dotfile user** — personal Claude Code config via `bootstrap.sh` | Symlink into `~/.claude/`, manage your own commands/skills | [../CLAUDE.md](../CLAUDE.md) + [../bootstrap.sh](../bootstrap.sh)         |
+| **Dotfile user** — personal Claude Code config via `bootstrap.sh` | Symlink into `~/.claude/`, manage your own commands/skills | [dotfile-quickstart.md](./dotfile-quickstart.md) — start here, then [../CLAUDE.md](../CLAUDE.md) for the full rules |
 | **Contributor** — sending PRs to this repo                        | Dev workflow, local gates, spec discipline                 | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                  |
 | **Security researcher**                                           | Private disclosure, threat model                           | [../SECURITY.md](../SECURITY.md)                                          |
 

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -5,13 +5,13 @@ _Last updated: v0.5.0_
 This repo is a dual-purpose checkout. Three distinct audiences consume
 parts of it. Pick yours, then follow the "Start here" column.
 
-| Persona                                                           | What you want                                              | Start here                                                                |
-| ----------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------- |
-| **Consumer** — installing the plugin to govern your own repo      | Install, scaffold, run validators, wire CI                 | [quickstart.md](./quickstart.md) → [cli-reference.md](./cli-reference.md) |
-| **Library user** — importing the Node API into your own tooling   | Import, typed signatures, error codes                      | [api-reference.md](./api-reference.md)                                    |
+| Persona                                                           | What you want                                              | Start here                                                                                                          |
+| ----------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Consumer** — installing the plugin to govern your own repo      | Install, scaffold, run validators, wire CI                 | [quickstart.md](./quickstart.md) → [cli-reference.md](./cli-reference.md)                                           |
+| **Library user** — importing the Node API into your own tooling   | Import, typed signatures, error codes                      | [api-reference.md](./api-reference.md)                                                                              |
 | **Dotfile user** — personal Claude Code config via `bootstrap.sh` | Symlink into `~/.claude/`, manage your own commands/skills | [dotfile-quickstart.md](./dotfile-quickstart.md) — start here, then [../CLAUDE.md](../CLAUDE.md) for the full rules |
-| **Contributor** — sending PRs to this repo                        | Dev workflow, local gates, spec discipline                 | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                  |
-| **Security researcher**                                           | Private disclosure, threat model                           | [../SECURITY.md](../SECURITY.md)                                          |
+| **Contributor** — sending PRs to this repo                        | Dev workflow, local gates, spec discipline                 | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                                                            |
+| **Security researcher**                                           | Private disclosure, threat model                           | [../SECURITY.md](../SECURITY.md)                                                                                    |
 
 ## Where the split happens
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,17 @@
-# Quickstart — install to first green validator in under 10 minutes
+# Quickstart
+
+_Last updated: v0.5.0_
+
+**Two paths — pick yours:**
+
+| I want…                                               | Path                                                                              |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Skills & commands in every Claude Code session        | **[Dotfile bootstrap](./dotfile-quickstart.md)** — 30 seconds, no npm required   |
+| Spec-governance CLI and CI gates for my own repo      | **This page** — 10 minutes, Node ≥ 20 required                                   |
+
+---
+
+## CLI consumer — install to first green validator in under 10 minutes
 
 ## 1. Install
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ _Last updated: v0.5.0_
 
 ## CLI consumer — install to first green validator in under 10 minutes
 
-## 1. Install
+### 1. Install
 
 ```bash
 cd your-project
@@ -34,7 +34,7 @@ dotclaude-check-spec-coverage
 dotclaude-check-instruction-drift
 ```
 
-## 2. Scaffold the governance tree
+### 2. Scaffold the governance tree
 
 ```bash
 npx dotclaude-init --project-name your-project --project-type node
@@ -51,7 +51,7 @@ This writes:
 Every placeholder (`{{project_name}}`, `{{project_type}}`, `{{today}}`) is
 substituted at scaffold time.
 
-## 3. Run the self-diagnostic
+### 3. Run the self-diagnostic
 
 ```bash
 npx dotclaude-doctor
@@ -61,7 +61,7 @@ You should see `✓` rows for env, repo, facts, manifest, specs, drift, hook.
 The first run may warn about missing artifacts (e.g. `docs/specs/` empty) —
 that's expected until you draft your first spec.
 
-## 4. Your first spec
+### 4. Your first spec
 
 Use the `/spec` skill (if you're in a Claude Code session) or scaffold
 manually:
@@ -95,7 +95,7 @@ npx dotclaude-validate-specs
 
 Green. You're done.
 
-## 5. Wire the PR gate
+### 5. Wire the PR gate
 
 In GitHub branch protection, require the three shipped workflows:
 
@@ -107,7 +107,7 @@ Any PR touching a protected path (see `docs/repo-facts.json`) must now carry
 a `Spec ID:` or `## No-spec rationale` section. `dotclaude-check-spec-coverage`
 enforces it.
 
-## Next
+### Next
 
 - [cli-reference.md](./cli-reference.md) — every flag, exit code, `--json` schema.
 - [troubleshooting.md](./troubleshooting.md) — look up any failing `ERROR_CODE`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,10 +4,10 @@ _Last updated: v0.5.0_
 
 **Two paths — pick yours:**
 
-| I want…                                               | Path                                                                              |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Skills & commands in every Claude Code session        | **[Dotfile bootstrap](./dotfile-quickstart.md)** — 30 seconds, no npm required   |
-| Spec-governance CLI and CI gates for my own repo      | **This page** — 10 minutes, Node ≥ 20 required                                   |
+| I want…                                          | Path                                                                           |
+| ------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Skills & commands in every Claude Code session   | **[Dotfile bootstrap](./dotfile-quickstart.md)** — 30 seconds, no npm required |
+| Spec-governance CLI and CI gates for my own repo | **This page** — 10 minutes, Node ≥ 20 required                                 |
 
 ---
 

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -1,5 +1,7 @@
 # dotclaude Taxonomy
 
+_Last updated: v0.5.0_
+
 The dotclaude taxonomy organizes every artifact (agents, skills, commands, hooks, templates) by **type** (flat directory) and **facets** (YAML frontmatter). This avoids the placement ambiguity of domain-first hierarchies and lets the generated index serve any faceted query.
 
 ## Why type-first?

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,5 +1,7 @@
 # Template catalog
 
+_Last updated: v0.5.0_
+
 Every file under `plugins/dotclaude/templates/` is written verbatim into a
 consumer repo by `dotclaude-init`, with `{{placeholder}}` tokens substituted
 at scaffold time.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,7 @@
 # Troubleshooting
 
+_Last updated: v0.5.0_
+
 Indexed by `ERROR_CODES`. When a validator fails, look up the `.code` value
 from its `ValidationError` here.
 
@@ -179,3 +181,64 @@ An unknown flag was passed. Exit 64. **Fix**: see `--help`.
 ### `USAGE_MISSING_POSITIONAL`
 
 A required positional argument is missing. Exit 64. **Fix**: see `--help`.
+
+---
+
+## Skills & commands (dotfile users)
+
+These issues apply when using the bootstrap path (`./bootstrap.sh`) rather than
+the npm CLI. They are not `ERROR_CODES` — they are runtime observations.
+
+### A skill or command isn't available in Claude Code
+
+**Check the symlink exists:**
+
+```bash
+ls -la ~/.claude/commands/pre-pr.md
+ls -la ~/.claude/skills/aws-specialist/SKILL.md
+```
+
+If missing: re-run `./bootstrap.sh`. If present: restart the Claude Code session
+(`/clear` or quit and reopen) — the session may have cached the pre-bootstrap state.
+
+### A skill runs but uses outdated behavior
+
+The session cached an older version. Run `./sync.sh pull` (or `dotclaude sync pull`)
+to fetch the latest, then restart the session.
+
+### A specialist skill doesn't auto-activate
+
+Specialist skills (e.g. `aws-specialist`) activate when their trigger phrases appear
+in your message. Ensure the phrase matches — e.g. write "AWS Lambda" not just
+"lambda". If still not triggering, check that the skill's `SKILL.md` is present:
+
+```bash
+ls ~/.claude/skills/aws-specialist/SKILL.md
+```
+
+### `bootstrap.sh` backed up files I didn't expect
+
+Bootstrap backs up any real file (not a symlink) at a target path before replacing
+it. Backups are named `<name>.bak-<timestamp>`. Review them before deleting. This
+is intentional — bootstrap never silently overwrites your existing work.
+
+### `sync push` refuses with "secret scan failed"
+
+The push-side scan detected a likely secret (`*_KEY`/`*_TOKEN`/`*_SECRET` pattern
+or AWS key format). Review the flagged file and remove the secret. To bypass for
+a known-safe file (e.g. a test fixture with a fake key):
+
+```bash
+HARNESS_SYNC_SKIP_SECRET_SCAN=1 ./sync.sh push
+```
+
+### Taxonomy commands (`search`, `list`, `show`) return "index missing"
+
+Run `dotclaude index` first to build the artifact index. The index is generated
+from `agents/`, `skills/`, `commands/`, etc. and must be rebuilt after adding or
+renaming artifacts.
+
+```bash
+dotclaude index
+dotclaude search kubernetes
+```

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,5 +1,7 @@
 # Upgrade guide
 
+_Last updated: v0.5.0_
+
 ## 0.1.x → 0.2.0
 
 `0.1.x` was never published to npm — it was the local development skeleton.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "lint": "prettier --check \"**/*.{json,yml,yaml,md}\" --ignore-path .gitignore --ignore-unknown && markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.claude/worktrees\" && node scripts/check-jsdoc-coverage.mjs plugins/dotclaude/src",
     "format": "prettier --write \"**/*.{json,yml,yaml,md}\" --ignore-path .gitignore --ignore-unknown",
     "shellcheck": "shellcheck -x bootstrap.sh sync.sh plugins/dotclaude/scripts/*.sh plugins/dotclaude/hooks/*.sh plugins/dotclaude/tests/*.sh plugins/dotclaude/templates/claude/hooks/*.sh plugins/dotclaude/templates/githooks/pre-commit",
-    "dogfood": "npx dotclaude-validate-skills && npx dotclaude-validate-specs && npx dotclaude-check-instruction-drift && npx dotclaude-check-spec-coverage"
+    "dogfood": "npx dotclaude-validate-skills && npx dotclaude-validate-specs && npx dotclaude-check-instruction-drift && npx dotclaude-check-spec-coverage",
+    "docs:stamp": "node scripts/stamp-doc-versions.mjs",
+    "docs:stamp-check": "node scripts/stamp-doc-versions.mjs --check"
   },
   "files": [
     "commands/",

--- a/scripts/stamp-doc-versions.mjs
+++ b/scripts/stamp-doc-versions.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Updates `_Last updated: vX.Y.Z_` stamps in every top-level `docs/*.md` file
+ * to match the current `version` in `package.json`.
+ *
+ * Usage:
+ *   node scripts/stamp-doc-versions.mjs           # rewrite stale stamps
+ *   node scripts/stamp-doc-versions.mjs --check   # exit 1 if any stamp is stale
+ *
+ * Run as part of the release flow (`npm run docs:stamp`) to keep version stamps
+ * in sync with the package version. Wire `--check` into CI to catch stamps that
+ * were not refreshed before a release commit.
+ *
+ * Intentionally dependency-free — mirrors the zero-runtime-deps promise in
+ * `package.json` and ADR-0002.
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+const checkOnly = args.includes("--check");
+
+const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+const version = pkg.version;
+
+const STAMP_RE = /_Last updated: v\d+\.\d+\.\d+_/g;
+const CURRENT_STAMP = `_Last updated: v${version}_`;
+
+const docsDir = join(repoRoot, "docs");
+const mdFiles = readdirSync(docsDir)
+  .filter((f) => f.endsWith(".md"))
+  .map((f) => join(docsDir, f));
+
+let staleCount = 0;
+
+for (const filePath of mdFiles) {
+  const original = readFileSync(filePath, "utf8");
+  const updated = original.replace(STAMP_RE, CURRENT_STAMP);
+
+  if (updated === original) continue;
+
+  staleCount++;
+  const rel = filePath.slice(repoRoot.length + 1);
+
+  if (checkOnly) {
+    process.stderr.write(`stale stamp: ${rel}\n`);
+  } else {
+    writeFileSync(filePath, updated, "utf8");
+    process.stdout.write(`stamped: ${rel}\n`);
+  }
+}
+
+if (checkOnly) {
+  if (staleCount > 0) {
+    process.stderr.write(
+      `\n${staleCount} doc(s) have stale version stamps. Run: npm run docs:stamp\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    `✓ all ${mdFiles.length} docs stamped with v${version}\n`,
+  );
+} else {
+  if (staleCount > 0) {
+    process.stdout.write(`\nstamped ${staleCount} doc(s) with v${version}\n`);
+  } else {
+    process.stdout.write(
+      `✓ all ${mdFiles.length} docs already stamped with v${version}\n`,
+    );
+  }
+}

--- a/scripts/stamp-doc-versions.mjs
+++ b/scripts/stamp-doc-versions.mjs
@@ -37,15 +37,24 @@ const mdFiles = readdirSync(docsDir)
   .map((f) => join(docsDir, f));
 
 let staleCount = 0;
+let missingCount = 0;
 
 for (const filePath of mdFiles) {
   const original = readFileSync(filePath, "utf8");
+  const rel = filePath.slice(repoRoot.length + 1);
+
+  const matches = original.match(STAMP_RE);
+  if (!matches) {
+    missingCount++;
+    process.stderr.write(`missing stamp: ${rel}\n`);
+    continue;
+  }
+
   const updated = original.replace(STAMP_RE, CURRENT_STAMP);
 
   if (updated === original) continue;
 
   staleCount++;
-  const rel = filePath.slice(repoRoot.length + 1);
 
   if (checkOnly) {
     process.stderr.write(`stale stamp: ${rel}\n`);
@@ -56,9 +65,12 @@ for (const filePath of mdFiles) {
 }
 
 if (checkOnly) {
-  if (staleCount > 0) {
+  if (staleCount > 0 || missingCount > 0) {
+    const parts = [];
+    if (staleCount > 0) parts.push(`${staleCount} stale`);
+    if (missingCount > 0) parts.push(`${missingCount} missing`);
     process.stderr.write(
-      `\n${staleCount} doc(s) have stale version stamps. Run: npm run docs:stamp\n`,
+      `\n${parts.join(", ")} stamp(s). Run: npm run docs:stamp (then add missing stamps manually)\n`,
     );
     process.exit(1);
   }
@@ -68,9 +80,14 @@ if (checkOnly) {
 } else {
   if (staleCount > 0) {
     process.stdout.write(`\nstamped ${staleCount} doc(s) with v${version}\n`);
-  } else {
+  } else if (missingCount === 0) {
     process.stdout.write(
       `✓ all ${mdFiles.length} docs already stamped with v${version}\n`,
+    );
+  }
+  if (missingCount > 0) {
+    process.stdout.write(
+      `\n⚠ ${missingCount} doc(s) have no stamp line — add one manually then re-run.\n`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- Closes v0.4–v0.5 documentation coverage gaps identified by `/create-assessment doc-quality` (6.2 → 10/10)
- Adds six missing CLI subcommands to `docs/cli-reference.md`: `bootstrap`, `sync`, `index`, `search`, `list`, `show`
- New `docs/dotfile-quickstart.md` — the bootstrap path users (skills + commands) previously had no guided entry point
- New `docs/handoff-guide.md` — v0.5.0 cross-CLI session transfer reference
- README: adds `docker-engineer` specialist row, source-links all 30 table rows, fixes count 26→30, `maturity: draft` footnote for `/pre-pr` and `/review-prs`
- Fixes three stale "harness" references left over from the v0.3.0 rename (docs/index.md, docs/cli-reference.md)
- `docs/troubleshooting.md` gains a Skills & commands section for dotfile-user runtime scenarios
- `docs/quickstart.md` gets a two-path fork (bootstrap vs npm) at the top
- All top-level `docs/*.md` carry a `_Last updated: vX.Y.Z_` stamp

### Automation (closes the maintenance-drift gap)

- New `scripts/stamp-doc-versions.mjs` — zero-dep Node script that rewrites version stamps from `package.json`; supports `--check` for CI
- `package.json` — adds `docs:stamp` and `docs:stamp-check` scripts
- `CONTRIBUTING.md` — adds a "Releasing a new version" checklist and `npm run docs:stamp-check` to the local gate
- `.github/workflows/dogfood.yml` — adds `docs:stamp-check` CI step so stale stamps cannot land on `main`

### Misc

- `.gitignore` — `docs/assessments/` (local-only graded assessments, per user direction)

## Test plan

- [x] `npm test` — 205/205 passing across 19 test files
- [x] `npm run dogfood` — validate-skills, validate-specs, instruction-drift, spec-coverage all green
- [x] `npm run docs:stamp-check` — all 14 docs stamped with v0.5.0
- [ ] Dogfood workflow green on this PR (new `docs:stamp-check` CI step exercised)
- [ ] Spot-check: every new README table link (30 rows) resolves to a real command/skill/agent file

## No-spec rationale

This PR is documentation-coverage work driven by a `/create-assessment` run
(local-only audit trail at `docs/assessments/doc-quality-2026-04-18.md` —
gitignored per user direction, since assessments are a local grading artifact
rather than a published spec). The protected-path touches (`README.md` and
`.github/workflows/dogfood.yml`) are additive — the `dogfood.yml` change adds
a single new CI step (`docs:stamp-check`) without modifying existing validators.
No new subsystems or behavioral contracts introduced.