### PR TITLE
chore(release): keep minor bumps pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
     { "type": "feat", "section": "Added" },
     { "type": "fix", "section": "Fixed" },


### PR DESCRIPTION
## Summary

- Configures release-please to keep the project on pre-1.0 minor bumps:
  - `bump-minor-pre-major: true` — `feat!` commits bump `0.y.z` → `0.(y+1).0` instead of jumping to `1.0.0`.
  - `bump-patch-for-minor-pre-major: true` — non-breaking `feat` commits bump `0.y.z` → `0.y.(z+1)` instead of `0.(y+1).0`.
- Without this change, release-please proposed 1.0.0 after merging PR #66 (see PR #64). That would have committed the project to API-stability semantics it isn't ready for yet — the handoff skill is `maturity: draft`, and several other skills are still iterating.
- Once this PR merges, release-please will re-open PR #64 as `chore(main): release 0.8.0` with the same changelog content.

## Test plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('release-please-config.json','utf8'))"` — config parses as valid JSON.
- [x] `npm run lint` — clean.
- [x] `npm run dogfood` — clean; reports 0 protected files changed (`release-please-config.json` is not a protected path, so no Spec ID / No-spec rationale required).
- [ ] After merge: release-please workflow reopens PR #64 with title `chore(main): release 0.8.0`. Manual verification step — will confirm in the PR thread once the reopen fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
