### PR TITLE
test(handoff): Phase 2 — boundary + observability + integration bats

### DIFF
--- a/plugins/dotclaude/tests/bats/handoff-boundary.bats
+++ b/plugins/dotclaude/tests/bats/handoff-boundary.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+# Boundary tests for handoff shell scripts and JS CLI.
+# Degenerate inputs: empty files, unicode, CRLF, whitespace in paths,
+# prefix collisions, and negative/zero --limit values.
+
+load helpers
+
+RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
+EXTRACT="$REPO_ROOT/plugins/dotclaude/scripts/handoff-extract.sh"
+
+setup() {
+  [ -x "$RESOLVE" ] || chmod +x "$RESOLVE"
+  [ -x "$EXTRACT" ] || chmod +x "$EXTRACT"
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# -- empty-file behavior, per CLI ---------------------------------------
+
+@test "extract meta claude on empty file returns null fields, exit 0" {
+  # Claude meta uses `first(inputs | select(...)) // {}` — no match means
+  # an empty shell; session_id becomes null via the fallback chain.
+  local empty
+  empty=$(mktemp)
+  run "$EXTRACT" meta claude "$empty"
+  rm -f "$empty"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"session_id":null'* ]]
+}
+
+@test "extract meta codex on empty file exits 2 with structured error" {
+  local empty
+  empty=$(mktemp)
+  run "$EXTRACT" meta codex "$empty"
+  rm -f "$empty"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no session_meta record"* ]]
+}
+
+@test "extract meta copilot on empty file exits 2 with structured error" {
+  local empty
+  empty=$(mktemp)
+  run "$EXTRACT" meta copilot "$empty"
+  rm -f "$empty"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no session.start record"* ]]
+}
+
+# -- JSONL format edge cases --------------------------------------------
+
+@test "extract meta claude parses file with no trailing newline" {
+  local uuid="aaaa1111-1111-1111-1111-111111111111"
+  local file="$TEST_HOME/.claude/projects/-demo/$uuid.jsonl"
+  mkdir -p "$(dirname "$file")"
+  # No trailing newline — jq must still read the last record.
+  printf '{"cwd":"/x","sessionId":"%s","version":"2.1"}' "$uuid" > "$file"
+  run "$EXTRACT" meta claude "$file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"cwd":"/x"'* ]]
+  [[ "$output" == *"\"session_id\":\"$uuid\""* ]]
+}
+
+@test "extract prompts claude preserves unicode verbatim" {
+  local uuid="bbbb2222-2222-2222-2222-222222222222"
+  local file="$TEST_HOME/.claude/projects/-demo/$uuid.jsonl"
+  mkdir -p "$(dirname "$file")"
+  printf '{"cwd":"/x","sessionId":"%s"}\n{"type":"user","message":{"content":"héllo wörld — 日本語 ✓"}}\n' \
+    "$uuid" "$uuid" > "$file"
+  run "$EXTRACT" prompts claude "$file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"héllo wörld"* ]]
+  [[ "$output" == *"日本語"* ]]
+}
+
+@test "resolve claude customTitle alias with emoji matches literally" {
+  local uuid="cccc3333-3333-3333-3333-333333333333"
+  local dir="$TEST_HOME/.claude/projects/-demo"
+  mkdir -p "$dir"
+  printf '{"cwd":"/x","sessionId":"%s"}\n{"type":"custom-title","customTitle":"🚀 launch","sessionId":"%s"}\n' \
+    "$uuid" "$uuid" > "$dir/$uuid.jsonl"
+  run "$RESOLVE" claude "🚀 launch"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$uuid.jsonl" ]]
+}
+
+# -- whitespace in session roots ----------------------------------------
+
+@test "resolve tolerates session roots with spaces in path" {
+  # Locked in regression in Phase 1 too; repeat here under a boundary
+  # framing to make the edge visible in the suite directory.
+  export HOME="$TEST_HOME/home with spaces"
+  mkdir -p "$HOME"
+  make_claude_session_tree "$HOME" "dddd4444-4444-4444-4444-444444444444"
+  run "$RESOLVE" claude dddd4444
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dddd4444-4444-4444-4444-444444444444.jsonl" ]]
+}
+
+# -- short-UUID prefix collisions ---------------------------------------
+
+@test "resolve picks newest when short-UUID prefix matches multiple files" {
+  # Seed three claude sessions all starting with "abcd1234".
+  local dir="$TEST_HOME/.claude/projects/-multi"
+  mkdir -p "$dir"
+  local older="$dir/abcd1234-0000-0000-0000-000000000001.jsonl"
+  local mid="$dir/abcd1234-0000-0000-0000-000000000002.jsonl"
+  local newer="$dir/abcd1234-0000-0000-0000-000000000003.jsonl"
+  printf '{"cwd":"/x","sessionId":"abcd1234-0000-0000-0000-000000000001"}\n' > "$older"
+  printf '{"cwd":"/x","sessionId":"abcd1234-0000-0000-0000-000000000002"}\n' > "$mid"
+  printf '{"cwd":"/x","sessionId":"abcd1234-0000-0000-0000-000000000003"}\n' > "$newer"
+  if ! touch -d '2026-01-01 00:00:00.100000000' "$older" 2>/dev/null; then
+    skip "fractional-second touch not supported"
+  fi
+  touch -d '2026-01-01 00:00:00.500000000' "$mid"
+  touch -d '2026-01-01 00:00:00.900000000' "$newer"
+  run "$RESOLVE" claude abcd1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"000000000003.jsonl" ]]
+}
+
+# -- empty session tree --------------------------------------------------
+
+@test "resolve any latest with no session roots exits 2" {
+  # HOME has nothing under .claude/.copilot/.codex — all three die_runtime
+  # and resolve_any reports "no session roots" or "no sessions found".
+  run "$RESOLVE" any latest
+  [ "$status" -eq 2 ]
+  # Either branch of the error path is acceptable — both signal absence.
+  [[ "$output" == *"no session"* ]]
+}
+
+@test "resolve any <id> with no session roots exits 2 with no-match error" {
+  run "$RESOLVE" any aaaa1111
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no session"* ]]
+}
+
+# -- extract turns: limit normalization ---------------------------------
+
+@test "extract turns with limit=0 yields no lines (SIGPIPE tolerated)" {
+  # Seed a session with 5 assistant turns. Behavior: `tail -n 0` closes
+  # its stdin immediately, sending SIGPIPE to jq. The pipeline exits 141
+  # (128 + 13) with empty stdout. Locked in — if a future change routes
+  # this through a head/awk filter with exit-0 semantics, update here.
+  local uuid="ffff6666-6666-6666-6666-666666666666"
+  local file="$TEST_HOME/.claude/projects/-demo/$uuid.jsonl"
+  mkdir -p "$(dirname "$file")"
+  {
+    printf '{"cwd":"/x","sessionId":"%s"}\n' "$uuid"
+    for i in 1 2 3 4 5; do
+      printf '{"type":"assistant","message":{"content":[{"type":"text","text":"turn %d"}]}}\n' "$i"
+    done
+  } > "$file"
+  run "$EXTRACT" turns claude "$file" 0
+  # Exit 141 is acceptable here (SIGPIPE from tail -n 0). The important
+  # invariant is that no turn content leaks through.
+  [[ "$status" -eq 0 || "$status" -eq 141 ]]
+  [ -z "$output" ]
+}
+
+@test "extract turns with absurdly large limit returns all turns" {
+  local uuid="eeee5555-5555-5555-5555-555555555555"
+  local file="$TEST_HOME/.claude/projects/-demo/$uuid.jsonl"
+  mkdir -p "$(dirname "$file")"
+  {
+    printf '{"cwd":"/x","sessionId":"%s"}\n' "$uuid"
+    for i in 1 2 3; do
+      printf '{"type":"assistant","message":{"content":[{"type":"text","text":"turn-%d"}]}}\n' "$i"
+    done
+  } > "$file"
+  run "$EXTRACT" turns claude "$file" 999999
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"turn-1"* ]]
+  [[ "$output" == *"turn-3"* ]]
+}

