### PR TITLE
docs: add Copilot instructions, review config, and AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ the full diagram; the short version:
 - `plugins/dotclaude/bin/*.mjs` — CLI entry points. Validator-style bins
   follow the standard pipeline:
   `parse(lib/argv) → validator → createOutput(lib/output) →
-  formatError(lib/errors) → exit(lib/exit-codes)`. Exceptions include
+formatError(lib/errors) → exit(lib/exit-codes)`. Exceptions include
   `plugins/dotclaude/bin/dotclaude.mjs` (the umbrella dispatcher) and
   `plugins/dotclaude/bin/dotclaude-detect-drift.mjs` (a thin wrapper that may
   use `spawn` / `process.exit`). Validator bins are exposed as standalone

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,8 +8,8 @@ it sets the global rule floor every session inherits.
 
 ## Build, test, lint
 
-Node ≥ 20. Zero runtime dependencies are tolerated by contract (ADR-0002) —
-do not add new ones without a very strong case (devdeps OK).
+Node ≥ 20. Avoid adding new runtime dependencies (ADR-0002) — any new
+runtime dep needs a very strong case (devdeps OK).
 
 ```bash
 npm ci
@@ -18,7 +18,7 @@ npm test -- plugins/dotclaude/tests/validate-specs.test.mjs   # single file
 npm test -- -t "regex matching test name"                     # single test
 npm run coverage                             # thresholds: lines 85 / fns 85 / branches 80 / stmts 85
 npm run lint                                 # prettier + markdownlint + JSDoc coverage
-npm run shellcheck                           # all bash scripts, severity=warning
+npm run shellcheck                           # all bash scripts
 npm run dogfood                              # runs the validators against this repo
 npm run docs:stamp-check                     # docs/*.md must carry _Last updated: vX.Y.Z_
 
@@ -36,11 +36,15 @@ run it before pushing changes that touch `plugins/dotclaude/src/`,
 Layered Node ESM, no TypeScript, no bundler. Read `docs/architecture.md` for
 the full diagram; the short version:
 
-- `plugins/dotclaude/bin/*.mjs` — CLI entry points. Every bin follows the
-  same pipeline: `parse(lib/argv) → validator → createOutput(lib/output) →
-formatError(lib/errors) → exit(lib/exit-codes)`. Each is also exposed as a
-  standalone `npx dotclaude-<thing>` bin **and** as a subcommand of the
-  umbrella `dotclaude` dispatcher.
+- `plugins/dotclaude/bin/*.mjs` — CLI entry points. Validator-style bins
+  follow the standard pipeline:
+  `parse(lib/argv) → validator → createOutput(lib/output) →
+  formatError(lib/errors) → exit(lib/exit-codes)`. Exceptions include
+  `plugins/dotclaude/bin/dotclaude.mjs` (the umbrella dispatcher) and
+  `plugins/dotclaude/bin/dotclaude-detect-drift.mjs` (a thin wrapper that may
+  use `spawn` / `process.exit`). Validator bins are exposed as standalone
+  `npx dotclaude-<thing>` commands, and most are also reachable as
+  subcommands of `dotclaude`.
 - `plugins/dotclaude/src/lib/` — shared primitives (`argv`, `output`,
   `errors`, `exit-codes`, `debug`). Validators must use these, not raw
   `console.log` / `process.exit` / `throw new Error(string)`.
@@ -85,7 +89,7 @@ plugin with its own `scripts/lib/output.sh` + `src/lib/argv.mjs` conventions
   undocumented `export`s under `plugins/dotclaude/src/`.
 - **Shell discipline.** `set -euo pipefail` at the top of every script;
   source `plugins/dotclaude/scripts/lib/output.sh` for `pass` / `fail` /
