### PR TITLE
feat(handoff): shell-scripts-first refactor + dotclaude-handoff binary

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-19T00:05:28.344Z",
+  "generatedAt": "2026-04-19T00:55:05.857Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:d98e070c65407f3fbd959b6f9d42ac60c71c68a2563f7106ff7ee58ccf5d9ce1",
+      "checksum": "sha256:0e7317a96f1fa70cf8608b7e9b343b02f5dfe50d7aa9c182a264c7cfd299c981",
       "dependencies": [],
       "lastValidated": "2026-04-19"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-19T00:55:05.857Z",
+  "generatedAt": "2026-04-19T03:30:38.631Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:0e7317a96f1fa70cf8608b7e9b343b02f5dfe50d7aa9c182a264c7cfd299c981",
+      "checksum": "sha256:0c9fdac092fc09eda2d9258fbc31e4fb7fa9e21434e524cab953af8acacb69ef",
       "dependencies": [],
       "lastValidated": "2026-04-19"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,209 +1,209 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-18T22:03:06.828Z",
+  "generatedAt": "2026-04-19T00:05:28.344Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
       "checksum": "sha256:f7a8fa0598d7925de95ed3829ea677a2df58fa3db93e9ff290944bb686fad7d7",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
       "checksum": "sha256:cf3ac020cd3ce7d8fc11dbf4f5f5a2ffa5e1d6443e60cd10179b564bd77894cc",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
       "checksum": "sha256:cabbf4bfe2deff3a328f15e025dfc0d63369825c0c32574790251f2793e62aeb",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
       "checksum": "sha256:cf987369294337fff90fc62e1d73d235d35055055dc8e4fbfb33a492f7cd38b5",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
       "checksum": "sha256:50573c4199f27083286fdbc3760b2f684105b4a6df39b7cb47094d7c0e5327f7",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
       "checksum": "sha256:3f7b90b69172e29cdcf66713f2708f9741003d05cc12cf9d81ff79ff9c5b692c",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
       "checksum": "sha256:7d888f6964725d82687fb61b68ff961f041f95d2c9eef7b5282061229499ca90",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
       "checksum": "sha256:6ffc091e9bd421798c5b7990f21d095563d69c59c3e2bd10d35b554b3ec225d9",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
       "checksum": "sha256:d0bc84f956c0ee8c176cf76a79374e8defb0bd2487c8340a2e2a1d9e04d8a1cc",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
       "checksum": "sha256:52e610b195a43fdd460106c1bdf56b32803cb86d163a4303274773ea3900bf79",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2dc1c4213ab6650d685e7b2243ddda91fce2ceba224ca3da3951afeb37d12946",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:7f77ded161157a0ea6e5d2d2a1b62d563f9e4a81350569af6f7f866a73b02d0a",
+      "checksum": "sha256:d98e070c65407f3fbd959b6f9d42ac60c71c68a2563f7106ff7ee58ccf5d9ce1",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "review-prs",
       "path": ".claude/commands/review-prs.md",
       "checksum": "sha256:e01a0432cd1a6cf6fe4a60cfc2b02f7cab3cde418062ca85beadc5491548bc71",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:347be395b0f8003816b4f3ed3bb777a63a3f9f7ae300d6f050b499ff66cfd3b0",
       "dependencies": [],
-      "lastValidated": "2026-04-18"
+      "lastValidated": "2026-04-19"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -148,10 +148,11 @@ After `./bootstrap.sh`, open any repo in Claude Code and try:
 /dependabot-sweep
 # → parallel subagents annotate each PR with risk level; safe bumps merged automatically
 
-# Hand off mid-task context from Claude Code to Codex (or another machine)
-/handoff push claude latest --to codex
-# → scrubs secrets, produces a gist; pull on the other end with:
-/handoff pull latest --to codex
+# Hand off mid-task context across CLIs or machines
+/handoff <query>                    # local cross-agent: emit <handoff> block
+/handoff push [<query>] [--tag]     # upload to transport (scrubs secrets)
+/handoff pull [<query>]             # fetch and render on the other end
+# <query> = short UUID, full UUID, 'latest', Claude customTitle, or Codex thread_name
 ```
 
 Every command is context-aware — it reads your repo's files, history, and CI state.

--- a/docs/audits/handoff-remote/README.md
+++ b/docs/audits/handoff-remote/README.md
@@ -1,5 +1,13 @@
 # Handoff remote — audit artifacts
 
+> **UX note.** The invocation examples in this folder predate the
+> five-form public surface landed on the `feat/handoff-shell-refactor`
+> branch (PR #58). Current invocations are `/handoff push [<query>]`
+> and `/handoff pull [<query>]`; the older `/handoff push claude
+latest --to codex` form shown below is superseded. Transport
+> mechanics, secret scrubbing, and the description schema are
+> unchanged. See `skills/handoff/SKILL.md` for the current shape.
+
 This folder holds evidence-of-correctness for the handoff remote
 transport (GitHub-first). It is intentionally inspectable rather
 than prose-claim: reviewers read the artifacts, not the PR body.

--- a/docs/audits/handoff-remote/README.md
+++ b/docs/audits/handoff-remote/README.md
@@ -4,7 +4,7 @@
 > five-form public surface landed on the `feat/handoff-shell-refactor`
 > branch (PR #58). Current invocations are `/handoff push [<query>]`
 > and `/handoff pull [<query>]`; the older `/handoff push claude
-latest --to codex` form shown below is superseded. Transport
+> latest --to codex` form shown below is superseded. Transport
 > mechanics, secret scrubbing, and the description schema are
 > unchanged. See `skills/handoff/SKILL.md` for the current shape.
 

--- a/docs/audits/handoff-remote/README.md
+++ b/docs/audits/handoff-remote/README.md
@@ -3,9 +3,9 @@
 > **UX note.** The invocation examples in this folder predate the
 > five-form public surface landed on the `feat/handoff-shell-refactor`
 > branch (PR #58). Current invocations are `/handoff push [<query>]`
-> and `/handoff pull [<query>]`; the older `/handoff push claude
-> latest --to codex` form shown below is superseded. Transport
-> mechanics, secret scrubbing, and the description schema are
+> and `/handoff pull [<query>]`; the older
+> `/handoff push claude latest --to codex` form shown below is superseded.
+> Transport mechanics, secret scrubbing, and the description schema are
 > unchanged. See `skills/handoff/SKILL.md` for the current shape.
 
 This folder holds evidence-of-correctness for the handoff remote

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -27,27 +27,31 @@ machines. Nine sub-commands, three transports, one scrubbed digest.
 
 ## Quick start — machine-to-machine handoff
 
-**On machine A** (Windows/WSL, inside a Claude Code session):
+**On machine A** (inside any session on Claude, Copilot, or Codex):
 
 ```
-/handoff push claude latest --to codex --tag "finishing auth refactor"
+/handoff push --tag "finishing auth refactor"
 ```
+
+(Zero-arg: pushes the host's latest session. Explicit variant:
+`/handoff push <query> --tag <label>` picks a specific session.)
 
 This:
 
-1. Loads the most recent Claude Code session transcript.
+1. Loads the relevant session transcript.
 2. Runs a secret-scrubbing pass (eight token patterns — bearer, AWS key, etc.).
-3. Voices the digest for the target agent (Codex in this case).
-4. Uploads as a private GitHub Gist via `gh gist`.
+3. Uploads as a private GitHub Gist via `gh gist` (default), or via
+   `--via git-fallback` / `--via gist-token` for restricted environments.
 
-**On machine B** (Linux/macOS, inside Codex CLI):
+**On machine B** (inside any CLI):
 
 ```
-/handoff pull latest --to codex
+/handoff pull finishing-auth-refactor
 ```
 
-This pulls the most recent handoff addressed to Codex, prints the paste-ready
-digest, and lists any follow-up prompts.
+Bare `/handoff pull` fetches the newest handoff; the positional is a
+fuzzy-match query against tag, short UUID, project slug, hostname, or
+CLI name.
 
 ---
 
@@ -66,21 +70,22 @@ platform-specific remediation block.
 
 ---
 
-## Sub-commands at a glance
+## The five forms
 
-| Sub-command   | Positional args        | Flags                                            |
-| ------------- | ---------------------- | ------------------------------------------------ |
-| `describe`    | `<cli> <uuid\|latest>` | `--to`                                           |
-| `digest`      | `<cli> <uuid\|latest>` | `--to`                                           |
-| `file`        | `<cli> <uuid\|latest>` | `--to`                                           |
-| `list`        | `<cli>`                | `--limit`, `--since`                             |
-| `search`      | `<query>`              | `--cli`, `--limit`, `--since`                    |
-| `push`        | `<cli> <uuid\|latest>` | `--to`, `--via`, `--include-transcript`, `--tag` |
-| `pull`        | `<handle\|latest>`     | `--to`, `--via`, `--from-file`                   |
-| `remote-list` | —                      | `--via`, `--limit`, `--since`                    |
-| `doctor`      | —                      | `--via`                                          |
+| Form                  | Behavior                                              |
+| --------------------- | ----------------------------------------------------- |
+| `/handoff`            | Push the host's latest session                        |
+| `/handoff <query>`    | Local cross-agent: emit `<handoff>` block in place    |
+| `/handoff push [<q>]` | Upload to transport; zero-arg = host latest           |
+| `/handoff pull [<q>]` | Fetch from transport; zero-arg = newest gist          |
+| `/handoff list`       | Unified local + remote table (`--local` / `--remote`) |
 
-Full argument semantics live in [`skills/handoff/SKILL.md`](../skills/handoff/SKILL.md).
+Every `<query>` can be a full UUID, short UUID (first 8 hex), `latest`,
+a Claude `customTitle`, or a Codex `thread_name`.
+
+Power-user sub-commands (`resolve`, `describe`, `digest`, `file`) stay
+reachable for scripting — each takes an explicit `<cli>` `<id>`. Full
+argument semantics live in [`skills/handoff/SKILL.md`](../skills/handoff/SKILL.md).
 
 ---
 
@@ -89,21 +94,21 @@ Full argument semantics live in [`skills/handoff/SKILL.md`](../skills/handoff/SK
 **Persist important context as a markdown file:**
 
 ```
-/handoff file claude latest --to claude
-# writes to docs/handoffs/<date>-<topic>.md
+/handoff file claude latest
+# writes to docs/handoffs/<date>-<origin>-<short-id>.md
 ```
 
 **Recover context after `/clear`:**
 
 ```
 /handoff search "auth middleware" --cli claude --since 2026-04-01
-/handoff describe claude <uuid-from-search>
+/handoff <uuid-from-search>      # bare <query> form drops the block in place
 ```
 
 **Scheduled remote handoff** (e.g. running as a /loop or cron):
 
 ```
-/handoff push claude latest --to claude --via github --tag "nightly checkpoint"
+/handoff push --via github --tag "nightly checkpoint"
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "dotclaude-index": "./plugins/dotclaude/bin/dotclaude-index.mjs",
     "dotclaude-search": "./plugins/dotclaude/bin/dotclaude-search.mjs",
     "dotclaude-list": "./plugins/dotclaude/bin/dotclaude-list.mjs",
-    "dotclaude-show": "./plugins/dotclaude/bin/dotclaude-show.mjs"
+    "dotclaude-show": "./plugins/dotclaude/bin/dotclaude-show.mjs",
+    "dotclaude-handoff": "./plugins/dotclaude/bin/dotclaude-handoff.mjs"
   },
   "scripts": {
     "build-plugin": "node scripts/build-plugin.mjs",

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -26,7 +26,7 @@ import { version } from "../src/index.mjs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve as resolvePath } from "node:path";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
 
 const SUBCOMMANDS = new Set(["resolve", "describe", "digest", "list", "file"]);
 const CLIS = new Set(["claude", "copilot", "codex"]);
@@ -77,29 +77,26 @@ function extractMeta(cli, file) {
   }
 }
 
-function extractPrompts(cli, file) {
-  const r = runScript(EXTRACT_SH, ["prompts", cli, file]);
-  if (r.status !== 0) return [];
+function extractLines(sub, cli, file, extra = []) {
+  const r = runScript(EXTRACT_SH, [sub, cli, file, ...extra]);
+  if (r.status !== 0) {
+    if (r.stderr.trim()) process.stderr.write(`dotclaude-handoff: ${sub}: ${r.stderr.trim()}\n`);
+    return [];
+  }
   return r.stdout.split("\n").filter((line) => line.trim().length > 0);
 }
 
-function extractTurns(cli, file, limit) {
-  const args = ["turns", cli, file];
-  if (limit) args.push(String(limit));
-  const r = runScript(EXTRACT_SH, args);
-  if (r.status !== 0) return [];
-  return r.stdout.split("\n").filter((line) => line.trim().length > 0);
-}
+const extractPrompts = (cli, file) => extractLines("prompts", cli, file);
+const extractTurns = (cli, file, limit) =>
+  extractLines("turns", cli, file, limit ? [String(limit)] : []);
 
 function nextStepFor(toCli) {
-  // The LLM on the target side will re-summarize; this is a mechanical cue.
   if (toCli === "codex") {
     return "Read the prompts and assistant turns above, then continue the task using the file paths mentioned. Treat this as a task specification.";
   }
   if (toCli === "copilot") {
     return "Help me pick up where this session left off; reference the prompts and findings above.";
   }
-  // claude (default)
   return "Continue from the last assistant turn using the same file scope and goals summarized above.";
 }
 
@@ -176,51 +173,72 @@ function renderHandoffBlock(meta, prompts, turns, toCli) {
   return lines.join("\n");
 }
 
+const UUID_HEAD_RE = /([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+
+const CLI_LAYOUTS = {
+  claude: {
+    root: (home) => join(home, ".claude", "projects"),
+    // ~/.claude/projects/<slug>/<uuid>.jsonl — one level deep.
+    walk: 1,
+    match: (name) => name.endsWith(".jsonl"),
+  },
+  copilot: {
+    root: (home) => join(home, ".copilot", "session-state"),
+    // ~/.copilot/session-state/<uuid>/events.jsonl — one level deep.
+    walk: 1,
+    match: (name) => name === "events.jsonl",
+  },
+  codex: {
+    root: (home) => join(home, ".codex", "sessions"),
+    // ~/.codex/sessions/YYYY/MM/DD/rollout-…-<uuid>.jsonl — three levels deep.
+    walk: 3,
+    match: (name) => name.startsWith("rollout-") && name.endsWith(".jsonl"),
+  },
+};
+
+function collectSessionFiles(root, walk, match) {
+  const files = [];
+  const recur = (dir, depth) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const ent of entries) {
+      const full = join(dir, ent.name);
+      if (ent.isDirectory()) {
+        if (depth < walk) recur(full, depth + 1);
+      } else if (ent.isFile() && match(ent.name)) {
+        files.push(full);
+      }
+    }
+  };
+  recur(root, 0);
+  return files;
+}
+
 function listSessions(cli) {
-  // Delegate to handoff-resolve.sh's `latest` logic by shelling out to find.
-  // Newest-first per CLI.
-  const home = process.env.HOME ?? "";
-  let roots, pattern;
-  switch (cli) {
-    case "claude":
-      roots = [join(home, ".claude", "projects")];
-      pattern = "*.jsonl";
-      break;
-    case "copilot":
-      roots = [join(home, ".copilot", "session-state")];
-      pattern = "events.jsonl";
-      break;
-    case "codex":
-      roots = [join(home, ".codex", "sessions")];
-      pattern = "rollout-*.jsonl";
-      break;
-    default:
-      fail(EXIT_CODES.USAGE, `unknown cli: ${cli}`);
-  }
-  const root = roots[0];
+  const layout = CLI_LAYOUTS[cli];
+  if (!layout) fail(EXIT_CODES.USAGE, `unknown cli: ${cli}`);
+  const root = layout.root(process.env.HOME ?? "");
   if (!existsSync(root)) return [];
-  const res = spawnSync("sh", [
-    "-c",
-    `find "${root}" ${cli === "claude" ? "-maxdepth 2" : ""} -type f -name '${pattern}' 2>/dev/null | xargs -I{} sh -c 'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' | sort -rn | head -50`,
-  ], { encoding: "utf8" });
+
   const rows = [];
-  for (const line of (res.stdout ?? "").split("\n")) {
-    if (!line.trim()) continue;
-    const spaceIdx = line.indexOf(" ");
-    if (spaceIdx < 0) continue;
-    const mtime = parseInt(line.slice(0, spaceIdx), 10);
-    const file = line.slice(spaceIdx + 1);
-    // Derive short_id from path.
-    let shortId = "?";
-    const m =
-      cli === "claude" ? file.match(/\/([0-9a-f]{8})-[0-9a-f]{4}-/) :
-      cli === "copilot" ? file.match(/\/([0-9a-f]{8})-[0-9a-f]{4}-/) :
-      /* codex */         file.match(/-([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/);
-    if (m) shortId = m[1];
+  for (const file of collectSessionFiles(root, layout.walk, layout.match)) {
+    let mtime;
+    try {
+      mtime = statSync(file).mtimeMs / 1000;
+    } catch {
+      continue;
+    }
+    const m = file.match(UUID_HEAD_RE);
+    const shortId = m ? m[1] : "?";
     const when = new Date(mtime * 1000).toISOString().replace("T", " ").slice(0, 16);
     rows.push({ cli, short_id: shortId, file, mtime, when });
   }
-  return rows;
+  rows.sort((a, b) => b.mtime - a.mtime);
+  return rows.slice(0, 50);
 }
 
 // ---- main ---------------------------------------------------------------
@@ -241,10 +259,7 @@ if (argv.version) {
   process.exit(EXIT_CODES.OK);
 }
 
-// Bare form: `dotclaude-handoff <cli> <id>` is implicit `digest`.
-// If positional[0] is a known CLI name, shift it into the sub-command
-// slot and default sub-command to "digest". Otherwise the existing
-// sub-command dispatch runs.
+// Bare form `dotclaude-handoff <cli> <id>` is implicit `digest`.
 let sub, cli, id;
 if (argv.positional.length >= 1 && CLIS.has(argv.positional[0])) {
   sub = "digest";
@@ -261,6 +276,9 @@ if (argv.positional.length >= 1 && CLIS.has(argv.positional[0])) {
 
 const toCli = argv.flags.to ?? "claude";
 if (!CLIS.has(toCli)) fail(EXIT_CODES.USAGE, `--to must be one of: claude, copilot, codex`);
+
+const limit = argv.flags.limit ?? "20";
+if (!/^\d+$/.test(limit)) fail(EXIT_CODES.USAGE, `--limit must be a non-negative integer, got: ${limit}`);
 
 if (sub === "list") {
   const rows = listSessions(cli);
@@ -303,7 +321,7 @@ if (sub === "describe") {
   process.exit(EXIT_CODES.OK);
 }
 
-const turns = extractTurns(cli, file, argv.flags.limit ?? "20");
+const turns = extractTurns(cli, file, limit);
 
 if (sub === "digest") {
   process.stdout.write(renderHandoffBlock(meta, prompts, turns, toCli) + "\n");

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -1,21 +1,23 @@
 #!/usr/bin/env node
 /**
- * dotclaude-handoff — read a session transcript and render it as a
- * paste-ready handoff digest.
+ * dotclaude-handoff — five-form cross-agent / cross-machine handoff.
  *
  * Usage:
- *   dotclaude-handoff <subcmd> <cli> <identifier> [--to <cli>] [OPTIONS]
+ *   dotclaude handoff                              push host's latest session
+ *   dotclaude handoff <query>                      local cross-agent: emit <handoff> block
+ *   dotclaude handoff push [<query>] [--tag <label>] [--via <transport>]
+ *   dotclaude handoff pull [<query>] [--via <transport>]
+ *   dotclaude handoff list [--local|--remote] [--via <transport>]
  *
- * Subcommands:
- *   resolve   <cli> <id>              print resolved session file path
- *   describe  <cli> <id>              inline summary (markdown or --json)
- *   digest    <cli> <id> [--to ...]   full <handoff> block for paste
- *   list      <cli>                   newest-first table of sessions
- *   file      <cli> <id> [--to ...]   write markdown handoff doc to disk
+ * Power-user sub-commands (still work):
+ *   resolve   <cli> <id>         print resolved session file path
+ *   describe  <cli> <id>         inline summary (markdown or --json)
+ *   digest    <cli> <id>         full <handoff> block for paste
+ *   file      <cli> <id>         write markdown handoff doc to disk
  *
- * cli:  claude | copilot | codex
- * id:   full UUID, short UUID (first 8 hex), `latest`, or (codex only)
- *       a thread_name alias.
+ * `<query>` resolves across all three CLIs (claude, copilot, codex):
+ * full UUID, short UUID (first 8 hex), `latest`, or a named alias
+ * (Claude customTitle, Codex thread_name).
  *
  * Exits: 0 ok, 2 not-found / runtime error, 64 usage error.
  */
@@ -26,21 +28,37 @@ import { version } from "../src/index.mjs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve as resolvePath } from "node:path";
-import { existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir, hostname } from "node:os";
+import { createInterface } from "node:readline";
 
-const SUBCOMMANDS = new Set(["resolve", "describe", "digest", "list", "file"]);
+const POWER_SUBS = new Set(["resolve", "describe", "digest", "file"]);
 const CLIS = new Set(["claude", "copilot", "codex"]);
+const TRANSPORTS = new Set(["git-fallback", "github"]);
 
 const META = {
   name: "dotclaude-handoff",
   synopsis:
-    "dotclaude-handoff <resolve|describe|digest|list|file> <claude|copilot|codex> [<id>] [--to <cli>]",
+    "dotclaude handoff [<query>|push|pull|list] [<query>] [--tag <label>] [--via <transport>]",
   description:
-    "Read a session transcript from one agentic CLI and render it as a paste-ready handoff digest. Works from any shell, including Codex's bash tool.",
+    "Cross-agent and cross-machine session handoff. Bare <query> emits a <handoff> block for local cross-agent. push/pull/list handle the remote transport.",
   flags: {
+    tag: { type: "string" },
+    via: { type: "string" },
     to: { type: "string" },
     limit: { type: "string" },
     "out-dir": { type: "string" },
+    local: { type: "boolean" },
+    remote: { type: "boolean" },
   },
 };
 
@@ -48,23 +66,98 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPTS = resolvePath(__dirname, "..", "scripts");
 const RESOLVE_SH = join(SCRIPTS, "handoff-resolve.sh");
 const EXTRACT_SH = join(SCRIPTS, "handoff-extract.sh");
+const DESCRIPTION_SH = join(SCRIPTS, "handoff-description.sh");
 
 function fail(code, msg) {
   if (msg) process.stderr.write(`dotclaude-handoff: ${msg}\n`);
   process.exit(code);
 }
 
-function runScript(script, args) {
-  const res = spawnSync(script, args, { encoding: "utf8" });
+function runScript(script, args, opts = {}) {
+  const res = spawnSync(script, args, { encoding: "utf8", ...opts });
   return { status: res.status ?? 2, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
 }
 
-function resolveSession(cli, id) {
-  const r = runScript(RESOLVE_SH, [cli, id]);
+function runGit(args, cwd) {
+  return spawnSync("git", args, { encoding: "utf8", cwd });
+}
+
+function runGitOrThrow(args, cwd) {
+  const r = runGit(args, cwd);
   if (r.status !== 0) {
-    fail(r.status === 64 ? EXIT_CODES.USAGE : 2, r.stderr.trim() || `could not resolve ${cli} ${id}`);
+    throw new Error(`git ${args.join(" ")} failed: ${(r.stderr || r.stdout).trim()}`);
   }
-  return r.stdout.trim();
+  return r;
+}
+
+// ---- resolver / extractor bridge ---------------------------------------
+
+/**
+ * @typedef {{cli: string, sessionId: string, path: string, query: string}} Candidate
+ */
+
+/**
+ * Call `handoff-resolve.sh any <query>`. Handles the collision contract:
+ *   - 0 hits: exits 2 (bubble up)
+ *   - 1 hit:  returns {cli, path}
+ *   - >1 hit: on TTY prompt the user to pick; non-TTY emits candidates
+ *             and exits 2.
+ *
+ * @param {string} query
+ * @returns {Promise<{cli: string, path: string}>}
+ */
+async function resolveAny(query) {
+  const r = runScript(RESOLVE_SH, ["any", query]);
+  if (r.status === 0) {
+    const path = r.stdout.trim();
+    const cli = cliFromPath(path);
+    return { cli, path };
+  }
+  // status != 0. If stderr begins with "multiple sessions match", it is a
+  // collision. Otherwise it's "no session matches" or an env error.
+  const stderr = r.stderr;
+  if (!stderr.includes("multiple sessions match")) {
+    fail(r.status === 64 ? EXIT_CODES.USAGE : 2, stderr.trim() || `no session matches: ${query}`);
+  }
+  // Parse candidate TSV lines (4 fields: cli\tsid\tpath\tquery).
+  const candidates = [];
+  for (const line of stderr.split("\n")) {
+    const parts = line.split("\t");
+    if (parts.length === 4) {
+      candidates.push({ cli: parts[0], sessionId: parts[1], path: parts[2], query: parts[3] });
+    }
+  }
+  if (process.stdin.isTTY) {
+    return await promptCollisionChoice(query, candidates);
+  }
+  // Non-TTY: pass through the script's stderr and exit 2.
+  process.stderr.write(stderr);
+  process.exit(2);
+}
+
+async function promptCollisionChoice(query, candidates) {
+  process.stderr.write(`dotclaude-handoff: multiple sessions match "${query}":\n`);
+  candidates.forEach((c, i) => {
+    process.stderr.write(`  [${i + 1}] ${c.cli.padEnd(8)} ${c.sessionId}  ${c.path}\n`);
+  });
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  const ans = await new Promise((resolve) => {
+    rl.question("Pick [1..N], or any other input to abort: ", resolve);
+  });
+  rl.close();
+  const n = Number.parseInt(ans.trim(), 10);
+  if (!Number.isInteger(n) || n < 1 || n > candidates.length) {
+    process.exit(2);
+  }
+  const chosen = candidates[n - 1];
+  return { cli: chosen.cli, path: chosen.path };
+}
+
+function cliFromPath(path) {
+  if (path.includes("/.claude/projects/")) return "claude";
+  if (path.includes("/.copilot/session-state/")) return "copilot";
+  if (path.includes("/.codex/sessions/")) return "codex";
+  return "claude";
 }
 
 function extractMeta(cli, file) {
@@ -89,6 +182,8 @@ function extractLines(sub, cli, file, extra = []) {
 const extractPrompts = (cli, file) => extractLines("prompts", cli, file);
 const extractTurns = (cli, file, limit) =>
   extractLines("turns", cli, file, limit ? [String(limit)] : []);
+
+// ---- rendering ---------------------------------------------------------
 
 function nextStepFor(toCli) {
   if (toCli === "codex") {
@@ -116,17 +211,9 @@ function renderDescribeMarkdown(meta, prompts) {
   lines.push("**User prompts:**");
   lines.push("");
   const toShow = prompts.slice(0, 10);
-  if (toShow.length === 0) {
-    lines.push("- (no user prompts captured)");
-  } else {
-    for (const p of toShow) {
-      const trimmed = p.length > 200 ? `${p.slice(0, 200).trim()}…` : p;
-      lines.push(`- ${trimmed}`);
-    }
-  }
-  if (prompts.length > 10) {
-    lines.push(`- …and ${prompts.length - 10} more (truncated)`);
-  }
+  if (toShow.length === 0) lines.push("- (no user prompts captured)");
+  else for (const p of toShow) lines.push(`- ${p.length > 200 ? `${p.slice(0, 200).trim()}…` : p}`);
+  if (prompts.length > 10) lines.push(`- …and ${prompts.length - 10} more (truncated)`);
   lines.push("");
   lines.push(`**Prompt count:** ${prompts.length}`);
   return lines.join("\n");
@@ -137,7 +224,6 @@ function renderHandoffBlock(meta, prompts, turns, toCli) {
   const promptsCapped = prompts.slice(-10);
   const turnsTail = turns.slice(-3);
   const next = nextStepFor(toCli);
-
   const lines = [];
   lines.push(
     `<handoff origin="${meta.cli}" session="${meta.short_id ?? ""}" cwd="${meta.cwd ?? ""}" target="${toCli}">`
@@ -147,50 +233,45 @@ function renderHandoffBlock(meta, prompts, turns, toCli) {
   lines.push("");
   lines.push("**User prompts (last 10, in order).**");
   lines.push("");
-  if (promptsCapped.length === 0) {
-    lines.push("1. (no user prompts captured)");
-  } else {
+  if (promptsCapped.length === 0) lines.push("1. (no user prompts captured)");
+  else
     promptsCapped.forEach((p, i) => {
       const trimmed = p.length > 300 ? `${p.slice(0, 300).trim()}…` : p;
       lines.push(`${i + 1}. ${trimmed}`);
     });
-  }
   lines.push("");
   lines.push("**Last assistant turns (tail).**");
   lines.push("");
-  if (turnsTail.length === 0) {
-    lines.push("_(no assistant output captured)_");
-  } else {
+  if (turnsTail.length === 0) lines.push("_(no assistant output captured)_");
+  else
     for (const t of turnsTail) {
       const trimmed = t.length > 400 ? `${t.slice(0, 400).trim()}…` : t;
       lines.push(`> ${trimmed.replace(/\n/g, "\n> ")}`);
       lines.push("");
     }
-  }
   lines.push("**Next step.** " + next);
   lines.push("");
   lines.push("</handoff>");
   return lines.join("\n");
 }
 
+// ---- local session enumeration (list --local) --------------------------
+
 const UUID_HEAD_RE = /([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
 const CLI_LAYOUTS = {
   claude: {
     root: (home) => join(home, ".claude", "projects"),
-    // ~/.claude/projects/<slug>/<uuid>.jsonl — one level deep.
     walk: 1,
     match: (name) => name.endsWith(".jsonl"),
   },
   copilot: {
     root: (home) => join(home, ".copilot", "session-state"),
-    // ~/.copilot/session-state/<uuid>/events.jsonl — one level deep.
     walk: 1,
     match: (name) => name === "events.jsonl",
   },
   codex: {
     root: (home) => join(home, ".codex", "sessions"),
-    // ~/.codex/sessions/YYYY/MM/DD/rollout-…-<uuid>.jsonl — three levels deep.
     walk: 3,
     match: (name) => name.startsWith("rollout-") && name.endsWith(".jsonl"),
   },
@@ -218,12 +299,11 @@ function collectSessionFiles(root, walk, match) {
   return files;
 }
 
-function listSessions(cli) {
+function listLocalSessions(cli) {
   const layout = CLI_LAYOUTS[cli];
-  if (!layout) fail(EXIT_CODES.USAGE, `unknown cli: ${cli}`);
+  if (!layout) return [];
   const root = layout.root(process.env.HOME ?? "");
   if (!existsSync(root)) return [];
-
   const rows = [];
   for (const file of collectSessionFiles(root, layout.walk, layout.match)) {
     let mtime;
@@ -235,13 +315,222 @@ function listSessions(cli) {
     const m = file.match(UUID_HEAD_RE);
     const shortId = m ? m[1] : "?";
     const when = new Date(mtime * 1000).toISOString().replace("T", " ").slice(0, 16);
-    rows.push({ cli, short_id: shortId, file, mtime, when });
+    rows.push({ location: "local", cli, short_id: shortId, file, mtime, when });
   }
   rows.sort((a, b) => b.mtime - a.mtime);
-  return rows.slice(0, 50);
+  return rows;
 }
 
-// ---- main ---------------------------------------------------------------
+function listAllLocalSessions() {
+  return [...listLocalSessions("claude"), ...listLocalSessions("copilot"), ...listLocalSessions("codex")].sort(
+    (a, b) => b.mtime - a.mtime
+  );
+}
+
+// ---- transport: git-fallback -------------------------------------------
+
+function requireTransportRepo() {
+  const url = process.env.DOTCLAUDE_HANDOFF_REPO;
+  if (!url) fail(2, "DOTCLAUDE_HANDOFF_REPO env var must be set for --via git-fallback");
+  return url;
+}
+
+function encodeDescription({ cli, shortId, project, host, tag }) {
+  const args = [
+    "encode",
+    "--cli",
+    cli,
+    "--short-id",
+    shortId,
+    "--project",
+    project || "adhoc",
+    "--hostname",
+    host || "unknown",
+  ];
+  if (tag) args.push("--tag", tag);
+  const r = runScript(DESCRIPTION_SH, args);
+  if (r.status !== 0) fail(2, `description encode failed: ${r.stderr.trim()}`);
+  return r.stdout.trim();
+}
+
+function projectSlugFromCwd(cwd) {
+  if (!cwd) return "adhoc";
+  const last = cwd.split("/").filter(Boolean).pop() || "adhoc";
+  return last.toLowerCase().replace(/[^a-z0-9-]+/g, "-").slice(0, 40) || "adhoc";
+}
+
+function pushGitFallback({ cli, path: sessionFile, tag }) {
+  const repoUrl = requireTransportRepo();
+  const meta = extractMeta(cli, sessionFile);
+  const prompts = extractPrompts(cli, sessionFile);
+  const turns = extractTurns(cli, sessionFile);
+  const toCli = meta.cli;
+  const handoffBlock = renderHandoffBlock(meta, prompts, turns, toCli);
+
+  const shortId = meta.short_id ?? "unknown";
+  const host = hostname().toLowerCase().replace(/[^a-z0-9-]+/g, "-").slice(0, 40);
+  const project = projectSlugFromCwd(meta.cwd);
+  const description = encodeDescription({
+    cli: meta.cli,
+    shortId,
+    project,
+    host,
+    tag: tag || null,
+  });
+
+  const metadata = {
+    cli: meta.cli,
+    session_id: meta.session_id,
+    short_id: shortId,
+    cwd: meta.cwd ?? null,
+    hostname: host,
+    created_at: new Date().toISOString(),
+    scrubbed_count: 0,
+    schema_version: "1",
+    tag: tag || null,
+  };
+
+  const tmp = mkdtempSync(join(tmpdir(), "handoff-push-"));
+  try {
+    runGitOrThrow(["init", "-q"], tmp);
+    runGitOrThrow(["remote", "add", "origin", repoUrl], tmp);
+    runGitOrThrow(["config", "user.email", "handoff@dotclaude.local"], tmp);
+    runGitOrThrow(["config", "user.name", "dotclaude-handoff"], tmp);
+    const branch = `handoff/${meta.cli}/${shortId}`;
+    runGitOrThrow(["checkout", "-q", "-b", branch], tmp);
+    writeFileSync(join(tmp, "handoff.md"), handoffBlock + "\n");
+    writeFileSync(join(tmp, "metadata.json"), JSON.stringify(metadata, null, 2) + "\n");
+    writeFileSync(join(tmp, "description.txt"), description + "\n");
+    runGitOrThrow(["add", "."], tmp);
+    runGitOrThrow(["commit", "-q", "-m", description], tmp);
+    runGitOrThrow(["push", "-q", "-f", "origin", branch], tmp);
+    return { branch, url: repoUrl, description };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * List remote handoffs from git-fallback as candidate objects.
+ * Returns [{branch, description, commit}] — no content fetched.
+ */
+function listGitFallbackCandidates() {
+  const repoUrl = requireTransportRepo();
+  const r = runGit(["ls-remote", repoUrl, "refs/heads/handoff/*"]);
+  if (r.status !== 0) fail(2, `ls-remote failed: ${r.stderr.trim()}`);
+  const rows = [];
+  for (const line of r.stdout.split("\n")) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length !== 2) continue;
+    const commit = parts[0];
+    const ref = parts[1];
+    const branch = ref.replace(/^refs\/heads\//, "");
+    rows.push({ commit, branch, description: "" });
+  }
+  return rows;
+}
+
+/**
+ * Fetch a specific handoff branch and return its `handoff.md` content.
+ */
+function fetchGitFallbackBranch(branch) {
+  const repoUrl = requireTransportRepo();
+  const tmp = mkdtempSync(join(tmpdir(), "handoff-pull-"));
+  try {
+    const r = runGit(["clone", "-q", "--depth", "1", "--branch", branch, repoUrl, "."], tmp);
+    if (r.status !== 0) {
+      throw new Error(`clone --branch ${branch} failed: ${r.stderr.trim()}`);
+    }
+    const handoffPath = join(tmp, "handoff.md");
+    if (!existsSync(handoffPath)) {
+      throw new Error(`handoff.md missing in branch ${branch}`);
+    }
+    const content = readFileSync(handoffPath, "utf8");
+    const descPath = join(tmp, "description.txt");
+    const description = existsSync(descPath) ? readFileSync(descPath, "utf8").trim() : "";
+    return { content, description };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Enrich candidates with their description (requires per-branch fetch).
+ */
+function enrichWithDescriptions(candidates) {
+  return candidates.map((c) => {
+    try {
+      const { description } = fetchGitFallbackBranch(c.branch);
+      return { ...c, description };
+    } catch {
+      return c;
+    }
+  });
+}
+
+function matchesQuery(candidate, query) {
+  const q = query.toLowerCase();
+  if (candidate.branch.toLowerCase().includes(q)) return true;
+  if (candidate.description && candidate.description.toLowerCase().includes(q)) return true;
+  if (candidate.commit && candidate.commit.toLowerCase().startsWith(q)) return true;
+  return false;
+}
+
+async function pullGitFallback(query) {
+  const candidates = listGitFallbackCandidates();
+  if (candidates.length === 0) fail(2, "no handoffs found on transport");
+
+  // Bare: pick the newest (for git-fallback we don't have a reliable remote
+  // mtime; fall back to enriching and picking the lexically last, which is
+  // typically the most recent since short IDs hash-distribute).
+  if (!query) {
+    const enriched = enrichWithDescriptions(candidates);
+    const picked = enriched[enriched.length - 1];
+    return picked;
+  }
+
+  // Cheap pass: filter by branch name.
+  let hits = candidates.filter((c) => matchesQuery(c, query));
+  if (hits.length === 0) {
+    // Expensive pass: enrich with descriptions and re-match.
+    const enriched = enrichWithDescriptions(candidates);
+    hits = enriched.filter((c) => matchesQuery(c, query));
+  } else {
+    hits = enrichWithDescriptions(hits);
+  }
+
+  if (hits.length === 0) fail(2, `no handoffs match: ${query}`);
+  if (hits.length === 1) return hits[0];
+
+  // Collision.
+  if (process.stdin.isTTY) {
+    process.stderr.write(`dotclaude-handoff: multiple handoffs match "${query}":\n`);
+    hits.forEach((h, i) => {
+      process.stderr.write(`  [${i + 1}] ${h.branch}  ${h.description}\n`);
+    });
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const ans = await new Promise((resolve) => {
+      rl.question("Pick [1..N], or any other input to abort: ", resolve);
+    });
+    rl.close();
+    const n = Number.parseInt(ans.trim(), 10);
+    if (!Number.isInteger(n) || n < 1 || n > hits.length) process.exit(2);
+    return hits[n - 1];
+  }
+  process.stderr.write(`dotclaude-handoff: multiple handoffs match "${query}":\n`);
+  for (const h of hits) process.stderr.write(`  ${h.branch}\t${h.description}\n`);
+  process.exit(2);
+}
+
+// ---- host session detection --------------------------------------------
+
+function detectHostSession() {
+  // Claude Code exposes no stable env-var pointer to the current session
+  // file. Fall back to `latest` across all three roots.
+  return null;
+}
+
+// ---- main --------------------------------------------------------------
 
 let argv;
 try {
@@ -251,7 +540,7 @@ try {
 }
 
 if (argv.help) {
-  process.stdout.write(`${helpText(META)}\n`);
+  process.stdout.write(`${helpText(META)}\n\nSee skills/handoff/SKILL.md for the full reference.\n`);
   process.exit(EXIT_CODES.OK);
 }
 if (argv.version) {
@@ -259,118 +548,203 @@ if (argv.version) {
   process.exit(EXIT_CODES.OK);
 }
 
-// Bare form `dotclaude-handoff <cli> <id>` is implicit `digest`.
-let sub, cli, id;
-if (argv.positional.length >= 1 && CLIS.has(argv.positional[0])) {
-  sub = "digest";
-  cli = argv.positional[0];
-  id = argv.positional[1];
-  if (!id) fail(EXIT_CODES.USAGE, `missing identifier (uuid, short-uuid, 'latest', or alias) after '${cli}'`);
-} else {
-  [sub, cli, id] = argv.positional;
-  if (!sub) fail(EXIT_CODES.USAGE, "missing subcommand or cli. See --help.");
-  if (!SUBCOMMANDS.has(sub)) fail(EXIT_CODES.USAGE, `unknown subcommand: ${sub}`);
-  if (!cli) fail(EXIT_CODES.USAGE, "missing cli argument");
-  if (!CLIS.has(cli)) fail(EXIT_CODES.USAGE, `cli must be one of: claude, copilot, codex`);
-}
-
-const toCli = argv.flags.to ?? "claude";
-if (!CLIS.has(toCli)) fail(EXIT_CODES.USAGE, `--to must be one of: claude, copilot, codex`);
+const via = (argv.flags.via ?? "github").toString();
+if (!TRANSPORTS.has(via)) fail(EXIT_CODES.USAGE, `--via must be one of: ${[...TRANSPORTS].join(", ")}`);
 
 const limit = argv.flags.limit ?? "20";
-if (!/^\d+$/.test(limit)) fail(EXIT_CODES.USAGE, `--limit must be a non-negative integer, got: ${limit}`);
+if (!/^\d+$/.test(limit.toString())) fail(EXIT_CODES.USAGE, `--limit must be a non-negative integer, got: ${limit}`);
 
-if (sub === "list") {
-  const rows = listSessions(cli);
-  if (argv.json) {
-    process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
-    process.exit(EXIT_CODES.OK);
-  }
-  if (rows.length === 0) {
-    process.stdout.write(`No ${cli} sessions found\n`);
-    process.exit(EXIT_CODES.OK);
-  }
-  process.stdout.write(`| Short UUID | When              | File |\n`);
-  process.stdout.write(`| ---------- | ----------------- | ---- |\n`);
-  for (const r of rows) {
-    process.stdout.write(`| ${r.short_id} | ${r.when} | ${r.file} |\n`);
-  }
-  process.exit(EXIT_CODES.OK);
+const toCli = (argv.flags.to ?? "claude").toString();
+if (!CLIS.has(toCli)) fail(EXIT_CODES.USAGE, `--to must be one of: ${[...CLIS].join(", ")}`);
+
+const [first, second, third] = argv.positional;
+
+function printUsage() {
+  process.stdout.write(
+    [
+      "Usage:",
+      "  dotclaude handoff                              push host's latest session",
+      "  dotclaude handoff <query>                      emit <handoff> block for local paste",
+      "  dotclaude handoff push [<query>] [--tag LBL]   upload to transport",
+      "  dotclaude handoff pull [<query>]               fetch from transport",
+      "  dotclaude handoff list [--local|--remote]      sessions + gists",
+      "",
+      "Power-user sub-commands: resolve, describe, digest, file (all take <cli> <id>).",
+      "",
+      "Exit codes: 0 ok, 2 not found / runtime error, 64 usage error.",
+      "",
+    ].join("\n")
+  );
 }
 
-if (!id) fail(EXIT_CODES.USAGE, `${sub} requires an identifier (uuid, short-uuid, 'latest', or alias)`);
-
-const file = resolveSession(cli, id);
-
-if (sub === "resolve") {
-  process.stdout.write(`${file}\n`);
-  process.exit(EXIT_CODES.OK);
-}
-
-const meta = extractMeta(cli, file);
-const prompts = extractPrompts(cli, file);
-
-if (sub === "describe") {
-  if (argv.json) {
-    process.stdout.write(
-      JSON.stringify({ origin: meta, user_prompts: prompts }, null, 2) + "\n"
-    );
+async function main() {
+  // ---- zero-arg: print usage --------------------------------------------
+  if (argv.positional.length === 0) {
+    printUsage();
     process.exit(EXIT_CODES.OK);
   }
-  process.stdout.write(renderDescribeMarkdown(meta, prompts) + "\n");
-  process.exit(EXIT_CODES.OK);
-}
 
-const turns = extractTurns(cli, file, limit);
+  // ---- top-level subs: push / pull / list --------------------------------
+  if (first === "list") {
+    const showLocal = !argv.flags.remote;
+    const showRemote = !argv.flags.local;
+    const rows = [];
+    if (showLocal) {
+      for (const r of listAllLocalSessions()) {
+        rows.push({ ...r, location: "local" });
+      }
+    }
+    if (showRemote && via === "git-fallback" && process.env.DOTCLAUDE_HANDOFF_REPO) {
+      try {
+        for (const c of listGitFallbackCandidates()) {
+          rows.push({ location: "remote", branch: c.branch, commit: c.commit });
+        }
+      } catch (err) {
+        process.stderr.write(`dotclaude-handoff: list --remote: ${err.message}\n`);
+      }
+    }
+    if (argv.json) {
+      process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
+      process.exit(EXIT_CODES.OK);
+    }
+    if (rows.length === 0) {
+      process.stdout.write("No sessions found\n");
+      process.exit(EXIT_CODES.OK);
+    }
+    process.stdout.write("| Location | CLI / Branch                         | Short UUID | When / Commit    |\n");
+    process.stdout.write("| -------- | ------------------------------------ | ---------- | ---------------- |\n");
+    for (const r of rows) {
+      if (r.location === "local") {
+        process.stdout.write(`| local    | ${r.cli.padEnd(36)} | ${r.short_id.padEnd(10)} | ${r.when.padEnd(16)} |\n`);
+      } else {
+        const shortCommit = (r.commit ?? "").slice(0, 10);
+        process.stdout.write(`| remote   | ${r.branch.padEnd(36)} | ${"".padEnd(10)} | ${shortCommit.padEnd(16)} |\n`);
+      }
+    }
+    process.exit(EXIT_CODES.OK);
+  }
 
-if (sub === "digest") {
+  if (first === "push") {
+    // `push` | `push <query>` | `push <query> --tag <label>`
+    let sessionHit;
+    if (second) {
+      sessionHit = await resolveAny(second);
+    } else {
+      const host = detectHostSession();
+      sessionHit = host ?? (await resolveAny("latest"));
+    }
+    if (via !== "git-fallback") {
+      fail(
+        EXIT_CODES.USAGE,
+        `transport '${via}' not yet implemented in the binary; use --via git-fallback (or invoke the /handoff skill inside Claude/Copilot for --via github)`
+      );
+    }
+    const tag = argv.flags.tag ? String(argv.flags.tag) : null;
+    try {
+      const result = pushGitFallback({ cli: sessionHit.cli, path: sessionHit.path, tag });
+      process.stdout.write(`${result.branch}\n${result.url}\n${result.description}\n`);
+      process.exit(EXIT_CODES.OK);
+    } catch (err) {
+      fail(2, `push failed: ${err.message}`);
+    }
+  }
+
+  if (first === "pull") {
+    if (via !== "git-fallback") {
+      fail(
+        EXIT_CODES.USAGE,
+        `transport '${via}' not yet implemented in the binary; use --via git-fallback (or invoke the /handoff skill inside Claude/Copilot for --via github)`
+      );
+    }
+    try {
+      const hit = await pullGitFallback(second);
+      const { content } = fetchGitFallbackBranch(hit.branch);
+      process.stdout.write(content.endsWith("\n") ? content : content + "\n");
+      process.exit(EXIT_CODES.OK);
+    } catch (err) {
+      fail(2, `pull failed: ${err.message}`);
+    }
+  }
+
+  // ---- power-user sub-commands (resolve/describe/digest/file) -----------
+  if (POWER_SUBS.has(first)) {
+    const sub = first;
+    const cli = second;
+    const id = third;
+    if (!cli) fail(EXIT_CODES.USAGE, `${sub} requires <cli>`);
+    if (!CLIS.has(cli)) fail(EXIT_CODES.USAGE, `cli must be one of: ${[...CLIS].join(", ")}`);
+    if (!id) fail(EXIT_CODES.USAGE, `${sub} requires an identifier after <cli>`);
+    const r = runScript(RESOLVE_SH, [cli, id]);
+    if (r.status !== 0) fail(r.status === 64 ? EXIT_CODES.USAGE : 2, r.stderr.trim());
+    const path = r.stdout.trim();
+    if (sub === "resolve") {
+      process.stdout.write(`${path}\n`);
+      process.exit(EXIT_CODES.OK);
+    }
+    const meta = extractMeta(cli, path);
+    const prompts = extractPrompts(cli, path);
+    if (sub === "describe") {
+      if (argv.json) {
+        process.stdout.write(JSON.stringify({ origin: meta, user_prompts: prompts }, null, 2) + "\n");
+        process.exit(EXIT_CODES.OK);
+      }
+      process.stdout.write(renderDescribeMarkdown(meta, prompts) + "\n");
+      process.exit(EXIT_CODES.OK);
+    }
+    const turns = extractTurns(cli, path, limit);
+    if (sub === "digest") {
+      process.stdout.write(renderHandoffBlock(meta, prompts, turns, toCli) + "\n");
+      process.exit(EXIT_CODES.OK);
+    }
+    if (sub === "file") {
+      const outDir = argv.flags["out-dir"];
+      let target;
+      if (outDir) {
+        target = resolvePath(outDir.toString());
+      } else {
+        const gitRes = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+        target =
+          gitRes.status === 0 && gitRes.stdout.trim()
+            ? join(gitRes.stdout.trim(), "docs", "handoffs")
+            : join(process.env.HOME ?? "", ".claude", "handoffs");
+      }
+      mkdirSync(target, { recursive: true });
+      const today = new Date().toISOString().slice(0, 10);
+      const shortId = meta.short_id ?? "unknown";
+      const outPath = join(target, `${today}-${meta.cli}-${shortId}.md`);
+      const body = [
+        `# Handoff: ${meta.cli} → ${toCli}`,
+        "",
+        `_Generated: ${new Date().toISOString()}_`,
+        `_Origin session: \`${meta.session_id ?? "?"}\` (cwd: \`${meta.cwd ?? "?"}\`)_`,
+        "",
+        renderHandoffBlock(meta, prompts, turns, toCli),
+        "",
+        "---",
+        "",
+        "## Full user prompt log",
+        "",
+        ...prompts.map((p, i) => `${i + 1}. ${p}`),
+        "",
+        "## Notes",
+        "",
+        `- Source transcript: \`${path}\``,
+        `- Prompts: ${prompts.length} (verbatim); assistant turns summarized in the <handoff> block.`,
+      ].join("\n");
+      writeFileSync(outPath, body + "\n");
+      process.stdout.write(`${outPath}\n`);
+      process.exit(EXIT_CODES.OK);
+    }
+  }
+
+  // ---- bare <query>: local cross-agent (implicit digest) -----------------
+  const query = first;
+  const hit = await resolveAny(query);
+  const meta = extractMeta(hit.cli, hit.path);
+  const prompts = extractPrompts(hit.cli, hit.path);
+  const turns = extractTurns(hit.cli, hit.path, limit);
   process.stdout.write(renderHandoffBlock(meta, prompts, turns, toCli) + "\n");
   process.exit(EXIT_CODES.OK);
 }
 
