### PR TITLE
test(handoff): Phase 1 — testability refactor + security/regression/unit suites

### DIFF
--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -26,7 +26,7 @@ import { parse, helpText } from "../src/lib/argv.mjs";
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
 import { version } from "../src/index.mjs";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import {
   existsSync,
@@ -751,4 +751,20 @@ async function main() {
   process.exit(EXIT_CODES.OK);
 }
 
-main().catch((err) => fail(2, err.message));
+// Only execute the CLI when invoked directly; stay import-safe for unit tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => fail(2, err.message));
+}
+
+// Internals exposed for unit testing.
+export {
+  cliFromPath,
+  encodeDescription,
+  mechanicalSummary,
+  matchesQuery,
+  nextStepFor,
+  projectSlugFromCwd,
+  requireTransportRepo,
+  CLI_LAYOUTS,
+  UUID_HEAD_RE,
+};

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -756,7 +756,6 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   main().catch((err) => fail(2, err.message));
 }
 
-// Internals exposed for unit testing.
 export {
   cliFromPath,
   encodeDescription,

--- a/plugins/dotclaude/tests/bats/handoff-regression.bats
+++ b/plugins/dotclaude/tests/bats/handoff-regression.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# Regression seeds: each test locks in a bug previously fixed in the
+# handoff scripts. Failing any of these means a fix has been lost.
+
+load helpers
+
+RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
+EXTRACT="$REPO_ROOT/plugins/dotclaude/scripts/handoff-extract.sh"
+HANDOFF_BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  [ -x "$RESOLVE" ] || chmod +x "$RESOLVE"
+  [ -x "$EXTRACT" ] || chmod +x "$EXTRACT"
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# -- pick_newest sub-second mtime regression -----------------------------
+
+@test "pick_newest distinguishes files created within the same second" {
+  # Bug: old `stat -c "%Y"` returned whole seconds, so `latest` was
+  # non-deterministic for files created <1s apart. Fix moved to
+  # `find -printf '%T@'` (GNU) / `stat -f '%Fm'` (BSD) with ms arithmetic.
+  local dir="$TEST_HOME/.claude/projects/-regression"
+  mkdir -p "$dir"
+  local a="$dir/aaaa1111-1111-1111-1111-111111111111.jsonl"
+  local b="$dir/bbbb2222-2222-2222-2222-222222222222.jsonl"
+  printf '{"cwd":"/x","sessionId":"aaaa1111-1111-1111-1111-111111111111"}\n' > "$a"
+  printf '{"cwd":"/x","sessionId":"bbbb2222-2222-2222-2222-222222222222"}\n' > "$b"
+  # Force deterministic mtimes, 100 ms apart, same whole second.
+  if touch -d '2026-04-18 12:00:00.100000000' "$a" 2>/dev/null; then
+    touch -d '2026-04-18 12:00:00.500000000' "$b"
+  else
+    skip "GNU touch -d with fractional seconds unavailable"
+  fi
+  run "$RESOLVE" claude latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222"* ]]
+}
+
+# -- jq streaming regression (no slurp) ----------------------------------
+
+@test "meta_claude handles multi-record transcript without slurping" {
+  # Bug: early version read the whole file with `[inputs]` (slurp) and
+  # quadratic memory on long transcripts. Fix switched to
+  # `first(inputs | select(...))` which stops at the first matching record.
+  # This test only proves correctness on a moderate input — the ms
+  # characteristic is covered in Phase 2/3 large-file tests.
+  local uuid="cccc3333-3333-3333-3333-333333333333"
+  local file="$TEST_HOME/.claude/projects/-demo/$uuid.jsonl"
+  mkdir -p "$(dirname "$file")"
+  # 1 cwd-bearing record followed by 100 noise records with no cwd.
+  printf '{"cwd":"/real","sessionId":"%s","version":"2.1"}\n' "$uuid" > "$file"
+  for i in $(seq 1 100); do
+    printf '{"type":"noise","n":%d}\n' "$i" >> "$file"
+  done
+  run "$EXTRACT" meta claude "$file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"cwd":"/real"'* ]]
+  [[ "$output" == *"\"session_id\":\"$uuid\""* ]]
+}
+
+# -- word-split regression (paths with spaces) ---------------------------
+
+@test "resolve tolerates session roots with spaces" {
+  # Bug: a `for f in $(find ...)` in the alias-scan path would word-split
+  # on spaces. Fix uses `while IFS= read -r`. A path with spaces in
+  # $HOME must still resolve.
+  export HOME="$TEST_HOME/home with spaces"
+  mkdir -p "$HOME"
+  make_claude_session_tree "$HOME" "dddd4444-4444-4444-4444-444444444444"
+  run "$RESOLVE" claude dddd4444
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dddd4444-4444-4444-4444-444444444444.jsonl" ]]
+}
+
+# -- DOTCLAUDE_HANDOFF_REPO absolute path regression --------------------
+
+@test "push accepts absolute-path DOTCLAUDE_HANDOFF_REPO (bare repo)" {
+  # Bug: the URL allowlist originally required an explicit URL scheme
+  # (https/git@/ssh://), rejecting local bare-repo paths used by tests
+  # and by air-gapped setups. Fix added `/` and `file://` to the regex.
+  local bare="$TEST_HOME/bare.git"
+  make_transport_repo "$bare"
+  # Seed a session so push has something to extract.
+  make_claude_session_tree "$TEST_HOME" "eeee5555-5555-5555-5555-555555555555"
+  DOTCLAUDE_HANDOFF_REPO="$bare" \
+    run node "$HANDOFF_BIN" push eeee5555 --via git-fallback
+  # The push path may fail later for unrelated reasons in a hermetic env
+  # (no git user config etc.) — what we care about is that the URL
+  # validator did NOT reject up-front. Accept exit 0 OR a non-URL-related
+  # error as a pass.
+  [[ "$status" -eq 0 || ( "$status" -ne 0 && "$output" != *"must be an https"* ) ]]
+}
+
+# -- grep-prefilter alias scan regression --------------------------------
+
+@test "codex alias scan finds thread_name via grep-prefilter path" {
+  # Bug: a naive implementation jq-parsed every rollout file even when
+  # none contained the alias. Fix uses `grep -rl -F` to prefilter and
+  # only jq-verifies candidates. This test proves the prefilter + verify
+  # round trip still finds a match.
+  local uuid="ffff6666-6666-6666-6666-666666666666"
+  local path="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T12-00-00-${uuid}.jsonl"
+  mkdir -p "$(dirname "$path")"
+  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"regression-target","type":"thread_renamed"}}\n' \
+    "$uuid" "$uuid" > "$path"
+  run "$RESOLVE" codex "regression-target"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$path" ]
+}