-  `warn` / `out_summary`; gate JSON output via `HARNESS_JSON=1`. `bash`
+  `warn` / `out_summary`; gate JSON output via `DOTCLAUDE_JSON=1`. `bash`
   only — never `zsh` (its read-only `$status` silently breaks scripts).
 - **Bats tests** capture stderr by redirecting `2>&1` because `run` only
   captures stdout; handoff scripts intentionally print usage/errors to

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,118 @@
+# Copilot instructions for `@dotclaude/dotclaude`
+
+This repo is a **dual-purpose checkout**: a portable npm package
+(`@dotclaude/dotclaude`) **and** the maintainer's personal global Claude Code
+config that gets symlinked into `~/.claude/`. Most contributions land in the
+package. See `docs/personas.md` for the distinction. Read `CLAUDE.md` first —
+it sets the global rule floor every session inherits.
+
+## Build, test, lint
+
+Node ≥ 20. Zero runtime dependencies are tolerated by contract (ADR-0002) —
+do not add new ones without a very strong case (devdeps OK).
+
+```bash
+npm ci
+npm test                                     # vitest, must stay 90/90+ green
+npm test -- plugins/dotclaude/tests/validate-specs.test.mjs   # single file
+npm test -- -t "regex matching test name"                     # single test
+npm run coverage                             # thresholds: lines 85 / fns 85 / branches 80 / stmts 85
+npm run lint                                 # prettier + markdownlint + JSDoc coverage
+npm run shellcheck                           # all bash scripts, severity=warning
+npm run dogfood                              # runs the validators against this repo
+npm run docs:stamp-check                     # docs/*.md must carry _Last updated: vX.Y.Z_
+
+# Shell test suites (not part of `npm test`)
+bash plugins/dotclaude/tests/test_validate_settings.sh
+npx bats plugins/dotclaude/tests/bats/
+```
+
+`npm run dogfood` is the same gate CI runs in `.github/workflows/dogfood.yml`;
+run it before pushing changes that touch `plugins/dotclaude/src/`,
+`docs/specs/**`, `CLAUDE.md`, or `README.md`.
+
+## Architecture (the big picture)
+
+Layered Node ESM, no TypeScript, no bundler. Read `docs/architecture.md` for
+the full diagram; the short version:
+
+- `plugins/dotclaude/bin/*.mjs` — CLI entry points. Every bin follows the
+  same pipeline: `parse(lib/argv) → validator → createOutput(lib/output) →
+  formatError(lib/errors) → exit(lib/exit-codes)`. Each is also exposed as a
+  standalone `npx dotclaude-<thing>` bin **and** as a subcommand of the
+  umbrella `dotclaude` dispatcher.
+- `plugins/dotclaude/src/lib/` — shared primitives (`argv`, `output`,
+  `errors`, `exit-codes`, `debug`). Validators must use these, not raw
+  `console.log` / `process.exit` / `throw new Error(string)`.
+- `plugins/dotclaude/src/*.mjs` — the validators themselves
+  (`validate-specs`, `validate-skills-inventory`, `check-spec-coverage`,
+  `check-instruction-drift`, `init-harness-scaffold`, `bootstrap-global`,
+  `sync-global`, `build-index`). Every `errors.push(...)` emits a
+  `ValidationError(code, …)` from `src/lib/errors.mjs`.
+- `plugins/dotclaude/src/spec-harness-lib.mjs` — the only place that touches
+  filesystem / git / PR-context primitives. Validators consume it; they do
+  not reach for `fs` or `child_process` directly.
+- `plugins/dotclaude/src/index.mjs` — the public Node API barrel
+  (`createHarnessContext`, `validateSpecs`, `ERROR_CODES`, `EXIT_CODES`, …).
+  Excluded from coverage on purpose; treat it as wiring only.
+
+The other plugin slot, `plugins/harness/`, is a sibling consumer-facing
+plugin with its own `scripts/lib/output.sh` + `src/lib/argv.mjs` conventions
+— do not cross-import between `plugins/dotclaude/` and `plugins/harness/`.
+
+## Repo conventions worth knowing
+
+- **Worktrees, not branches on the main checkout.** Non-trivial work belongs
+  in `.claude/worktrees/<slug>/` branched from `origin/main`. Multiple
+  agents/humans run concurrently; the main checkout is effectively read-only.
+  Enforced by `CLAUDE.md §Worktree discipline`.
+- **Spec-anchored PRs.** Any PR touching a path listed in
+  `docs/repo-facts.json → protected_paths` (currently `CLAUDE.md`,
+  `README.md`, `.github/workflows/**`, `.claude/**`, `docs/repo-facts.json`,
+  `docs/specs/**/spec.json`, `plugins/dotclaude/{src,bin,templates}/**`)
+  must carry either `Spec ID: dotclaude-core` (H2 heading — the validator
+  extracts it via H2 regex) **or** a `## No-spec rationale` section in the
+  PR body. `dotclaude-check-spec-coverage` is the gate.
+- **Spec status vocabulary.** `docs/specs/**/spec.json` `status` is one of
+  `draft | approved | implementing | done`. Coverage only counts
+  `approved | implementing | done`.
+- **CLI contract for every bin.** Honor `--help`, `--version`, `--json`,
+  `--verbose`, `--no-color`. Exit via the named `EXIT_CODES`:
+  `OK=0`, `VALIDATION=1`, `ENV=2`, `USAGE=64` (BSD `sysexits.h EX_USAGE`).
+- **Structured errors.** Add new failure classes to `ERROR_CODES` rather
+  than throwing string errors; consumers branch on the code.
+- **JSDoc every export.** `scripts/check-jsdoc-coverage.mjs` fails CI on
+  undocumented `export`s under `plugins/dotclaude/src/`.
+- **Shell discipline.** `set -euo pipefail` at the top of every script;
+  source `plugins/dotclaude/scripts/lib/output.sh` for `pass` / `fail` /
+  `warn` / `out_summary`; gate JSON output via `HARNESS_JSON=1`. `bash`
+  only — never `zsh` (its read-only `$status` silently breaks scripts).
+- **Bats tests** capture stderr by redirecting `2>&1` because `run` only
+  captures stdout; handoff scripts intentionally print usage/errors to
+  stderr.
+- **Doc version stamps.** `docs/*.md` carry `_Last updated: vX.Y.Z_`
+  matching `package.json` `version`. Never edit by hand — run
+  `npm run docs:stamp` after a version bump; CI runs `docs:stamp-check`.
+- **Commands & skills are part of the published package.** Files under
+  `commands/`, `skills/`, `schemas/`, and `CLAUDE.md` ship in the npm
+  tarball (see `package.json → files`). Treat them as user-visible API.
+- **Manifest invariant.** Every file under `.claude/commands/` must be
+  indexed in `.claude/skills-manifest.json` or `validate-skills` fails
+  with `MANIFEST_ORPHAN_FILE`.
+- **Agent template rules.** Templates under
+  `plugins/dotclaude/templates/claude/agents/` require YAML frontmatter
+  (`name`, `description`, `tools`, `model`); `model` must be one of
+  `opus | sonnet | haiku | inherit`. Agents whose name matches
+  auditor / reviewer / inspector must **not** include `Write` or `Edit`
+  in `tools`.
+- **Prettier ignore.** `npm run lint` invokes prettier with
+  `--ignore-path .gitignore`, so `.prettierignore` is **not** consulted
+  unless the script changes.
+- **Release flow.** Bump `package.json` `version` → `npm run docs:stamp`
+  → add `## [X.Y.Z] — YYYY-MM-DD` to `CHANGELOG.md` → PR titled
+  `chore(release): vX.Y.Z` with a `## No-spec rationale` block.
+- **Commits.** Conventional commits (`feat(scope): …`,
+  `fix(scope): …`, `chore(scope): …`). Never `--amend` a published
+  commit, force-push someone else's branch, or pass `--no-verify` /
+  `--no-gpg-sign`. Prefer new commits over `--amend` once a PR is in
+  review.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ the full diagram; the short version:
 
 - `plugins/dotclaude/bin/*.mjs` — CLI entry points. Every bin follows the
   same pipeline: `parse(lib/argv) → validator → createOutput(lib/output) →
-  formatError(lib/errors) → exit(lib/exit-codes)`. Each is also exposed as a
+formatError(lib/errors) → exit(lib/exit-codes)`. Each is also exposed as a
   standalone `npx dotclaude-<thing>` bin **and** as a subcommand of the
   umbrella `dotclaude` dispatcher.
 - `plugins/dotclaude/src/lib/` — shared primitives (`argv`, `output`,

--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -31,7 +31,7 @@ unless they prevent a bug.
   this is what `dotclaude-check-spec-coverage` enforces and a missing
   block fails CI.
 - **`spec.json status`** must be one of `draft | approved | implementing
