### PR TITLE
fix(test): avoid bats $output capture for 10k-session stress test

### DIFF
--- a/plugins/dotclaude/tests/bats/handoff-stress.bats
+++ b/plugins/dotclaude/tests/bats/handoff-stress.bats
@@ -24,13 +24,21 @@ teardown() {
   local file_count
   file_count=$(find "$TEST_HOME/.codex/sessions" -name "rollout-*.jsonl" 2>/dev/null | wc -l)
   file_count=$(( file_count + 0 ))  # strip whitespace
-  run timeout 30s node "$BIN" list --local
-  [ "$status" -eq 0 ]
-  local line_count
-  line_count=$(printf '%s\n' "$output" | wc -l)
-  # The list must enumerate substantially all created sessions (≥ 90%).
-  # If file_count < 100 the fixture seeder itself failed; fail the gate.
+  # Gate on fixture health before the timed run.
   [ "$file_count" -ge 100 ]
+
+  # Write directly to a temp file instead of capturing in $output — bats
+  # serialises the entire stdout into a shell variable, which can miscount
+  # newlines when output exceeds ~800 KB (10k sessions × 80 chars/row).
+  local outfile exit_status line_count
+  outfile=$(mktemp)
+  exit_status=0
+  timeout 30s node "$BIN" list --local > "$outfile" 2>/dev/null || exit_status=$?
+  line_count=$(wc -l < "$outfile")
+  rm -f "$outfile"
+
+  [ "$exit_status" -eq 0 ]
+  # The list must enumerate substantially all created sessions (≥ 90%).
   [ "$line_count" -ge $(( file_count * 9 / 10 )) ]
 }
 


### PR DESCRIPTION
## Summary

- Fixes intermittent CI failure in `handoff-stress.bats` test 195 (`list --local over 10k codex sessions completes under 30s`).
- Root cause: bats serialises the entire stdout into `$output` before the test can inspect it. At ~800 KB (10 000 sessions × 80 chars/row) this causes intermittent undercounting on CI — the captured variable is short-read or newline-stripped under load, making the ≥ 90 % assertion fail non-deterministically.
- Fix: redirect `node` output directly to a `mktemp` file and count with `wc -l < $outfile` instead of `printf '%s\n' "$output" | wc -l`. Gate on `file_count ≥ 100` is moved before the timed run.

## Test plan

- [x] `time npx bats plugins/dotclaude/tests/bats/handoff-stress.bats` — 4 pass in 38s (local, node 22)
- [x] `npx bats plugins/dotclaude/tests/bats/` — full bats suite passes

## Spec ID

dotclaude-core