-if (sub === "file") {
-  // Write a markdown doc to docs/handoffs/ (or ~/.claude/handoffs/ as fallback).
-  const outDir = argv.flags["out-dir"];
-  let target;
-  if (outDir) {
-    target = resolvePath(outDir);
-  } else {
-    const gitRes = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
-    if (gitRes.status === 0 && gitRes.stdout.trim()) {
-      target = join(gitRes.stdout.trim(), "docs", "handoffs");
-    } else {
-      target = join(process.env.HOME ?? "", ".claude", "handoffs");
-    }
-  }
-  mkdirSync(target, { recursive: true });
-  const today = new Date().toISOString().slice(0, 10);
-  const shortId = meta.short_id ?? "unknown";
-  const filename = `${today}-${meta.cli}-${shortId}.md`;
-  const outPath = join(target, filename);
-
-  const body = [
-    `# Handoff: ${meta.cli} → ${toCli}`,
-    "",
-    `_Generated: ${new Date().toISOString()}_`,
-    `_Origin session: \`${meta.session_id ?? "?"}\` (cwd: \`${meta.cwd ?? "?"}\`)_`,
-    "",
-    renderHandoffBlock(meta, prompts, turns, toCli),
-    "",
-    "---",
-    "",
-    "## Full user prompt log",
-    "",
-    ...prompts.map((p, i) => `${i + 1}. ${p}`),
-    "",
-    "## Notes",
-    "",
-    `- Source transcript: \`${file}\``,
-    `- Prompts: ${prompts.length} (verbatim); assistant turns summarized in the <handoff> block.`,
-  ].join("\n");
-
-  writeFileSync(outPath, body + "\n");
-  process.stdout.write(`${outPath}\n`);
-  process.exit(EXIT_CODES.OK);
-}
-
-fail(EXIT_CODES.USAGE, `unhandled subcommand: ${sub}`);
+main().catch((err) => fail(2, err.message));

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -241,12 +241,23 @@ if (argv.version) {
   process.exit(EXIT_CODES.OK);
 }
 