-  | done`. Coverage only counts `approved | implementing | done`.
+| done`. Coverage only counts `approved | implementing | done`.
 - **Drift between `CLAUDE.md` "Protected paths" and `docs/repo-facts.json`.**
   Every protected path in the JSON must appear in `CLAUDE.md`'s list and
   vice versa — `dotclaude-check-instruction-drift` enforces this.
@@ -49,7 +49,7 @@ unless they prevent a bug.
   (ADR-0002). Block.
 - **Bin without the standard pipeline.** Every `plugins/dotclaude/bin/*.mjs`
   must `parse(lib/argv) → validator → createOutput(lib/output) →
-  formatError(lib/errors) → exit(lib/exit-codes)`. Flag raw
+formatError(lib/errors) → exit(lib/exit-codes)`. Flag raw
   `console.log` / `process.exit(N)` / `throw new Error("string")` in bin
   or validator code.
 - **Wrong exit code.** Bins must exit with the named `EXIT_CODES`:

--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -42,22 +42,29 @@ unless they prevent a bug.
 
 ### CLI / library contract (`plugins/dotclaude/`)
 
-- **New runtime dependency.** Zero-dep is enforced by ADR-0002. Adding
-  anything to `dependencies` (not `devDependencies`) needs an explicit
-  rationale in the PR body. Block.
+- **New runtime dependency.** ADR-0002 aims to avoid adding new runtime
+  deps. Adding anything to `dependencies` (not `devDependencies`) needs
+  an explicit rationale in the PR body. Block if missing.
 - **TypeScript / build step.** Plain Node 20+ ESM only, no bundler
   (ADR-0002). Block.
-- **Bin without the standard pipeline.** Every `plugins/dotclaude/bin/*.mjs`
-  must `parse(lib/argv) → validator → createOutput(lib/output) →
-formatError(lib/errors) → exit(lib/exit-codes)`. Flag raw
-  `console.log` / `process.exit(N)` / `throw new Error("string")` in bin
-  or validator code.
+- **Bin without the standard pipeline.** Validator-style
+  `plugins/dotclaude/bin/*.mjs` must use
+  `parse(lib/argv) → validator → createOutput(lib/output) →
+  formatError(lib/errors) → exit(lib/exit-codes)`. Flag raw
+  `console.log` / `process.exit(N)` / `throw new Error("string")` in
+  validator bins. Exception: `dotclaude.mjs` (umbrella dispatcher) and
+  `dotclaude-detect-drift.mjs` (thin wrapper) intentionally use
+  `spawn` / `process.exit`.
 - **Wrong exit code.** Bins must exit with the named `EXIT_CODES`:
   `OK=0`, `VALIDATION=1`, `ENV=2`, `USAGE=64`. Flag literal numbers other
   than these or misuse (e.g. exiting `1` for a usage error — should be
   `64`).
-- **Missing CLI flags.** Every bin honors `--help`, `--version`, `--json`,
-  `--verbose`, `--no-color`. Flag bins that don't.
+- **Missing CLI flags.** Non-wrapper bins must honor `--help`,
+  `--version`, `--json`, `--verbose`, `--no-color`. For
+  wrapper/dispatcher bins, it's acceptable to own only `--help` /
+  `--version` if they transparently forward `--json`, `--verbose`, and
+  `--no-color` to the delegated command. Flag bins that neither
+  implement nor forward the standard flags correctly.
 - **Unstructured errors.** Validator `errors.push(...)` must push a
   `ValidationError(code, …)` from `src/lib/errors.mjs`. New failure
   classes need a new entry in `ERROR_CODES`. Flag string-only errors.
@@ -78,7 +85,7 @@ formatError(lib/errors) → exit(lib/exit-codes)`. Flag raw
 - Reserved variable names: `status`, `path`, `pwd`, `prompt`, `HISTFILE`.
 - Direct `echo`/`printf` for status output instead of `pass` / `fail` /
   `warn` / `out_summary` from `plugins/dotclaude/scripts/lib/output.sh`.
-- JSON output not gated behind `HARNESS_JSON=1`.
+- JSON output not gated behind `DOTCLAUDE_JSON=1`.
 - Bats tests asserting on stderr without `2>&1` redirect — `run` only
   captures stdout, and handoff scripts deliberately print to stderr.
 

--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -50,7 +50,7 @@ unless they prevent a bug.
 - **Bin without the standard pipeline.** Validator-style
   `plugins/dotclaude/bin/*.mjs` must use
   `parse(lib/argv) → validator → createOutput(lib/output) →
-  formatError(lib/errors) → exit(lib/exit-codes)`. Flag raw
+formatError(lib/errors) → exit(lib/exit-codes)`. Flag raw
   `console.log` / `process.exit(N)` / `throw new Error("string")` in
   validator bins. Exception: `dotclaude.mjs` (umbrella dispatcher) and
   `dotclaude-detect-drift.mjs` (thin wrapper) intentionally use

--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -1,0 +1,134 @@
+# Copilot PR review instructions for `@dotclaude/dotclaude`
+
+> Paste the body of this file into **Repo Settings → Code & automation →
+> Copilot → Code review → Custom instructions** so the GitHub Copilot PR
+> reviewer picks it up. This in-repo copy is the versioned source of truth.
+> For general session context (build/test/architecture) see
+> [`copilot-instructions.md`](./copilot-instructions.md).
+
+## Review priorities (in order)
+
+1. **Correctness over style.** This repo is dogfooded — a wrong validator
+   silently breaks consumer CI. Skip nits about wording/whitespace.
+2. **Contract violations** in the bin/library surface.
+3. **Repo-specific invariants** (listed below).
+4. **Test coverage gaps** for the changed behavior.
+5. Everything else.
+
+Be terse. One comment per real issue. No "consider extracting…" suggestions
+unless they prevent a bug.
+
+## Things to flag (high-signal)
+
+### Spec & governance invariants
+
+- **Protected paths without spec coverage.** If the PR touches any path in
+  `docs/repo-facts.json → protected_paths` (`CLAUDE.md`, `README.md`,
+  `.github/workflows/**`, `.claude/**`, `docs/repo-facts.json`,
+  `docs/specs/**/spec.json`, `plugins/dotclaude/{src,bin,templates}/**`)
+  the PR body **must** contain either an H2 `## Spec ID` block (e.g.
+  `Spec ID: dotclaude-core`) or `## No-spec rationale`. Flag if missing —
+  this is what `dotclaude-check-spec-coverage` enforces and a missing
+  block fails CI.
+- **`spec.json status`** must be one of `draft | approved | implementing
+  | done`. Coverage only counts `approved | implementing | done`.
+- **Drift between `CLAUDE.md` "Protected paths" and `docs/repo-facts.json`.**
+  Every protected path in the JSON must appear in `CLAUDE.md`'s list and
+  vice versa — `dotclaude-check-instruction-drift` enforces this.
+- **Doc version stamps.** Every `docs/*.md` carries
+  `_Last updated: vX.Y.Z_` matching `package.json → version`. If
+  `version` was bumped, `npm run docs:stamp` must have been run. Flag any
+  hand-edited stamp.
+
+### CLI / library contract (`plugins/dotclaude/`)
+
+- **New runtime dependency.** Zero-dep is enforced by ADR-0002. Adding
+  anything to `dependencies` (not `devDependencies`) needs an explicit
+  rationale in the PR body. Block.
+- **TypeScript / build step.** Plain Node 20+ ESM only, no bundler
+  (ADR-0002). Block.
+- **Bin without the standard pipeline.** Every `plugins/dotclaude/bin/*.mjs`
+  must `parse(lib/argv) → validator → createOutput(lib/output) →
+  formatError(lib/errors) → exit(lib/exit-codes)`. Flag raw
+  `console.log` / `process.exit(N)` / `throw new Error("string")` in bin
+  or validator code.
+- **Wrong exit code.** Bins must exit with the named `EXIT_CODES`:
+  `OK=0`, `VALIDATION=1`, `ENV=2`, `USAGE=64`. Flag literal numbers other
+  than these or misuse (e.g. exiting `1` for a usage error — should be
+  `64`).
+- **Missing CLI flags.** Every bin honors `--help`, `--version`, `--json`,
+  `--verbose`, `--no-color`. Flag bins that don't.
+- **Unstructured errors.** Validator `errors.push(...)` must push a
+  `ValidationError(code, …)` from `src/lib/errors.mjs`. New failure
+  classes need a new entry in `ERROR_CODES`. Flag string-only errors.
+- **Missing JSDoc on exports.** `scripts/check-jsdoc-coverage.mjs` fails
+  CI on undocumented `export`s under `plugins/dotclaude/src/`. Flag any
+  new export without JSDoc.
+- **Direct `fs` / `child_process` in validators.** Filesystem and git
+  primitives belong in `spec-harness-lib.mjs`. Validators should consume
+  it, not reach for `node:fs` directly.
+- **Cross-plugin import.** `plugins/dotclaude/` and `plugins/harness/`
+  must not import from each other.
+
+### Shell scripts
+
+- Missing `set -euo pipefail` at the top of any new `.sh`.
+- `zsh` shebang or `zsh`-specific syntax — bash only (`zsh` makes
+  `$status` read-only, breaks scripts silently).
+- Reserved variable names: `status`, `path`, `pwd`, `prompt`, `HISTFILE`.
+- Direct `echo`/`printf` for status output instead of `pass` / `fail` /
+  `warn` / `out_summary` from `plugins/dotclaude/scripts/lib/output.sh`.
+- JSON output not gated behind `HARNESS_JSON=1`.
+- Bats tests asserting on stderr without `2>&1` redirect — `run` only
+  captures stdout, and handoff scripts deliberately print to stderr.
+
+### Commands, skills, templates (shipped artifacts)
+
+- Files under `commands/`, `skills/`, `schemas/`, `CLAUDE.md`,
+  `plugins/dotclaude/{src,bin,scripts,templates,hooks}/`,
+  `plugins/dotclaude/README.md`, and
+  `plugins/dotclaude/.claude-plugin/` ship in the npm tarball
+  (`package.json → files`). Treat changes here as user-visible API —
+  flag breaking changes without a `CHANGELOG.md` entry.
+- New `.claude/commands/*` file not added to `.claude/skills-manifest.json`
+  → `validate-skills` will fail with `MANIFEST_ORPHAN_FILE`.
+- Agent template under `plugins/dotclaude/templates/claude/agents/`
+  missing YAML frontmatter (`name`, `description`, `tools`, `model`),
+  using a `model` outside `opus | sonnet | haiku | inherit`, or — if its
+  `name` matches auditor / reviewer / inspector — including `Write` or
+  `Edit` in `tools`.
+- Command markdown under `commands/` missing frontmatter (`name`,
+  `description`, `argument-hint`).
+
+### Tests
+
+- New code path in `plugins/dotclaude/src/` without a corresponding
+  `plugins/dotclaude/tests/*.test.mjs` covering it. Coverage thresholds
+  are 85/85/80/85 (lines/functions/branches/statements) — flag changes
+  that obviously push coverage below those.
+- Test that imports a bin's `main()` without the import-safety guard
+  (bins must only run `main()` when invoked directly, so they're
+  importable by Vitest).
+- New shell script without a `bats` or `test_*.sh` companion in
+  `plugins/dotclaude/tests/`.
+
+### PR hygiene
+
+- Missing `## Summary` or `## Test plan` section in the PR body.
+- Commit message not in conventional-commits form
+  (`feat(scope): …`, `fix(scope): …`, `chore(scope): …`).
+- `.env`, credentials, or API-key-shaped strings in the diff. Block.
+- Force-push or `--amend` of a commit that's already in a published PR.
+
+## Things NOT to flag
+
+- Wording, whitespace, or import ordering — `prettier` /
+  `markdownlint-cli2` handle these and are gated by `npm run lint`.
+- Missing `.prettierignore` entries — `npm run lint` runs prettier with
+  `--ignore-path .gitignore`, so `.prettierignore` is intentionally not
+  consulted.
+- Suggestions to migrate to TypeScript or add a build step — ADR-0002
+  rejects both.
+- Suggestions to add a runtime dep "for convenience".
+- Style preferences inside `docs/specs/**` markdown bodies.
+- "Consider adding a comment" — only flag missing JSDoc on exports.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is a dual-purpose checkout: the published `@dotclaude/dotclaude` package and a personal Claude Code configuration. Core Node implementation lives in `plugins/dotclaude/src/*.mjs`; CLI entrypoints live in `plugins/dotclaude/bin/`. Shell helpers, hooks, and templates sit under `plugins/dotclaude/{scripts,hooks,templates}`. Tests live in `plugins/dotclaude/tests/` and mix Vitest, Bats, and shell harnesses. Shared content for consumers is kept in `commands/`, `skills/`, `agents/`, `schemas/`, `docs/`, and `examples/`.
+
+## Build, Test, and Development Commands
+Run `npm ci` first. Use `npm test` for the Vitest suite and `npm run coverage` for coverage output. Run `npx bats plugins/dotclaude/tests/bats/` for shell integration coverage and `bash plugins/dotclaude/tests/test_validate_settings.sh` for settings validation. `npm run lint` checks Markdown/JSON/YAML formatting and exported JSDoc coverage; `npm run shellcheck` lints shell scripts. `npm run dogfood` runs the packaged validators against this repo, and `npm run build-plugin` builds the distributable plugin.
+
+## Coding Style & Naming Conventions
+Target Node 20+ and keep source in ESM `.mjs` files. Follow `.editorconfig`: UTF-8, LF, final newline, and 2-space indentation; `Makefile` is the only tab-indented exception. Prettier governs Markdown/JSON/YAML formatting (`npm run format`) with `printWidth: 100` and double quotes. Name CLI bins `dotclaude-*`, keep tests as `*.test.mjs` or `*.bats`, and add JSDoc to every exported symbol under `plugins/dotclaude/src/`. Avoid adding new runtime dependencies without a strong justification.
+
+## Testing Guidelines
+Keep unit tests in `plugins/dotclaude/tests/**/*.test.mjs`. Use Bats for cross-shell or CLI regression scenarios and plain `.sh` harnesses where needed. Coverage thresholds are enforced in Vitest: 85% lines, 85% functions, 80% branches, and 85% statements. For bug fixes, add a failing regression test first and make it pass in the same change.
+
+## Commit & Pull Request Guidelines
+Follow conventional commits such as `feat(handoff): ...`, `fix(cli): ...`, `test(sync): ...`, and `chore(main): ...`. Prefer a dedicated worktree like `.claude/worktrees/my-change` instead of editing in the main checkout. PRs must include `## Summary` and `## Test plan`. If you touch protected paths such as `plugins/dotclaude/src/**`, `plugins/dotclaude/bin/**`, `README.md`, or `.github/workflows/**`, include either `## Spec ID` or `## No-spec rationale`. Record the exact verification commands you ran, and do not use `--no-verify` or amend published commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,21 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 This repository is a dual-purpose checkout: the published `@dotclaude/dotclaude` package and a personal Claude Code configuration. Core Node implementation lives in `plugins/dotclaude/src/*.mjs`; CLI entrypoints live in `plugins/dotclaude/bin/`. Shell helpers, hooks, and templates sit under `plugins/dotclaude/{scripts,hooks,templates}`. Tests live in `plugins/dotclaude/tests/` and mix Vitest, Bats, and shell harnesses. Shared content for consumers is kept in `commands/`, `skills/`, `agents/`, `schemas/`, `docs/`, and `examples/`.
 
 ## Build, Test, and Development Commands