--- a/plugins/dotclaude/tests/bats/handoff-boundary.bats
+++ b/plugins/dotclaude/tests/bats/handoff-boundary.bats
@@ -69,7 +69,7 @@ teardown() {
   local file="$TEST_HOME/.claude/projects/-demo/$uuid.jsonl"
   mkdir -p "$(dirname "$file")"
   printf '{"cwd":"/x","sessionId":"%s"}\n{"type":"user","message":{"content":"héllo wörld — 日本語 ✓"}}\n' \
-    "$uuid" "$uuid" > "$file"
+    "$uuid" > "$file"
   run "$EXTRACT" prompts claude "$file"
   [ "$status" -eq 0 ]
   [[ "$output" == *"héllo wörld"* ]]

--- a/plugins/dotclaude/tests/bats/handoff-integration.bats
+++ b/plugins/dotclaude/tests/bats/handoff-integration.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bats
+# Integration tests — cross-script end-to-end flows.
+#
+# Complements dotclaude-handoff-five-form.bats, which covers the user-facing
+# five-form surface. These tests chain multiple handoff scripts together
+# (resolve → extract → digest / push → pull → file / list → describe) to
+# verify the boundaries between them hold.
+
+load helpers
+
+RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
+EXTRACT="$REPO_ROOT/plugins/dotclaude/scripts/handoff-extract.sh"
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  [ -x "$RESOLVE" ] || chmod +x "$RESOLVE"
+  [ -x "$EXTRACT" ] || chmod +x "$EXTRACT"
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+
+  # Seed a claude session with prompts + custom title, so the resolve →
+  # extract → digest chain has non-trivial content to carry through.
+  CLAUDE_UUID="aaaa1111-1111-1111-1111-111111111111"
+  CLAUDE_DIR="$TEST_HOME/.claude/projects/-home-u-demo"
+  mkdir -p "$CLAUDE_DIR"
+  CLAUDE_FILE="$CLAUDE_DIR/$CLAUDE_UUID.jsonl"
+  cat > "$CLAUDE_FILE" <<EOF
+{"type":"user","cwd":"/home/u/demo","sessionId":"$CLAUDE_UUID","version":"2.1","message":{"content":"first prompt"}}
+{"type":"user","cwd":"/home/u/demo","sessionId":"$CLAUDE_UUID","message":{"content":"second prompt"}}
+{"type":"user","cwd":"/home/u/demo","sessionId":"$CLAUDE_UUID","message":{"content":"third prompt"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"reply A"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"reply B"}]}}
+{"type":"custom-title","customTitle":"integration-demo","sessionId":"$CLAUDE_UUID"}
+EOF
+
+  # Seed a codex session for cross-CLI list/describe coverage.
+  CODEX_UUID="bbbb2222-2222-2222-2222-222222222222"
+  CODEX_DIR="$TEST_HOME/.codex/sessions/2026/04/18"
+  mkdir -p "$CODEX_DIR"
+  CODEX_FILE="$CODEX_DIR/rollout-2026-04-18T10-00-00-$CODEX_UUID.jsonl"
+  cat > "$CODEX_FILE" <<EOF
+{"type":"session_meta","payload":{"id":"$CODEX_UUID","cwd":"/work/demo","cli_version":"0.1"}}
+{"type":"event_msg","payload":{"thread_name":"codex-thread","type":"thread_renamed"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"codex prompt"}]}}
+EOF
+
+  # Bare git repo as the git-fallback transport.
+  TRANSPORT_REPO=$(mktemp -d)
+  rm -rf "$TRANSPORT_REPO"
+  git init -q --bare "$TRANSPORT_REPO"
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+
+  export CLAUDE_UUID CLAUDE_FILE CODEX_UUID CODEX_FILE TRANSPORT_REPO
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+}
+
+# -- resolve → extract → digest chain -----------------------------------
+
+@test "resolve (short UUID) → extract meta → valid JSON with expected session_id" {
+  # Chain the scripts by hand: resolve emits a path, extract reads it.
+  # This catches any disagreement between the two on what a session file
+  # looks like (e.g., if resolve accepts a path extract can't parse).
+  run "$RESOLVE" claude aaaa1111
+  [ "$status" -eq 0 ]
+  local path="$output"
+  [ -n "$path" ]
+  run "$EXTRACT" meta claude "$path"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\"session_id\":\"$CLAUDE_UUID\""* ]]
+  [[ "$output" == *"\"cwd\":\"/home/u/demo\""* ]]
+}
+
+@test "resolve (customTitle) → digest via CLI → <handoff> block names the session" {
+  # The five-form suite exercises customTitle lookup but doesn't assert
+  # that the resulting digest carries the session_id through. Lock that in.
+  run node "$BIN" digest claude integration-demo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+  [[ "$output" == *"</handoff>"* ]]
+  [[ "$output" == *"aaaa1111"* ]]
+}
+
+@test "resolve (codex thread_name alias) → extract turns limited → assistant text" {
+  # Codex alias path runs through a separate grep-prefilter branch in
+  # resolve; the happy-path existence is covered elsewhere, but the
+  # resolve→extract chain across the codex layout is worth pinning.
+  run "$RESOLVE" codex codex-thread
+  [ "$status" -eq 0 ]
+  local path="$output"
+  run "$EXTRACT" prompts codex "$path"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"codex prompt"* ]]
+}
+
+# -- push → pull round-trip content integrity ----------------------------
+
+@test "push → pull <short-uuid> round-trip returns equivalent <handoff> content" {
+  # Stronger than existing "pull emits <handoff>" tests: we capture the
+  # pulled block and assert it carries the session markers from the seed.
+  run node "$BIN" push integration-demo --via git-fallback
+  [ "$status" -eq 0 ]
+  run node "$BIN" pull aaaa1111 --via git-fallback
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+  # Short UUID must survive the transport round-trip.
+  [[ "$output" == *"aaaa1111"* ]]
+}
+
+@test "push --tag → transport description carries the tag segment" {
+  # The tag is stored in the transport metadata (commit subject + description
+  # slug), not in the handoff block itself. Pulls by the tag substring still
+  # resolve the right session even though the tag isn't echoed back inside
+  # the <handoff> content — that's by design (the block is the payload, the
+  # tag is routing metadata). Lock in the metadata location here; the
+  # routing behavior is covered by the separate pull-by-tag test.
+  run node "$BIN" push integration-demo --via git-fallback --tag shipping-the-thing
+  [ "$status" -eq 0 ]
+  # Transport description appears on stdout as the final line of the push.
+  [[ "$output" == *"shipping-the-thing"* ]]
+  # And it persists into the transport repo commit subject.
+  run bash -c "git --git-dir='$TRANSPORT_REPO' log --format=%s handoff/claude/aaaa1111"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"shipping-the-thing"* ]]
+  # Pull-by-tag resolves and returns a valid block (content-equivalence
+  # already asserted above; here we just prove routing works).
+  run node "$BIN" pull shipping-the-thing --via git-fallback
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+}
+
+# -- list → describe chain (unified view → detail) -----------------------
+
+@test "list --local → describe on each candidate → 0 exit for both CLIs" {
+  # The `list` sub enumerates sessions; `describe` must accept each of
+  # them via (cli, short-UUID). Iterate both CLIs to catch layout-specific
+  # regressions in either branch.
+  run node "$BIN" list --local
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  [[ "$output" == *"bbbb2222"* ]]
+
+  run node "$BIN" describe claude aaaa1111
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"first prompt"* ]]
+
+  run node "$BIN" describe codex bbbb2222
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"codex prompt"* ]]
+}
+
+# -- file subcommand: digest rendered to a markdown file ----------------
+
+@test "file <cli> <id> with --out-dir writes markdown containing <handoff> block" {
+  local outdir
+  outdir=$(mktemp -d)
+  run node "$BIN" file claude aaaa1111 --out-dir "$outdir"
+  [ "$status" -eq 0 ]
+  # The command prints the absolute path of the file written.
+  local outpath="$output"
+  [ -f "$outpath" ]
+  run cat "$outpath"
+  [[ "$output" == *"<handoff"* ]]
+  [[ "$output" == *"first prompt"* ]]
+  [[ "$output" == *"Source transcript"* ]]
+  rm -rf "$outdir"
+}
+
+# -- multi-push ordering in list -----------------------------------------
+
+@test "list after multiple pushes shows all sessions (remote column populated)" {
+  # Two distinct pushes should both surface in the unified list output.
+  run node "$BIN" push integration-demo --via git-fallback --tag first
+  [ "$status" -eq 0 ]
+  run node "$BIN" push codex-thread --via git-fallback --tag second
+  [ "$status" -eq 0 ]
+  run node "$BIN" list --via git-fallback </dev/null
+  [ "$status" -eq 0 ]
+  # Both short UUIDs should be visible somewhere in the unified list.
+  [[ "$output" == *"aaaa1111"* ]]
+  [[ "$output" == *"bbbb2222"* ]]
+}
+
+# -- describe --json is a self-contained document -----------------------
+
+@test "describe --json → pipe to jq → origin.session_id equals seeded UUID" {
+  # Integration check: describe --json must be parseable by jq *and*
+  # expose a usable path to the session id. This is what tooling-on-top
+  # (skills, agents) actually does.
+  run bash -c "node '$BIN' describe claude aaaa1111 --json | jq -r '.origin.session_id'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "$CLAUDE_UUID" ]]
+}