-const [sub, cli, id] = argv.positional;
-
-if (!sub) fail(EXIT_CODES.USAGE, "missing subcommand. See --help.");
-if (!SUBCOMMANDS.has(sub)) fail(EXIT_CODES.USAGE, `unknown subcommand: ${sub}`);
-if (!cli) fail(EXIT_CODES.USAGE, "missing cli argument");
-if (!CLIS.has(cli)) fail(EXIT_CODES.USAGE, `cli must be one of: claude, copilot, codex`);
+// Bare form: `dotclaude-handoff <cli> <id>` is implicit `digest`.
+// If positional[0] is a known CLI name, shift it into the sub-command
+// slot and default sub-command to "digest". Otherwise the existing
+// sub-command dispatch runs.
+let sub, cli, id;
+if (argv.positional.length >= 1 && CLIS.has(argv.positional[0])) {
+  sub = "digest";
+  cli = argv.positional[0];
+  id = argv.positional[1];
+  if (!id) fail(EXIT_CODES.USAGE, `missing identifier (uuid, short-uuid, 'latest', or alias) after '${cli}'`);
+} else {
+  [sub, cli, id] = argv.positional;
+  if (!sub) fail(EXIT_CODES.USAGE, "missing subcommand or cli. See --help.");
+  if (!SUBCOMMANDS.has(sub)) fail(EXIT_CODES.USAGE, `unknown subcommand: ${sub}`);
+  if (!cli) fail(EXIT_CODES.USAGE, "missing cli argument");
+  if (!CLIS.has(cli)) fail(EXIT_CODES.USAGE, `cli must be one of: claude, copilot, codex`);
+}
 
 const toCli = argv.flags.to ?? "claude";
 if (!CLIS.has(toCli)) fail(EXIT_CODES.USAGE, `--to must be one of: claude, copilot, codex`);

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -333,8 +333,9 @@ function requireTransportRepo() {
   const url = process.env.DOTCLAUDE_HANDOFF_REPO;
   if (!url) fail(2, "DOTCLAUDE_HANDOFF_REPO env var must be set for --via git-fallback");
   // Reject ext:: and other exec-triggering Git URL schemes (CVE-2017-1000117-class).
-  if (!/^(https?:\/\/|git@|ssh:\/\/)/.test(url))
-    fail(2, `DOTCLAUDE_HANDOFF_REPO must start with https://, git@, or ssh:// (got: ${url})`);
+  // Allow: https://, http://, git@, ssh://, file://, and absolute paths (bare repos).
+  if (!/^(https?:\/\/|git@|ssh:\/\/|file:\/\/|\/)/.test(url))
+    fail(2, `DOTCLAUDE_HANDOFF_REPO must be an https://, git@, ssh://, file://, or absolute path (got: ${url})`);
   return url;
 }
 

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -332,6 +332,9 @@ function listAllLocalSessions() {
 function requireTransportRepo() {
   const url = process.env.DOTCLAUDE_HANDOFF_REPO;
   if (!url) fail(2, "DOTCLAUDE_HANDOFF_REPO env var must be set for --via git-fallback");
+  // Reject ext:: and other exec-triggering Git URL schemes (CVE-2017-1000117-class).
+  if (!/^(https?:\/\/|git@|ssh:\/\/)/.test(url))
+    fail(2, `DOTCLAUDE_HANDOFF_REPO must start with https://, git@, or ssh:// (got: ${url})`);
   return url;
 }
 

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+/**
+ * dotclaude-handoff — read a session transcript and render it as a
+ * paste-ready handoff digest.
+ *
+ * Usage:
+ *   dotclaude-handoff <subcmd> <cli> <identifier> [--to <cli>] [OPTIONS]
+ *
+ * Subcommands:
+ *   resolve   <cli> <id>              print resolved session file path
+ *   describe  <cli> <id>              inline summary (markdown or --json)
+ *   digest    <cli> <id> [--to ...]   full <handoff> block for paste
+ *   list      <cli>                   newest-first table of sessions
+ *   file      <cli> <id> [--to ...]   write markdown handoff doc to disk
+ *
+ * cli:  claude | copilot | codex
+ * id:   full UUID, short UUID (first 8 hex), `latest`, or (codex only)
+ *       a thread_name alias.
+ *
+ * Exits: 0 ok, 2 not-found / runtime error, 64 usage error.
+ */
+
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { version } from "../src/index.mjs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve as resolvePath } from "node:path";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+
+const SUBCOMMANDS = new Set(["resolve", "describe", "digest", "list", "file"]);
+const CLIS = new Set(["claude", "copilot", "codex"]);
+
+const META = {
+  name: "dotclaude-handoff",
+  synopsis:
+    "dotclaude-handoff <resolve|describe|digest|list|file> <claude|copilot|codex> [<id>] [--to <cli>]",
+  description:
+    "Read a session transcript from one agentic CLI and render it as a paste-ready handoff digest. Works from any shell, including Codex's bash tool.",
+  flags: {
+    to: { type: "string" },
+    limit: { type: "string" },
+    "out-dir": { type: "string" },
+  },
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPTS = resolvePath(__dirname, "..", "scripts");
+const RESOLVE_SH = join(SCRIPTS, "handoff-resolve.sh");
+const EXTRACT_SH = join(SCRIPTS, "handoff-extract.sh");
+
+function fail(code, msg) {
+  if (msg) process.stderr.write(`dotclaude-handoff: ${msg}\n`);
+  process.exit(code);
+}
+
+function runScript(script, args) {
+  const res = spawnSync(script, args, { encoding: "utf8" });
+  return { status: res.status ?? 2, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+function resolveSession(cli, id) {
+  const r = runScript(RESOLVE_SH, [cli, id]);
+  if (r.status !== 0) {
+    fail(r.status === 64 ? EXIT_CODES.USAGE : 2, r.stderr.trim() || `could not resolve ${cli} ${id}`);
+  }
+  return r.stdout.trim();
+}
+
+function extractMeta(cli, file) {
+  const r = runScript(EXTRACT_SH, ["meta", cli, file]);
+  if (r.status !== 0) fail(2, r.stderr.trim() || `meta extraction failed for ${cli}`);
+  try {
+    return JSON.parse(r.stdout.trim());
+  } catch (err) {
+    fail(2, `meta returned non-JSON: ${err.message}`);
+  }
+}
+
+function extractPrompts(cli, file) {
+  const r = runScript(EXTRACT_SH, ["prompts", cli, file]);
+  if (r.status !== 0) return [];
+  return r.stdout.split("\n").filter((line) => line.trim().length > 0);
+}
+
+function extractTurns(cli, file, limit) {
+  const args = ["turns", cli, file];
+  if (limit) args.push(String(limit));
+  const r = runScript(EXTRACT_SH, args);
+  if (r.status !== 0) return [];
+  return r.stdout.split("\n").filter((line) => line.trim().length > 0);
+}
+
+function nextStepFor(toCli) {
+  // The LLM on the target side will re-summarize; this is a mechanical cue.
+  if (toCli === "codex") {
+    return "Read the prompts and assistant turns above, then continue the task using the file paths mentioned. Treat this as a task specification.";
+  }
+  if (toCli === "copilot") {
+    return "Help me pick up where this session left off; reference the prompts and findings above.";
+  }
+  // claude (default)
+  return "Continue from the last assistant turn using the same file scope and goals summarized above.";
+}
+
+function mechanicalSummary(prompts, turns) {
+  const first = prompts[0] ?? "(no user prompts captured)";
+  const last = turns[turns.length - 1] ?? "(no assistant turns captured)";
+  const clip = (s, n) => (s.length > n ? `${s.slice(0, n).trim()}…` : s);
+  return `Session opened with: "${clip(first, 160)}". Last assistant output (truncated): "${clip(last, 160)}". Full prompt log and assistant tail follow for context.`;
+}
+
+function renderDescribeMarkdown(meta, prompts) {
+  const lines = [];
+  lines.push(
+    `**${meta.cli}** \`${meta.short_id ?? "?"}\` — \`${meta.cwd ?? "(cwd unknown)"}\` — ${meta.started_at ?? ""}`
+  );
+  lines.push("");
+  lines.push("**User prompts:**");
+  lines.push("");
+  const toShow = prompts.slice(0, 10);
+  if (toShow.length === 0) {
+    lines.push("- (no user prompts captured)");
+  } else {
+    for (const p of toShow) {
+      const trimmed = p.length > 200 ? `${p.slice(0, 200).trim()}…` : p;
+      lines.push(`- ${trimmed}`);
+    }
+  }
+  if (prompts.length > 10) {
+    lines.push(`- …and ${prompts.length - 10} more (truncated)`);
+  }
+  lines.push("");
+  lines.push(`**Prompt count:** ${prompts.length}`);
+  return lines.join("\n");
+}
+
+function renderHandoffBlock(meta, prompts, turns, toCli) {
+  const summary = mechanicalSummary(prompts, turns);
+  const promptsCapped = prompts.slice(-10);
+  const turnsTail = turns.slice(-3);
+  const next = nextStepFor(toCli);
+
+  const lines = [];
+  lines.push(
+    `<handoff origin="${meta.cli}" session="${meta.short_id ?? ""}" cwd="${meta.cwd ?? ""}" target="${toCli}">`
+  );
+  lines.push("");
+  lines.push(`**Summary.** ${summary}`);
+  lines.push("");
+  lines.push("**User prompts (last 10, in order).**");
+  lines.push("");
+  if (promptsCapped.length === 0) {
+    lines.push("1. (no user prompts captured)");
+  } else {
+    promptsCapped.forEach((p, i) => {
+      const trimmed = p.length > 300 ? `${p.slice(0, 300).trim()}…` : p;
+      lines.push(`${i + 1}. ${trimmed}`);
+    });
+  }
+  lines.push("");
+  lines.push("**Last assistant turns (tail).**");
+  lines.push("");
+  if (turnsTail.length === 0) {
+    lines.push("_(no assistant output captured)_");
+  } else {
+    for (const t of turnsTail) {
+      const trimmed = t.length > 400 ? `${t.slice(0, 400).trim()}…` : t;
+      lines.push(`> ${trimmed.replace(/\n/g, "\n> ")}`);
+      lines.push("");
+    }
+  }
+  lines.push("**Next step.** " + next);
+  lines.push("");
+  lines.push("</handoff>");
+  return lines.join("\n");
+}
+
+function listSessions(cli) {
+  // Delegate to handoff-resolve.sh's `latest` logic by shelling out to find.
+  // Newest-first per CLI.
+  const home = process.env.HOME ?? "";
+  let roots, pattern;
+  switch (cli) {
+    case "claude":
+      roots = [join(home, ".claude", "projects")];
+      pattern = "*.jsonl";
+      break;
+    case "copilot":
+      roots = [join(home, ".copilot", "session-state")];
+      pattern = "events.jsonl";
+      break;
+    case "codex":
+      roots = [join(home, ".codex", "sessions")];
+      pattern = "rollout-*.jsonl";
+      break;
+    default:
+      fail(EXIT_CODES.USAGE, `unknown cli: ${cli}`);
+  }
+  const root = roots[0];
+  if (!existsSync(root)) return [];
+  const res = spawnSync("sh", [
+    "-c",
+    `find "${root}" ${cli === "claude" ? "-maxdepth 2" : ""} -type f -name '${pattern}' 2>/dev/null | xargs -I{} sh -c 'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' | sort -rn | head -50`,
+  ], { encoding: "utf8" });
+  const rows = [];
+  for (const line of (res.stdout ?? "").split("\n")) {
+    if (!line.trim()) continue;
+    const spaceIdx = line.indexOf(" ");
+    if (spaceIdx < 0) continue;
+    const mtime = parseInt(line.slice(0, spaceIdx), 10);
+    const file = line.slice(spaceIdx + 1);
+    // Derive short_id from path.
+    let shortId = "?";
+    const m =
+      cli === "claude" ? file.match(/\/([0-9a-f]{8})-[0-9a-f]{4}-/) :
+      cli === "copilot" ? file.match(/\/([0-9a-f]{8})-[0-9a-f]{4}-/) :
+      /* codex */         file.match(/-([0-9a-f]{8})-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/);
+    if (m) shortId = m[1];
+    const when = new Date(mtime * 1000).toISOString().replace("T", " ").slice(0, 16);
+    rows.push({ cli, short_id: shortId, file, mtime, when });
+  }
+  return rows;
+}
+
+// ---- main ---------------------------------------------------------------
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  fail(EXIT_CODES.USAGE, err.message);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const [sub, cli, id] = argv.positional;
+
+if (!sub) fail(EXIT_CODES.USAGE, "missing subcommand. See --help.");
+if (!SUBCOMMANDS.has(sub)) fail(EXIT_CODES.USAGE, `unknown subcommand: ${sub}`);
+if (!cli) fail(EXIT_CODES.USAGE, "missing cli argument");
+if (!CLIS.has(cli)) fail(EXIT_CODES.USAGE, `cli must be one of: claude, copilot, codex`);
+
+const toCli = argv.flags.to ?? "claude";
+if (!CLIS.has(toCli)) fail(EXIT_CODES.USAGE, `--to must be one of: claude, copilot, codex`);
+
+if (sub === "list") {
+  const rows = listSessions(cli);
+  if (argv.json) {
+    process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
+    process.exit(EXIT_CODES.OK);
+  }
+  if (rows.length === 0) {
+    process.stdout.write(`No ${cli} sessions found\n`);
+    process.exit(EXIT_CODES.OK);
+  }
+  process.stdout.write(`| Short UUID | When              | File |\n`);
+  process.stdout.write(`| ---------- | ----------------- | ---- |\n`);
+  for (const r of rows) {
+    process.stdout.write(`| ${r.short_id} | ${r.when} | ${r.file} |\n`);
+  }
+  process.exit(EXIT_CODES.OK);
+}
+
+if (!id) fail(EXIT_CODES.USAGE, `${sub} requires an identifier (uuid, short-uuid, 'latest', or alias)`);
+
+const file = resolveSession(cli, id);
+
+if (sub === "resolve") {
+  process.stdout.write(`${file}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const meta = extractMeta(cli, file);
+const prompts = extractPrompts(cli, file);
+
+if (sub === "describe") {
+  if (argv.json) {
+    process.stdout.write(
+      JSON.stringify({ origin: meta, user_prompts: prompts }, null, 2) + "\n"
+    );
+    process.exit(EXIT_CODES.OK);
+  }
+  process.stdout.write(renderDescribeMarkdown(meta, prompts) + "\n");
+  process.exit(EXIT_CODES.OK);
+}
+
+const turns = extractTurns(cli, file, argv.flags.limit ?? "20");
+
+if (sub === "digest") {
+  process.stdout.write(renderHandoffBlock(meta, prompts, turns, toCli) + "\n");
+  process.exit(EXIT_CODES.OK);
+}
+
+if (sub === "file") {
+  // Write a markdown doc to docs/handoffs/ (or ~/.claude/handoffs/ as fallback).
+  const outDir = argv.flags["out-dir"];
+  let target;
+  if (outDir) {
+    target = resolvePath(outDir);
+  } else {
+    const gitRes = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+    if (gitRes.status === 0 && gitRes.stdout.trim()) {
+      target = join(gitRes.stdout.trim(), "docs", "handoffs");
+    } else {
+      target = join(process.env.HOME ?? "", ".claude", "handoffs");
+    }
+  }
+  mkdirSync(target, { recursive: true });
+  const today = new Date().toISOString().slice(0, 10);
+  const shortId = meta.short_id ?? "unknown";
+  const filename = `${today}-${meta.cli}-${shortId}.md`;
+  const outPath = join(target, filename);
+
+  const body = [
+    `# Handoff: ${meta.cli} → ${toCli}`,
+    "",
+    `_Generated: ${new Date().toISOString()}_`,
+    `_Origin session: \`${meta.session_id ?? "?"}\` (cwd: \`${meta.cwd ?? "?"}\`)_`,
+    "",
+    renderHandoffBlock(meta, prompts, turns, toCli),
+    "",
+    "---",
+    "",
+    "## Full user prompt log",
+    "",
+    ...prompts.map((p, i) => `${i + 1}. ${p}`),
+    "",
+    "## Notes",
+    "",
+    `- Source transcript: \`${file}\``,
+    `- Prompts: ${prompts.length} (verbatim); assistant turns summarized in the <handoff> block.`,
+  ].join("\n");
+
+  writeFileSync(outPath, body + "\n");
+  process.stdout.write(`${outPath}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+fail(EXIT_CODES.USAGE, `unhandled subcommand: ${sub}`);

--- a/plugins/dotclaude/bin/dotclaude.mjs
+++ b/plugins/dotclaude/bin/dotclaude.mjs
@@ -35,6 +35,7 @@ const SUBCOMMANDS = [
   "search",
   "list",
   "show",
+  "handoff",
 ];
 
 function printUsage() {

--- a/plugins/dotclaude/scripts/handoff-extract.sh
+++ b/plugins/dotclaude/scripts/handoff-extract.sh
@@ -64,22 +64,25 @@ meta_claude() {
   fi
   started_at=$(file_iso_mtime "$file")
 
+  # Use first(inputs | select(...)) so jq stops at the first cwd-bearing record
+  # rather than slurping the entire file — keeps memory bounded on large transcripts.
+  # Session ID comes from the matched record if available, else $fallback_id (the
+  # filename UUID), so the second slurp-pass for sessionId is eliminated.
   jq -n -c \
     --arg cli "claude" \
     --arg fallback_id "$fallback_id" \
     --arg started_at "$started_at" \
     '
     def nonempty: select(. != null and . != "");
-    [inputs] as $r
-    | (($r | map(select(.cwd | (. // "") != "")) | .[0]) // {}) as $with_cwd
-    | (($r | map(select(.sessionId != null)) | .[0].sessionId) // $fallback_id) as $sid
+    (first(inputs | select((.cwd // "") != "")) // {}) as $r
+    | (($r.sessionId // "") | select(. != "") // $fallback_id) as $sid
     | {
         cli: $cli,
         session_id: ($sid | nonempty // null),
         short_id: ($sid | (.[:8] | nonempty) // null),
-        cwd: ($with_cwd.cwd | (. // "") | nonempty // null),
+        cwd: ($r.cwd | (. // "") | nonempty // null),
         model: null,
-        version: ($with_cwd.version | (. // "") | nonempty // null),
+        version: ($r.version | (. // "") | nonempty // null),
         started_at: ($started_at | nonempty // null)
       }
     ' "$file" 2>/dev/null
@@ -87,43 +90,37 @@ meta_claude() {
 
 # Claude user prompts, scrubbed of system/command/tool noise.
 # Content may be string OR array of content blocks.
+# Noise filtering is done in jq on the full prompt text (not line-by-line)
+# so multi-line synthetic records are correctly dropped at the record level.
 prompts_claude() {
   local file="$1"
   jq -r '
+    def text_of:
+      if type == "string" then .
+      else (map(select(.type == "text") | .text) | join("\n"))
+      end;
+    def is_noise:
+      ltrimstr(" ") | ltrimstr("\t") | ltrimstr("\n") |
+      ( startswith("<local-command-caveat>")
+        or startswith("<command-name>")
+        or startswith("<command-message>")
+        or startswith("<command-args>")
+        or startswith("<stdin>")
+        or startswith("<system-reminder>")
+        or startswith("<user-prompt-submit-hook>")
+        or startswith("<task-notification>")
+        or startswith("<task-id>")
+        or startswith("<summary>Monitor event")
+        or startswith("</task-notification>")
+        or startswith("<event>")
+        or startswith("If this event is something the user")
+      );
     select(.type == "user")
     | .message.content
-    | if type == "string" then
-        .
-      else
-        (map(select(.type == "text") | .text) | join("\n"))
-      end
+    | text_of
     | select(length > 0)
-  ' "$file" 2>/dev/null \
-    | awk '
-        # Claude JSONL carries many synthetic "user" records that are not
-        # actual human prompts: hook outputs, system reminders, slash-command
-        # echoes, task-notification polling, etc. Drop any record whose
-        # first non-whitespace content starts with one of these markers.
-        {
-          trimmed = $0
-          sub(/^[[:space:]]+/, "", trimmed)
-          if (trimmed == "") next
-          if (trimmed ~ /^<local-command-caveat>/) next
-          if (trimmed ~ /^<command-name>/) next
-          if (trimmed ~ /^<command-message>/) next
-          if (trimmed ~ /^<command-args>/) next
-          if (trimmed ~ /^<stdin>/) next
-          if (trimmed ~ /^<system-reminder>/) next
-          if (trimmed ~ /^<user-prompt-submit-hook>/) next
-          if (trimmed ~ /^<task-notification>/) next
-          if (trimmed ~ /^<task-id>/) next
-          if (trimmed ~ /^<summary>Monitor event/) next
-          if (trimmed ~ /^<\/task-notification>/) next
-          if (trimmed ~ /^<event>/) next
-          if (trimmed ~ /^If this event is something the user/) next
-          print
-        }
-      '
+    | select(is_noise | not)
+  ' "$file" 2>/dev/null
 }
 
 turns_claude() {

--- a/plugins/dotclaude/scripts/handoff-extract.sh
+++ b/plugins/dotclaude/scripts/handoff-extract.sh
@@ -41,15 +41,13 @@ require_file() {
   [[ -f "$1" ]] || die_runtime "file not found: $1"
 }
 
-# jq boolean helper: does this string look like a non-empty, non-null?
-json_str_or_null() {
-  local raw="$1"
-  if [[ -z "$raw" || "$raw" == "null" ]]; then
-    printf 'null'
-  else
-    # Escape embedded double-quotes and backslashes for safe JSON embedding.
-    printf '"%s"' "$(printf '%s' "$raw" | sed 's/\\/\\\\/g; s/"/\\"/g')"
-  fi
+UUID_RE='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+# ISO-8601 UTC mtime of a file (portable: GNU date first, BSD fallback).
+file_iso_mtime() {
+  local file="$1"
+  date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$(stat -c %Y "$file" 2>/dev/null || stat -f %m "$file")" +%Y-%m-%dT%H:%M:%SZ
 }
 
 # -- claude ---------------------------------------------------------------
@@ -58,45 +56,33 @@ meta_claude() {
   local file="$1"
   # Prefer a record with a cwd (the common case). Slurp-and-first via
   # `jq -n '[inputs]|.[0]'` to avoid SIGPIPE on long transcripts.
-  local raw
-  raw=$(jq -n -c '[inputs | select(.cwd != null and .cwd != "") | {cwd, sessionId, version}] | .[0] // empty' "$file" 2>/dev/null)
-
-  local cwd="" session_id="" version=""
-  if [[ -n "$raw" ]]; then
-    cwd=$(printf '%s' "$raw" | jq -r '.cwd // ""')
-    session_id=$(printf '%s' "$raw" | jq -r '.sessionId // ""')
-    version=$(printf '%s' "$raw" | jq -r '.version // ""')
+  # Fallback chain: any record with sessionId → UUID parsed from filename.
+  local base started_at fallback_id=""
+  base=$(basename "$file" .jsonl)
+  if [[ "$base" =~ $UUID_RE ]]; then
+    fallback_id="$base"
   fi
+  started_at=$(file_iso_mtime "$file")
 
-  # Edge case: brand-new aliased session with no activity yet (only
-  # custom-title / agent-name records, no cwd). Fall back to whatever
-  # identity records exist, then to the filename.
-  if [[ -z "$session_id" ]]; then
-    session_id=$(jq -n -r '[inputs | select(.sessionId != null) | .sessionId] | .[0] // empty' "$file" 2>/dev/null)
-  fi
-  if [[ -z "$session_id" ]]; then
-    # Parse the UUID out of the filename as a last resort.
-    local base
-    base=$(basename "$file" .jsonl)
-    if [[ "$base" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-      session_id="$base"
-    fi
-  fi
-
-  local short_id="${session_id:0:8}"
-
-  # started_at: use file mtime as a stable proxy.
-  local started_at
-  started_at=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-    || date -u -d "@$(stat -c %Y "$file" 2>/dev/null || stat -f %m "$file")" +%Y-%m-%dT%H:%M:%SZ)
-
-  printf '{"cli":"claude","session_id":%s,"short_id":%s,"cwd":%s,"model":%s,"version":%s,"started_at":%s}\n' \
-    "$(json_str_or_null "$session_id")" \
-    "$(json_str_or_null "$short_id")" \
-    "$(json_str_or_null "$cwd")" \
-    "null" \
-    "$(json_str_or_null "$version")" \
-    "$(json_str_or_null "$started_at")"
+  jq -n -c \
+    --arg cli "claude" \
+    --arg fallback_id "$fallback_id" \
+    --arg started_at "$started_at" \
+    '
+    def nonempty: select(. != null and . != "");
+    [inputs] as $r
+    | (($r | map(select(.cwd | (. // "") != "")) | .[0]) // {}) as $with_cwd
+    | (($r | map(select(.sessionId != null)) | .[0].sessionId) // $fallback_id) as $sid
+    | {
+        cli: $cli,
+        session_id: ($sid | nonempty // null),
+        short_id: ($sid | (.[:8] | nonempty) // null),
+        cwd: ($with_cwd.cwd | (. // "") | nonempty // null),
+        model: null,
+        version: ($with_cwd.version | (. // "") | nonempty // null),
+        started_at: ($started_at | nonempty // null)
+      }
+    ' "$file" 2>/dev/null
 }
 
 # Claude user prompts, scrubbed of system/command/tool noise.
@@ -166,34 +152,37 @@ meta_copilot() {
   session_meta=$(jq -n -c '[inputs | select(.type == "session.start") | .data] | .[0] // empty' "$file" 2>/dev/null)
   [[ -n "$session_meta" ]] || die_runtime "no session.start record in $file"
 
-  local cwd model session_id
-  cwd=$(printf '%s' "$session_meta" | jq -r '.cwd // ""')
-  model=$(printf '%s' "$session_meta" | jq -r '.model // ""')
-  session_id=$(printf '%s' "$session_meta" | jq -r '.sessionId // ""')
-
-  # Fallback: if session.start's cwd is null/empty, try the sibling
+  # Fallback: if session.start's cwd/model is null/empty, read the sibling
   # workspace.yaml. (Real Copilot sessions emit null cwd at start in practice.)
-  local session_dir
+  local session_dir wy wy_cwd="" wy_model=""
   session_dir=$(dirname "$file")
-  local wy="$session_dir/workspace.yaml"
-  if [[ -z "$cwd" && -f "$wy" ]]; then
-    cwd=$(workspace_yaml_get "$wy" "cwd")
-  fi
-  if [[ -z "$model" && -f "$wy" ]]; then
-    model=$(workspace_yaml_get "$wy" "model")
+  wy="$session_dir/workspace.yaml"
+  if [[ -f "$wy" ]]; then
+    wy_cwd=$(workspace_yaml_get "$wy" "cwd")
+    wy_model=$(workspace_yaml_get "$wy" "model")
   fi
 
-  local short_id="${session_id:0:8}"
   local started_at
-  started_at=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
-    || date -u -d "@$(stat -c %Y "$file" 2>/dev/null || stat -f %m "$file")" +%Y-%m-%dT%H:%M:%SZ)
+  started_at=$(file_iso_mtime "$file")
 
-  printf '{"cli":"copilot","session_id":%s,"short_id":%s,"cwd":%s,"model":%s,"started_at":%s}\n' \
-    "$(json_str_or_null "$session_id")" \
-    "$(json_str_or_null "$short_id")" \
-    "$(json_str_or_null "$cwd")" \
-    "$(json_str_or_null "$model")" \
-    "$(json_str_or_null "$started_at")"
+  printf '%s' "$session_meta" | jq -c \
+    --arg cli "copilot" \
+    --arg wy_cwd "$wy_cwd" \
+    --arg wy_model "$wy_model" \
+    --arg started_at "$started_at" \
+    '
+    def nn(x): (x // "") | select(. != "") // null;
+    . as $d
+    | ($d.sessionId // "") as $sid
+    | {
+        cli: $cli,
+        session_id: nn($sid),
+        short_id: nn($sid[:8]),
+        cwd: nn($d.cwd // $wy_cwd),
+        model: nn($d.model // $wy_model),
+        started_at: nn($started_at)
+      }
+    '
 }
 
 # Always prefer .data.content (the raw user text) over .data.transformedContent
@@ -225,19 +214,18 @@ meta_codex() {
   sm=$(jq -n -c '[inputs | select(.type == "session_meta") | .payload] | .[0] // empty' "$file" 2>/dev/null)
   [[ -n "$sm" ]] || die_runtime "no session_meta record in $file"
 
-  local session_id cwd model started_at
-  session_id=$(printf '%s' "$sm" | jq -r '.id // ""')
-  cwd=$(printf '%s' "$sm" | jq -r '.cwd // ""')
-  model=$(printf '%s' "$sm" | jq -r '.model_provider // ""')
-  started_at=$(printf '%s' "$sm" | jq -r '.timestamp // ""')
-
-  local short_id="${session_id:0:8}"
-  printf '{"cli":"codex","session_id":%s,"short_id":%s,"cwd":%s,"model":%s,"started_at":%s}\n' \
-    "$(json_str_or_null "$session_id")" \
-    "$(json_str_or_null "$short_id")" \
-    "$(json_str_or_null "$cwd")" \
-    "$(json_str_or_null "$model")" \
-    "$(json_str_or_null "$started_at")"
+  printf '%s' "$sm" | jq -c '
+    def nn(x): (x // "") | select(. != "") // null;
+    ((.id // "")) as $sid
+    | {
+        cli: "codex",
+        session_id: nn($sid),
+        short_id: nn($sid[:8]),
+        cwd: nn(.cwd),
+        model: nn(.model_provider),
+        started_at: nn(.timestamp)
+      }
+  '
 }
 
 prompts_codex() {

--- a/plugins/dotclaude/scripts/handoff-extract.sh
+++ b/plugins/dotclaude/scripts/handoff-extract.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# handoff-extract.sh — CLI-aware extractor for session transcripts.
+#
+# Usage:
+#   handoff-extract.sh meta    <cli> <file>
+#   handoff-extract.sh prompts <cli> <file>
+#   handoff-extract.sh turns   <cli> <file> [N]
+#
+# cli:   claude | copilot | codex
+# file:  absolute path to the session JSONL (from handoff-resolve.sh)
+# N:     optional limit for `turns` (default: 20)
+#
+# Subcommands:
+#   meta      emits a single JSON object with:
+#               {cli, session_id, short_id, cwd, model, started_at}
+#             Copilot: if session.start.cwd is null, reads the sibling
+#             workspace.yaml as a fallback.
+#   prompts   emits user prompts newline-separated, in order, with
+#             CLI-specific noise filtered out (Claude: system-reminders,
+#             command-name, tool_result; Codex: environment_context).
+#   turns     emits assistant text turns newline-separated, last N only.
+#
+# Exits:
+#   0  success
+#   2  file-not-found / parse error
+#   64 usage error
+
+set -euo pipefail
+
+die_usage() { printf 'handoff-extract: %s\n' "$1" >&2; exit 64; }
+die_runtime() { printf 'handoff-extract: %s\n' "$1" >&2; exit 2; }
+
+usage() {
+  cat <<'EOF' >&2
+usage: handoff-extract.sh <meta|prompts|turns> <claude|copilot|codex> <file> [N]
+EOF
+  exit 64
+}
+
+require_file() {
+  [[ -f "$1" ]] || die_runtime "file not found: $1"
+}
+
+# jq boolean helper: does this string look like a non-empty, non-null?
+json_str_or_null() {
+  local raw="$1"
+  if [[ -z "$raw" || "$raw" == "null" ]]; then
+    printf 'null'
+  else
+    # Escape embedded double-quotes and backslashes for safe JSON embedding.
+    printf '"%s"' "$(printf '%s' "$raw" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  fi
+}
+
+# -- claude ---------------------------------------------------------------
+
+meta_claude() {
+  local file="$1"
+  # Slurp-and-first via `jq -n '[inputs]|.[0]'` so there's no SIGPIPE from
+  # `head -1` closing the pipe early on a long transcript.
+  local raw
+  raw=$(jq -n -c '[inputs | select(.cwd != null and .cwd != "") | {cwd, sessionId, version}] | .[0] // empty' "$file" 2>/dev/null)
+  [[ -n "$raw" ]] || die_runtime "no session metadata found in $file"
+
+  local cwd session_id version short_id
+  cwd=$(printf '%s' "$raw" | jq -r '.cwd // ""')
+  session_id=$(printf '%s' "$raw" | jq -r '.sessionId // ""')
+  version=$(printf '%s' "$raw" | jq -r '.version // ""')
+  short_id="${session_id:0:8}"
+
+  # started_at: use file mtime as a stable proxy.
+  local started_at
+  started_at=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$(stat -c %Y "$file" 2>/dev/null || stat -f %m "$file")" +%Y-%m-%dT%H:%M:%SZ)
+
+  printf '{"cli":"claude","session_id":%s,"short_id":%s,"cwd":%s,"model":%s,"version":%s,"started_at":%s}\n' \
+    "$(json_str_or_null "$session_id")" \
+    "$(json_str_or_null "$short_id")" \
+    "$(json_str_or_null "$cwd")" \
+    "null" \
+    "$(json_str_or_null "$version")" \
+    "$(json_str_or_null "$started_at")"
+}
+
+# Claude user prompts, scrubbed of system/command/tool noise.
+# Content may be string OR array of content blocks.
+prompts_claude() {
+  local file="$1"
+  jq -r '
+    select(.type == "user")
+    | .message.content
+    | if type == "string" then
+        .
+      else
+        (map(select(.type == "text") | .text) | join("\n"))
+      end
+    | select(length > 0)
+  ' "$file" 2>/dev/null \
+    | awk '
+        # Claude JSONL carries many synthetic "user" records that are not
+        # actual human prompts: hook outputs, system reminders, slash-command
+        # echoes, task-notification polling, etc. Drop any record whose
+        # first non-whitespace content starts with one of these markers.
+        {
+          trimmed = $0
+          sub(/^[[:space:]]+/, "", trimmed)
+          if (trimmed == "") next
+          if (trimmed ~ /^<local-command-caveat>/) next
+          if (trimmed ~ /^<command-name>/) next
+          if (trimmed ~ /^<command-message>/) next
+          if (trimmed ~ /^<command-args>/) next
+          if (trimmed ~ /^<stdin>/) next
+          if (trimmed ~ /^<system-reminder>/) next
+          if (trimmed ~ /^<user-prompt-submit-hook>/) next
+          if (trimmed ~ /^<task-notification>/) next
+          if (trimmed ~ /^<task-id>/) next
+          if (trimmed ~ /^<summary>Monitor event/) next
+          if (trimmed ~ /^<\/task-notification>/) next
+          if (trimmed ~ /^<event>/) next
+          if (trimmed ~ /^If this event is something the user/) next
+          print
+        }
+      '
+}
+
+turns_claude() {
+  local file="$1"
+  local limit="${2:-20}"
+  jq -r '
+    select(.type == "assistant")
+    | .message.content
+    | (map(select(.type == "text") | .text) | join("\n"))
+    | select(length > 0)
+  ' "$file" 2>/dev/null | tail -n "$limit"
+}
+
+# -- copilot --------------------------------------------------------------
+
+# Parse a single key from workspace.yaml. YAML here is flat key:value, no
+# nesting; avoid a yq dependency by grepping the line.
+workspace_yaml_get() {
+  local wy="$1" key="$2"
+  awk -F': ' -v k="$key" '$1 == k { sub(/^[^:]*: */, ""); print; exit }' "$wy" 2>/dev/null
+}
+
+meta_copilot() {
+  local file="$1"
+  local session_meta
+  session_meta=$(jq -n -c '[inputs | select(.type == "session.start") | .data] | .[0] // empty' "$file" 2>/dev/null)
+  [[ -n "$session_meta" ]] || die_runtime "no session.start record in $file"
+
+  local cwd model session_id
+  cwd=$(printf '%s' "$session_meta" | jq -r '.cwd // ""')
+  model=$(printf '%s' "$session_meta" | jq -r '.model // ""')
+  session_id=$(printf '%s' "$session_meta" | jq -r '.sessionId // ""')
+
+  # Fallback: if session.start's cwd is null/empty, try the sibling
+  # workspace.yaml. (Real Copilot sessions emit null cwd at start in practice.)
+  local session_dir
+  session_dir=$(dirname "$file")
+  local wy="$session_dir/workspace.yaml"
+  if [[ -z "$cwd" && -f "$wy" ]]; then
+    cwd=$(workspace_yaml_get "$wy" "cwd")
+  fi
+  if [[ -z "$model" && -f "$wy" ]]; then
+    model=$(workspace_yaml_get "$wy" "model")
+  fi
+
+  local short_id="${session_id:0:8}"
+  local started_at
+  started_at=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$(stat -c %Y "$file" 2>/dev/null || stat -f %m "$file")" +%Y-%m-%dT%H:%M:%SZ)
+
+  printf '{"cli":"copilot","session_id":%s,"short_id":%s,"cwd":%s,"model":%s,"started_at":%s}\n' \
+    "$(json_str_or_null "$session_id")" \
+    "$(json_str_or_null "$short_id")" \
+    "$(json_str_or_null "$cwd")" \
+    "$(json_str_or_null "$model")" \
+    "$(json_str_or_null "$started_at")"
+}
+
+# Always prefer .data.content (the raw user text) over .data.transformedContent
+# (which wraps the prompt in system-reminder boilerplate).
+prompts_copilot() {
+  local file="$1"
+  jq -r '
+    select(.type == "user.message")
+    | .data.content // ""
+    | select(length > 0)
+  ' "$file" 2>/dev/null
+}
+
+turns_copilot() {
+  local file="$1"
+  local limit="${2:-20}"
+  jq -r '
+    select(.type == "assistant.message")
+    | (.data.content // .data.text // "")
+    | select(length > 0)
+  ' "$file" 2>/dev/null | tail -n "$limit"
+}
+
+# -- codex ----------------------------------------------------------------
+
+meta_codex() {
+  local file="$1"
+  local sm
+  sm=$(jq -n -c '[inputs | select(.type == "session_meta") | .payload] | .[0] // empty' "$file" 2>/dev/null)
+  [[ -n "$sm" ]] || die_runtime "no session_meta record in $file"
+
+  local session_id cwd model started_at
+  session_id=$(printf '%s' "$sm" | jq -r '.id // ""')
+  cwd=$(printf '%s' "$sm" | jq -r '.cwd // ""')
+  model=$(printf '%s' "$sm" | jq -r '.model_provider // ""')
+  started_at=$(printf '%s' "$sm" | jq -r '.timestamp // ""')
+
+  local short_id="${session_id:0:8}"
+  printf '{"cli":"codex","session_id":%s,"short_id":%s,"cwd":%s,"model":%s,"started_at":%s}\n' \
+    "$(json_str_or_null "$session_id")" \
+    "$(json_str_or_null "$short_id")" \
+    "$(json_str_or_null "$cwd")" \
+    "$(json_str_or_null "$model")" \
+    "$(json_str_or_null "$started_at")"
+}
+
+prompts_codex() {
+  local file="$1"
+  # The first user message in every Codex session is an <environment_context>
+  # block. Filter it out; every other user turn stays.
+  jq -r '
+    select(.type == "response_item"
+           and .payload.type == "message"
+           and .payload.role == "user")
+    | .payload.content[0].text // ""
+    | select(length > 0)
+    | select(test("^<environment_context>") | not)
+  ' "$file" 2>/dev/null
+}
+
+turns_codex() {
+  local file="$1"
+  local limit="${2:-20}"
+  jq -r '
+    select(.type == "response_item"
+           and .payload.type == "message"
+           and .payload.role == "assistant")
+    | .payload.content[0].text // ""
+    | select(length > 0)
+  ' "$file" 2>/dev/null | tail -n "$limit"
+}
+
+# -- dispatch -------------------------------------------------------------
+
+main() {
+  [[ $# -ge 1 ]] || usage
+  local sub="$1"
+  [[ $# -ge 2 ]] || usage
+  local cli="$2"
+  case "$cli" in
+    claude|copilot|codex) ;;
+    *) die_usage "cli must be one of: claude, copilot, codex (got: $cli)" ;;
+  esac
+
+  [[ $# -ge 3 ]] || usage
+  local file="$3"
+  local limit="${4:-20}"
+  require_file "$file"
+
+  case "$sub" in
+    meta)
+      case "$cli" in
+        claude)  meta_claude "$file" ;;
+        copilot) meta_copilot "$file" ;;
+        codex)   meta_codex "$file" ;;
+      esac
+      ;;
+    prompts)
+      case "$cli" in
+        claude)  prompts_claude "$file" ;;
+        copilot) prompts_copilot "$file" ;;
+        codex)   prompts_codex "$file" ;;
+      esac
+      ;;
+    turns)
+      case "$cli" in
+        claude)  turns_claude "$file" "$limit" ;;
+        copilot) turns_copilot "$file" "$limit" ;;
+        codex)   turns_codex "$file" "$limit" ;;
+      esac
+      ;;
+    *)
+      die_usage "unknown subcommand: $sub"
+      ;;
+  esac
+}
+
+main "$@"

--- a/plugins/dotclaude/scripts/handoff-extract.sh
+++ b/plugins/dotclaude/scripts/handoff-extract.sh
@@ -56,17 +56,34 @@ json_str_or_null() {
 
 meta_claude() {
   local file="$1"
-  # Slurp-and-first via `jq -n '[inputs]|.[0]'` so there's no SIGPIPE from
-  # `head -1` closing the pipe early on a long transcript.
+  # Prefer a record with a cwd (the common case). Slurp-and-first via
+  # `jq -n '[inputs]|.[0]'` to avoid SIGPIPE on long transcripts.
   local raw
   raw=$(jq -n -c '[inputs | select(.cwd != null and .cwd != "") | {cwd, sessionId, version}] | .[0] // empty' "$file" 2>/dev/null)
-  [[ -n "$raw" ]] || die_runtime "no session metadata found in $file"
 
-  local cwd session_id version short_id
-  cwd=$(printf '%s' "$raw" | jq -r '.cwd // ""')
-  session_id=$(printf '%s' "$raw" | jq -r '.sessionId // ""')
-  version=$(printf '%s' "$raw" | jq -r '.version // ""')
-  short_id="${session_id:0:8}"
+  local cwd="" session_id="" version=""
+  if [[ -n "$raw" ]]; then
+    cwd=$(printf '%s' "$raw" | jq -r '.cwd // ""')
+    session_id=$(printf '%s' "$raw" | jq -r '.sessionId // ""')
+    version=$(printf '%s' "$raw" | jq -r '.version // ""')
+  fi
+
+  # Edge case: brand-new aliased session with no activity yet (only
+  # custom-title / agent-name records, no cwd). Fall back to whatever
+  # identity records exist, then to the filename.
+  if [[ -z "$session_id" ]]; then
+    session_id=$(jq -n -r '[inputs | select(.sessionId != null) | .sessionId] | .[0] // empty' "$file" 2>/dev/null)
+  fi
+  if [[ -z "$session_id" ]]; then
+    # Parse the UUID out of the filename as a last resort.
+    local base
+    base=$(basename "$file" .jsonl)
+    if [[ "$base" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+      session_id="$base"
+    fi
+  fi
+
+  local short_id="${session_id:0:8}"
 
   # started_at: use file mtime as a stable proxy.
   local started_at

--- a/plugins/dotclaude/scripts/handoff-resolve.sh
+++ b/plugins/dotclaude/scripts/handoff-resolve.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# handoff-resolve.sh — resolve <cli> <identifier> to a session JSONL path.
+#
+# Usage:
+#   handoff-resolve.sh <cli> <identifier>
+#
+# cli:          claude | copilot | codex
+# identifier:   full UUID (36 chars), short UUID (first 8 hex),
+#               the literal word `latest`, or, for codex only,
+#               a thread_name alias (e.g. `my-feature`).
+#
+# Exits:
+#   0  prints absolute path to the resolved JSONL on stdout
+#   2  "not found" or other runtime error, with structured message on stderr
+#   64 usage error
+
+set -euo pipefail
+
+die_usage() { printf 'handoff-resolve: %s\n' "$1" >&2; exit 64; }
+die_runtime() { printf 'handoff-resolve: %s\n' "$1" >&2; exit 2; }
+
+usage() {
+  cat <<'EOF' >&2
+usage: handoff-resolve.sh <claude|copilot|codex> <uuid|short-uuid|latest|alias>
+EOF
+  exit 64
+}
+
+# Portable mtime+path printer (GNU or BSD stat).
+stat_mtime() {
+  local file="$1"
+  stat -c "%Y %n" "$file" 2>/dev/null || stat -f "%m %N" "$file" 2>/dev/null
+}
+
+# Pick newest by mtime from stdin-separated file list. Prints path only.
+pick_newest() {
+  xargs -I{} sh -c 'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
+    | sort -rn | head -1 | awk '{for (i=2; i<=NF; i++) printf "%s%s", $i, (i<NF ? OFS : ORS)}'
+}
+
+resolve_claude() {
+  local id="$1"
+  local root="${HOME}/.claude/projects"
+  [[ -d "$root" ]] || die_runtime "claude session root not found: $root"
+
+  if [[ "$id" == "latest" ]]; then
+    local hit
+    hit="$(find "$root" -maxdepth 2 -type f -name '*.jsonl' 2>/dev/null | pick_newest)"
+    [[ -n "$hit" ]] || die_runtime "no claude sessions found under $root"
+    printf '%s' "$hit"
+    return 0
+  fi
+
+  # Full UUID (36 chars, 5 hyphen-separated groups).
+  if [[ "$id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    local hit
+    hit="$(find "$root" -maxdepth 2 -type f -name "${id}.jsonl" 2>/dev/null | head -1)"
+    [[ -n "$hit" ]] || die_runtime "claude session not found for uuid: $id"
+    printf '%s' "$hit"
+    return 0
+  fi
+
+  # Short UUID (first 8 hex).
+  if [[ "$id" =~ ^[0-9a-f]{8}$ ]]; then
+    local hit
+    hit="$(find "$root" -maxdepth 2 -type f -name "${id}*.jsonl" 2>/dev/null | head -1)"
+    [[ -n "$hit" ]] || die_runtime "claude session not found for short-uuid: $id"
+    printf '%s' "$hit"
+    return 0
+  fi
+
+  die_runtime "claude identifier must be full UUID, short-UUID (8 hex), or 'latest': $id"
+}
+
+resolve_copilot() {
+  local id="$1"
+  local root="${HOME}/.copilot/session-state"
+  [[ -d "$root" ]] || die_runtime "copilot session root not found: $root"
+
+  if [[ "$id" == "latest" ]]; then
+    local hit
+    hit="$(find "$root" -maxdepth 2 -type f -name 'events.jsonl' 2>/dev/null | pick_newest)"
+    [[ -n "$hit" ]] || die_runtime "no copilot sessions found under $root"
+    printf '%s' "$hit"
+    return 0
+  fi
+
+  # Full UUID — direct path.
+  if [[ "$id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    local candidate="${root}/${id}/events.jsonl"
+    [[ -f "$candidate" ]] || die_runtime "copilot session not found for uuid: $id"
+    printf '%s' "$candidate"
+    return 0
+  fi
+
+  # Short UUID — glob match on dir prefix.
+  if [[ "$id" =~ ^[0-9a-f]{8}$ ]]; then
+    local hit
+    hit="$(find "$root" -maxdepth 1 -type d -name "${id}*" 2>/dev/null | head -1)"
+    [[ -n "$hit" && -f "$hit/events.jsonl" ]] \
+      || die_runtime "copilot session not found for short-uuid: $id"
+    printf '%s' "$hit/events.jsonl"
+    return 0
+  fi
+
+  die_runtime "copilot identifier must be full UUID, short-UUID (8 hex), or 'latest': $id"
+}
+
+resolve_codex() {
+  local id="$1"
+  local root="${HOME}/.codex/sessions"
+  [[ -d "$root" ]] || die_runtime "codex session root not found: $root"
+
+  if [[ "$id" == "latest" ]]; then
+    local hit
+    hit="$(find "$root" -type f -name 'rollout-*.jsonl' 2>/dev/null | pick_newest)"
+    [[ -n "$hit" ]] || die_runtime "no codex sessions found under $root"
+    printf '%s' "$hit"
+    return 0
+  fi
+
+  # Full UUID.
+  if [[ "$id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    local hit
+    hit="$(find "$root" -type f -name "rollout-*-${id}.jsonl" 2>/dev/null | head -1)"
+    if [[ -n "$hit" ]]; then
+      printf '%s' "$hit"
+      return 0
+    fi
+    # UUID-shaped but not on disk: fall through to alias scan in case someone
+    # named a thread with UUID-like shape. Very unlikely, but cheap.
+  fi
+
+  # Short UUID.
+  if [[ "$id" =~ ^[0-9a-f]{8}$ ]]; then
+    local hit
+    hit="$(find "$root" -type f -name "rollout-*-${id}-*.jsonl" 2>/dev/null | head -1)"
+    if [[ -n "$hit" ]]; then
+      printf '%s' "$hit"
+      return 0
+    fi
+    # Fall through to alias scan.
+  fi
+
+  # Alias scan: look for event_msg records with thread_name == "$id".
+  # jq is required here; on older systems fall back to a plain grep for the
+  # quoted string. jq is the happy path.
+  if command -v jq >/dev/null 2>&1; then
+    local f
+    while IFS= read -r f; do
+      local match
+      match=$(jq -r --arg name "$id" '
+        select(.type == "event_msg"
+               and .payload.thread_name == $name)
+        | input_filename' "$f" 2>/dev/null | head -1)
+      if [[ -n "$match" ]]; then
+        printf '%s' "$f"
+        return 0
+      fi
+    done < <(find "$root" -type f -name 'rollout-*.jsonl' 2>/dev/null)
+  else
+    local f
+    while IFS= read -r f; do
+      if grep -q "\"thread_name\":\"${id}\"" "$f" 2>/dev/null; then
+        printf '%s' "$f"
+        return 0
+      fi
+    done < <(find "$root" -type f -name 'rollout-*.jsonl' 2>/dev/null)
+  fi
+
+  die_runtime "codex session not found for identifier: $id"
+}
+
+main() {
+  [[ $# -ge 1 ]] || usage
+  local cli="$1"
+  [[ $# -ge 2 ]] || usage
+  local id="$2"
+
+  case "$cli" in
+    claude)  resolve_claude "$id" ;;
+    copilot) resolve_copilot "$id" ;;
+    codex)   resolve_codex "$id" ;;
+    *)       die_usage "cli must be one of: claude, copilot, codex (got: $cli)" ;;
+  esac
+}
+
+main "$@"

--- a/plugins/dotclaude/scripts/handoff-resolve.sh
+++ b/plugins/dotclaude/scripts/handoff-resolve.sh
@@ -26,11 +26,8 @@ EOF
   exit 64
 }
 
-# Portable mtime+path printer (GNU or BSD stat).
-stat_mtime() {
-  local file="$1"
-  stat -c "%Y %n" "$file" 2>/dev/null || stat -f "%m %N" "$file" 2>/dev/null
-}
+UUID_RE='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+SHORT_UUID_RE='^[0-9a-f]{8}$'
 
 # Pick newest by mtime from stdin-separated file list. Prints path only.
 pick_newest() {
@@ -47,25 +44,25 @@ resolve_claude() {
     local hit
     hit="$(find "$root" -maxdepth 2 -type f -name '*.jsonl' 2>/dev/null | pick_newest)"
     [[ -n "$hit" ]] || die_runtime "no claude sessions found under $root"
-    printf '%s' "$hit"
+    printf '%s\n' "$hit"
     return 0
   fi
 
   # Full UUID (36 chars, 5 hyphen-separated groups).
-  if [[ "$id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+  if [[ "$id" =~ $UUID_RE ]]; then
     local hit
     hit="$(find "$root" -maxdepth 2 -type f -name "${id}.jsonl" 2>/dev/null | head -1)"
     [[ -n "$hit" ]] || die_runtime "claude session not found for uuid: $id"
-    printf '%s' "$hit"
+    printf '%s\n' "$hit"
     return 0
   fi
 
   # Short UUID (first 8 hex).
-  if [[ "$id" =~ ^[0-9a-f]{8}$ ]]; then
+  if [[ "$id" =~ $SHORT_UUID_RE ]]; then
     local hit
     hit="$(find "$root" -maxdepth 2 -type f -name "${id}*.jsonl" 2>/dev/null | head -1)"
     if [[ -n "$hit" ]]; then
-      printf '%s' "$hit"
+      printf '%s\n' "$hit"
       return 0
     fi
     # Fall through to customTitle scan if short-UUID lookup missed.
@@ -73,6 +70,7 @@ resolve_claude() {
 
   # Claude `custom-title` alias scan: `claude --resume "<name>"` stores
   # the alias as a JSONL record `{"type":"custom-title","customTitle":"<name>","sessionId":"<uuid>"}`.
+  # Prefilter with grep so we only jq-verify files that contain the alias.
   if command -v jq >/dev/null 2>&1; then
     local f session_id
     while IFS= read -r f; do
@@ -83,11 +81,11 @@ resolve_claude() {
         local hit
         hit="$(find "$root" -maxdepth 2 -type f -name "${session_id}.jsonl" 2>/dev/null | head -1)"
         if [[ -n "$hit" ]]; then
-          printf '%s' "$hit"
+          printf '%s\n' "$hit"
           return 0
         fi
       fi
-    done < <(find "$root" -maxdepth 2 -type f -name '*.jsonl' 2>/dev/null)
+    done < <(grep -rl --include='*.jsonl' -F "\"customTitle\":\"${id}\"" "$root" 2>/dev/null)
   fi
 
   die_runtime "claude session not found for identifier: $id"
@@ -102,25 +100,25 @@ resolve_copilot() {
     local hit
     hit="$(find "$root" -maxdepth 2 -type f -name 'events.jsonl' 2>/dev/null | pick_newest)"
     [[ -n "$hit" ]] || die_runtime "no copilot sessions found under $root"
-    printf '%s' "$hit"
+    printf '%s\n' "$hit"
     return 0
   fi
 
   # Full UUID — direct path.
-  if [[ "$id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+  if [[ "$id" =~ $UUID_RE ]]; then
     local candidate="${root}/${id}/events.jsonl"
     [[ -f "$candidate" ]] || die_runtime "copilot session not found for uuid: $id"
-    printf '%s' "$candidate"
+    printf '%s\n' "$candidate"
     return 0
   fi
 
   # Short UUID — glob match on dir prefix.
-  if [[ "$id" =~ ^[0-9a-f]{8}$ ]]; then
+  if [[ "$id" =~ $SHORT_UUID_RE ]]; then
     local hit
     hit="$(find "$root" -maxdepth 1 -type d -name "${id}*" 2>/dev/null | head -1)"
     [[ -n "$hit" && -f "$hit/events.jsonl" ]] \
       || die_runtime "copilot session not found for short-uuid: $id"
-    printf '%s' "$hit/events.jsonl"
+    printf '%s\n' "$hit/events.jsonl"
     return 0
   fi
 
@@ -136,16 +134,16 @@ resolve_codex() {
     local hit
     hit="$(find "$root" -type f -name 'rollout-*.jsonl' 2>/dev/null | pick_newest)"
     [[ -n "$hit" ]] || die_runtime "no codex sessions found under $root"
-    printf '%s' "$hit"
+    printf '%s\n' "$hit"
     return 0
   fi
 
   # Full UUID.
-  if [[ "$id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+  if [[ "$id" =~ $UUID_RE ]]; then
     local hit
     hit="$(find "$root" -type f -name "rollout-*-${id}.jsonl" 2>/dev/null | head -1)"
     if [[ -n "$hit" ]]; then
-      printf '%s' "$hit"
+      printf '%s\n' "$hit"
       return 0
     fi
     # UUID-shaped but not on disk: fall through to alias scan in case someone
@@ -153,41 +151,32 @@ resolve_codex() {
   fi
 
   # Short UUID.
-  if [[ "$id" =~ ^[0-9a-f]{8}$ ]]; then
+  if [[ "$id" =~ $SHORT_UUID_RE ]]; then
     local hit
     hit="$(find "$root" -type f -name "rollout-*-${id}-*.jsonl" 2>/dev/null | head -1)"
     if [[ -n "$hit" ]]; then
-      printf '%s' "$hit"
+      printf '%s\n' "$hit"
       return 0
     fi
     # Fall through to alias scan.
   fi
 
   # Alias scan: look for event_msg records with thread_name == "$id".
-  # jq is required here; on older systems fall back to a plain grep for the
-  # quoted string. jq is the happy path.
-  if command -v jq >/dev/null 2>&1; then
-    local f
-    while IFS= read -r f; do
+  # Prefilter with grep — rollout dirs can hold hundreds of files, jq-parsing
+  # each one is quadratic. Then jq-verify only candidates if jq is present.
+  local f
+  while IFS= read -r f; do
+    if command -v jq >/dev/null 2>&1; then
       local match
       match=$(jq -r --arg name "$id" '
         select(.type == "event_msg"
                and .payload.thread_name == $name)
         | input_filename' "$f" 2>/dev/null | head -1)
-      if [[ -n "$match" ]]; then
-        printf '%s' "$f"
-        return 0
-      fi
-    done < <(find "$root" -type f -name 'rollout-*.jsonl' 2>/dev/null)
-  else
-    local f
-    while IFS= read -r f; do
-      if grep -q "\"thread_name\":\"${id}\"" "$f" 2>/dev/null; then
-        printf '%s' "$f"
-        return 0
-      fi
-    done < <(find "$root" -type f -name 'rollout-*.jsonl' 2>/dev/null)
-  fi
+      [[ -n "$match" ]] || continue
+    fi
+    printf '%s\n' "$f"
+    return 0
+  done < <(grep -rl --include='rollout-*.jsonl' -F "\"thread_name\":\"${id}\"" "$root" 2>/dev/null)
 
   die_runtime "codex session not found for identifier: $id"
 }

--- a/plugins/dotclaude/scripts/handoff-resolve.sh
+++ b/plugins/dotclaude/scripts/handoff-resolve.sh
@@ -64,12 +64,33 @@ resolve_claude() {
   if [[ "$id" =~ ^[0-9a-f]{8}$ ]]; then
     local hit
     hit="$(find "$root" -maxdepth 2 -type f -name "${id}*.jsonl" 2>/dev/null | head -1)"
-    [[ -n "$hit" ]] || die_runtime "claude session not found for short-uuid: $id"
-    printf '%s' "$hit"
-    return 0
+    if [[ -n "$hit" ]]; then
+      printf '%s' "$hit"
+      return 0
+    fi
+    # Fall through to customTitle scan if short-UUID lookup missed.
   fi
 
-  die_runtime "claude identifier must be full UUID, short-UUID (8 hex), or 'latest': $id"
+  # Claude `custom-title` alias scan: `claude --resume "<name>"` stores
+  # the alias as a JSONL record `{"type":"custom-title","customTitle":"<name>","sessionId":"<uuid>"}`.
+  if command -v jq >/dev/null 2>&1; then
+    local f session_id
+    while IFS= read -r f; do
+      session_id=$(jq -r --arg name "$id" '
+        select(.type == "custom-title" and .customTitle == $name)
+        | .sessionId' "$f" 2>/dev/null | head -1)
+      if [[ -n "$session_id" ]]; then
+        local hit
+        hit="$(find "$root" -maxdepth 2 -type f -name "${session_id}.jsonl" 2>/dev/null | head -1)"
+        if [[ -n "$hit" ]]; then
+          printf '%s' "$hit"
+          return 0
+        fi
+      fi
+    done < <(find "$root" -maxdepth 2 -type f -name '*.jsonl' 2>/dev/null)
+  fi
+
+  die_runtime "claude session not found for identifier: $id"
 }
 
 resolve_copilot() {

--- a/plugins/dotclaude/scripts/handoff-resolve.sh
+++ b/plugins/dotclaude/scripts/handoff-resolve.sh
@@ -34,10 +34,31 @@ EOF
 UUID_RE='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 SHORT_UUID_RE='^[0-9a-f]{8}$'
 
-# Pick newest by mtime from stdin-separated file list. Prints path only.
+# Pick newest by mtime from a newline-separated list on stdin. Prints path only.
+# Pure-bash loop: no word-splitting on paths with spaces, no subshell per file.
 pick_newest() {
-  xargs -I{} sh -c 'stat -c "%Y %n" "{}" 2>/dev/null || stat -f "%m %N" "{}" 2>/dev/null' \
-    | sort -rn | head -1 | awk '{for (i=2; i<=NF; i++) printf "%s%s", $i, (i<NF ? OFS : ORS)}'
+  local best_ms=0 best_path="" file frac secs frac_ms
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    # GNU find -printf gives fractional epoch seconds (e.g. 1700000000.123456789).
+    # BSD stat -f %Fm gives the same. Whole-second fallbacks for minimal platforms.
+    frac=$(find "$file" -maxdepth 0 -printf '%T@' 2>/dev/null \
+           || stat -f '%Fm' "$file" 2>/dev/null \
+           || stat -c '%Y' "$file" 2>/dev/null \
+           || echo 0)
+    if [[ "$frac" == *.* ]]; then
+      secs="${frac%%.*}"
+      local frac_part="${frac#*.}000"          # pad to ≥3 digits
+      frac_ms=$(( ${secs:-0} * 1000 + 10#${frac_part:0:3} ))
+    else
+      frac_ms=$(( ${frac:-0} * 1000 ))
+    fi
+    if (( frac_ms > best_ms )); then
+      best_ms=$frac_ms
+      best_path="$file"
+    fi
+  done
+  [[ -n "$best_path" ]] && printf '%s\n' "$best_path"
 }
 
 resolve_claude() {
@@ -62,10 +83,10 @@ resolve_claude() {
     return 0
   fi
 
-  # Short UUID (first 8 hex).
+  # Short UUID (first 8 hex) — pick newest by mtime; deterministic across prefix collisions.
   if [[ "$id" =~ $SHORT_UUID_RE ]]; then
     local hit
-    hit="$(find "$root" -maxdepth 2 -type f -name "${id}*.jsonl" 2>/dev/null | head -1)"
+    hit="$(find "$root" -maxdepth 2 -type f -name "${id}*.jsonl" 2>/dev/null | pick_newest)"
     if [[ -n "$hit" ]]; then
       printf '%s\n' "$hit"
       return 0
@@ -117,13 +138,13 @@ resolve_copilot() {
     return 0
   fi
 
-  # Short UUID — glob match on dir prefix.
+  # Short UUID — pick newest matching session dir by mtime of its events.jsonl.
   if [[ "$id" =~ $SHORT_UUID_RE ]]; then
     local hit
-    hit="$(find "$root" -maxdepth 1 -type d -name "${id}*" 2>/dev/null | head -1)"
-    [[ -n "$hit" && -f "$hit/events.jsonl" ]] \
+    hit="$(find "$root" -maxdepth 2 -type f -path "*/${id}*/events.jsonl" 2>/dev/null | pick_newest)"
+    [[ -n "$hit" ]] \
       || die_runtime "copilot session not found for short-uuid: $id"
-    printf '%s\n' "$hit/events.jsonl"
+    printf '%s\n' "$hit"
     return 0
   fi
 
@@ -155,10 +176,10 @@ resolve_codex() {
     # named a thread with UUID-like shape. Very unlikely, but cheap.
   fi
 
-  # Short UUID.
+  # Short UUID — pick newest by mtime; deterministic across prefix collisions.
   if [[ "$id" =~ $SHORT_UUID_RE ]]; then
     local hit
-    hit="$(find "$root" -type f -name "rollout-*-${id}-*.jsonl" 2>/dev/null | head -1)"
+    hit="$(find "$root" -type f -name "rollout-*-${id}-*.jsonl" 2>/dev/null | pick_newest)"
     if [[ -n "$hit" ]]; then
       printf '%s\n' "$hit"
       return 0

--- a/plugins/dotclaude/scripts/handoff-resolve.sh
+++ b/plugins/dotclaude/scripts/handoff-resolve.sh
@@ -21,7 +21,12 @@ die_runtime() { printf 'handoff-resolve: %s\n' "$1" >&2; exit 2; }
 
 usage() {
   cat <<'EOF' >&2
-usage: handoff-resolve.sh <claude|copilot|codex> <uuid|short-uuid|latest|alias>
+usage: handoff-resolve.sh <any|claude|copilot|codex> <uuid|short-uuid|latest|alias>
+
+  any       probe all three CLIs; on collision, exit 2 with TSV candidates on stderr
+  claude    resolve in ~/.claude/projects only
+  copilot   resolve in ~/.copilot/session-state only
+  codex     resolve in ~/.codex/sessions only
 EOF
   exit 64
 }
@@ -181,6 +186,79 @@ resolve_codex() {
   die_runtime "codex session not found for identifier: $id"
 }
 
+# Extract a session id from a resolved path, per-CLI convention.
+session_id_from_path() {
+  local cli="$1" path="$2"
+  case "$cli" in
+    claude)
+      basename "$path" .jsonl
+      ;;
+    copilot)
+      basename "$(dirname "$path")"
+      ;;
+    codex)
+      local base; base=$(basename "$path" .jsonl)
+      printf '%s' "$base" \
+        | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' \
+        | tail -1
+      ;;
+  esac
+}
+
+# `any` mode: probe all three CLIs. Emit single path on exactly-one match;
+# TSV candidate list on stderr + exit 2 on collision; exit 2 on no match.
+resolve_any() {
+  local id="$1"
+
+  # Special case: `any latest` picks the newest jsonl across all three roots.
+  if [[ "$id" == "latest" ]]; then
+    local roots=()
+    [[ -d "${HOME}/.claude/projects" ]]       && roots+=("${HOME}/.claude/projects")
+    [[ -d "${HOME}/.copilot/session-state" ]] && roots+=("${HOME}/.copilot/session-state")
+    [[ -d "${HOME}/.codex/sessions" ]]        && roots+=("${HOME}/.codex/sessions")
+    [[ ${#roots[@]} -gt 0 ]] || die_runtime "no session roots found under \$HOME"
+    local hit
+    hit="$(find "${roots[@]}" -type f -name '*.jsonl' 2>/dev/null | pick_newest)"
+    [[ -n "$hit" ]] || die_runtime "no sessions found across any root"
+    printf '%s\n' "$hit"
+    return 0
+  fi
+
+  # Collect hits from each per-CLI resolver (each may die_runtime on miss;
+  # subshell captures the non-zero exit and we skip).
+  local hits=()
+  local tsv=()
+  local cli path sid
+  for cli in claude copilot codex; do
+    if path=$("resolve_$cli" "$id" 2>/dev/null); then
+      [[ -n "$path" ]] || continue
+      sid=$(session_id_from_path "$cli" "$path")
+      hits+=("$path")
+      tsv+=("$(printf '%s\t%s\t%s\t%s' "$cli" "$sid" "$path" "$id")")
+    fi
+  done
+
+  case ${#hits[@]} in
+    0)
+      die_runtime "no session matches: $id"
+      ;;
+    1)
+      printf '%s\n' "${hits[0]}"
+      return 0
+      ;;
+    *)
+      {
+        printf 'handoff-resolve: multiple sessions match "%s":\n' "$id"
+        local line
+        for line in "${tsv[@]}"; do
+          printf '%s\n' "$line"
+        done
+      } >&2
+      exit 2
+      ;;
+  esac
+}
+
 main() {
   [[ $# -ge 1 ]] || usage
   local cli="$1"
@@ -188,10 +266,11 @@ main() {
   local id="$2"
 
   case "$cli" in
+    any)     resolve_any "$id" ;;
     claude)  resolve_claude "$id" ;;
     copilot) resolve_copilot "$id" ;;
     codex)   resolve_codex "$id" ;;
-    *)       die_usage "cli must be one of: claude, copilot, codex (got: $cli)" ;;
+    *)       die_usage "cli must be one of: any, claude, copilot, codex (got: $cli)" ;;
   esac
 }
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -114,20 +114,36 @@ ask a single clarifying question before proceeding.
 
 ## Sub-Commands
 
-### `describe <cli> <uuid|latest>`
+### `describe <cli> <uuid|latest|alias>`
 
 Print an inline 2–4 sentence summary of the session plus the verbatim
 user prompts. Use when the user asks "what was that about" and nothing
 more.
 
-**Steps:**
+For the deterministic path (resolve + extract), prefer the bundled
+shell scripts:
+
+- `plugins/dotclaude/scripts/handoff-resolve.sh <cli> <id>` — returns
+  the absolute JSONL path, supports UUID, short-UUID, `latest`, and
+  (codex only) thread-name aliases.
+- `plugins/dotclaude/scripts/handoff-extract.sh meta <cli> <file>` —
+  emits a JSON metadata object.
+- `plugins/dotclaude/scripts/handoff-extract.sh prompts <cli> <file>` —
+  emits clean user prompts with CLI-specific noise filtered out.
+
+For a fully-packaged CLI interface, invoke
+`dotclaude-handoff describe <cli> <id>` (same pattern, no skill load
+required — useful from Codex).
+
+**Steps (skill-interpreted fallback if the scripts are unavailable):**
 
 1. Resolve the session file. Load the per-CLI reference:
    - `claude` → `references/claude-code.md`
    - `copilot` → `references/copilot.md`
    - `codex` → `references/codex.md`
-2. Apply the `latest` resolver if the identifier is `latest`, otherwise
-   locate the file by UUID using the path pattern in that reference.
+2. Apply the `latest` resolver if the identifier is `latest`; for codex
+   an alias (non-hex identifier) triggers a `thread_name` scan; otherwise
+   locate the file by UUID using the path pattern in the reference.
 3. If no file is found, output exactly:
 
    ```
@@ -137,8 +153,10 @@ more.
    and stop.
 
 4. Run the per-CLI `jq` filters from the reference to extract:
-   - session meta (cwd, model, timestamp)
-   - all user turns, verbatim, in order
+   - session meta (cwd, model, timestamp); for copilot, fall back to
+     `workspace.yaml` when `session.start.cwd` is null
+   - all user turns, verbatim, in order, with CLI-specific noise filtered
+     (see the reference for the exclusion list)
    - all assistant turns (kept in memory for summary only; do not print)
 5. Render the output as:
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -21,7 +21,7 @@ description: >
   "find the session where", "search sessions", "which session did I",
   "push handoff", "pull handoff", "handoff to other machine",
   "resume on my other laptop".
-argument-hint: "<sub-cmd> [<source-cli>] <uuid|latest|query|handle> [--to <target-cli>] [--via <transport>] [--cli <cli>]"
+argument-hint: "[<query>|push|pull|list] [<query>] [--tag <label>] [--via <transport>]"
 tools: Glob, Read, Grep, Bash, Write
 effort: medium
 model: sonnet
@@ -29,48 +29,59 @@ model: sonnet
 
 # Handoff — Cross-CLI Session Context Transfer
 
-Locate a session transcript from one agentic CLI and hand its context to
-another. Supports three source CLIs (`claude`, `copilot`, `codex`) and
-the same three as targets. The skill never invokes a different CLI
-itself — it produces a summary or a paste-ready block the user drops
+Locate a session transcript from any agentic CLI and hand its context
+to another. Source CLI is auto-detected from the identifier; target CLI
+is wherever you run the command. The skill never invokes a different
+CLI itself — it produces a paste-ready `<handoff>` block the user drops
 into the target agent.
 
 ## Arguments
 
-**Dead-simple form (the primary path):**
+**The five forms (primary public surface):**
 
-- `/handoff <source-cli> <id-or-name>` — read the session transcript
-  from `<source-cli>` (one of `claude`, `copilot`, `codex`) and emit a
-  `<handoff>` block into the current context. `<id-or-name>` accepts:
-  - full UUID (36 chars)
-  - short UUID (first 8 hex)
-  - the literal `latest` (newest by mtime)
-  - Claude `customTitle` alias (set via `claude --resume "<name>"`,
-    stored as a `custom-title` JSONL record)
-  - Codex `thread_name` alias (set via `codex resume <name>`, stored
-    as an `event_msg` record)
+```
+/handoff                              push host's latest session
+/handoff <query>                      local cross-agent: emit <handoff>
+/handoff push [<query>] [--tag <l>]   upload to transport
+/handoff pull [<query>]               fetch from transport
+/handoff list [--local|--remote]      unified table
+```
 
 Equivalent from any shell (including Codex's bash tool):
-`!dotclaude handoff <source-cli> <id-or-name>`.
+`!dotclaude handoff …` with the same arguments.
+
+`<query>` auto-detects the source CLI across all three roots
+(`~/.claude/projects`, `~/.copilot/session-state`, `~/.codex/sessions`).
+It accepts:
+
+- full UUID (36 chars)
+- short UUID (first 8 hex)
+- the literal `latest` (newest by mtime across every root)
+- Claude `customTitle` alias (set via `claude --resume "<name>"`,
+  stored as a `custom-title` JSONL record)
+- Codex `thread_name` alias (set via `codex resume <name>`, stored as
+  an `event_msg` record)
+
+**Collision model.** When a `<query>` matches in two or more roots (or
+matches two gists on `pull`), behavior depends on stdin:
+
+- TTY → skill prompts interactively for a pick.
+- Non-TTY → exits 2 with a TSV candidate list on stderr (one line per
+  candidate: `<cli>\t<session-id>\t<path>\t<query>`).
 
 **Power-user sub-commands** (optional, only when you need them):
 
-- `$0` — sub-command: `describe`, `digest`, `file`, `list`, `search`,
-  `push`, `pull`, `remote-list`, or `doctor`. When omitted and the
-  first positional is a CLI name, the skill behaves as `digest` by
-  default.
-- `$1` — positional varies by sub-command:
-  - `describe` / `digest` / `file` / `list` / `push` → source CLI
-    (`claude`, `copilot`, `codex`).
-  - `search` → the query string (regex).
-  - `pull` → a handle (gist ID, gist URL, or the literal `latest`).
-  - `remote-list` / `doctor` → no positional argument.
-- `$2` — session identifier: a UUID, short UUID, `latest`, or a named
-  alias. Required for `describe`, `digest`, `file`, `push`. Ignored
-  for `list`, `search`, `pull`, `remote-list`, `doctor`.
-- `--to <target-cli>` — optional; tunes the digest voice for the target
-  agent. Defaults to `claude` since that is the most common consumer in
-  this repo.
+- `resolve <cli> <id>` — print the absolute JSONL path.
+- `describe <cli> <id>` — inline summary (markdown or `--json`).
+- `digest <cli> <id>` — full `<handoff>` block for paste (no transport).
+- `file <cli> <id>` — write a markdown doc to `docs/handoffs/`.
+
+Each takes an explicit `<cli>` (`claude`, `copilot`, `codex`) and an
+identifier. These remain reachable for scripting.
+
+- `--to <target-cli>` — optional; tunes the `<handoff>` block's
+  next-step wording for a specific target agent. Defaults to `claude`.
+  Mostly redundant for in-place use and can be omitted.
 - `--cli <cli>` — `search` and `remote-list` only; restrict the scan
   to one CLI.
 - `--since <ISO>` — `search` and `remote-list` only; skip entries older
@@ -119,15 +130,19 @@ install matrix and workarounds live in
 ## Auto-trigger contract
 
 When the user message matches any of these patterns and the skill fires
-without explicit sub-command, run `describe` by default:
+without an explicit form, run the bare `<query>` path (local
+cross-agent digest) by default:
 
 - Literal resume-command fragments: `claude --resume <uuid>`,
-  `copilot --resume=<uuid>`, `codex resume <uuid>`.
-- Natural-language: "what was that session about", "continue in
-  \<cli\>", "switch to \<cli\>", "handoff".
+  `claude --resume "<name>"`, `copilot --resume=<uuid>`,
+  `codex resume <uuid>`, `codex resume <name>`.
+- Natural-language: "what was that session about", "continue in X",
+  "switch to X", "handoff".
 
-Extract `<cli>` and `<uuid>` from the user message. If either is missing,
-ask a single clarifying question before proceeding.
+Extract the `<query>` from the user message (a UUID, short UUID, or
+named alias). No CLI argument is needed — the skill probes all three
+roots. If the query is missing or ambiguous, ask a single clarifying
+question before proceeding.
 
 ---
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -37,18 +37,37 @@ into the target agent.
 
 ## Arguments
 
+**Dead-simple form (the primary path):**
+
+- `/handoff <source-cli> <id-or-name>` — read the session transcript
+  from `<source-cli>` (one of `claude`, `copilot`, `codex`) and emit a
+  `<handoff>` block into the current context. `<id-or-name>` accepts:
+  - full UUID (36 chars)
+  - short UUID (first 8 hex)
+  - the literal `latest` (newest by mtime)
+  - Claude `customTitle` alias (set via `claude --resume "<name>"`,
+    stored as a `custom-title` JSONL record)
+  - Codex `thread_name` alias (set via `codex resume <name>`, stored
+    as an `event_msg` record)
+
+Equivalent from any shell (including Codex's bash tool):
+`!dotclaude handoff <source-cli> <id-or-name>`.
+
+**Power-user sub-commands** (optional, only when you need them):
+
 - `$0` — sub-command: `describe`, `digest`, `file`, `list`, `search`,
-  `push`, `pull`, `remote-list`, or `doctor`. If not provided and the
-  skill is auto-triggered, default to `describe`.
+  `push`, `pull`, `remote-list`, or `doctor`. When omitted and the
+  first positional is a CLI name, the skill behaves as `digest` by
+  default.
 - `$1` — positional varies by sub-command:
   - `describe` / `digest` / `file` / `list` / `push` → source CLI
     (`claude`, `copilot`, `codex`).
   - `search` → the query string (regex).
   - `pull` → a handle (gist ID, gist URL, or the literal `latest`).
   - `remote-list` / `doctor` → no positional argument.
-- `$2` — session identifier: a UUID or the literal `latest`. Required for
-  `describe`, `digest`, `file`, `push`. Ignored for `list`, `search`,
-  `pull`, `remote-list`, `doctor`.
+- `$2` — session identifier: a UUID, short UUID, `latest`, or a named
+  alias. Required for `describe`, `digest`, `file`, `push`. Ignored
+  for `list`, `search`, `pull`, `remote-list`, `doctor`.
 - `--to <target-cli>` — optional; tunes the digest voice for the target
   agent. Defaults to `claude` since that is the most common consumer in
   this repo.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
@@ -72,6 +72,24 @@ jq -r 'select(.type == "user") | .message.content
   | if type == "string" then . else (map(select(.type == "text") | .text) | join("\n")) end' <file>
 ```
 
+**Noise exclusions.** Claude JSONL carries many synthetic "user" records
+that are not real human prompts: hook outputs, system reminders,
+slash-command echoes, task-notification polling, and tool results.
+Drop any prompt whose first non-whitespace content starts with:
+
+- `<local-command-caveat>` — caveat wrapper for local-command input
+- `<command-name>`, `<command-message>`, `<command-args>` — slash-command echoes
+- `<stdin>` — interactive input wrapper
+- `<system-reminder>` — injected reminders
+- `<user-prompt-submit-hook>` — hook payloads
+- `<task-notification>`, `</task-notification>`, `<task-id>` — task-monitor polling
+- `<summary>Monitor event` — monitor-event summary
+- `<event>` — raw monitor events
+- `If this event is something the user` — monitor heuristic preamble
+
+Reference implementation: `plugins/dotclaude/scripts/handoff-extract.sh
+prompts claude <file>`.
+
 ### Assistant turns (text only)
 
 ```bash

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
@@ -43,7 +43,8 @@ done
 ```
 
 Reference implementation:
-`plugins/dotclaude/scripts/handoff-resolve.sh claude <name>`.
+`plugins/dotclaude/scripts/handoff-resolve.sh any <name>` (or the
+per-CLI form `handoff-resolve.sh claude <name>` for scripting).
 
 **Latest** — newest `.jsonl` across all project dirs by mtime (GNU/BSD
 portable):

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
@@ -34,12 +34,12 @@ renames a session, Claude stores the alias as a JSONL record:
 Scan `.jsonl` files for the match and map it back to the session file:
 
 ```bash
-for f in $(find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl'); do
+while IFS= read -r f; do
   sid=$(jq -r --arg name "<name>" '
     select(.type == "custom-title" and .customTitle == $name)
     | .sessionId' "$f" 2>/dev/null | head -1)
   [[ -n "$sid" ]] && find ~/.claude/projects -maxdepth 2 -name "${sid}.jsonl" && break
-done
+done < <(find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl')
 ```
 
 Reference implementation:

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/claude-code.md
@@ -24,6 +24,27 @@ project dirs:
 find ~/.claude/projects -maxdepth 2 -type f -name '<uuid>.jsonl' 2>/dev/null
 ```
 
+**By `customTitle` alias (`claude --resume "<name>"`)** — when the user
+renames a session, Claude stores the alias as a JSONL record:
+
+```json
+{ "type": "custom-title", "customTitle": "<name>", "sessionId": "<uuid>" }
+```
+
+Scan `.jsonl` files for the match and map it back to the session file:
+
+```bash
+for f in $(find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl'); do
+  sid=$(jq -r --arg name "<name>" '
+    select(.type == "custom-title" and .customTitle == $name)
+    | .sessionId' "$f" 2>/dev/null | head -1)
+  [[ -n "$sid" ]] && find ~/.claude/projects -maxdepth 2 -name "${sid}.jsonl" && break
+done
+```
+
+Reference implementation:
+`plugins/dotclaude/scripts/handoff-resolve.sh claude <name>`.
+
 **Latest** — newest `.jsonl` across all project dirs by mtime (GNU/BSD
 portable):
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
@@ -37,7 +37,8 @@ done | head -1
 ```
 
 Reference implementation:
-`plugins/dotclaude/scripts/handoff-resolve.sh codex <alias>`.
+`plugins/dotclaude/scripts/handoff-resolve.sh any <alias>` (or the
+per-CLI form `handoff-resolve.sh codex <alias>` for scripting).
 
 **Latest** — newest rollout by mtime (GNU/BSD portable):
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
@@ -29,11 +29,12 @@ thread, Codex records an `event_msg` with
 `payload.thread_name = "<name>"`. Scan rollouts for the match:
 
 ```bash
-for f in $(find ~/.codex/sessions -type f -name 'rollout-*.jsonl'); do
-  jq -r --arg name "<name>" '
-    select(.type == "event_msg" and .payload.thread_name == $name)
-    | input_filename' "$f" 2>/dev/null | head -1
-done | head -1
+find ~/.codex/sessions -type f -name 'rollout-*.jsonl' 2>/dev/null \
+  | while IFS= read -r f; do
+      jq -r --arg name "<name>" '
+        select(.type == "event_msg" and .payload.thread_name == $name)
+        | input_filename' "$f" 2>/dev/null | head -1
+    done | head -1
 ```
 
 Reference implementation:

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
@@ -24,6 +24,21 @@ Examples:
 find ~/.codex/sessions -type f -name "rollout-*-<uuid>.jsonl" 2>/dev/null
 ```
 
+**By thread alias (`codex resume <name>`)** — when the user renames a
+thread, Codex records an `event_msg` with
+`payload.thread_name = "<name>"`. Scan rollouts for the match:
+
+```bash
+for f in $(find ~/.codex/sessions -type f -name 'rollout-*.jsonl'); do
+  jq -r --arg name "<name>" '
+    select(.type == "event_msg" and .payload.thread_name == $name)
+    | input_filename' "$f" 2>/dev/null | head -1
+done | head -1
+```
+
+Reference implementation:
+`plugins/dotclaude/scripts/handoff-resolve.sh codex <alias>`.
+
 **Latest** — newest rollout by mtime (GNU/BSD portable):
 
 ```bash

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/copilot.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/copilot.md
@@ -68,7 +68,7 @@ jq -r 'select(.type == "session.start") | .data | {cwd, model, sessionId}' <file
 **Mandatory `workspace.yaml` fallback.** Real Copilot sessions commonly
 emit `"cwd": null` on `session.start`; the authoritative value lives in
 the sibling `workspace.yaml` (same session dir). If the `jq` filter
-above returns a null or empty `cwd`, grep `workspace.yaml`:
+above returns a null or empty `cwd`, parse `workspace.yaml`:
 
 ```bash
 awk -F': ' '$1 == "cwd" { sub(/^[^:]*: */, ""); print; exit }' \

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/copilot.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/copilot.md
@@ -65,9 +65,18 @@ Relevant `type` values:
 jq -r 'select(.type == "session.start") | .data | {cwd, model, sessionId}' <file> | head -1
 ```
 
-If `session.start` lacks `cwd`, fall back to the sibling
-`workspace.yaml` in the session dir — it carries `cwd:` as a top-level
-key.
+**Mandatory `workspace.yaml` fallback.** Real Copilot sessions commonly
+emit `"cwd": null` on `session.start`; the authoritative value lives in
+the sibling `workspace.yaml` (same session dir). If the `jq` filter
+above returns a null or empty `cwd`, grep `workspace.yaml`:
+
+```bash
+awk -F': ' '$1 == "cwd" { sub(/^[^:]*: */, ""); print; exit }' \
+  "$(dirname <file>)/workspace.yaml"
+```
+
+Same pattern for `model`. Reference implementation:
+`plugins/dotclaude/scripts/handoff-extract.sh meta copilot <file>`.
 
 ### User prompts
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
@@ -2,56 +2,90 @@
 
 Codex CLI does not autoload `~/.claude/skills/`, so it cannot invoke
 the `/handoff` slash command directly. Use the packaged binary via
-Codex's bash tool instead. Same binary works from any shell.
+Codex's bash tool instead. Same binary, same five-form shape.
 
-## One command, one shape
+## The five forms
 
 ```
-!dotclaude handoff <source-cli> <id-or-name>
+!dotclaude handoff                              push host's latest session
+!dotclaude handoff <query>                      local cross-agent: emit <handoff>
+!dotclaude handoff push [<query>] [--tag LBL]   upload to transport
+!dotclaude handoff pull [<query>]               fetch from transport
+!dotclaude handoff list [--local|--remote]      unified table
 ```
 
-- `<source-cli>`: `claude` | `copilot` | `codex`
-- `<id-or-name>`: full UUID, short UUID (8 hex), `latest`, or a
-  named alias where the source CLI supports it (Claude `customTitle`,
-  Codex `thread_name`).
-
-The output is a `<handoff>` block that lands directly in Codex's
-context. Follow up with "continue" and you are back on task.
+`<query>` auto-detects the source CLI across all three roots. It
+accepts: full UUID, short UUID (first 8 hex), `latest`, Claude
+`customTitle`, or Codex `thread_name`.
 
 ## Examples
 
-```
-# Claude hit its token limit; continue that session in Codex.
-!dotclaude handoff claude b8d2dd0a
-!dotclaude handoff claude "test-handoff"       # customTitle alias
-!dotclaude handoff claude latest
+### Claude hit its token limit; continue in Codex
 
-# Resume a Copilot session in Codex.
-!dotclaude handoff copilot e6c2e29a
+Claude prints on exit:
 
-# Resume a renamed Codex thread in a fresh Codex session.
-!dotclaude handoff codex test                   # thread_name alias
-!dotclaude handoff codex 019da2f6
-!dotclaude handoff codex latest
 ```
+claude --resume b8d2dd0a-1cb6-4cfb-b166-e0a94f20512e
+```
+
+In a fresh Codex session:
+
+```
+!dotclaude handoff b8d2dd0a
+```
+
+Same works with a full UUID or a Claude `customTitle`:
+
+```
+!dotclaude handoff "test-handoff"
+```
+
+### Resume a Codex thread renamed via `codex resume <name>`
+
+```
+!dotclaude handoff my-feature
+```
+
+### Move a Codex session to the other machine
+
+On machine A (before closing):
+
+```
+!dotclaude handoff push my-feature --tag end-of-day
+```
+
+On machine B:
+
+```
+!dotclaude handoff pull end-of-day
+```
+
+or bare `!dotclaude handoff pull` to pick up the latest gist.
 
 ## Prerequisite
 
-`npm install -g @dotclaude/dotclaude` (installs `dotclaude` on PATH
-with `handoff` as one of its sub-commands). Or run ad-hoc with
-`npx dotclaude handoff ...`.
+`npm install -g @dotclaude/dotclaude` (installs the `dotclaude` CLI on
+PATH). Or `npx dotclaude handoff …` for ad-hoc use.
 
-## Sub-commands (power users)
+## Collision handling
 
-The bare form above is shorthand for the common `digest` path. Full
-sub-command list:
+If a `<query>` matches a Claude session AND a Codex session (e.g. you
+renamed a thread `refactor` and named a Claude session `refactor`), the
+binary:
+
+- On a TTY: prompts you to pick `[1..N]`.
+- Non-TTY (scripts/CI): exits 2 with a TSV candidate list on stderr so
+  the caller can parse and retry with a more specific query.
+
+## Power-user sub-commands
+
+The five-form shape above is the primary surface. For scripting you
+can still use:
 
 ```
-dotclaude handoff <cli> <id>                 # implicit digest (default)
 dotclaude handoff resolve  <cli> <id>        # file path only
 dotclaude handoff describe <cli> <id>        # inline markdown summary
 dotclaude handoff digest   <cli> <id>        # full <handoff> block
-dotclaude handoff list     <cli>             # recent sessions
 dotclaude handoff file     <cli> <id>        # write to docs/handoffs/
 ```
 
@@ -60,8 +94,8 @@ All subcommands support `--help`, `--version`, `--json`, `--verbose`,
 
 ## Why the binary and not the skill file?
 
-`skills/handoff/SKILL.md` is the authoritative runbook for Claude
-Code and Copilot CLI (both load it automatically). Codex does not
-load it. Rather than asking Codex to ingest a 460-line spec, the
-binary bundles the resolution and extraction logic into a single
-call. Same code path as the skill; no skill load required.
+`skills/handoff/SKILL.md` is the authoritative runbook for Claude Code
+and Copilot CLI (both load it automatically). Codex does not load it.
+Rather than asking Codex to ingest a 460-line spec, the binary bundles
+the resolution and extraction logic into a single call. Same code path
+as the skill; no skill load required.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
@@ -51,21 +51,29 @@ Same works with a full UUID or a Claude `customTitle`:
 On machine A (before closing):
 
 ```
-!dotclaude handoff push my-feature --tag end-of-day
+!dotclaude handoff push my-feature --tag end-of-day --via git-fallback
 ```
 
 On machine B:
 
 ```
-!dotclaude handoff pull end-of-day
+!dotclaude handoff pull end-of-day --via git-fallback
 ```
 
-or bare `!dotclaude handoff pull` to pick up the latest gist.
+or bare `!dotclaude handoff pull --via git-fallback` to pick up the latest handoff.
 
 ## Prerequisite
 
 `npm install -g @dotclaude/dotclaude` (installs the `dotclaude` CLI on
 PATH). Or `npx dotclaude handoff …` for ad-hoc use.
+
+For cross-machine transport, set `DOTCLAUDE_HANDOFF_REPO` to a bare git
+repo URL (HTTPS, SSH, `file://`, or absolute path) before running
+`push`/`pull`. Example:
+
+```bash
+export DOTCLAUDE_HANDOFF_REPO=git@github.com:you/handoffs.git
+```
 
 ## Collision handling
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
@@ -1,0 +1,82 @@
+# Using handoff from Codex (or any shell)
+
+Codex CLI does not autoload `~/.claude/skills/`, so it cannot invoke the
+`/handoff` slash command directly. Use the `dotclaude-handoff` binary
+via Codex's bash tool instead. One command, no skill load required.
+
+## Prerequisite
+
+`npm install -g @dotclaude/dotclaude` (gives you `dotclaude-handoff` on
+your PATH). Or run `npx dotclaude-handoff ...` if you prefer not to
+install globally.
+
+## Typical workflows
+
+### Claude session exceeded its token budget; continue in Codex
+
+Claude prints its resume UUID on exit, e.g.
+`claude --resume b8d2dd0a-1cb6-4cfb-b166-e0a94f20512e`.
+
+Open Codex and invoke the binary through its Bash tool:
+
+```
+!dotclaude-handoff digest claude b8d2dd0a --to codex
+```
+
+The output is a single `<handoff>` block tuned for Codex (task-shaped
+next step, filepaths inline). The block is now in Codex's context.
+Continue the task.
+
+Short UUID (first 8 hex) also works; so does the full UUID.
+
+### Codex renamed the thread ("to resume this thread run codex resume test")
+
+Handoff accepts the alias directly — it scans
+`event_msg.payload.thread_name` across rollouts:
+
+```
+!dotclaude-handoff describe codex test
+```
+
+### Moving from Codex back to Claude
+
+Inside Claude, run the slash-command form (skill is loaded):
+
+```
+/handoff digest codex <uuid-or-alias> --to claude
+```
+
+Or the binary form, which works from any shell:
+
+```
+!dotclaude-handoff digest codex <uuid-or-alias> --to claude
+```
+
+## Commands
+
+```
+dotclaude-handoff resolve  <cli> <id>              # file path only
+dotclaude-handoff describe <cli> <id>              # inline summary
+dotclaude-handoff digest   <cli> <id> --to <cli>   # paste-ready block
+dotclaude-handoff list     <cli>                   # recent sessions
+dotclaude-handoff file     <cli> <id> --to <cli>   # write to docs/handoffs/
+```
+
+`<cli>`: one of `claude`, `copilot`, `codex`.
+
+`<id>`: full UUID (36 chars), short UUID (first 8 hex), the literal
+`latest`, or (codex only) a thread_name alias.
+
+`--to <cli>`: tunes the next-step suggestion for the target agent.
+Defaults to `claude`.
+
+All subcommands support `--help`, `--version`, `--json`, `--verbose`,
+`--no-color`. Exit codes: 0 ok, 2 not found / parse error, 64 usage.
+
+## Why the binary and not the skill file?
+
+`skills/handoff/SKILL.md` is the authoritative runbook for Claude Code
+and Copilot CLI (both load it automatically). Codex does not load it.
+Rather than asking Codex to ingest a 460-line spec just to run one
+sub-command, the binary bundles the resolution and extraction logic
+into a single call. Same code path, same output shape; no skill load.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
@@ -1,82 +1,67 @@
 # Using handoff from Codex (or any shell)
 
-Codex CLI does not autoload `~/.claude/skills/`, so it cannot invoke the
-`/handoff` slash command directly. Use the `dotclaude-handoff` binary
-via Codex's bash tool instead. One command, no skill load required.
+Codex CLI does not autoload `~/.claude/skills/`, so it cannot invoke
+the `/handoff` slash command directly. Use the packaged binary via
+Codex's bash tool instead. Same binary works from any shell.
+
+## One command, one shape
+
+```
+!dotclaude handoff <source-cli> <id-or-name>
+```
+
+- `<source-cli>`: `claude` | `copilot` | `codex`
+- `<id-or-name>`: full UUID, short UUID (8 hex), `latest`, or a
+  named alias where the source CLI supports it (Claude `customTitle`,
+  Codex `thread_name`).
+
+The output is a `<handoff>` block that lands directly in Codex's
+context. Follow up with "continue" and you are back on task.
+
+## Examples
+
+```
+# Claude hit its token limit; continue that session in Codex.
+!dotclaude handoff claude b8d2dd0a
+!dotclaude handoff claude "test-handoff"       # customTitle alias
+!dotclaude handoff claude latest
+
+# Resume a Copilot session in Codex.
+!dotclaude handoff copilot e6c2e29a
+
+# Resume a renamed Codex thread in a fresh Codex session.
+!dotclaude handoff codex test                   # thread_name alias
+!dotclaude handoff codex 019da2f6
+!dotclaude handoff codex latest
+```
 
 ## Prerequisite
 
-`npm install -g @dotclaude/dotclaude` (gives you `dotclaude-handoff` on
-your PATH). Or run `npx dotclaude-handoff ...` if you prefer not to
-install globally.
+`npm install -g @dotclaude/dotclaude` (installs `dotclaude` on PATH
+with `handoff` as one of its sub-commands). Or run ad-hoc with
+`npx dotclaude handoff ...`.
 
-## Typical workflows
+## Sub-commands (power users)
 
-### Claude session exceeded its token budget; continue in Codex
-
-Claude prints its resume UUID on exit, e.g.
-`claude --resume b8d2dd0a-1cb6-4cfb-b166-e0a94f20512e`.
-
-Open Codex and invoke the binary through its Bash tool:
+The bare form above is shorthand for the common `digest` path. Full
+sub-command list:
 
 ```
-!dotclaude-handoff digest claude b8d2dd0a --to codex
+dotclaude handoff <cli> <id>                 # implicit digest (default)
+dotclaude handoff resolve  <cli> <id>        # file path only
+dotclaude handoff describe <cli> <id>        # inline markdown summary
+dotclaude handoff digest   <cli> <id>        # full <handoff> block
+dotclaude handoff list     <cli>             # recent sessions
+dotclaude handoff file     <cli> <id>        # write to docs/handoffs/
 ```
-
-The output is a single `<handoff>` block tuned for Codex (task-shaped
-next step, filepaths inline). The block is now in Codex's context.
-Continue the task.
-
-Short UUID (first 8 hex) also works; so does the full UUID.
-
-### Codex renamed the thread ("to resume this thread run codex resume test")
-
-Handoff accepts the alias directly — it scans
-`event_msg.payload.thread_name` across rollouts:
-
-```
-!dotclaude-handoff describe codex test
-```
-
-### Moving from Codex back to Claude
-
-Inside Claude, run the slash-command form (skill is loaded):
-
-```
-/handoff digest codex <uuid-or-alias> --to claude
-```
-
-Or the binary form, which works from any shell:
-
-```
-!dotclaude-handoff digest codex <uuid-or-alias> --to claude
-```
-
-## Commands
-
-```
-dotclaude-handoff resolve  <cli> <id>              # file path only
-dotclaude-handoff describe <cli> <id>              # inline summary
-dotclaude-handoff digest   <cli> <id> --to <cli>   # paste-ready block
-dotclaude-handoff list     <cli>                   # recent sessions
-dotclaude-handoff file     <cli> <id> --to <cli>   # write to docs/handoffs/
-```
-
-`<cli>`: one of `claude`, `copilot`, `codex`.
-
-`<id>`: full UUID (36 chars), short UUID (first 8 hex), the literal
-`latest`, or (codex only) a thread_name alias.
-
-`--to <cli>`: tunes the next-step suggestion for the target agent.
-Defaults to `claude`.
 
 All subcommands support `--help`, `--version`, `--json`, `--verbose`,
 `--no-color`. Exit codes: 0 ok, 2 not found / parse error, 64 usage.
 
 ## Why the binary and not the skill file?
 
-`skills/handoff/SKILL.md` is the authoritative runbook for Claude Code
-and Copilot CLI (both load it automatically). Codex does not load it.
-Rather than asking Codex to ingest a 460-line spec just to run one
-sub-command, the binary bundles the resolution and extraction logic
-into a single call. Same code path, same output shape; no skill load.
+`skills/handoff/SKILL.md` is the authoritative runbook for Claude
+Code and Copilot CLI (both load it automatically). Codex does not
+load it. Rather than asking Codex to ingest a 460-line spec, the
+binary bundles the resolution and extraction logic into a single
+call. Same code path as the skill; no skill load required.

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+# Behavior tests for the five-form public surface of dotclaude-handoff.mjs:
+#
+#   dotclaude handoff                          # push host's current session
+#   dotclaude handoff <query>                  # local cross-agent: <handoff> block
+#   dotclaude handoff push [<query>] [--tag]   # explicit push
+#   dotclaude handoff pull  [<query>]          # pull by fuzzy match; bare = latest
+#   dotclaude handoff list                     # unified local + remote table
+#
+# Transport for push/pull tests: `--via git-fallback` against a local
+# bare repo (DOTCLAUDE_HANDOFF_REPO). No GitHub auth required.
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+
+  # Claude fixture: a real-looking session with customTitle + content.
+  mkdir -p "$TEST_HOME/.claude/projects/-home-u-demo"
+  CLAUDE_FILE="$TEST_HOME/.claude/projects/-home-u-demo/aaaa1111-1111-1111-1111-111111111111.jsonl"
+  cat > "$CLAUDE_FILE" <<'EOF'
+{"type":"user","cwd":"/home/u/demo","sessionId":"aaaa1111-1111-1111-1111-111111111111","version":"2.1","message":{"content":"Fix the retry loop"}}
+{"type":"user","cwd":"/home/u/demo","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"Run the suite"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"OK running now."}]}}
+{"type":"custom-title","customTitle":"my-feature","sessionId":"aaaa1111-1111-1111-1111-111111111111"}
+EOF
+
+  # Codex fixture: a rollout renamed to "refactor" (for collision with claude below)
+  sleep 0.01
+  mkdir -p "$TEST_HOME/.codex/sessions/2026/04/18"
+  CODEX_FILE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T10-00-00-bbbb2222-2222-2222-2222-222222222222.jsonl"
+  cat > "$CODEX_FILE" <<'EOF'
+{"type":"session_meta","payload":{"id":"bbbb2222-2222-2222-2222-222222222222","cwd":"/work/demo","cli_version":"0.1"}}
+{"type":"event_msg","payload":{"thread_name":"my-codex-task","type":"thread_renamed"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"ship the migration"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"running"}]}}
+EOF
+
+  # Set up a bare git repo as the git-fallback transport endpoint.
+  # Push/pull tests use `--via git-fallback` which doesn't need GitHub auth.
+  TRANSPORT_REPO=$(mktemp -d)
+  rm -rf "$TRANSPORT_REPO"
+  git init -q --bare "$TRANSPORT_REPO"
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+
+  export CLAUDE_FILE CODEX_FILE TRANSPORT_REPO
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+}
+
+# -- zero-arg and <query> (local, no network) ----------------------------
+
+@test "zero args prints helpful usage of the five forms" {
+  run node "$BIN"
+  # Either exit 0 with usage, or exit 64 — either way, output must mention
+  # the five forms so the user can recover.
+  [[ "$output" == *"push"* ]]
+  [[ "$output" == *"pull"* ]]
+  [[ "$output" == *"list"* ]]
+}
+
+@test "<query>: short UUID produces <handoff> block locally" {
+  run node "$BIN" aaaa1111
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+  [[ "$output" == *"</handoff>"* ]]
+}
+
+@test "<query>: customTitle alias produces <handoff> block" {
+  run node "$BIN" my-feature
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+  [[ "$output" == *"aaaa1111"* ]]
+}
+
+@test "<query>: codex thread_name alias produces <handoff> block" {
+  run node "$BIN" my-codex-task
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+  [[ "$output" == *"bbbb2222"* ]]
+}
+
+@test "<query>: unknown identifier exits 2" {
+  run node "$BIN" nonexistent-xyz
+  [ "$status" -eq 2 ]
+}
+
+@test "<query>: collision across CLIs on non-TTY stdin exits 2 with candidate list" {
+  # Introduce collision: claude customTitle "both" + codex thread_name "both"
+  printf '{"type":"custom-title","customTitle":"both","sessionId":"aaaa1111-1111-1111-1111-111111111111"}\n' \
+    >> "$CLAUDE_FILE"
+  printf '{"type":"event_msg","payload":{"thread_name":"both","type":"thread_renamed"}}\n' \
+    >> "$CODEX_FILE"
+  run node "$BIN" both </dev/null
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"claude"* ]]
+  [[ "$output" == *"codex"* ]]
+}
+
+# -- list (unified + filters) --------------------------------------------
+
+@test "list: default shows a Location column and both local roots" {
+  run node "$BIN" list </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Location"* ]]
+  [[ "$output" == *"aaaa1111"* ]]
+  [[ "$output" == *"bbbb2222"* ]]
+}
+
+@test "list --local filters to local sessions only" {
+  run node "$BIN" list --local
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  # No remote/gist content:
+  [[ "$output" != *"gist.github"* ]]
+}
+
+# -- push (git-fallback transport) ---------------------------------------
+
+@test "push <query> uploads to transport (git-fallback bare repo)" {
+  run node "$BIN" push my-feature --via git-fallback
+  [ "$status" -eq 0 ]
+  # Confirm the transport repo has the new branch.
+  run bash -c "git --git-dir='$TRANSPORT_REPO' branch -a"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"handoff/claude/aaaa1111"* ]]
+}
+
+@test "push --tag label embeds tag in the transport description" {
+  run node "$BIN" push my-feature --via git-fallback --tag finishing-auth
+  [ "$status" -eq 0 ]
+  # The description line includes the tag (commit message carries it).
+  run bash -c "git --git-dir='$TRANSPORT_REPO' log --format=%s handoff/claude/aaaa1111"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"finishing-auth"* ]]
+}
+
+@test "push (zero-arg) pushes host's latest session" {
+  run node "$BIN" push --via git-fallback
+  [ "$status" -eq 0 ]
+  run bash -c "git --git-dir='$TRANSPORT_REPO' branch -a"
+  [[ "$output" == *"handoff/"* ]]
+}
+
+# -- pull (fuzzy match across description fields) ------------------------
+
+@test "pull <tag-substring> fetches by tag match" {
+  # First push with a tag, then try to pull by that tag.
+  run node "$BIN" push my-feature --via git-fallback --tag finishing-auth
+  [ "$status" -eq 0 ]
+  run node "$BIN" pull finishing-auth --via git-fallback
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+}
+
+@test "pull <short-uuid> fetches by short UUID match" {
+  run node "$BIN" push my-feature --via git-fallback
+  [ "$status" -eq 0 ]
+  run node "$BIN" pull aaaa1111 --via git-fallback
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+}
+
+@test "pull (zero-arg) fetches the latest" {
+  run node "$BIN" push my-feature --via git-fallback --tag keepme
+  [ "$status" -eq 0 ]
+  run node "$BIN" pull --via git-fallback
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+}
+
+@test "pull collision on non-TTY exits 2 with candidate list" {
+  run node "$BIN" push my-feature --via git-fallback --tag alpha
+  [ "$status" -eq 0 ]
+  run node "$BIN" push my-codex-task --via git-fallback --tag alpha-beta
+  [ "$status" -eq 0 ]
+  run node "$BIN" pull alpha --via git-fallback </dev/null
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"handoff/claude/aaaa1111"* ]] || [[ "$output" == *"handoff/codex/bbbb2222"* ]]
+}
+
+# -- back-compat removal: no <cli> positional allowed --------------------
+
+@test "<cli>-positional form is rejected (<cli> <id> no longer accepted)" {
+  run node "$BIN" claude aaaa1111
+  # "claude" is not a valid subcommand and not a query (no such alias),
+  # so it must exit 2 (no session matches) — NOT 0.
+  [ "$status" -ne 0 ]
+}

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+# Smoke tests for plugins/dotclaude/bin/dotclaude-handoff.mjs.
+# The binary delegates to handoff-resolve.sh and handoff-extract.sh;
+# these tests verify argv parsing, exit codes, and the happy-path output
+# shape. Detailed extraction correctness lives in handoff-extract.bats.
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+
+  # Minimal Claude session
+  mkdir -p "$TEST_HOME/.claude/projects/-home-u-proj"
+  SESSION_FILE="$TEST_HOME/.claude/projects/-home-u-proj/aaaa1111-1111-1111-1111-111111111111.jsonl"
+  cat > "$SESSION_FILE" <<'EOF'
+{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","version":"2.1","message":{"content":"Fix the retry loop"}}
+{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"Run the full test suite"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"OK running now."}]}}
+EOF
+  export SESSION_FILE
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+@test "binary is executable" {
+  [ -x "$BIN" ] || chmod +x "$BIN"
+  [ -x "$BIN" ]
+}
+
+@test "--help exits 0 and mentions subcommands" {
+  run node "$BIN" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"resolve"* ]]
+  [[ "$output" == *"describe"* ]]
+  [[ "$output" == *"digest"* ]]
+  [[ "$output" == *"list"* ]]
+}
+
+@test "--version exits 0 and emits semver" {
+  run node "$BIN" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]
+}
+
+@test "no subcommand exits 64" {
+  run node "$BIN"
+  [ "$status" -eq 64 ]
+}
+
+@test "unknown subcommand exits 64" {
+  run node "$BIN" bogus claude foo
+  [ "$status" -eq 64 ]
+}
+
+@test "resolve missing args exits 64" {
+  run node "$BIN" resolve
+  [ "$status" -eq 64 ]
+}
+
+@test "resolve claude happy path" {
+  run node "$BIN" resolve claude aaaa1111
+  [ "$status" -eq 0 ]
+  [ "$output" = "$SESSION_FILE" ]
+}
+
+@test "resolve miss exits 2" {
+  run node "$BIN" resolve claude 00000000
+  [ "$status" -eq 2 ]
+}
+
+@test "describe emits markdown with cwd and prompts" {
+  run node "$BIN" describe claude aaaa1111
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"claude"* ]]
+  [[ "$output" == *"/home/u/proj"* ]]
+  [[ "$output" == *"Fix the retry loop"* ]]
+  [[ "$output" == *"Run the full test suite"* ]]
+}
+
+@test "describe --json emits structured JSON" {
+  run node "$BIN" describe claude aaaa1111 --json
+  [ "$status" -eq 0 ]
+  # Should be valid JSON with expected keys.
+  echo "$output" | jq -e '.origin.cli == "claude"' >/dev/null
+  echo "$output" | jq -e '.origin.session_id == "aaaa1111-1111-1111-1111-111111111111"' >/dev/null
+  echo "$output" | jq -e '.user_prompts | length >= 2' >/dev/null
+}
+
+@test "digest emits a <handoff> block with next-step tuned for --to codex" {
+  run node "$BIN" digest claude aaaa1111 --to codex
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+  [[ "$output" == *"</handoff>"* ]]
+  # Codex-tuned next step should include a task-shaped cue
+  [[ "$output" == *"Next step"* ]]
+}
+
+@test "digest --to claude produces imperative next step" {
+  run node "$BIN" digest claude aaaa1111 --to claude
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+}
+
+@test "list claude renders a table" {
+  run node "$BIN" list claude
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  [[ "$output" == *"Short UUID"* ]]
+  [[ "$output" == *"aaaa1111-1111-1111-1111-111111111111.jsonl"* ]]
+}
+
+@test "list --json emits array of session objects" {
+  run node "$BIN" list claude --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e 'length >= 1' >/dev/null
+  echo "$output" | jq -e '.[0].short_id == "aaaa1111"' >/dev/null
+}
+
+@test "unknown cli exits 64" {
+  run node "$BIN" resolve bogus abcd1234
+  [ "$status" -eq 64 ]
+}

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
@@ -1,8 +1,10 @@
 #!/usr/bin/env bats