+
 Run `npm ci` first. Use `npm test` for the Vitest suite and `npm run coverage` for coverage output. Run `npx bats plugins/dotclaude/tests/bats/` for shell integration coverage and `bash plugins/dotclaude/tests/test_validate_settings.sh` for settings validation. `npm run lint` checks Markdown/JSON/YAML formatting and exported JSDoc coverage; `npm run shellcheck` lints shell scripts. `npm run dogfood` runs the packaged validators against this repo, and `npm run build-plugin` builds the distributable plugin.
 
 ## Coding Style & Naming Conventions
+
 Target Node 20+ and keep source in ESM `.mjs` files. Follow `.editorconfig`: UTF-8, LF, final newline, and 2-space indentation; `Makefile` is the only tab-indented exception. Prettier governs Markdown/JSON/YAML formatting (`npm run format`) with `printWidth: 100` and double quotes. Name CLI bins `dotclaude-*`, keep tests as `*.test.mjs` or `*.bats`, and add JSDoc to every exported symbol under `plugins/dotclaude/src/`. Avoid adding new runtime dependencies without a strong justification.
 
 ## Testing Guidelines
+
 Keep unit tests in `plugins/dotclaude/tests/**/*.test.mjs`. Use Bats for cross-shell or CLI regression scenarios and plain `.sh` harnesses where needed. Coverage thresholds are enforced in Vitest: 85% lines, 85% functions, 80% branches, and 85% statements. For bug fixes, add a failing regression test first and make it pass in the same change.
 
 ## Commit & Pull Request Guidelines