--- a/plugins/dotclaude/tests/bats/handoff-integration.bats
+++ b/plugins/dotclaude/tests/bats/handoff-integration.bats
@@ -80,7 +80,7 @@ teardown() {
   [[ "$output" == *"aaaa1111"* ]]
 }
 
-@test "resolve (codex thread_name alias) → extract turns limited → assistant text" {
+@test "resolve (codex thread_name alias) → extract prompts → user prompt present" {
   # Codex alias path runs through a separate grep-prefilter branch in
   # resolve; the happy-path existence is covered elsewhere, but the
   # resolve→extract chain across the codex layout is worth pinning.

--- a/plugins/dotclaude/tests/bats/handoff-integration.bats
+++ b/plugins/dotclaude/tests/bats/handoff-integration.bats
@@ -151,8 +151,10 @@ teardown() {
 # -- file subcommand: digest rendered to a markdown file ----------------
 
 @test "file <cli> <id> with --out-dir writes markdown containing <handoff> block" {
-  local outdir
-  outdir=$(mktemp -d)
+  # Nest outdir under TEST_HOME so teardown's rm -rf cleans it even if an
+  # assertion fails before the end of this test (no separate mktemp needed).
+  local outdir="$TEST_HOME/file-out"
+  mkdir -p "$outdir"
   run node "$BIN" file claude aaaa1111 --out-dir "$outdir"
   [ "$status" -eq 0 ]
   # The command prints the absolute path of the file written.
@@ -162,7 +164,6 @@ teardown() {
   [[ "$output" == *"<handoff"* ]]
   [[ "$output" == *"first prompt"* ]]
   [[ "$output" == *"Source transcript"* ]]
-  rm -rf "$outdir"
 }
 
 # -- multi-push ordering in list -----------------------------------------

--- a/plugins/dotclaude/tests/bats/handoff-integration.bats
+++ b/plugins/dotclaude/tests/bats/handoff-integration.bats
@@ -44,10 +44,7 @@ EOF
 {"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"codex prompt"}]}}
 EOF
 
-  # Bare git repo as the git-fallback transport.
-  TRANSPORT_REPO=$(mktemp -d)
-  rm -rf "$TRANSPORT_REPO"
-  git init -q --bare "$TRANSPORT_REPO"
+  TRANSPORT_REPO=$(make_transport_repo "$(mktemp -d)")
   export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
 
   export CLAUDE_UUID CLAUDE_FILE CODEX_UUID CODEX_FILE TRANSPORT_REPO

--- a/plugins/dotclaude/tests/bats/handoff-observability.bats
+++ b/plugins/dotclaude/tests/bats/handoff-observability.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# Observability tests: stderr prefixes, exit-code matrix, JSON/help/version
+# contracts. Each test asserts a *shape* callers can rely on to distinguish
+# user errors (64) from runtime errors (2) from success (0).
+
+load helpers
+
+RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
+EXTRACT="$REPO_ROOT/plugins/dotclaude/scripts/handoff-extract.sh"
+DESCRIPTION="$REPO_ROOT/plugins/dotclaude/scripts/handoff-description.sh"
+HANDOFF_BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  [ -x "$RESOLVE" ] || chmod +x "$RESOLVE"
+  [ -x "$EXTRACT" ] || chmod +x "$EXTRACT"
+  [ -x "$DESCRIPTION" ] || chmod +x "$DESCRIPTION"
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# -- stderr prefix contract: each tool tags its own messages -------------
+
+@test "handoff-resolve.sh usage errors carry 'usage:' prefix on stderr" {
+  # `run` captures stderr into $output because there's no stdout-only split.
+  # What matters is that consumers grepping stderr see the sentinel.
+  run "$RESOLVE"
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"usage:"* ]]
+}
+
+@test "handoff-resolve.sh runtime errors carry 'handoff-resolve:' prefix" {
+  run "$RESOLVE" claude 00000000-0000-0000-0000-000000000000
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"handoff-resolve:"* ]]
+}
+
+@test "handoff-extract.sh runtime errors carry 'handoff-extract:' prefix" {
+  run "$EXTRACT" meta claude /nonexistent/path.jsonl
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"handoff-extract:"* ]]
+}
+
+@test "handoff-description.sh runtime errors carry 'handoff-description:' prefix" {
+  run "$DESCRIPTION" encode
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"handoff-description:"* ]]
+}
+
+@test "dotclaude-handoff Node runtime errors carry 'dotclaude-handoff:' prefix" {
+  run node "$HANDOFF_BIN" nonexistent-query-xyz
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"dotclaude-handoff:"* ]]
+}
+
+# -- exit-code matrix ----------------------------------------------------
+
+@test "exit-code matrix: resolve (0 success / 2 miss / 64 usage)" {
+  make_claude_session_tree "$TEST_HOME" "aaaa1111-1111-1111-1111-111111111111"
+
+  # 0 — a successful resolve
+  run "$RESOLVE" claude aaaa1111-1111-1111-1111-111111111111
+  [ "$status" -eq 0 ]
+
+  # 2 — runtime miss
+  run "$RESOLVE" claude 00000000-0000-0000-0000-000000000000
+  [ "$status" -eq 2 ]
+
+  # 64 — usage error (missing identifier)
+  run "$RESOLVE" claude
+  [ "$status" -eq 64 ]
+
+  # 64 — unknown cli
+  run "$RESOLVE" foocli someid
+  [ "$status" -eq 64 ]
+}
+
+# -- JSON output contract ------------------------------------------------
+
+@test "describe --json emits valid JSON parsable by jq" {
+  make_claude_session_tree "$TEST_HOME" "aaaa1111-1111-1111-1111-111111111111"
+  run node "$HANDOFF_BIN" describe claude latest --json
+  [ "$status" -eq 0 ]
+  # jq must be able to parse the entire output as a single JSON document.
+  # If it is malformed, jq exits non-zero and the chained assertion fails.
+  echo "$output" | jq -e . >/dev/null
+}
+
+# -- --help / --version contracts ---------------------------------------
+
+@test "dotclaude-handoff --version exits 0 and prints to stdout" {
+  run node "$HANDOFF_BIN" --version
+  [ "$status" -eq 0 ]
+  # Semantic version line should be first; no "usage:" or error prefix.
+  [[ "${lines[0]}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]
+}
+
+@test "dotclaude-handoff --help exits 0 and names itself in output" {
+  run node "$HANDOFF_BIN" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dotclaude handoff"* ]]
+}

--- a/plugins/dotclaude/tests/bats/helpers.bash
+++ b/plugins/dotclaude/tests/bats/helpers.bash
@@ -101,7 +101,6 @@ make_copilot_session_tree() {
     mkdir -p "$dir"
     printf '{"type":"session.start","data":{"cwd":"/tmp","model":"gpt","sessionId":"%s"}}\n' \
       "$uuid" > "$dir/events.jsonl"
-    sleep 0.01
   done
   COPILOT_SESSION_UUIDS="${uuids[*]}"
   export COPILOT_SESSION_UUIDS
@@ -127,8 +126,7 @@ make_codex_session_tree() {
     i=$((i + 1))
   done
   CODEX_SESSION_UUIDS="${uuids[*]}"
-  CODEX_SESSION_PATHS="${paths[*]}"
-  export CODEX_SESSION_UUIDS CODEX_SESSION_PATHS
+  export CODEX_SESSION_UUIDS
 }
 
 # make_transport_repo <dir>

--- a/plugins/dotclaude/tests/fixtures/transport-repo.mjs
+++ b/plugins/dotclaude/tests/fixtures/transport-repo.mjs
@@ -11,14 +11,13 @@ import { spawnSync } from "node:child_process";
  * @returns {{path: string, cleanup: () => void}}
  */
 export function makeTransportRepo() {
-  const root = mkdtempSync(join(tmpdir(), "handoff-transport-"));
-  const bare = join(root, "bare.git");
+  const bare = mkdtempSync(join(tmpdir(), "handoff-bare-"));
   const result = spawnSync("git", ["init", "-q", "--bare", bare], { stdio: "ignore" });
   if (result.status !== 0) {
     throw new Error(`git init --bare failed (exit ${result.status})`);
   }
   return {
     path: bare,
-    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    cleanup: () => rmSync(bare, { recursive: true, force: true }),
   };
 }

--- a/plugins/dotclaude/tests/handoff-encoder.test.mjs
+++ b/plugins/dotclaude/tests/handoff-encoder.test.mjs
@@ -64,7 +64,6 @@ describe("encodeDescription", () => {
       project: "",
       host: "laptop",
     });
-    // Handled in JS: `project || "adhoc"` before shelling out.
     expect(parse(s).project).toBe("adhoc");
   });
 

--- a/plugins/dotclaude/tests/handoff-url-validator.test.mjs
+++ b/plugins/dotclaude/tests/handoff-url-validator.test.mjs
@@ -7,16 +7,17 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { requireTransportRepo } from "../bin/dotclaude-handoff.mjs";
 
 describe("requireTransportRepo", () => {
-  const savedEnv = process.env.DOTCLAUDE_HANDOFF_REPO;
   let exitSpy;
   let stderrSpy;
+  let savedEnv;
 
   beforeEach(() => {
+    savedEnv = process.env.DOTCLAUDE_HANDOFF_REPO;
     // Stub process.exit so fail() throws instead of ending the test runner.
     exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
       throw new Error(`__exit__${code}`);
     });
-    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Phase 2 of the handoff test expansion (plan: 3 PRs, ~90 scenarios total).
**Stacked on #60** — this branch targets `feat/handoff-tests-phase1`, so
merging will reparent to `main` automatically once #60 lands.

Adds boundary, observability, and integration bats suites that build on
the fixture helpers landed in Phase 1.

- **+12 boundary scenarios** (`handoff-boundary.bats`) — per-CLI
  empty-file asymmetry (claude exits 0 with `null`, codex/copilot exit
  2), JSONL without trailing newline, unicode + emoji preserved
  verbatim, session roots with spaces in path, short-UUID prefix
  collisions (newest wins by mtime), empty session tree, `--limit 0`
  (SIGPIPE tolerated) vs absurdly-large limit.
- **+9 observability scenarios** (`handoff-observability.bats`) —
  stderr prefix contract for each tool (`handoff-resolve:`,
  `handoff-extract:`, `handoff-description:`, `dotclaude-handoff:`),
  exit-code matrix for `resolve` (0/2/64), `describe --json` parses via
  `jq -e .`, `--version` and `--help` exit 0 to stdout.
- **+9 integration scenarios** (`handoff-integration.bats`) —
  cross-script chains not covered by the five-form suite: resolve →
  extract meta carries `session_id` through, customTitle → digest
  embeds short UUID, codex thread_name alias → extract prompts, push →
  pull short-UUID round-trip, `--tag` persists in transport commit
  subject, list --local → describe per CLI, `file --out-dir` writes
  markdown with `<handoff>` block + source path reference, multi-push
  list completeness, `describe --json | jq '.origin.session_id'`.

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/` — 201 pass (was 171 on
      #60, +30 from this PR)
- [x] `npm test` — 253 pass (no vitest deltas in this PR; integration
      coverage is bats-only)
- [x] Each new bats file runs clean in isolation (`npx bats <file>`
      targeted runs during authoring)
- [x] `node plugins/dotclaude/bin/dotclaude-handoff.mjs --help` /
      `--version` still exit 0 (locked in by the observability suite)

## Notes

- One deliberate edge locked in: `extract turns <file> 0` exits 141
  (SIGPIPE from `tail -n 0 | jq`) with empty stdout. The test accepts
  either 0 or 141 and asserts the invariant that matters (no turn
  content leaks). If a future change routes this through a head/awk
  filter with exit-0 semantics, update the assertion.
- One inconsistency surfaced but intentionally not fixed here:
  `handoff-description.sh` uses exit 2 for usage errors while the other
  scripts use 64. The observability suite pins current behavior for
  each tool; harmonizing is out of scope for a tests PR.
- Phase 3 (concurrency / large-file stress / portability, ~25
  scenarios) remains scheduled as a follow-up PR.

## Spec ID

dotclaude-core