--- a/plugins/dotclaude/tests/bats/handoff-security.bats
+++ b/plugins/dotclaude/tests/bats/handoff-security.bats
@@ -73,7 +73,8 @@ teardown() {
   mkdir -p "$(dirname "$path")"
   printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"safe","type":"thread_renamed"}}\n' \
     "$uuid" "$uuid" > "$path"
-  run "$RESOLVE" codex $'multi\nline'
+  local alias=$'multi\nline'
+  run "$RESOLVE" codex "$alias"
   [ "$status" -eq 2 ]
   [[ "$output" == *"not found"* ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-security.bats
+++ b/plugins/dotclaude/tests/bats/handoff-security.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# Security tests for the handoff shell scripts and JS CLI.
+# Each test asserts that a hostile input is neutralised (regex gate rejects,
+# jq --arg literalises, grep -F disables regex, symlinks don't escape, etc.).
+
+load helpers
+
+RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
+EXTRACT="$REPO_ROOT/plugins/dotclaude/scripts/handoff-extract.sh"
+HANDOFF_BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  [ -x "$RESOLVE" ] || chmod +x "$RESOLVE"
+  [ -x "$EXTRACT" ] || chmod +x "$EXTRACT"
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  make_claude_session_tree "$TEST_HOME" "aaaa1111-1111-1111-1111-111111111111"
+  # Also lay down a codex session for alias-scan tests.
+  make_codex_session_tree "$TEST_HOME" "eeee5555-5555-5555-5555-555555555555"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# -- resolve: path traversal + injection ---------------------------------
+
+@test "resolve rejects path traversal identifier" {
+  run "$RESOLVE" claude "../../../etc/passwd"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+  # The script must not have tried to read /etc/passwd under any guise.
+  [[ "$output" != *"root:"* ]]
+}
+
+@test "resolve does not shell-expand malicious identifier" {
+  # If `$id` were interpolated unquoted anywhere, "; touch /tmp/pwned" would fire.
+  local canary="$TEST_HOME/pwned-canary"
+  run "$RESOLVE" claude "foo; touch $canary"
+  [ "$status" -eq 2 ]
+  [ ! -e "$canary" ]
+}
+
+@test "resolve treats command-substitution-shaped identifier as literal" {
+  # `$(...)` must be passed verbatim — it appears in the error string intact,
+  # proving it was not evaluated. The literal "$(" sequence in the error is
+  # the positive signal; execution would have replaced it with stdout.
+  run "$RESOLVE" claude 'x$(echo PWNED)'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *'x$(echo PWNED)'* ]]
+}
+
+# -- resolve: customTitle / alias with shell metachars -------------------
+
+@test "resolve handles customTitle alias with shell metachars" {
+  # Seed a fixture session that claims customTitle = literal "; rm -rf /".
+  local uuid="cccc1111-1111-1111-1111-111111111111"
+  local dir="$TEST_HOME/.claude/projects/-home-user-projects-demo"
+  mkdir -p "$dir"
+  printf '{"cwd":"/x","sessionId":"%s","version":"2.1"}\n{"type":"custom-title","customTitle":"; rm -rf /","sessionId":"%s"}\n' \
+    "$uuid" "$uuid" > "$dir/$uuid.jsonl"
+  # The alias scan must find it by literal-match; grep -F + jq --arg keep it safe.
+  run "$RESOLVE" claude "; rm -rf /"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$uuid.jsonl" ]]
+}
+
+@test "resolve codex alias with newline does not match spurious records" {
+  # Insert a codex rollout with a benign thread_name. Then search for a
+  # newline-containing alias. Must not match.
+  local uuid="ffff6666-6666-6666-6666-666666666666"
+  local path="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T99-00-00-${uuid}.jsonl"
+  mkdir -p "$(dirname "$path")"
+  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"safe","type":"thread_renamed"}}\n' \
+    "$uuid" "$uuid" > "$path"
+  run "$RESOLVE" codex $'multi\nline'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+# -- DOTCLAUDE_HANDOFF_REPO: ext:: rejection -----------------------------
+
+@test "push rejects ext:: transport URL" {
+  DOTCLAUDE_HANDOFF_REPO='ext::sh -c evil' \
+    run node "$HANDOFF_BIN" push latest --via git-fallback
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"DOTCLAUDE_HANDOFF_REPO"* ]]
+  [[ "$output" == *"ext::"* ]]
+}
+
+@test "push rejects data: transport URL" {
+  DOTCLAUDE_HANDOFF_REPO='data:text/plain,x' \
+    run node "$HANDOFF_BIN" push latest --via git-fallback
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"DOTCLAUDE_HANDOFF_REPO"* ]]
+}
+
+# -- symlink containment ------------------------------------------------
+
+@test "resolve does not follow symlinks that escape session root" {
+  # Dangle a symlink inside ~/.claude/projects/ pointing at /etc. The
+  # resolver only calls find under the session root; -name filters exclude
+  # /etc/passwd regardless, so the symlink must not surface it.
+  ln -s /etc "$TEST_HOME/.claude/projects/escape"
+  run "$RESOLVE" claude latest
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"/etc/passwd"* ]]
+  [[ "$output" == *".jsonl" ]]
+}