+
 Follow conventional commits such as `feat(handoff): ...`, `fix(cli): ...`, `test(sync): ...`, and `chore(main): ...`. Prefer a dedicated worktree like `.claude/worktrees/my-change` instead of editing in the main checkout. PRs must include `## Summary` and `## Test plan`. If you touch protected paths such as `plugins/dotclaude/src/**`, `plugins/dotclaude/bin/**`, `README.md`, or `.github/workflows/**`, include either `## Spec ID` or `## No-spec rationale`. Record the exact verification commands you ran, and do not use `--no-verify` or amend published commits.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with top-level repository guidelines for Codex and other agent-based workflows.
- Add `.github/copilot-instructions.md` — build/test/lint commands, layered architecture overview, and repo-specific conventions for GitHub Copilot CLI sessions.
- Add `.github/copilot-review-instructions.md` — high-signal reviewer config covering protected-path spec coverage, bin/library contract violations, shell discipline, and an explicit anti-noise list for Copilot PR review (paste into Repo Settings → Copilot → Code review).

## Test plan

- [x] `node plugins/dotclaude/bin/dotclaude-validate-skills.mjs` — no regressions (doc-only change)
- [x] `npx markdownlint .github/copilot-instructions.md .github/copilot-review-instructions.md AGENTS.md` — passes

## No-spec rationale

Documentation-only: no production code or protected bin/src paths touched.