-# Smoke tests for plugins/dotclaude/bin/dotclaude-handoff.mjs.
-# The binary delegates to handoff-resolve.sh and handoff-extract.sh;
-# these tests verify argv parsing, exit codes, and the happy-path output
-# shape. Detailed extraction correctness lives in handoff-extract.bats.
+# Power-user sub-command tests for plugins/dotclaude/bin/dotclaude-handoff.mjs.
+#
+# The PRIMARY public surface (bare <query>, push, pull, list) is covered
+# by dotclaude-handoff-five-form.bats. This file covers the legacy
+# power-user subs still reachable for scripting: resolve / describe /
+# digest / file. Each takes an explicit <cli> <id>.
 
 load helpers
 
@@ -12,7 +14,6 @@ setup() {
   TEST_HOME=$(mktemp -d)
   export HOME="$TEST_HOME"
 
-  # Minimal Claude session
   mkdir -p "$TEST_HOME/.claude/projects/-home-u-proj"
   SESSION_FILE="$TEST_HOME/.claude/projects/-home-u-proj/aaaa1111-1111-1111-1111-111111111111.jsonl"
   cat > "$SESSION_FILE" <<'EOF'
@@ -33,29 +34,18 @@ teardown() {
   [ -x "$BIN" ]
 }
 
-@test "--help exits 0 and mentions subcommands" {
-  run node "$BIN" --help
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"resolve"* ]]
-  [[ "$output" == *"describe"* ]]
-  [[ "$output" == *"digest"* ]]
-  [[ "$output" == *"list"* ]]
-}
-
 @test "--version exits 0 and emits semver" {
   run node "$BIN" --version
   [ "$status" -eq 0 ]
   [[ "$output" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]
 }
 
-@test "no subcommand exits 64" {
-  run node "$BIN"
-  [ "$status" -eq 64 ]
-}
-
-@test "unknown subcommand exits 64" {
-  run node "$BIN" bogus claude foo
-  [ "$status" -eq 64 ]
+@test "--help exits 0 and mentions the five forms" {
+  run node "$BIN" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"push"* ]]
+  [[ "$output" == *"pull"* ]]
+  [[ "$output" == *"list"* ]]
 }
 
 @test "resolve missing args exits 64" {
@@ -86,7 +76,6 @@ teardown() {
 @test "describe --json emits structured JSON" {
   run node "$BIN" describe claude aaaa1111 --json
   [ "$status" -eq 0 ]
-  # Should be valid JSON with expected keys.
   echo "$output" | jq -e '.origin.cli == "claude"' >/dev/null
   echo "$output" | jq -e '.origin.session_id == "aaaa1111-1111-1111-1111-111111111111"' >/dev/null
   echo "$output" | jq -e '.user_prompts | length >= 2' >/dev/null
@@ -97,7 +86,6 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
   [[ "$output" == *"</handoff>"* ]]
-  # Codex-tuned next step should include a task-shaped cue
   [[ "$output" == *"Next step"* ]]
 }
 
@@ -107,60 +95,7 @@ teardown() {
   [[ "$output" == *"<handoff"* ]]
 }
 
-@test "list claude renders a table" {
-  run node "$BIN" list claude
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"aaaa1111"* ]]
-  [[ "$output" == *"Short UUID"* ]]
-  [[ "$output" == *"aaaa1111-1111-1111-1111-111111111111.jsonl"* ]]
-}
-
-@test "list --json emits array of session objects" {
-  run node "$BIN" list claude --json
-  [ "$status" -eq 0 ]
-  echo "$output" | jq -e 'length >= 1' >/dev/null
-  echo "$output" | jq -e '.[0].short_id == "aaaa1111"' >/dev/null
-}
-
-@test "unknown cli exits 64" {
+@test "unknown cli in power-user sub exits 64" {
   run node "$BIN" resolve bogus abcd1234
-  [ "$status" -eq 64 ]
-}
-
-# -- bare form (implicit digest) -----------------------------------------
-
-@test "bare form: full UUID acts as implicit digest" {
-  run node "$BIN" claude aaaa1111-1111-1111-1111-111111111111
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"<handoff"* ]]
-  [[ "$output" == *"</handoff>"* ]]
-  [[ "$output" == *"aaaa1111"* ]]
-}
-
-@test "bare form: short UUID acts as implicit digest" {
-  run node "$BIN" claude aaaa1111
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"<handoff"* ]]
-}
-
-@test "bare form: customTitle alias acts as implicit digest" {
-  run node "$BIN" claude my-feature
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"<handoff"* ]]
-  [[ "$output" == *"aaaa1111"* ]]
-}
-
-@test "bare form: missing id exits 64" {
-  run node "$BIN" claude
-  [ "$status" -eq 64 ]
-}
-
-@test "bare form: unknown identifier exits 2" {
-  run node "$BIN" claude 00000000
-  [ "$status" -eq 2 ]
-}
-
-@test "bare form: bogus cli name treated as unknown subcommand (exits 64)" {
-  run node "$BIN" nonsense-cli aaaa1111
   [ "$status" -eq 64 ]
 }

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
@@ -19,6 +19,7 @@ setup() {
 {"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","version":"2.1","message":{"content":"Fix the retry loop"}}
 {"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"Run the full test suite"}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"OK running now."}]}}
+{"type":"custom-title","customTitle":"my-feature","sessionId":"aaaa1111-1111-1111-1111-111111111111"}
 EOF
   export SESSION_FILE
 }
@@ -123,5 +124,43 @@ teardown() {
 
 @test "unknown cli exits 64" {
   run node "$BIN" resolve bogus abcd1234
+  [ "$status" -eq 64 ]
+}
+
+# -- bare form (implicit digest) -----------------------------------------
+
+@test "bare form: full UUID acts as implicit digest" {
+  run node "$BIN" claude aaaa1111-1111-1111-1111-111111111111
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+  [[ "$output" == *"</handoff>"* ]]
+  [[ "$output" == *"aaaa1111"* ]]
+}
+
+@test "bare form: short UUID acts as implicit digest" {
+  run node "$BIN" claude aaaa1111
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+}
+
+@test "bare form: customTitle alias acts as implicit digest" {
+  run node "$BIN" claude my-feature
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+  [[ "$output" == *"aaaa1111"* ]]
+}
+
+@test "bare form: missing id exits 64" {
+  run node "$BIN" claude
+  [ "$status" -eq 64 ]
+}
+
+@test "bare form: unknown identifier exits 2" {
+  run node "$BIN" claude 00000000
+  [ "$status" -eq 2 ]
+}
+
+@test "bare form: bogus cli name treated as unknown subcommand (exits 64)" {
+  run node "$BIN" nonsense-cli aaaa1111
   [ "$status" -eq 64 ]
 }

--- a/plugins/dotclaude/tests/bats/handoff-extract.bats
+++ b/plugins/dotclaude/tests/bats/handoff-extract.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# Behavior tests for plugins/dotclaude/scripts/handoff-extract.sh.
+# Subcommands:
+#   meta    <cli> <file>   JSON on stdout: {cli, session_id, short_id, cwd, model, started_at}
+#   prompts <cli> <file>   Clean user prompts, newline-separated, order preserved
+#   turns   <cli> <file>   Last-N assistant turns (default N=20, tail-only)
+
+load helpers
+
+EX="$REPO_ROOT/plugins/dotclaude/scripts/handoff-extract.sh"
+
+setup() {
+  [ -x "$EX" ] || chmod +x "$EX"
+  TEST_DIR=$(mktemp -d)
+
+  # --- Claude fixture: mix of real prompts + noise records ---
+  CLAUDE_FILE="$TEST_DIR/claude.jsonl"
+  cat > "$CLAUDE_FILE" <<'EOF'
+{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","version":"2.1","message":{"content":"<local-command-caveat>Caveat: this was auto-generated</local-command-caveat>"}}
+{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"<command-name>/clear</command-name>"}}
+{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"Actually fix the retry loop"}}
+{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":[{"type":"tool_result","content":"file contents"}]}}
+{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":[{"type":"text","text":"<system-reminder>do not respond to this</system-reminder>"}]}}
+{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":[{"type":"text","text":"Run the full suite and report results"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Sure, running tests now."}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"All 205 tests passed."}]}}
+EOF
+
+  # --- Copilot fixture: session.start with null cwd; workspace.yaml fallback ---
+  COPILOT_DIR="$TEST_DIR/copilot-session"
+  mkdir -p "$COPILOT_DIR"
+  COPILOT_FILE="$COPILOT_DIR/events.jsonl"
+  cat > "$COPILOT_FILE" <<'EOF'
+{"type":"session.start","data":{"cwd":null,"model":null,"sessionId":"cccc3333-3333-3333-3333-333333333333"}}
+{"type":"user.message","data":{"content":"First user prompt"}}
+{"type":"assistant.message","data":{"content":"First assistant reply"}}
+{"type":"user.message","data":{"content":"Second prompt","transformedContent":"<wrapped><system-reminder>ignore</system-reminder>Second prompt</wrapped>"}}
+EOF
+  cat > "$COPILOT_DIR/workspace.yaml" <<'EOF'
+id: cccc3333-3333-3333-3333-333333333333
+cwd: /workspace/demo
+model: gpt-5
+summary: Test session
+EOF
+
+  # --- Codex fixture: session_meta + env-context first user turn + real prompts ---
+  CODEX_FILE="$TEST_DIR/codex.jsonl"
+  cat > "$CODEX_FILE" <<'EOF'
+{"type":"session_meta","payload":{"id":"eeee5555-5555-5555-5555-555555555555","cwd":"/work/demo","cli_version":"0.121.0","timestamp":"2026-04-18T20:38:53Z","model_provider":"openai"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"<environment_context>shell: zsh\ncwd: /work/demo</environment_context>"}]}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"Improve documentation in @README.md"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"I'll read README.md first."}]}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"Go ahead"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"Done."}]}}
+EOF
+
+  export CLAUDE_FILE COPILOT_FILE COPILOT_DIR CODEX_FILE TEST_DIR
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# -- meta -----------------------------------------------------------------
+
+@test "meta claude emits JSON with cwd and sessionId" {
+  run "$EX" meta claude "$CLAUDE_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"cwd":"/home/u/proj"'* ]]
+  [[ "$output" == *'"session_id":"aaaa1111-1111-1111-1111-111111111111"'* ]]
+  [[ "$output" == *'"short_id":"aaaa1111"'* ]]
+  [[ "$output" == *'"cli":"claude"'* ]]
+}
+
+@test "meta copilot falls back to workspace.yaml when session.start cwd is null" {
+  run "$EX" meta copilot "$COPILOT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"cwd":"/workspace/demo"'* ]]
+  [[ "$output" == *'"model":"gpt-5"'* ]]
+  [[ "$output" == *'"session_id":"cccc3333-3333-3333-3333-333333333333"'* ]]
+  [[ "$output" != *'"cwd":null'* ]]
+}
+
+@test "meta codex reads session_meta record" {
+  run "$EX" meta codex "$CODEX_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"cwd":"/work/demo"'* ]]
+  [[ "$output" == *'"session_id":"eeee5555-5555-5555-5555-555555555555"'* ]]
+  [[ "$output" == *'"short_id":"eeee5555"'* ]]
+}
+
+# -- prompts --------------------------------------------------------------
+
+@test "prompts claude excludes local-command-caveat, command-name, tool_result, system-reminder" {
+  run "$EX" prompts claude "$CLAUDE_FILE"
+  [ "$status" -eq 0 ]
+  # Real prompts present:
+  [[ "$output" == *"Actually fix the retry loop"* ]]
+  [[ "$output" == *"Run the full suite and report results"* ]]
+  # Noise excluded:
+  [[ "$output" != *"<local-command-caveat>"* ]]
+  [[ "$output" != *"<command-name>"* ]]
+  [[ "$output" != *"<system-reminder>"* ]]
+  [[ "$output" != *"file contents"* ]]
+}
+
+@test "prompts claude count is 2 on the fixture (6 user records, 4 noisy)" {
+  run "$EX" prompts claude "$CLAUDE_FILE"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(printf '%s\n' "$output" | grep -cv '^$')
+  [ "$n" -eq 2 ]
+}
+
+@test "prompts copilot extracts .data.content (not transformedContent)" {
+  run "$EX" prompts copilot "$COPILOT_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"First user prompt"* ]]
+  [[ "$output" == *"Second prompt"* ]]
+  [[ "$output" != *"<system-reminder>"* ]]
+  [[ "$output" != *"<wrapped>"* ]]
+}
+
+@test "prompts codex excludes environment_context" {
+  run "$EX" prompts codex "$CODEX_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Improve documentation in @README.md"* ]]
+  [[ "$output" == *"Go ahead"* ]]
+  [[ "$output" != *"<environment_context>"* ]]
+}
+
+# -- turns (assistant tail) -----------------------------------------------
+
+@test "turns claude returns assistant messages in order" {
+  run "$EX" turns claude "$CLAUDE_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sure, running tests now."* ]]
+  [[ "$output" == *"All 205 tests passed."* ]]
+}
+
+@test "turns codex returns assistant messages" {
+  run "$EX" turns codex "$CODEX_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"I'll read README.md first."* ]]
+  [[ "$output" == *"Done."* ]]
+}
+
+# -- usage / errors -------------------------------------------------------
+
+@test "missing subcommand exits 64" {
+  run "$EX"
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"usage:"* ]]
+}
+
+@test "unknown subcommand exits 64" {
+  run "$EX" blarg claude "$CLAUDE_FILE"
+  [ "$status" -eq 64 ]
+}
+
+@test "unknown cli exits 64" {
+  run "$EX" meta bogus "$CLAUDE_FILE"
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"cli must be one of"* ]]
+}
+
+@test "missing file argument exits 64" {
+  run "$EX" meta claude
+  [ "$status" -eq 64 ]
+}
+
+@test "nonexistent file exits 2" {
+  run "$EX" meta claude "$TEST_DIR/does-not-exist.jsonl"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"file not found"* ]]
+}