--- a/plugins/dotclaude/tests/bats/helpers.bash
+++ b/plugins/dotclaude/tests/bats/helpers.bash
@@ -125,7 +125,6 @@ make_codex_session_tree() {
       "$uuid" > "$path"
     paths+=("$path")
     i=$((i + 1))
-    sleep 0.01
   done
   CODEX_SESSION_UUIDS="${uuids[*]}"
   CODEX_SESSION_PATHS="${paths[*]}"
@@ -141,11 +140,11 @@ make_transport_repo() {
   echo "$dir"
 }
 
-# make_session_with_content <cli> <path> <content>
+# make_session_with_content <path> <content>
 # Overwrite the session JSONL at <path> with <content>. Useful for
 # boundary tests (empty files, unicode, malformed records).
 make_session_with_content() {
-  local cli="$1" path="$2" content="$3"
+  local path="$1" content="$2"
   mkdir -p "$(dirname "$path")"
   printf '%s' "$content" > "$path"
 }

--- a/plugins/dotclaude/tests/bats/helpers.bash
+++ b/plugins/dotclaude/tests/bats/helpers.bash
@@ -61,6 +61,95 @@ EOF
   echo "$dir"
 }
 
+# -- handoff session-tree fixtures ----------------------------------------
+#
+# Each helper seeds a hermetic session tree under $1 (usually an ephemeral
+# $HOME created by mktemp in setup()). Callers select which fixtures they
+# need — suites that only touch claude don't pay the codex/copilot cost.
+# All helpers are idempotent-ish: they create parent directories with -p.
+
+# make_claude_session_tree <home> [uuid1] [uuid2] ...
+# Seeds ~/.claude/projects/<slug>/<uuid>.jsonl with one record containing
+# cwd + sessionId. Subsequent UUIDs get unique slugs so the resolver finds
+# them deterministically. Exports CLAUDE_SESSION_UUIDS (space-separated).
+make_claude_session_tree() {
+  local home="$1"; shift
+  local uuids=("$@")
+  [[ ${#uuids[@]} -gt 0 ]] || uuids=("aaaa1111-1111-1111-1111-111111111111")
+  local i=0
+  for uuid in "${uuids[@]}"; do
+    local slug="-home-user-projects-demo${i}"
+    local dir="$home/.claude/projects/$slug"
+    mkdir -p "$dir"
+    printf '{"cwd":"/home/user/projects/demo%d","sessionId":"%s","version":"2.1"}\n' \
+      "$i" "$uuid" > "$dir/$uuid.jsonl"
+    i=$((i + 1))
+    sleep 0.01
+  done
+  CLAUDE_SESSION_UUIDS="${uuids[*]}"
+  export CLAUDE_SESSION_UUIDS
+}
+
+# make_copilot_session_tree <home> [uuid1] [uuid2] ...
+# Seeds ~/.copilot/session-state/<uuid>/events.jsonl.
+make_copilot_session_tree() {
+  local home="$1"; shift
+  local uuids=("$@")
+  [[ ${#uuids[@]} -gt 0 ]] || uuids=("cccc3333-3333-3333-3333-333333333333")
+  for uuid in "${uuids[@]}"; do
+    local dir="$home/.copilot/session-state/$uuid"
+    mkdir -p "$dir"
+    printf '{"type":"session.start","data":{"cwd":"/tmp","model":"gpt","sessionId":"%s"}}\n' \
+      "$uuid" > "$dir/events.jsonl"
+    sleep 0.01
+  done
+  COPILOT_SESSION_UUIDS="${uuids[*]}"
+  export COPILOT_SESSION_UUIDS
+}
+
+# make_codex_session_tree <home> [uuid1] [uuid2] ...
+# Seeds ~/.codex/sessions/2026/04/18/rollout-<ts>-<uuid>.jsonl.
+# Each UUID gets a distinct timestamp so file-ordering is deterministic.
+make_codex_session_tree() {
+  local home="$1"; shift
+  local uuids=("$@")
+  [[ ${#uuids[@]} -gt 0 ]] || uuids=("eeee5555-5555-5555-5555-555555555555")
+  local dir="$home/.codex/sessions/2026/04/18"
+  mkdir -p "$dir"
+  local i=0
+  local -a paths=()
+  for uuid in "${uuids[@]}"; do
+    local hh; printf -v hh '%02d' "$i"
+    local path="$dir/rollout-2026-04-18T${hh}-00-00-${uuid}.jsonl"
+    printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n' \
+      "$uuid" > "$path"
+    paths+=("$path")
+    i=$((i + 1))
+    sleep 0.01
+  done
+  CODEX_SESSION_UUIDS="${uuids[*]}"
+  CODEX_SESSION_PATHS="${paths[*]}"
+  export CODEX_SESSION_UUIDS CODEX_SESSION_PATHS
+}
+
+# make_transport_repo <dir>
+# Initialise a bare git repo at <dir>. Use as DOTCLAUDE_HANDOFF_REPO for
+# push/pull tests. Caller is responsible for cleanup.
+make_transport_repo() {
+  local dir="$1"
+  git init -q --bare "$dir"
+  echo "$dir"
+}
+
+# make_session_with_content <cli> <path> <content>
+# Overwrite the session JSONL at <path> with <content>. Useful for
+# boundary tests (empty files, unicode, malformed records).
+make_session_with_content() {
+  local cli="$1" path="$2" content="$3"
+  mkdir -p "$(dirname "$path")"
+  printf '%s' "$content" > "$path"
+}
+
 # Feed a hook JSON payload to a PreToolUse guard script.
 # Usage: feed_hook_json <path-to-hook> <command-string>
 # Sets ${status}, ${output}, ${lines[@]} as bats' standard `run` would.

--- a/plugins/dotclaude/tests/fixtures/handoff-sessions.mjs
+++ b/plugins/dotclaude/tests/fixtures/handoff-sessions.mjs
@@ -1,0 +1,124 @@
+// Programmatic JSONL builders for Claude / Copilot / Codex session trees.
+// Used by vitest unit tests that need realistic inputs for the shell-script
+// callers without shelling out to bash. Each builder writes files under
+// <root> and returns the absolute path(s) it created.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+function writeFile(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+  return path;
+}
+
+/**
+ * Build a Claude session JSONL under <root>/.claude/projects/<slug>/<uuid>.jsonl.
+ * @param {string} root - hermetic $HOME root
+ * @param {object} opts
+ * @param {string} opts.uuid
+ * @param {string} [opts.slug] - defaults to `-home-user-projects-demo`
+ * @param {string} [opts.cwd] - defaults to `/home/user/projects/demo`
+ * @param {string} [opts.customTitle] - adds a custom-title record if set
+ * @param {string[]} [opts.prompts] - user prompts appended as records
+ * @returns {string} absolute path to the JSONL file
+ */
+export function makeClaudeSession(root, opts = {}) {
+  const {
+    uuid,
+    slug = "-home-user-projects-demo",
+    cwd = "/home/user/projects/demo",
+    customTitle,
+    prompts = [],
+  } = opts;
+  if (!uuid) throw new Error("makeClaudeSession: uuid required");
+  const file = join(root, ".claude", "projects", slug, `${uuid}.jsonl`);
+  const lines = [
+    JSON.stringify({ cwd, sessionId: uuid, version: "2.1" }),
+  ];
+  if (customTitle) {
+    lines.push(JSON.stringify({
+      type: "custom-title",
+      customTitle,
+      sessionId: uuid,
+    }));
+  }
+  for (const text of prompts) {
+    lines.push(JSON.stringify({
+      type: "user",
+      message: { content: text },
+    }));
+  }
+  return writeFile(file, lines.join("\n") + "\n");
+}
+
+/**
+ * Build a Copilot session JSONL under
+ * <root>/.copilot/session-state/<uuid>/events.jsonl.
+ */
+export function makeCopilotSession(root, opts = {}) {
+  const {
+    uuid,
+    cwd = "/work",
+    model = "gpt-4",
+    prompts = [],
+  } = opts;
+  if (!uuid) throw new Error("makeCopilotSession: uuid required");
+  const file = join(root, ".copilot", "session-state", uuid, "events.jsonl");
+  const lines = [
+    JSON.stringify({
+      type: "session.start",
+      data: { cwd, model, sessionId: uuid },
+    }),
+  ];
+  for (const text of prompts) {
+    lines.push(JSON.stringify({
+      type: "user.message",
+      data: { content: text },
+    }));
+  }
+  return writeFile(file, lines.join("\n") + "\n");
+}
+
+/**
+ * Build a Codex rollout under
+ * <root>/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl.
+ */
+export function makeCodexSession(root, opts = {}) {
+  const {
+    uuid,
+    cwd = "/work",
+    timestamp = "2026-04-18T10-00-00",
+    threadName,
+    prompts = [],
+  } = opts;
+  if (!uuid) throw new Error("makeCodexSession: uuid required");
+  const [year, month, day] = timestamp.split("T")[0].split("-");
+  const file = join(
+    root, ".codex", "sessions", year, month, day,
+    `rollout-${timestamp}-${uuid}.jsonl`
+  );
+  const lines = [
+    JSON.stringify({
+      type: "session_meta",
+      payload: { id: uuid, cwd },
+    }),
+  ];
+  if (threadName) {
+    lines.push(JSON.stringify({
+      type: "event_msg",
+      payload: { thread_id: uuid, thread_name: threadName, type: "thread_renamed" },
+    }));
+  }
+  for (const text of prompts) {
+    lines.push(JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text }],
+      },
+    }));
+  }
+  return writeFile(file, lines.join("\n") + "\n");
+}

--- a/plugins/dotclaude/tests/fixtures/transport-repo.mjs
+++ b/plugins/dotclaude/tests/fixtures/transport-repo.mjs
@@ -1,0 +1,24 @@
+// Helpers for standing up a bare git repo inside a tmpdir, suitable for
+// DOTCLAUDE_HANDOFF_REPO tests. Each helper returns an absolute path.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+/**
+ * Create a bare git repo. Caller must clean up with `cleanupTransportRepo`.
+ * @returns {{path: string, cleanup: () => void}}
+ */
+export function makeTransportRepo() {
+  const root = mkdtempSync(join(tmpdir(), "handoff-transport-"));
+  const bare = join(root, "bare.git");
+  const result = spawnSync("git", ["init", "-q", "--bare", bare], { stdio: "ignore" });
+  if (result.status !== 0) {
+    throw new Error(`git init --bare failed (exit ${result.status})`);
+  }
+  return {
+    path: bare,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}

--- a/plugins/dotclaude/tests/handoff-encoder.test.mjs
+++ b/plugins/dotclaude/tests/handoff-encoder.test.mjs
@@ -1,0 +1,80 @@
+// Round-trip tests for encodeDescription. It shells out to
+// scripts/handoff-description.sh so the test exercises both the JS wrapper
+// and the shell encoder.
+//
+// Schema: handoff:v1:<cli>:<short-uuid>:<project-slug>:<hostname>[:<tag>]
+
+import { describe, it, expect } from "vitest";
+import { encodeDescription } from "../bin/dotclaude-handoff.mjs";
+
+function parse(encoded) {
+  const [prefix, version, cli, shortId, project, host, tag] = encoded.split(":");
+  return { prefix, version, cli, shortId, project, host, tag };
+}
+
+describe("encodeDescription", () => {
+  it("produces a 6-segment string when no tag is supplied", () => {
+    const s = encodeDescription({
+      cli: "claude",
+      shortId: "abcd1234",
+      project: "my-app",
+      host: "laptop",
+    });
+    expect(s.split(":")).toHaveLength(6);
+    const p = parse(s);
+    expect(p.prefix).toBe("handoff");
+    expect(p.version).toBe("v1");
+    expect(p.cli).toBe("claude");
+    expect(p.shortId).toBe("abcd1234");
+    expect(p.project).toBe("my-app");
+    expect(p.host).toBe("laptop");
+    expect(p.tag).toBeUndefined();
+  });
+
+  it("appends the tag segment when provided", () => {
+    const s = encodeDescription({
+      cli: "copilot",
+      shortId: "12345678",
+      project: "my-app",
+      host: "laptop",
+      tag: "wip-refactor",
+    });
+    expect(s.split(":")).toHaveLength(7);
+    expect(parse(s).tag).toBe("wip-refactor");
+  });
+
+  it("normalises uppercase and special characters in project/host/tag slugs", () => {
+    const s = encodeDescription({
+      cli: "codex",
+      shortId: "deadbeef",
+      project: "My Project!",
+      host: "My.Laptop",
+      tag: "V2 Feature",
+    });
+    const p = parse(s);
+    expect(p.project).toBe("my-project");
+    expect(p.host).toBe("my-laptop");
+    expect(p.tag).toBe("v2-feature");
+  });
+
+  it("substitutes 'adhoc' for empty project", () => {
+    const s = encodeDescription({
+      cli: "claude",
+      shortId: "abcd1234",
+      project: "",
+      host: "laptop",
+    });
+    // Handled in JS: `project || "adhoc"` before shelling out.
+    expect(parse(s).project).toBe("adhoc");
+  });
+
+  it("substitutes 'unknown' for empty host", () => {
+    const s = encodeDescription({
+      cli: "claude",
+      shortId: "abcd1234",
+      project: "my-app",
+      host: "",
+    });
+    expect(parse(s).host).toBe("unknown");
+  });
+});

--- a/plugins/dotclaude/tests/handoff-unit.test.mjs
+++ b/plugins/dotclaude/tests/handoff-unit.test.mjs
@@ -1,0 +1,189 @@
+// Pure-function unit tests for dotclaude-handoff internals.
+// Covers: UUID_HEAD_RE, cliFromPath, projectSlugFromCwd, matchesQuery,
+// nextStepFor, mechanicalSummary, CLI_LAYOUTS.
+
+import { describe, it, expect } from "vitest";
+import {
+  UUID_HEAD_RE,
+  CLI_LAYOUTS,
+  cliFromPath,
+  projectSlugFromCwd,
+  matchesQuery,
+  nextStepFor,
+  mechanicalSummary,
+} from "../bin/dotclaude-handoff.mjs";
+
+describe("UUID_HEAD_RE", () => {
+  it("captures the first 8 hex of a UUID embedded in a path", () => {
+    const m = "/root/rollout-2026-04-18T10-00-00-abcd1234-5678-90ab-cdef-112233445566.jsonl"
+      .match(UUID_HEAD_RE);
+    expect(m?.[1]).toBe("abcd1234");
+  });
+
+  it("returns null for strings without a UUID", () => {
+    expect("no uuid here".match(UUID_HEAD_RE)).toBeNull();
+  });
+
+  it("captures the first UUID when multiple appear", () => {
+    const m = "aaaa1111-1111-1111-1111-111111111111 / bbbb2222-2222-2222-2222-222222222222"
+      .match(UUID_HEAD_RE);
+    expect(m?.[1]).toBe("aaaa1111");
+  });
+});
+
+describe("cliFromPath", () => {
+  it("recognises claude paths", () => {
+    expect(cliFromPath("/home/u/.claude/projects/foo/abc.jsonl")).toBe("claude");
+  });
+
+  it("recognises copilot paths", () => {
+    expect(cliFromPath("/home/u/.copilot/session-state/abc/events.jsonl")).toBe("copilot");
+  });
+
+  it("recognises codex paths", () => {
+    expect(cliFromPath("/home/u/.codex/sessions/2026/04/18/rollout-x.jsonl")).toBe("codex");
+  });
+
+  it("falls back to claude for unrecognised paths (documented default)", () => {
+    // The function returns "claude" for anything it can't identify. Locked in
+    // here so a future refactor does not silently change the default.
+    expect(cliFromPath("/tmp/random.jsonl")).toBe("claude");
+  });
+});
+
+describe("projectSlugFromCwd", () => {
+  it("returns 'adhoc' for empty / missing cwd", () => {
+    expect(projectSlugFromCwd("")).toBe("adhoc");
+    expect(projectSlugFromCwd(undefined)).toBe("adhoc");
+    expect(projectSlugFromCwd(null)).toBe("adhoc");
+  });
+
+  it("takes the last path segment", () => {
+    expect(projectSlugFromCwd("/home/user/projects/my-app")).toBe("my-app");
+  });
+
+  it("ignores trailing slashes", () => {
+    expect(projectSlugFromCwd("/home/user/projects/my-app/")).toBe("my-app");
+  });
+
+  it("normalises to lowercase and replaces special characters", () => {
+    expect(projectSlugFromCwd("/root/My Project.v2")).toBe("my-project-v2");
+  });
+
+  it("caps the slug at 40 characters", () => {
+    const long = "/root/" + "a".repeat(80);
+    expect(projectSlugFromCwd(long).length).toBeLessThanOrEqual(40);
+  });
+
+  it("only collapses to 'adhoc' when normalisation leaves an empty string", () => {
+    // Documented edge: "..." normalises to "-", which is non-empty so the
+    // `|| "adhoc"` fallback does NOT fire. Locked in so a regex tweak that
+    // silently changes this behaviour is surfaced by the suite.
+    expect(projectSlugFromCwd("/root/...")).toBe("-");
+  });
+});
+
+describe("matchesQuery", () => {
+  const candidate = {
+    branch: "handoffs/claude/abc12345",
+    description: "claude/abc12345/my-app/laptop",
+    commit: "1a2b3c4d5e",
+  };
+
+  it("matches by branch substring", () => {
+    expect(matchesQuery(candidate, "abc12345")).toBe(true);
+  });
+
+  it("matches by description substring", () => {
+    expect(matchesQuery(candidate, "my-app")).toBe(true);
+  });
+
+  it("matches by commit prefix (startsWith)", () => {
+    expect(matchesQuery(candidate, "1a2b")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchesQuery(candidate, "CLAUDE")).toBe(true);
+    expect(matchesQuery(candidate, "MY-APP")).toBe(true);
+  });
+
+  it("does not match unrelated strings", () => {
+    expect(matchesQuery(candidate, "zzz-not-present")).toBe(false);
+  });
+
+  it("handles missing optional fields without throwing", () => {
+    const minimal = { branch: "handoffs/claude/x" };
+    expect(matchesQuery(minimal, "claude")).toBe(true);
+    expect(matchesQuery(minimal, "nope")).toBe(false);
+  });
+});
+
+describe("nextStepFor", () => {
+  it("emits claude-flavoured guidance by default", () => {
+    expect(nextStepFor("claude")).toContain("assistant turn");
+  });
+
+  it("emits codex-flavoured guidance", () => {
+    expect(nextStepFor("codex")).toContain("task specification");
+  });
+
+  it("emits copilot-flavoured guidance", () => {
+    expect(nextStepFor("copilot")).toContain("pick up where");
+  });
+
+  it("falls back to the claude string for unknown targets", () => {
+    // Locks in the default-claude fallback so a new CLI never silently
+    // inherits generic prose instead of a tailored prompt.
+    expect(nextStepFor("gibberish")).toBe(nextStepFor("claude"));
+  });
+});
+
+describe("mechanicalSummary", () => {
+  it("handles empty prompts and turns", () => {
+    const s = mechanicalSummary([], []);
+    expect(s).toContain("(no user prompts captured)");
+    expect(s).toContain("(no assistant turns captured)");
+  });
+
+  it("quotes the first prompt and the last turn", () => {
+    const s = mechanicalSummary(
+      ["first prompt", "second prompt"],
+      ["turn 1", "turn 2", "final turn"]
+    );
+    expect(s).toContain('"first prompt"');
+    expect(s).toContain('"final turn"');
+  });
+
+  it("truncates long prompts with an ellipsis", () => {
+    const long = "x".repeat(200);
+    const s = mechanicalSummary([long], ["ok"]);
+    expect(s).toMatch(/…/);
+    expect(s).not.toContain(long);
+  });
+});
+
+describe("CLI_LAYOUTS", () => {
+  it("exposes root/walk/match triples for each CLI", () => {
+    for (const cli of ["claude", "copilot", "codex"]) {
+      expect(CLI_LAYOUTS[cli]).toBeDefined();
+      expect(typeof CLI_LAYOUTS[cli].root).toBe("function");
+      expect(typeof CLI_LAYOUTS[cli].walk).toBe("number");
+      expect(typeof CLI_LAYOUTS[cli].match).toBe("function");
+    }
+  });
+
+  it("claude.root joins HOME with .claude/projects", () => {
+    expect(CLI_LAYOUTS.claude.root("/h")).toBe("/h/.claude/projects");
+  });
+
+  it("copilot.match requires the filename to be events.jsonl", () => {
+    expect(CLI_LAYOUTS.copilot.match("events.jsonl")).toBe(true);
+    expect(CLI_LAYOUTS.copilot.match("other.jsonl")).toBe(false);
+  });
+
+  it("codex.match requires rollout-*.jsonl", () => {
+    expect(CLI_LAYOUTS.codex.match("rollout-2026-04-18-abc.jsonl")).toBe(true);
+    expect(CLI_LAYOUTS.codex.match("events.jsonl")).toBe(false);
+    expect(CLI_LAYOUTS.codex.match("rollout.json")).toBe(false);
+  });
+});

--- a/plugins/dotclaude/tests/handoff-url-validator.test.mjs
+++ b/plugins/dotclaude/tests/handoff-url-validator.test.mjs
@@ -1,0 +1,77 @@
+// Table-driven matrix for requireTransportRepo — the URL-scheme guard that
+// rejects ext::, data:, javascript:, and other exec-triggering Git URLs
+// (CVE-2017-1000117-class), while allowing https/http/ssh/git@/file:// and
+// absolute filesystem paths (bare repos).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { requireTransportRepo } from "../bin/dotclaude-handoff.mjs";
+
+describe("requireTransportRepo", () => {
+  const savedEnv = process.env.DOTCLAUDE_HANDOFF_REPO;
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    // Stub process.exit so fail() throws instead of ending the test runner.
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`__exit__${code}`);
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    if (savedEnv === undefined) delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    else process.env.DOTCLAUDE_HANDOFF_REPO = savedEnv;
+  });
+
+  const accepted = [
+    ["https URL",          "https://github.com/x/y.git"],
+    ["http URL",           "http://ghe.example.com/x/y.git"],
+    ["git@ SSH shorthand", "git@github.com:x/y.git"],
+    ["ssh:// URL",         "ssh://git@host:22/x.git"],
+    ["file:// URL",        "file:///tmp/bare.git"],
+    ["absolute path",      "/tmp/bare-repo"],
+  ];
+
+  for (const [label, url] of accepted) {
+    it(`accepts ${label}`, () => {
+      process.env.DOTCLAUDE_HANDOFF_REPO = url;
+      expect(requireTransportRepo()).toBe(url);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  }
+
+  const rejected = [
+    ["ext:: exec scheme",     "ext::sh -c evil"],
+    ["data: URI",             "data:text/plain,x"],
+    ["javascript: URI",       "javascript:alert(1)"],
+    ["relative path",         "relative/path/to/repo"],
+    ["bare hostname",         "github.com/x/y"],
+  ];
+
+  for (const [label, url] of rejected) {
+    it(`rejects ${label}`, () => {
+      process.env.DOTCLAUDE_HANDOFF_REPO = url;
+      expect(() => requireTransportRepo()).toThrow(/__exit__2/);
+      expect(stderrSpy).toHaveBeenCalled();
+      // The failure message must name the offending URL so the operator
+      // can see what was rejected.
+      const stderrArgs = stderrSpy.mock.calls.map((c) => c[0]).join("");
+      expect(stderrArgs).toContain(url);
+    });
+  }
+
+  it("rejects unset env with a clear error", () => {
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    expect(() => requireTransportRepo()).toThrow(/__exit__2/);
+    const stderrArgs = stderrSpy.mock.calls.map((c) => c[0]).join("");
+    expect(stderrArgs).toContain("DOTCLAUDE_HANDOFF_REPO");
+  });
+
+  it("rejects empty string env", () => {
+    process.env.DOTCLAUDE_HANDOFF_REPO = "";
+    expect(() => requireTransportRepo()).toThrow(/__exit__2/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the handoff test expansion (plan: 3 PRs, ~90 scenarios total).
Lands high-leverage coverage: testability refactor + security, regression,
unit, URL-validator matrix, and encoder round-trip suites.

- **+48 vitest scenarios** (30 unit, 13 URL-validator, 5 encoder) — pure
  assertions against internals of `dotclaude-handoff.mjs`, enabled by a
  new `export { ... }` block behind an `import.meta.url === process.argv[1]`
  gate so `import` no longer runs the CLI.
- **+13 bats scenarios** (8 security, 5 regression) — path-traversal
  rejection, `ext::`/`data:` transport rejection, symlink containment,
  shell-metachar customTitle aliases, plus seeds locking in already-fixed
  bugs (sub-second mtime, jq streaming vs slurp, word-split on paths with
  spaces, absolute-path `DOTCLAUDE_HANDOFF_REPO`, grep-prefilter alias scan).
- Fixture helpers (`make_claude_session_tree` / `make_copilot_session_tree`
  / `make_codex_session_tree` / `make_transport_repo` in `helpers.bash`,
  programmatic builders in `tests/fixtures/handoff-sessions.mjs` and
  `transport-repo.mjs`) for reuse by Phase 2 and Phase 3.

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/` — 171 pass (was 158, +13)
- [x] `npm test` — 253 pass (was 205, +48)
- [x] `npx vitest run --coverage` — thresholds hold: 91.47% stmt /
      80.34% branch / 98.47% fn / 93.65% lines
- [x] `node plugins/dotclaude/bin/dotclaude-handoff.mjs --version` still
      prints `0.6.0` (import-safe gate not regressing CLI entrypoint)
- [x] `node -e "import('./plugins/dotclaude/bin/dotclaude-handoff.mjs')"`
      exits cleanly without running main() (import-safety proof)

## Notes

- The bin file is **not** added to the vitest coverage `include`. It is
  mostly procedural CLI glue delegating to bash scripts; including it
  dropped coverage to ~70% and created a false signal. Integration
  coverage for the bin lives in the bats suite.
- One documented edge surfaced by the unit tests: `projectSlugFromCwd("/root/...")`
  returns `"-"` (non-empty after `[^a-z0-9-]+ → -` normalisation, so the
  `|| "adhoc"` fallback doesn't fire). Locked in as-is; not treated as a
  bug in this PR.
- Phases 2 and 3 are scheduled follow-ups: boundary / observability /
  integration (P2), concurrency / large-file / portability (P3).

## Spec ID

dotclaude-core