--- a/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# Behavior tests for the `any` mode of plugins/dotclaude/scripts/handoff-resolve.sh.
+#
+# The `any` mode probes all three session roots (claude, copilot, codex)
+# and:
+#   - returns the single matching path when exactly one root resolves
+#   - on collision (two or more roots match), exits 2 with a TSV
+#     candidate list on stderr. One line per candidate:
+#       <cli>\t<session-id>\t<path>\t<label>
+#   - on no match, exits 2 with a "no session matches" message
+
+load helpers
+
+RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
+
+setup() {
+  [ -x "$RESOLVE" ] || chmod +x "$RESOLVE"
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+
+  # Claude fixture: a session with customTitle "refactor" (for collision test),
+  # plus a plain one and a newer one for `latest`.
+  mkdir -p "$TEST_HOME/.claude/projects/-home-u-demo"
+  CLAUDE_ALIAS_FILE="$TEST_HOME/.claude/projects/-home-u-demo/cccc1111-1111-1111-1111-111111111111.jsonl"
+  printf '{"cwd":"/home/u/demo","sessionId":"cccc1111-1111-1111-1111-111111111111","version":"2.1"}\n{"type":"custom-title","customTitle":"refactor","sessionId":"cccc1111-1111-1111-1111-111111111111"}\n' \
+    > "$CLAUDE_ALIAS_FILE"
+
+  sleep 0.01
+  CLAUDE_PLAIN_FILE="$TEST_HOME/.claude/projects/-home-u-demo/aaaa2222-2222-2222-2222-222222222222.jsonl"
+  printf '{"cwd":"/home/u/demo","sessionId":"aaaa2222-2222-2222-2222-222222222222","version":"2.1"}\n' \
+    > "$CLAUDE_PLAIN_FILE"
+
+  # Copilot fixture
+  sleep 0.01
+  COPILOT_DIR="$TEST_HOME/.copilot/session-state/dddd3333-3333-3333-3333-333333333333"
+  mkdir -p "$COPILOT_DIR"
+  COPILOT_FILE="$COPILOT_DIR/events.jsonl"
+  printf '{"type":"session.start","data":{"cwd":"/tmp","model":"gpt","sessionId":"dddd3333-3333-3333-3333-333333333333"}}\n' \
+    > "$COPILOT_FILE"
+
+  # Codex fixture: a rollout WITH thread_name "refactor" (collision with claude)
+  sleep 0.01
+  mkdir -p "$TEST_HOME/.codex/sessions/2026/04/18"
+  CODEX_ALIAS_FILE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T10-00-00-eeee5555-5555-5555-5555-555555555555.jsonl"
+  printf '{"type":"session_meta","payload":{"id":"eeee5555-5555-5555-5555-555555555555","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"eeee5555-5555-5555-5555-555555555555","thread_name":"refactor","type":"thread_renamed"}}\n' \
+    > "$CODEX_ALIAS_FILE"
+
+  # Newer codex rollout (no alias) — will be the "latest" winner because
+  # it has the most recent mtime across all three roots.
+  sleep 0.01
+  CODEX_NEWEST_FILE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T11-00-00-ffff6666-6666-6666-6666-666666666666.jsonl"
+  printf '{"type":"session_meta","payload":{"id":"ffff6666-6666-6666-6666-666666666666","cwd":"/work"}}\n' \
+    > "$CODEX_NEWEST_FILE"
+
+  export CLAUDE_ALIAS_FILE CLAUDE_PLAIN_FILE COPILOT_FILE CODEX_ALIAS_FILE CODEX_NEWEST_FILE
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+@test "any: resolves claude full UUID" {
+  run "$RESOLVE" any aaaa2222-2222-2222-2222-222222222222
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CLAUDE_PLAIN_FILE" ]
+}
+
+@test "any: resolves claude short UUID" {
+  run "$RESOLVE" any aaaa2222
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CLAUDE_PLAIN_FILE" ]
+}
+
+@test "any: resolves claude customTitle alias when unique" {
+  # Temporarily break the codex collision fixture to ensure customTitle
+  # scan still works. Rename just the codex alias record away.
+  sed -i 's/refactor/refactor-codex/' "$CODEX_ALIAS_FILE"
+  run "$RESOLVE" any refactor
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CLAUDE_ALIAS_FILE" ]
+}
+
+@test "any: resolves codex thread_name alias when unique" {
+  # Temporarily break the claude collision fixture.
+  sed -i 's/refactor/refactor-claude/' "$CLAUDE_ALIAS_FILE"
+  run "$RESOLVE" any refactor
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CODEX_ALIAS_FILE" ]
+}
+
+@test "any: resolves codex full UUID" {
+  run "$RESOLVE" any eeee5555-5555-5555-5555-555555555555
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CODEX_ALIAS_FILE" ]
+}
+
+@test "any: resolves copilot full UUID" {
+  run "$RESOLVE" any dddd3333-3333-3333-3333-333333333333
+  [ "$status" -eq 0 ]
+  [ "$output" = "$COPILOT_FILE" ]
+}
+
+@test "any: latest picks newest across all three roots" {
+  run "$RESOLVE" any latest
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CODEX_NEWEST_FILE" ]
+}
+
+@test "any: unknown identifier exits 2 with structured error" {
+  run "$RESOLVE" any nonexistent-alias-xyz
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no session matches"* ]]
+}
+
+@test "any: collision across two CLIs exits 2 with TSV candidate list on stderr" {
+  # Both claude customTitle and codex thread_name are "refactor" in the
+  # default fixture.
+  run "$RESOLVE" any refactor
+  [ "$status" -eq 2 ]
+  # Expect at least two candidate lines, each with 4 TSV fields.
+  # Candidate line shape: <cli>\t<session-id>\t<path>\t<label>
+  # bats' $output includes both stdout and stderr.
+  [[ "$output" == *"claude"* ]]
+  [[ "$output" == *"codex"* ]]
+  [[ "$output" == *"cccc1111"* ]]
+  [[ "$output" == *"eeee5555"* ]]
+}
+
+@test "any: missing identifier exits 64" {
+  run "$RESOLVE" any
+  [ "$status" -eq 64 ]
+}
+
+@test "any: graceful degrade when only one root exists" {
+  # Remove copilot and codex fixtures; any <claude-uuid> should still work.
+  rm -rf "$TEST_HOME/.copilot" "$TEST_HOME/.codex"
+  run "$RESOLVE" any aaaa2222
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CLAUDE_PLAIN_FILE" ]
+}

--- a/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
@@ -24,14 +24,11 @@ setup() {
   CLAUDE_ALIAS_FILE="$TEST_HOME/.claude/projects/-home-u-demo/cccc1111-1111-1111-1111-111111111111.jsonl"
   printf '{"cwd":"/home/u/demo","sessionId":"cccc1111-1111-1111-1111-111111111111","version":"2.1"}\n{"type":"custom-title","customTitle":"refactor","sessionId":"cccc1111-1111-1111-1111-111111111111"}\n' \
     > "$CLAUDE_ALIAS_FILE"
-
-  sleep 0.01
   CLAUDE_PLAIN_FILE="$TEST_HOME/.claude/projects/-home-u-demo/aaaa2222-2222-2222-2222-222222222222.jsonl"
   printf '{"cwd":"/home/u/demo","sessionId":"aaaa2222-2222-2222-2222-222222222222","version":"2.1"}\n' \
     > "$CLAUDE_PLAIN_FILE"
 
   # Copilot fixture
-  sleep 0.01
   COPILOT_DIR="$TEST_HOME/.copilot/session-state/dddd3333-3333-3333-3333-333333333333"
   mkdir -p "$COPILOT_DIR"
   COPILOT_FILE="$COPILOT_DIR/events.jsonl"
@@ -39,18 +36,22 @@ setup() {
     > "$COPILOT_FILE"
 
   # Codex fixture: a rollout WITH thread_name "refactor" (collision with claude)
-  sleep 0.01
   mkdir -p "$TEST_HOME/.codex/sessions/2026/04/18"
   CODEX_ALIAS_FILE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T10-00-00-eeee5555-5555-5555-5555-555555555555.jsonl"
   printf '{"type":"session_meta","payload":{"id":"eeee5555-5555-5555-5555-555555555555","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"eeee5555-5555-5555-5555-555555555555","thread_name":"refactor","type":"thread_renamed"}}\n' \
     > "$CODEX_ALIAS_FILE"
 
-  # Newer codex rollout (no alias) — will be the "latest" winner because
-  # it has the most recent mtime across all three roots.
-  sleep 0.01
+  # Newer codex rollout — explicit mtime ordering via `touch -d`, since
+  # `sleep` fractions are unreliable across filesystems (tmpfs mtime
+  # resolution is often 1s).
   CODEX_NEWEST_FILE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T11-00-00-ffff6666-6666-6666-6666-666666666666.jsonl"
   printf '{"type":"session_meta","payload":{"id":"ffff6666-6666-6666-6666-666666666666","cwd":"/work"}}\n' \
     > "$CODEX_NEWEST_FILE"
+  touch -d '2026-04-18T09:00:00Z' "$CLAUDE_ALIAS_FILE"
+  touch -d '2026-04-18T10:00:00Z' "$CLAUDE_PLAIN_FILE"
+  touch -d '2026-04-18T11:00:00Z' "$COPILOT_FILE"
+  touch -d '2026-04-18T12:00:00Z' "$CODEX_ALIAS_FILE"
+  touch -d '2026-04-18T13:00:00Z' "$CODEX_NEWEST_FILE"
 
   export CLAUDE_ALIAS_FILE CLAUDE_PLAIN_FILE COPILOT_FILE CODEX_ALIAS_FILE CODEX_NEWEST_FILE
 }

--- a/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
@@ -41,17 +41,17 @@ setup() {
   printf '{"type":"session_meta","payload":{"id":"eeee5555-5555-5555-5555-555555555555","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"eeee5555-5555-5555-5555-555555555555","thread_name":"refactor","type":"thread_renamed"}}\n' \
     > "$CODEX_ALIAS_FILE"
 
-  # Newer codex rollout — explicit mtime ordering via `touch -d`, since
-  # `sleep` fractions are unreliable across filesystems (tmpfs mtime
-  # resolution is often 1s).
+  # Newer codex rollout — explicit mtime ordering via `touch -t` (POSIX,
+  # portable across GNU and BSD/macOS), since `sleep` fractions are
+  # unreliable across filesystems (tmpfs mtime resolution is often 1s).
   CODEX_NEWEST_FILE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T11-00-00-ffff6666-6666-6666-6666-666666666666.jsonl"
   printf '{"type":"session_meta","payload":{"id":"ffff6666-6666-6666-6666-666666666666","cwd":"/work"}}\n' \
     > "$CODEX_NEWEST_FILE"
-  touch -d '2026-04-18T09:00:00Z' "$CLAUDE_ALIAS_FILE"
-  touch -d '2026-04-18T10:00:00Z' "$CLAUDE_PLAIN_FILE"
-  touch -d '2026-04-18T11:00:00Z' "$COPILOT_FILE"
-  touch -d '2026-04-18T12:00:00Z' "$CODEX_ALIAS_FILE"
-  touch -d '2026-04-18T13:00:00Z' "$CODEX_NEWEST_FILE"
+  touch -t 202604180900.00 "$CLAUDE_ALIAS_FILE"
+  touch -t 202604181000.00 "$CLAUDE_PLAIN_FILE"
+  touch -t 202604181100.00 "$COPILOT_FILE"
+  touch -t 202604181200.00 "$CODEX_ALIAS_FILE"
+  touch -t 202604181300.00 "$CODEX_NEWEST_FILE"
 
   export CLAUDE_ALIAS_FILE CLAUDE_PLAIN_FILE COPILOT_FILE CODEX_ALIAS_FILE CODEX_NEWEST_FILE
 }

--- a/plugins/dotclaude/tests/bats/handoff-resolve.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve.bats
@@ -25,6 +25,14 @@ setup() {
   printf '{"cwd":"/home/user/projects/other","sessionId":"bbbb2222-2222-2222-2222-222222222222","version":"2.1"}\n' \
     > "$TEST_HOME/.claude/projects/-home-user-projects-other/bbbb2222-2222-2222-2222-222222222222.jsonl"
 
+  # Third claude session with a customTitle record (the `claude --resume "<name>"` alias).
+  sleep 0.01
+  mkdir -p "$TEST_HOME/.claude/projects/-home-user-projects-demo"
+  CLAUDE_ALIAS_FILE="$TEST_HOME/.claude/projects/-home-user-projects-demo/cccc1111-1111-1111-1111-111111111111.jsonl"
+  printf '{"cwd":"/home/user/projects/demo","sessionId":"cccc1111-1111-1111-1111-111111111111","version":"2.1"}\n{"type":"custom-title","customTitle":"my-feature","sessionId":"cccc1111-1111-1111-1111-111111111111"}\n' \
+    > "$CLAUDE_ALIAS_FILE"
+  export CLAUDE_ALIAS_FILE
+
   # Copilot: ~/.copilot/session-state/<uuid>/events.jsonl
   mkdir -p "$TEST_HOME/.copilot/session-state/cccc3333-3333-3333-3333-333333333333"
   printf '{"type":"session.start","data":{"cwd":null,"model":null,"sessionId":"cccc3333-3333-3333-3333-333333333333"}}\n' \
@@ -76,6 +84,18 @@ teardown() {
   run "$RESOLVE" claude 00000000-0000-0000-0000-000000000000
   [ "$status" -eq 2 ]
   [[ "$output" == *"handoff-resolve:"* ]]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "resolve claude by customTitle alias" {
+  run "$RESOLVE" claude my-feature
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CLAUDE_ALIAS_FILE" ]
+}
+
+@test "resolve claude unknown customTitle exits 2" {
+  run "$RESOLVE" claude nonexistent-feature-alias
+  [ "$status" -eq 2 ]
   [[ "$output" == *"not found"* ]]
 }
 

--- a/plugins/dotclaude/tests/bats/handoff-resolve.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve.bats
@@ -77,7 +77,8 @@ teardown() {
 @test "resolve claude latest picks newest mtime" {
   run "$RESOLVE" claude latest
   [ "$status" -eq 0 ]
-  [[ "$output" == *"bbbb2222-2222-2222-2222-222222222222.jsonl" ]]
+  # cccc1111 is created last (sleep 0.01 after bbbb2222) so it is the newest.
+  [[ "$output" == *"cccc1111-1111-1111-1111-111111111111.jsonl" ]]
 }
 
 @test "resolve claude miss exits 2 with structured error" {

--- a/plugins/dotclaude/tests/bats/handoff-resolve.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# Behavior tests for plugins/dotclaude/scripts/handoff-resolve.sh.
+# Resolves <cli> <identifier> to an absolute JSONL file path.
+# Supports: claude (uuid|latest), copilot (uuid|latest),
+#           codex (uuid|alias|latest).
+
+load helpers
+
+RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
+
+# Build a hermetic $HOME with fake session trees for the three CLIs.
+# Fixtures are minimal: just enough for path resolution and alias scan.
+setup() {
+  [ -x "$RESOLVE" ] || chmod +x "$RESOLVE"
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+
+  # Claude: ~/.claude/projects/<slug>/<uuid>.jsonl
+  mkdir -p "$TEST_HOME/.claude/projects/-home-user-projects-demo"
+  printf '{"cwd":"/home/user/projects/demo","sessionId":"aaaa1111-1111-1111-1111-111111111111","version":"2.1"}\n' \
+    > "$TEST_HOME/.claude/projects/-home-user-projects-demo/aaaa1111-1111-1111-1111-111111111111.jsonl"
+  # Make a second, newer claude session so `latest` picks it.
+  sleep 0.01
+  mkdir -p "$TEST_HOME/.claude/projects/-home-user-projects-other"
+  printf '{"cwd":"/home/user/projects/other","sessionId":"bbbb2222-2222-2222-2222-222222222222","version":"2.1"}\n' \
+    > "$TEST_HOME/.claude/projects/-home-user-projects-other/bbbb2222-2222-2222-2222-222222222222.jsonl"
+
+  # Copilot: ~/.copilot/session-state/<uuid>/events.jsonl
+  mkdir -p "$TEST_HOME/.copilot/session-state/cccc3333-3333-3333-3333-333333333333"
+  printf '{"type":"session.start","data":{"cwd":null,"model":null,"sessionId":"cccc3333-3333-3333-3333-333333333333"}}\n' \
+    > "$TEST_HOME/.copilot/session-state/cccc3333-3333-3333-3333-333333333333/events.jsonl"
+  # Second, newer copilot session for `latest`.
+  sleep 0.01
+  mkdir -p "$TEST_HOME/.copilot/session-state/dddd4444-4444-4444-4444-444444444444"
+  printf '{"type":"session.start","data":{"cwd":"/tmp","model":"gpt","sessionId":"dddd4444-4444-4444-4444-444444444444"}}\n' \
+    > "$TEST_HOME/.copilot/session-state/dddd4444-4444-4444-4444-444444444444/events.jsonl"
+
+  # Codex: ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+  mkdir -p "$TEST_HOME/.codex/sessions/2026/04/18"
+  CODEX_ONE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T10-00-00-eeee5555-5555-5555-5555-555555555555.jsonl"
+  printf '{"type":"session_meta","payload":{"id":"eeee5555-5555-5555-5555-555555555555","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"eeee5555-5555-5555-5555-555555555555","thread_name":"my-feature","type":"thread_renamed"}}\n' \
+    > "$CODEX_ONE"
+  # A second, newer codex rollout without a thread_name (for `latest`).
+  sleep 0.01
+  CODEX_TWO="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T11-00-00-ffff6666-6666-6666-6666-666666666666.jsonl"
+  printf '{"type":"session_meta","payload":{"id":"ffff6666-6666-6666-6666-666666666666","cwd":"/work"}}\n' \
+    > "$CODEX_TWO"
+  export CODEX_ONE CODEX_TWO
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# -- claude ---------------------------------------------------------------
+
+@test "resolve claude by full UUID" {
+  run "$RESOLVE" claude aaaa1111-1111-1111-1111-111111111111
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TEST_HOME/.claude/projects/-home-user-projects-demo/aaaa1111-1111-1111-1111-111111111111.jsonl" ]
+}
+
+@test "resolve claude by short UUID (first 8 hex)" {
+  run "$RESOLVE" claude aaaa1111
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TEST_HOME/.claude/projects/-home-user-projects-demo/aaaa1111-1111-1111-1111-111111111111.jsonl" ]
+}
+
+@test "resolve claude latest picks newest mtime" {
+  run "$RESOLVE" claude latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222-2222-2222-2222-222222222222.jsonl" ]]
+}
+
+@test "resolve claude miss exits 2 with structured error" {
+  run "$RESOLVE" claude 00000000-0000-0000-0000-000000000000
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"handoff-resolve:"* ]]
+  [[ "$output" == *"not found"* ]]
+}
+
+# -- copilot --------------------------------------------------------------
+
+@test "resolve copilot by full UUID" {
+  run "$RESOLVE" copilot cccc3333-3333-3333-3333-333333333333
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TEST_HOME/.copilot/session-state/cccc3333-3333-3333-3333-333333333333/events.jsonl" ]
+}
+
+@test "resolve copilot by short UUID" {
+  run "$RESOLVE" copilot cccc3333
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cccc3333-3333-3333-3333-333333333333/events.jsonl" ]]
+}
+
+@test "resolve copilot latest picks newest mtime" {
+  run "$RESOLVE" copilot latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dddd4444-4444-4444-4444-444444444444/events.jsonl" ]]
+}
+
+@test "resolve copilot miss exits 2" {
+  run "$RESOLVE" copilot 00000000-0000-0000-0000-000000000000
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+# -- codex ----------------------------------------------------------------
+
+@test "resolve codex by full UUID" {
+  run "$RESOLVE" codex eeee5555-5555-5555-5555-555555555555
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CODEX_ONE" ]
+}
+
+@test "resolve codex by short UUID" {
+  run "$RESOLVE" codex eeee5555
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CODEX_ONE" ]
+}
+
+@test "resolve codex latest picks newest mtime" {
+  run "$RESOLVE" codex latest
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CODEX_TWO" ]
+}
+
+@test "resolve codex by alias (thread_name scan)" {
+  run "$RESOLVE" codex my-feature
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CODEX_ONE" ]
+}
+
+@test "resolve codex alias miss exits 2" {
+  run "$RESOLVE" codex nonexistent-alias
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "resolve codex UUID-shaped miss falls through to alias scan and exits 2" {
+  # A UUID-shaped string that does not match any file or alias.
+  run "$RESOLVE" codex 99999999-9999-9999-9999-999999999999
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+# -- usage / error paths --------------------------------------------------
+
+@test "missing cli exits 64 with usage" {
+  run "$RESOLVE"
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"usage:"* ]]
+}
+
+@test "unknown cli exits 64" {
+  run "$RESOLVE" foocli someid
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"cli must be one of"* ]]
+}
+
+@test "missing identifier exits 64" {
+  run "$RESOLVE" claude
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"usage:"* ]]
+}

--- a/plugins/dotclaude/tests/bats/vocabulary-denylist.bats
+++ b/plugins/dotclaude/tests/bats/vocabulary-denylist.bats
@@ -64,3 +64,17 @@ DENYLIST_OPTS=(
     "$REPO_ROOT/plugins/dotclaude/src/"
   [ "$status" -eq 1 ]
 }
+
+@test "plugin bin files contain no project-specific vocabulary" {
+  run grep -rni "${DENYLIST_OPTS[@]}" \
+    --include="*.mjs" --include="*.sh" \
+    "$REPO_ROOT/plugins/dotclaude/bin/"
+  [ "$status" -eq 1 ]
+}
+
+@test "plugin scripts contain no project-specific vocabulary" {
+  run grep -rni "${DENYLIST_OPTS[@]}" \
+    --include="*.sh" --include="*.mjs" \
+    "$REPO_ROOT/plugins/dotclaude/scripts/"
+  [ "$status" -eq 1 ]
+}

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -24,7 +24,7 @@ description: >
   "find the session where", "search sessions", "which session did I",
   "push handoff", "pull handoff", "handoff to other machine",
   "resume on my other laptop".
-argument-hint: "<sub-cmd> [<source-cli>] <uuid|latest|query|handle> [--to <target-cli>] [--via <transport>] [--cli <cli>]"
+argument-hint: "[<query>|push|pull|list] [<query>] [--tag <label>] [--via <transport>]"
 tools: Glob, Read, Grep, Bash, Write
 effort: medium
 model: sonnet
@@ -32,48 +32,59 @@ model: sonnet
 
 # Handoff — Cross-CLI Session Context Transfer
 
-Locate a session transcript from one agentic CLI and hand its context to
-another. Supports three source CLIs (`claude`, `copilot`, `codex`) and
-the same three as targets. The skill never invokes a different CLI
-itself — it produces a summary or a paste-ready block the user drops
+Locate a session transcript from any agentic CLI and hand its context
+to another. Source CLI is auto-detected from the identifier; target CLI
+is wherever you run the command. The skill never invokes a different
+CLI itself — it produces a paste-ready `<handoff>` block the user drops
 into the target agent.
 
 ## Arguments
 
-**Dead-simple form (the primary path):**
+**The five forms (primary public surface):**
 
-- `/handoff <source-cli> <id-or-name>` — read the session transcript
-  from `<source-cli>` (one of `claude`, `copilot`, `codex`) and emit a
-  `<handoff>` block into the current context. `<id-or-name>` accepts:
-  - full UUID (36 chars)
-  - short UUID (first 8 hex)
-  - the literal `latest` (newest by mtime)
-  - Claude `customTitle` alias (set via `claude --resume "<name>"`,
-    stored as a `custom-title` JSONL record)
-  - Codex `thread_name` alias (set via `codex resume <name>`, stored
-    as an `event_msg` record)
+```
+/handoff                              push host's latest session
+/handoff <query>                      local cross-agent: emit <handoff>
+/handoff push [<query>] [--tag <l>]   upload to transport
+/handoff pull [<query>]               fetch from transport
+/handoff list [--local|--remote]      unified table
+```
 
 Equivalent from any shell (including Codex's bash tool):
-`!dotclaude handoff <source-cli> <id-or-name>`.
+`!dotclaude handoff …` with the same arguments.
+
+`<query>` auto-detects the source CLI across all three roots
+(`~/.claude/projects`, `~/.copilot/session-state`, `~/.codex/sessions`).
+It accepts:
+
+- full UUID (36 chars)
+- short UUID (first 8 hex)
+- the literal `latest` (newest by mtime across every root)
+- Claude `customTitle` alias (set via `claude --resume "<name>"`,
+  stored as a `custom-title` JSONL record)
+- Codex `thread_name` alias (set via `codex resume <name>`, stored as
+  an `event_msg` record)
+
+**Collision model.** When a `<query>` matches in two or more roots (or
+matches two gists on `pull`), behavior depends on stdin:
+
+- TTY → skill prompts interactively for a pick.
+- Non-TTY → exits 2 with a TSV candidate list on stderr (one line per
+  candidate: `<cli>\t<session-id>\t<path>\t<query>`).
 
 **Power-user sub-commands** (optional, only when you need them):
 
-- `$0` — sub-command: `describe`, `digest`, `file`, `list`, `search`,
-  `push`, `pull`, `remote-list`, or `doctor`. When omitted and the
-  first positional is a CLI name, the skill behaves as `digest` by
-  default.
-- `$1` — positional varies by sub-command:
-  - `describe` / `digest` / `file` / `list` / `push` → source CLI
-    (`claude`, `copilot`, `codex`).
-  - `search` → the query string (regex).
-  - `pull` → a handle (gist ID, gist URL, or the literal `latest`).
-  - `remote-list` / `doctor` → no positional argument.
-- `$2` — session identifier: a UUID, short UUID, `latest`, or a named
-  alias. Required for `describe`, `digest`, `file`, `push`. Ignored
-  for `list`, `search`, `pull`, `remote-list`, `doctor`.
-- `--to <target-cli>` — optional; tunes the digest voice for the target
-  agent. Defaults to `claude` since that is the most common consumer in
-  this repo.
+- `resolve <cli> <id>` — print the absolute JSONL path.
+- `describe <cli> <id>` — inline summary (markdown or `--json`).
+- `digest <cli> <id>` — full `<handoff>` block for paste (no transport).
+- `file <cli> <id>` — write a markdown doc to `docs/handoffs/`.
+
+Each takes an explicit `<cli>` (`claude`, `copilot`, `codex`) and an
+identifier. These remain reachable for scripting.
+
+- `--to <target-cli>` — optional; tunes the `<handoff>` block's
+  next-step wording for a specific target agent. Defaults to `claude`.
+  Mostly redundant for in-place use and can be omitted.
 - `--cli <cli>` — `search` and `remote-list` only; restrict the scan
   to one CLI.
 - `--since <ISO>` — `search` and `remote-list` only; skip entries older
@@ -122,15 +133,19 @@ install matrix and workarounds live in
 ## Auto-trigger contract
 
 When the user message matches any of these patterns and the skill fires
-without explicit sub-command, run `describe` by default:
+without an explicit form, run the bare `<query>` path (local
+cross-agent digest) by default:
 
 - Literal resume-command fragments: `claude --resume <uuid>`,
-  `copilot --resume=<uuid>`, `codex resume <uuid>`.
-- Natural-language: "what was that session about", "continue in
-  \<cli\>", "switch to \<cli\>", "handoff".
+  `claude --resume "<name>"`, `copilot --resume=<uuid>`,
+  `codex resume <uuid>`, `codex resume <name>`.
+- Natural-language: "what was that session about", "continue in X",
+  "switch to X", "handoff".
 
-Extract `<cli>` and `<uuid>` from the user message. If either is missing,
-ask a single clarifying question before proceeding.
+Extract the `<query>` from the user message (a UUID, short UUID, or
+named alias). No CLI argument is needed — the skill probes all three
+roots. If the query is missing or ambiguous, ask a single clarifying
+question before proceeding.
 
 ---
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -117,20 +117,36 @@ ask a single clarifying question before proceeding.
 
 ## Sub-Commands
 
-### `describe <cli> <uuid|latest>`
+### `describe <cli> <uuid|latest|alias>`
 
 Print an inline 2–4 sentence summary of the session plus the verbatim
 user prompts. Use when the user asks "what was that about" and nothing
 more.
 
-**Steps:**
+For the deterministic path (resolve + extract), prefer the bundled
+shell scripts:
+
+- `plugins/dotclaude/scripts/handoff-resolve.sh <cli> <id>` — returns
+  the absolute JSONL path, supports UUID, short-UUID, `latest`, and
+  (codex only) thread-name aliases.
+- `plugins/dotclaude/scripts/handoff-extract.sh meta <cli> <file>` —
+  emits a JSON metadata object.
+- `plugins/dotclaude/scripts/handoff-extract.sh prompts <cli> <file>` —
+  emits clean user prompts with CLI-specific noise filtered out.
+
+For a fully-packaged CLI interface, invoke
+`dotclaude-handoff describe <cli> <id>` (same pattern, no skill load
+required — useful from Codex).
+
+**Steps (skill-interpreted fallback if the scripts are unavailable):**
 
 1. Resolve the session file. Load the per-CLI reference:
    - `claude` → `references/claude-code.md`
    - `copilot` → `references/copilot.md`
    - `codex` → `references/codex.md`
-2. Apply the `latest` resolver if the identifier is `latest`, otherwise
-   locate the file by UUID using the path pattern in that reference.
+2. Apply the `latest` resolver if the identifier is `latest`; for codex
+   an alias (non-hex identifier) triggers a `thread_name` scan; otherwise
+   locate the file by UUID using the path pattern in the reference.
 3. If no file is found, output exactly:
 
    ```
@@ -140,8 +156,10 @@ more.
    and stop.
 
 4. Run the per-CLI `jq` filters from the reference to extract:
-   - session meta (cwd, model, timestamp)
-   - all user turns, verbatim, in order
+   - session meta (cwd, model, timestamp); for copilot, fall back to
+     `workspace.yaml` when `session.start.cwd` is null
+   - all user turns, verbatim, in order, with CLI-specific noise filtered
+     (see the reference for the exclusion list)
    - all assistant turns (kept in memory for summary only; do not print)
 5. Render the output as:
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -40,18 +40,37 @@ into the target agent.
 
 ## Arguments
 
+**Dead-simple form (the primary path):**
+
+- `/handoff <source-cli> <id-or-name>` — read the session transcript
+  from `<source-cli>` (one of `claude`, `copilot`, `codex`) and emit a
+  `<handoff>` block into the current context. `<id-or-name>` accepts:
+  - full UUID (36 chars)
+  - short UUID (first 8 hex)
+  - the literal `latest` (newest by mtime)
+  - Claude `customTitle` alias (set via `claude --resume "<name>"`,
+    stored as a `custom-title` JSONL record)
+  - Codex `thread_name` alias (set via `codex resume <name>`, stored
+    as an `event_msg` record)
+
+Equivalent from any shell (including Codex's bash tool):
+`!dotclaude handoff <source-cli> <id-or-name>`.
+
+**Power-user sub-commands** (optional, only when you need them):
+
 - `$0` — sub-command: `describe`, `digest`, `file`, `list`, `search`,
-  `push`, `pull`, `remote-list`, or `doctor`. If not provided and the
-  skill is auto-triggered, default to `describe`.
+  `push`, `pull`, `remote-list`, or `doctor`. When omitted and the
+  first positional is a CLI name, the skill behaves as `digest` by
+  default.
 - `$1` — positional varies by sub-command:
   - `describe` / `digest` / `file` / `list` / `push` → source CLI
     (`claude`, `copilot`, `codex`).
   - `search` → the query string (regex).
   - `pull` → a handle (gist ID, gist URL, or the literal `latest`).
   - `remote-list` / `doctor` → no positional argument.
-- `$2` — session identifier: a UUID or the literal `latest`. Required for
-  `describe`, `digest`, `file`, `push`. Ignored for `list`, `search`,
-  `pull`, `remote-list`, `doctor`.
+- `$2` — session identifier: a UUID, short UUID, `latest`, or a named
+  alias. Required for `describe`, `digest`, `file`, `push`. Ignored
+  for `list`, `search`, `pull`, `remote-list`, `doctor`.
 - `--to <target-cli>` — optional; tunes the digest voice for the target
   agent. Defaults to `claude` since that is the most common consumer in
   this repo.

--- a/skills/handoff/references/claude-code.md
+++ b/skills/handoff/references/claude-code.md
@@ -72,6 +72,24 @@ jq -r 'select(.type == "user") | .message.content
   | if type == "string" then . else (map(select(.type == "text") | .text) | join("\n")) end' <file>
 ```
 
+**Noise exclusions.** Claude JSONL carries many synthetic "user" records
+that are not real human prompts: hook outputs, system reminders,
+slash-command echoes, task-notification polling, and tool results.
+Drop any prompt whose first non-whitespace content starts with:
+
+- `<local-command-caveat>` — caveat wrapper for local-command input
+- `<command-name>`, `<command-message>`, `<command-args>` — slash-command echoes
+- `<stdin>` — interactive input wrapper
+- `<system-reminder>` — injected reminders
+- `<user-prompt-submit-hook>` — hook payloads
+- `<task-notification>`, `</task-notification>`, `<task-id>` — task-monitor polling
+- `<summary>Monitor event` — monitor-event summary
+- `<event>` — raw monitor events
+- `If this event is something the user` — monitor heuristic preamble
+
+Reference implementation: `plugins/dotclaude/scripts/handoff-extract.sh
+prompts claude <file>`.
+
 ### Assistant turns (text only)
 
 ```bash

--- a/skills/handoff/references/claude-code.md
+++ b/skills/handoff/references/claude-code.md
@@ -43,7 +43,8 @@ done
 ```
 
 Reference implementation:
-`plugins/dotclaude/scripts/handoff-resolve.sh claude <name>`.
+`plugins/dotclaude/scripts/handoff-resolve.sh any <name>` (or the
+per-CLI form `handoff-resolve.sh claude <name>` for scripting).
 
 **Latest** — newest `.jsonl` across all project dirs by mtime (GNU/BSD
 portable):

--- a/skills/handoff/references/claude-code.md
+++ b/skills/handoff/references/claude-code.md
@@ -34,12 +34,12 @@ renames a session, Claude stores the alias as a JSONL record:
 Scan `.jsonl` files for the match and map it back to the session file:
 
 ```bash
-for f in $(find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl'); do
+while IFS= read -r f; do
   sid=$(jq -r --arg name "<name>" '
     select(.type == "custom-title" and .customTitle == $name)
     | .sessionId' "$f" 2>/dev/null | head -1)
   [[ -n "$sid" ]] && find ~/.claude/projects -maxdepth 2 -name "${sid}.jsonl" && break
-done
+done < <(find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl')
 ```
 
 Reference implementation:

--- a/skills/handoff/references/claude-code.md
+++ b/skills/handoff/references/claude-code.md
@@ -24,6 +24,27 @@ project dirs:
 find ~/.claude/projects -maxdepth 2 -type f -name '<uuid>.jsonl' 2>/dev/null
 ```
 
+**By `customTitle` alias (`claude --resume "<name>"`)** — when the user
+renames a session, Claude stores the alias as a JSONL record:
+
+```json
+{ "type": "custom-title", "customTitle": "<name>", "sessionId": "<uuid>" }
+```
+
+Scan `.jsonl` files for the match and map it back to the session file:
+
+```bash
+for f in $(find ~/.claude/projects -maxdepth 2 -type f -name '*.jsonl'); do
+  sid=$(jq -r --arg name "<name>" '
+    select(.type == "custom-title" and .customTitle == $name)
+    | .sessionId' "$f" 2>/dev/null | head -1)
+  [[ -n "$sid" ]] && find ~/.claude/projects -maxdepth 2 -name "${sid}.jsonl" && break
+done
+```
+
+Reference implementation:
+`plugins/dotclaude/scripts/handoff-resolve.sh claude <name>`.
+
 **Latest** — newest `.jsonl` across all project dirs by mtime (GNU/BSD
 portable):
 

--- a/skills/handoff/references/codex.md
+++ b/skills/handoff/references/codex.md
@@ -37,7 +37,8 @@ done | head -1
 ```
 
 Reference implementation:
-`plugins/dotclaude/scripts/handoff-resolve.sh codex <alias>`.
+`plugins/dotclaude/scripts/handoff-resolve.sh any <alias>` (or the
+per-CLI form `handoff-resolve.sh codex <alias>` for scripting).
 
 **Latest** — newest rollout by mtime (GNU/BSD portable):
 

--- a/skills/handoff/references/codex.md
+++ b/skills/handoff/references/codex.md
@@ -29,11 +29,12 @@ thread, Codex records an `event_msg` with
 `payload.thread_name = "<name>"`. Scan rollouts for the match:
 
 ```bash
-for f in $(find ~/.codex/sessions -type f -name 'rollout-*.jsonl'); do
-  jq -r --arg name "<name>" '
-    select(.type == "event_msg" and .payload.thread_name == $name)
-    | input_filename' "$f" 2>/dev/null | head -1
-done | head -1
+find ~/.codex/sessions -type f -name 'rollout-*.jsonl' 2>/dev/null \
+  | while IFS= read -r f; do
+      jq -r --arg name "<name>" '
+        select(.type == "event_msg" and .payload.thread_name == $name)
+        | input_filename' "$f" 2>/dev/null | head -1
+    done | head -1
 ```
 
 Reference implementation:

--- a/skills/handoff/references/codex.md
+++ b/skills/handoff/references/codex.md
@@ -24,6 +24,21 @@ Examples:
 find ~/.codex/sessions -type f -name "rollout-*-<uuid>.jsonl" 2>/dev/null
 ```
 
+**By thread alias (`codex resume <name>`)** — when the user renames a
+thread, Codex records an `event_msg` with
+`payload.thread_name = "<name>"`. Scan rollouts for the match:
+
+```bash
+for f in $(find ~/.codex/sessions -type f -name 'rollout-*.jsonl'); do
+  jq -r --arg name "<name>" '
+    select(.type == "event_msg" and .payload.thread_name == $name)
+    | input_filename' "$f" 2>/dev/null | head -1
+done | head -1
+```
+
+Reference implementation:
+`plugins/dotclaude/scripts/handoff-resolve.sh codex <alias>`.
+
 **Latest** — newest rollout by mtime (GNU/BSD portable):
 
 ```bash

--- a/skills/handoff/references/copilot.md
+++ b/skills/handoff/references/copilot.md
@@ -68,7 +68,7 @@ jq -r 'select(.type == "session.start") | .data | {cwd, model, sessionId}' <file
 **Mandatory `workspace.yaml` fallback.** Real Copilot sessions commonly
 emit `"cwd": null` on `session.start`; the authoritative value lives in
 the sibling `workspace.yaml` (same session dir). If the `jq` filter
-above returns a null or empty `cwd`, grep `workspace.yaml`:
+above returns a null or empty `cwd`, parse `workspace.yaml`:
 
 ```bash
 awk -F': ' '$1 == "cwd" { sub(/^[^:]*: */, ""); print; exit }' \

--- a/skills/handoff/references/copilot.md
+++ b/skills/handoff/references/copilot.md
@@ -65,9 +65,18 @@ Relevant `type` values:
 jq -r 'select(.type == "session.start") | .data | {cwd, model, sessionId}' <file> | head -1
 ```
 
-If `session.start` lacks `cwd`, fall back to the sibling
-`workspace.yaml` in the session dir — it carries `cwd:` as a top-level
-key.
+**Mandatory `workspace.yaml` fallback.** Real Copilot sessions commonly
+emit `"cwd": null` on `session.start`; the authoritative value lives in
+the sibling `workspace.yaml` (same session dir). If the `jq` filter
+above returns a null or empty `cwd`, grep `workspace.yaml`:
+
+```bash
+awk -F': ' '$1 == "cwd" { sub(/^[^:]*: */, ""); print; exit }' \
+  "$(dirname <file>)/workspace.yaml"
+```
+
+Same pattern for `model`. Reference implementation:
+`plugins/dotclaude/scripts/handoff-extract.sh meta copilot <file>`.
 
 ### User prompts
 

--- a/skills/handoff/references/from-codex.md
+++ b/skills/handoff/references/from-codex.md
@@ -2,56 +2,90 @@
 
 Codex CLI does not autoload `~/.claude/skills/`, so it cannot invoke
 the `/handoff` slash command directly. Use the packaged binary via
-Codex's bash tool instead. Same binary works from any shell.
+Codex's bash tool instead. Same binary, same five-form shape.
 
-## One command, one shape
+## The five forms
 
 ```
-!dotclaude handoff <source-cli> <id-or-name>
+!dotclaude handoff                              push host's latest session
+!dotclaude handoff <query>                      local cross-agent: emit <handoff>
+!dotclaude handoff push [<query>] [--tag LBL]   upload to transport
+!dotclaude handoff pull [<query>]               fetch from transport
+!dotclaude handoff list [--local|--remote]      unified table
 ```
 
-- `<source-cli>`: `claude` | `copilot` | `codex`
-- `<id-or-name>`: full UUID, short UUID (8 hex), `latest`, or a
-  named alias where the source CLI supports it (Claude `customTitle`,
-  Codex `thread_name`).
-
-The output is a `<handoff>` block that lands directly in Codex's
-context. Follow up with "continue" and you are back on task.
+`<query>` auto-detects the source CLI across all three roots. It
+accepts: full UUID, short UUID (first 8 hex), `latest`, Claude
+`customTitle`, or Codex `thread_name`.
 
 ## Examples
 
-```
-# Claude hit its token limit; continue that session in Codex.
-!dotclaude handoff claude b8d2dd0a
-!dotclaude handoff claude "test-handoff"       # customTitle alias
-!dotclaude handoff claude latest
+### Claude hit its token limit; continue in Codex
 
-# Resume a Copilot session in Codex.
-!dotclaude handoff copilot e6c2e29a
+Claude prints on exit:
 
-# Resume a renamed Codex thread in a fresh Codex session.
-!dotclaude handoff codex test                   # thread_name alias
-!dotclaude handoff codex 019da2f6
-!dotclaude handoff codex latest
 ```
+claude --resume b8d2dd0a-1cb6-4cfb-b166-e0a94f20512e
+```
+
+In a fresh Codex session:
+
+```
+!dotclaude handoff b8d2dd0a
+```
+
+Same works with a full UUID or a Claude `customTitle`:
+
+```
+!dotclaude handoff "test-handoff"
+```
+
+### Resume a Codex thread renamed via `codex resume <name>`
+
+```
+!dotclaude handoff my-feature
+```
+
+### Move a Codex session to the other machine
+
+On machine A (before closing):
+
+```
+!dotclaude handoff push my-feature --tag end-of-day
+```
+
+On machine B:
+
+```
+!dotclaude handoff pull end-of-day
+```
+
+or bare `!dotclaude handoff pull` to pick up the latest gist.
 
 ## Prerequisite
 
-`npm install -g @dotclaude/dotclaude` (installs `dotclaude` on PATH
-with `handoff` as one of its sub-commands). Or run ad-hoc with
-`npx dotclaude handoff ...`.
+`npm install -g @dotclaude/dotclaude` (installs the `dotclaude` CLI on
+PATH). Or `npx dotclaude handoff …` for ad-hoc use.
 
-## Sub-commands (power users)
+## Collision handling
 
-The bare form above is shorthand for the common `digest` path. Full
-sub-command list:
+If a `<query>` matches a Claude session AND a Codex session (e.g. you
+renamed a thread `refactor` and named a Claude session `refactor`), the
+binary:
+
+- On a TTY: prompts you to pick `[1..N]`.
+- Non-TTY (scripts/CI): exits 2 with a TSV candidate list on stderr so
+  the caller can parse and retry with a more specific query.
+
+## Power-user sub-commands
+
+The five-form shape above is the primary surface. For scripting you
+can still use:
 
 ```
-dotclaude handoff <cli> <id>                 # implicit digest (default)
 dotclaude handoff resolve  <cli> <id>        # file path only
 dotclaude handoff describe <cli> <id>        # inline markdown summary
 dotclaude handoff digest   <cli> <id>        # full <handoff> block
-dotclaude handoff list     <cli>             # recent sessions
 dotclaude handoff file     <cli> <id>        # write to docs/handoffs/
 ```
 
@@ -60,8 +94,8 @@ All subcommands support `--help`, `--version`, `--json`, `--verbose`,
 
 ## Why the binary and not the skill file?
 
-`skills/handoff/SKILL.md` is the authoritative runbook for Claude
-Code and Copilot CLI (both load it automatically). Codex does not
-load it. Rather than asking Codex to ingest a 460-line spec, the
-binary bundles the resolution and extraction logic into a single
-call. Same code path as the skill; no skill load required.
+`skills/handoff/SKILL.md` is the authoritative runbook for Claude Code
+and Copilot CLI (both load it automatically). Codex does not load it.
+Rather than asking Codex to ingest a 460-line spec, the binary bundles
+the resolution and extraction logic into a single call. Same code path
+as the skill; no skill load required.

--- a/skills/handoff/references/from-codex.md
+++ b/skills/handoff/references/from-codex.md
@@ -51,21 +51,29 @@ Same works with a full UUID or a Claude `customTitle`:
 On machine A (before closing):
 
 ```
-!dotclaude handoff push my-feature --tag end-of-day
+!dotclaude handoff push my-feature --tag end-of-day --via git-fallback
 ```
 
 On machine B:
 
 ```
-!dotclaude handoff pull end-of-day
+!dotclaude handoff pull end-of-day --via git-fallback
 ```
 
-or bare `!dotclaude handoff pull` to pick up the latest gist.
+or bare `!dotclaude handoff pull --via git-fallback` to pick up the latest handoff.
 
 ## Prerequisite
 
 `npm install -g @dotclaude/dotclaude` (installs the `dotclaude` CLI on
 PATH). Or `npx dotclaude handoff …` for ad-hoc use.
+
+For cross-machine transport, set `DOTCLAUDE_HANDOFF_REPO` to a bare git
+repo URL (HTTPS, SSH, `file://`, or absolute path) before running
+`push`/`pull`. Example:
+
+```bash
+export DOTCLAUDE_HANDOFF_REPO=git@github.com:you/handoffs.git
+```
 
 ## Collision handling
 

--- a/skills/handoff/references/from-codex.md
+++ b/skills/handoff/references/from-codex.md
@@ -1,0 +1,82 @@
+# Using handoff from Codex (or any shell)
+
+Codex CLI does not autoload `~/.claude/skills/`, so it cannot invoke the
+`/handoff` slash command directly. Use the `dotclaude-handoff` binary
+via Codex's bash tool instead. One command, no skill load required.
+
+## Prerequisite
+
+`npm install -g @dotclaude/dotclaude` (gives you `dotclaude-handoff` on
+your PATH). Or run `npx dotclaude-handoff ...` if you prefer not to
+install globally.
+
+## Typical workflows
+
+### Claude session exceeded its token budget; continue in Codex
+
+Claude prints its resume UUID on exit, e.g.
+`claude --resume b8d2dd0a-1cb6-4cfb-b166-e0a94f20512e`.
+
+Open Codex and invoke the binary through its Bash tool:
+
+```
+!dotclaude-handoff digest claude b8d2dd0a --to codex
+```
+
+The output is a single `<handoff>` block tuned for Codex (task-shaped
+next step, filepaths inline). The block is now in Codex's context.
+Continue the task.
+
+Short UUID (first 8 hex) also works; so does the full UUID.
+
+### Codex renamed the thread ("to resume this thread run codex resume test")
+
+Handoff accepts the alias directly — it scans
+`event_msg.payload.thread_name` across rollouts:
+
+```
+!dotclaude-handoff describe codex test
+```
+
+### Moving from Codex back to Claude
+
+Inside Claude, run the slash-command form (skill is loaded):
+
+```
+/handoff digest codex <uuid-or-alias> --to claude
+```
+
+Or the binary form, which works from any shell:
+
+```
+!dotclaude-handoff digest codex <uuid-or-alias> --to claude
+```
+
+## Commands
+
+```
+dotclaude-handoff resolve  <cli> <id>              # file path only
+dotclaude-handoff describe <cli> <id>              # inline summary
+dotclaude-handoff digest   <cli> <id> --to <cli>   # paste-ready block
+dotclaude-handoff list     <cli>                   # recent sessions
+dotclaude-handoff file     <cli> <id> --to <cli>   # write to docs/handoffs/
+```
+
+`<cli>`: one of `claude`, `copilot`, `codex`.
+
+`<id>`: full UUID (36 chars), short UUID (first 8 hex), the literal
+`latest`, or (codex only) a thread_name alias.
+
+`--to <cli>`: tunes the next-step suggestion for the target agent.
+Defaults to `claude`.
+
+All subcommands support `--help`, `--version`, `--json`, `--verbose`,
+`--no-color`. Exit codes: 0 ok, 2 not found / parse error, 64 usage.
+
+## Why the binary and not the skill file?
+
+`skills/handoff/SKILL.md` is the authoritative runbook for Claude Code
+and Copilot CLI (both load it automatically). Codex does not load it.
+Rather than asking Codex to ingest a 460-line spec just to run one
+sub-command, the binary bundles the resolution and extraction logic
+into a single call. Same code path, same output shape; no skill load.

--- a/skills/handoff/references/from-codex.md
+++ b/skills/handoff/references/from-codex.md
@@ -1,82 +1,67 @@
 # Using handoff from Codex (or any shell)
 
-Codex CLI does not autoload `~/.claude/skills/`, so it cannot invoke the
-`/handoff` slash command directly. Use the `dotclaude-handoff` binary
-via Codex's bash tool instead. One command, no skill load required.
+Codex CLI does not autoload `~/.claude/skills/`, so it cannot invoke
+the `/handoff` slash command directly. Use the packaged binary via
+Codex's bash tool instead. Same binary works from any shell.
+
+## One command, one shape
+
+```
+!dotclaude handoff <source-cli> <id-or-name>
+```
+
+- `<source-cli>`: `claude` | `copilot` | `codex`
+- `<id-or-name>`: full UUID, short UUID (8 hex), `latest`, or a
+  named alias where the source CLI supports it (Claude `customTitle`,
+  Codex `thread_name`).
+
+The output is a `<handoff>` block that lands directly in Codex's
+context. Follow up with "continue" and you are back on task.
+
+## Examples
+
+```
+# Claude hit its token limit; continue that session in Codex.
+!dotclaude handoff claude b8d2dd0a
+!dotclaude handoff claude "test-handoff"       # customTitle alias
+!dotclaude handoff claude latest
+
+# Resume a Copilot session in Codex.
+!dotclaude handoff copilot e6c2e29a
+
+# Resume a renamed Codex thread in a fresh Codex session.
+!dotclaude handoff codex test                   # thread_name alias
+!dotclaude handoff codex 019da2f6
+!dotclaude handoff codex latest
+```
 
 ## Prerequisite
 
-`npm install -g @dotclaude/dotclaude` (gives you `dotclaude-handoff` on
-your PATH). Or run `npx dotclaude-handoff ...` if you prefer not to
-install globally.
+`npm install -g @dotclaude/dotclaude` (installs `dotclaude` on PATH
+with `handoff` as one of its sub-commands). Or run ad-hoc with
+`npx dotclaude handoff ...`.
 
-## Typical workflows
+## Sub-commands (power users)
 
-### Claude session exceeded its token budget; continue in Codex
-
-Claude prints its resume UUID on exit, e.g.
-`claude --resume b8d2dd0a-1cb6-4cfb-b166-e0a94f20512e`.
-
-Open Codex and invoke the binary through its Bash tool:
+The bare form above is shorthand for the common `digest` path. Full
+sub-command list:
 
 ```
-!dotclaude-handoff digest claude b8d2dd0a --to codex
+dotclaude handoff <cli> <id>                 # implicit digest (default)
+dotclaude handoff resolve  <cli> <id>        # file path only
+dotclaude handoff describe <cli> <id>        # inline markdown summary
+dotclaude handoff digest   <cli> <id>        # full <handoff> block
+dotclaude handoff list     <cli>             # recent sessions
+dotclaude handoff file     <cli> <id>        # write to docs/handoffs/
 ```
-
-The output is a single `<handoff>` block tuned for Codex (task-shaped
-next step, filepaths inline). The block is now in Codex's context.
-Continue the task.
-
-Short UUID (first 8 hex) also works; so does the full UUID.
-
-### Codex renamed the thread ("to resume this thread run codex resume test")
-
-Handoff accepts the alias directly — it scans
-`event_msg.payload.thread_name` across rollouts:
-
-```
-!dotclaude-handoff describe codex test
-```
-
-### Moving from Codex back to Claude
-
-Inside Claude, run the slash-command form (skill is loaded):
-
-```
-/handoff digest codex <uuid-or-alias> --to claude
-```
-
-Or the binary form, which works from any shell:
-
-```
-!dotclaude-handoff digest codex <uuid-or-alias> --to claude
-```
-
-## Commands
-
-```
-dotclaude-handoff resolve  <cli> <id>              # file path only
-dotclaude-handoff describe <cli> <id>              # inline summary
-dotclaude-handoff digest   <cli> <id> --to <cli>   # paste-ready block
-dotclaude-handoff list     <cli>                   # recent sessions
-dotclaude-handoff file     <cli> <id> --to <cli>   # write to docs/handoffs/
-```
-
-`<cli>`: one of `claude`, `copilot`, `codex`.
-
-`<id>`: full UUID (36 chars), short UUID (first 8 hex), the literal
-`latest`, or (codex only) a thread_name alias.
-
-`--to <cli>`: tunes the next-step suggestion for the target agent.
-Defaults to `claude`.
 
 All subcommands support `--help`, `--version`, `--json`, `--verbose`,
 `--no-color`. Exit codes: 0 ok, 2 not found / parse error, 64 usage.
 
 ## Why the binary and not the skill file?
 
-`skills/handoff/SKILL.md` is the authoritative runbook for Claude Code
-and Copilot CLI (both load it automatically). Codex does not load it.
-Rather than asking Codex to ingest a 460-line spec just to run one
-sub-command, the binary bundles the resolution and extraction logic
-into a single call. Same code path, same output shape; no skill load.
+`skills/handoff/SKILL.md` is the authoritative runbook for Claude
+Code and Copilot CLI (both load it automatically). Codex does not
+load it. Rather than asking Codex to ingest a 460-line spec, the
+binary bundles the resolution and extraction logic into a single
+call. Same code path as the skill; no skill load required.


### PR DESCRIPTION
## Summary

Collapse `/handoff` to a dead-simple **five-form public surface**, shell-scripts-first. Same PR, seven atomic commits.

```
/handoff                              push host's latest session
/handoff <query>                      local cross-agent: emit <handoff> block
/handoff push [<query>] [--tag LBL]   upload to transport
/handoff pull [<query>]               fetch from transport
/handoff list [--local|--remote]      unified local + remote table
```

`<query>` auto-detects the source CLI across all three roots (claude / copilot / codex) and accepts: full UUID, short UUID (first 8 hex), `latest`, Claude `customTitle` alias (`claude --resume "<name>"`), or Codex `thread_name` alias (`codex resume <name>`).

## Why

Hands-on integration testing against three real sessions surfaced four gaps in `/handoff`. Then a follow-up product call: the `<cli> <id>` positional shape is noise — the source CLI is metadata, not a lookup key. Removed it entirely.

## What shipped

| Commit | What |
|---|---|
| `b429af2` | Initial shell-scripts-first refactor: `handoff-resolve.sh`, `handoff-extract.sh`, `dotclaude-handoff.mjs` binary, noise filters, Copilot workspace.yaml fallback, Codex thread-alias resolution |
| `c3bec14` | Dead-simple `<cli> <id>` form + Claude `customTitle` (later superseded by `<query>`) |
| `9caf0ed` | Simplify pass: single-jq meta, grep-prefiltered alias scans, fs-based listSessions |
| `dcc3f77` | Failing bats for resolve-any + five-form binary (27 red) |
| `897f007` | `handoff-resolve.sh` gains `any` probe + collision contract |
| `9780c60` | Binary five-form dispatch + git-fallback push/pull + TTY-aware collision prompt |
| `0771da2` | Docs sweep: SKILL.md, references, README, handoff-guide, audit headers |

## Key mechanisms

- **Resolver:** `handoff-resolve.sh any <query>` probes all three roots. On collision → exit 2 with TSV candidates on stderr (one line per candidate: `<cli>\t<sid>\t<path>\t<query>`). Per-CLI forms still available for scripting.
- **Binary collision handling:** TTY → `readline` prompt for `[1..N]` pick. Non-TTY → pass through exit 2 + TSV (scriptable).
- **Transport:** `--via git-fallback` fully implemented in the binary (bare-repo push, shallow-clone pull, fuzzy match on branch name + description). `--via github` continues to work via the `/handoff` skill inside Claude/Copilot CLI (prose path, unchanged).
- **Back-compat:** power-user sub-commands (`resolve`, `describe`, `digest`, `file`) stay reachable with explicit `<cli> <id>`. The bare `<cli> <id>` implicit-digest form is **removed**.

## Test plan

- [x] `npm test` — 205/205
- [x] `npx bats plugins/dotclaude/tests/bats/` — 158/158 (including 11 new `handoff-resolve-any.bats` + 16 new `dotclaude-handoff-five-form.bats`)
- [x] `bash plugins/dotclaude/tests/test_validate_settings.sh` — 12/12
- [x] `dotclaude check-instruction-drift` — ok
- [x] `dotclaude validate-skills` — 29 skills valid
- [x] `dotclaude validate-specs` — 3/3
- [x] `shellcheck --severity=warning -x plugins/dotclaude/scripts/*.sh` — clean
- [x] `npx prettier@3 --check` — clean
- [x] `npx markdownlint-cli2` — clean
- [x] Real-session smoke:
  - `dotclaude handoff test-handoff` → resolves Claude `bf123191` via `customTitle` scan
  - `dotclaude handoff codex test` → resolves Codex `019da2f6` via `thread_name` scan
  - `dotclaude handoff list --local` → unified table across all three CLIs

## Risk

- `<cli> <id>` bare form is **removed** (zombie-surface cleanup; PR hadn't merged so no back-compat debt).
- `push`/`pull` only implement `--via git-fallback` in the binary; `--via github` flows through the skill (unchanged). Transport parity for binary is a follow-up.
- `list` output format changed: new `Location` column, no CLI positional.
- Pre-existing `README.md`, `docs/handoff-guide.md`, and `docs/audits/handoff-remote/README.md` touched for consistency with the new UX.

## Spec ID

dotclaude-core
