### PR TITLE
feat(handoff): promote doctor, remote-list, search into the binary

### DIFF
--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -8,6 +8,9 @@
  *   dotclaude handoff push [<query>] [--tag <label>]
  *   dotclaude handoff pull [<query>]
  *   dotclaude handoff list [--local|--remote]
+ *   dotclaude handoff doctor
+ *   dotclaude handoff remote-list [--cli <cli>] [--since <ISO>] [--limit <N>]
+ *   dotclaude handoff search <query> [--cli <cli>] [--since <ISO>] [--limit <N>]
  *
  * Remote transport is always git: push/pull commit a `handoff/<cli>/<short>`
  * branch into the user-owned private repo named by `DOTCLAUDE_HANDOFF_REPO`.
@@ -50,7 +53,7 @@ const CLIS = new Set(["claude", "copilot", "codex"]);
 const META = {
   name: "dotclaude-handoff",
   synopsis:
-    "dotclaude handoff [<query>|push|pull|list] [<query>] [--from <cli>] [--to <cli>] [--tag <label>]",
+    "dotclaude handoff [<query>|push|pull|list|doctor|remote-list|search] [args...] [--from <cli>] [--to <cli>] [--tag <label>] [--cli <cli>] [--since <ISO>] [--limit <N>]",
   description:
     "Cross-agent and cross-machine session handoff. Bare <query> emits a <handoff> block for local cross-agent. push/pull/list handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO).",
   flags: {
@@ -58,6 +61,8 @@ const META = {
     from: { type: "string" },
     to: { type: "string" },
     limit: { type: "string" },
+    since: { type: "string" },
+    cli: { type: "string" },
     "out-dir": { type: "string" },
     local: { type: "boolean" },
     remote: { type: "boolean" },
@@ -69,6 +74,7 @@ const SCRIPTS = resolvePath(__dirname, "..", "scripts");
 const RESOLVE_SH = join(SCRIPTS, "handoff-resolve.sh");
 const EXTRACT_SH = join(SCRIPTS, "handoff-extract.sh");
 const DESCRIPTION_SH = join(SCRIPTS, "handoff-description.sh");
+const DOCTOR_SH = join(SCRIPTS, "handoff-doctor.sh");
 
 function fail(code, msg) {
   if (msg) process.stderr.write(`dotclaude-handoff: ${msg}\n`);
@@ -601,6 +607,89 @@ function detectHost(env = process.env) {
   return "unknown";
 }
 
+// ---- doctor / remote-list / search (binary-side parity with SKILL.md) --
+
+/**
+ * Decode a `handoff:v1:...` description string by shelling out to
+ * handoff-description.sh — keeps the schema owner in one place.
+ */
+function decodeDescription(desc) {
+  if (!desc || !desc.startsWith("handoff:v1:")) return null;
+  const r = runScript(DESCRIPTION_SH, ["decode", desc]);
+  if (r.status !== 0) return null;
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Truncate `s` to `max` chars, appending `…` when it gets clipped.
+ * Used by `search` to keep snippet cells at a sane width.
+ */
+function truncate(s, max) {
+  if (!s) return "";
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}
+
+/**
+ * Port of SKILL.md's `search` algorithm (L258-324 in v0.8.0). Walks
+ * each CLI's session roots, mtime-prefilters against `--since`,
+ * matches the raw JSONL via a case-insensitive regex, then refines
+ * the hit against the extracted user prompts so matches in
+ * tool-use / metadata noise are dropped.
+ *
+ * Returns a newest-first array of {cli, short_id, cwd, mtime,
+ * snippet} objects capped at `limit`. The binary caller handles
+ * table rendering vs `--json` serialization.
+ */
+function searchSessions({ query, cli, since, limit }) {
+  const re = new RegExp(query, "i");
+  const sinceMs = since
+    ? Date.parse(since)
+    : Date.now() - 30 * 24 * 60 * 60 * 1000;
+  if (Number.isNaN(sinceMs)) fail(EXIT_CODES.USAGE, `--since must be ISO-8601, got: ${since}`);
+  const clis = cli ? [cli] : Object.keys(CLI_LAYOUTS);
+  const out = [];
+  for (const c of clis) {
+    const layout = CLI_LAYOUTS[c];
+    if (!layout) continue;
+    const root = layout.root(process.env.HOME ?? "");
+    if (!existsSync(root)) continue;
+    for (const file of collectSessionFiles(root, layout.walk, layout.match)) {
+      let stat;
+      try {
+        stat = statSync(file);
+      } catch {
+        continue;
+      }
+      if (stat.mtimeMs < sinceMs) continue;
+      let raw;
+      try {
+        raw = readFileSync(file, "utf8");
+      } catch {
+        continue;
+      }
+      if (!re.test(raw)) continue;
+      const prompts = extractPrompts(c, file);
+      const hit = prompts.find((p) => re.test(p));
+      if (!hit) continue;
+      const meta = extractMeta(c, file);
+      const m = file.match(UUID_HEAD_RE);
+      out.push({
+        cli: c,
+        short_id: m ? m[1] : "?",
+        cwd: meta.cwd ?? null,
+        mtime: stat.mtimeMs,
+        snippet: truncate(`user: ${hit}`, 80),
+      });
+    }
+  }
+  out.sort((a, b) => b.mtime - a.mtime);
+  return out.slice(0, Number.parseInt(limit ?? "20", 10));
+}
+
 // ---- main --------------------------------------------------------------
 
 let argv;
@@ -653,6 +742,104 @@ async function main() {
       EXIT_CODES.USAGE,
       `${first} no longer takes a <cli> positional; use --from ${second} or drop it entirely`
     );
+  }
+
+  // ---- doctor / remote-list / search -------------------------------------
+  // These were previously skill-interpreted (Claude/Copilot read SKILL.md
+  // and ran the steps by hand). Porting them into the binary closes the
+  // Codex parity gap — Codex's bash tool can call them directly.
+
+  if (first === "doctor") {
+    const r = runScript(DOCTOR_SH, []);
+    process.stdout.write(r.stdout);
+    process.stderr.write(r.stderr);
+    process.exit(r.status);
+  }
+
+  if (first === "remote-list") {
+    requireTransportRepo();
+    let candidates;
+    try {
+      candidates = listRemoteCandidates();
+    } catch (err) {
+      fail(2, `remote-list failed: ${err.message}`);
+    }
+    const enriched = enrichWithDescriptions(candidates);
+    const sinceMs = argv.flags.since
+      ? Date.parse(String(argv.flags.since))
+      : Date.now() - 30 * 24 * 60 * 60 * 1000;
+    if (Number.isNaN(sinceMs)) {
+      fail(EXIT_CODES.USAGE, `--since must be ISO-8601, got: ${argv.flags.since}`);
+    }
+    const filterCli = argv.flags.cli ? String(argv.flags.cli) : null;
+    if (filterCli !== null && !CLIS.has(filterCli)) {
+      fail(EXIT_CODES.USAGE, `--cli must be one of: ${[...CLIS].join(", ")}`);
+    }
+    const rows = [];
+    for (const c of enriched) {
+      const decoded = decodeDescription(c.description);
+      if (!decoded) continue;
+      if (filterCli && decoded.cli !== filterCli) continue;
+      rows.push({
+        branch: c.branch,
+        cli: decoded.cli,
+        short_id: decoded.short_id,
+        project: decoded.project,
+        hostname: decoded.hostname,
+        tag: decoded.tag ?? null,
+        commit: c.commit,
+      });
+    }
+    const capped = rows.slice(0, Number.parseInt(limit.toString(), 10));
+    if (argv.json) {
+      process.stdout.write(JSON.stringify(capped, null, 2) + "\n");
+      process.exit(EXIT_CODES.OK);
+    }
+    if (capped.length === 0) {
+      process.stdout.write("No handoffs found\n");
+      process.exit(EXIT_CODES.OK);
+    }
+    process.stdout.write("| Branch                               | CLI     | Short UUID | Project                  | Hostname                 | Tag                      |\n");
+    process.stdout.write("| ------------------------------------ | ------- | ---------- | ------------------------ | ------------------------ | ------------------------ |\n");
+    for (const r of capped) {
+      process.stdout.write(
+        `| ${r.branch.padEnd(36)} | ${r.cli.padEnd(7)} | ${r.short_id.padEnd(10)} | ${(r.project ?? "").padEnd(24)} | ${(r.hostname ?? "").padEnd(24)} | ${(r.tag ?? "").padEnd(24)} |\n`
+      );
+    }
+    process.exit(EXIT_CODES.OK);
+  }
+
+  if (first === "search") {
+    const query = second;
+    if (!query) fail(EXIT_CODES.USAGE, "search requires a <query> argument");
+    const filterCli = argv.flags.cli ? String(argv.flags.cli) : null;
+    if (filterCli !== null && !CLIS.has(filterCli)) {
+      fail(EXIT_CODES.USAGE, `--cli must be one of: ${[...CLIS].join(", ")}`);
+    }
+    const hits = searchSessions({
+      query,
+      cli: filterCli,
+      since: argv.flags.since ? String(argv.flags.since) : null,
+      limit: limit.toString(),
+    });
+    if (argv.json) {
+      process.stdout.write(JSON.stringify(hits, null, 2) + "\n");
+      process.exit(EXIT_CODES.OK);
+    }
+    if (hits.length === 0) {
+      process.stdout.write(`No sessions matching '${query}'\n`);
+      process.exit(EXIT_CODES.OK);
+    }
+    process.stdout.write("| CLI     | Short UUID | cwd                                   | Last modified       | Match                                    |\n");
+    process.stdout.write("| ------- | ---------- | ------------------------------------- | ------------------- | ---------------------------------------- |\n");
+    for (const h of hits) {
+      const when = new Date(h.mtime).toISOString().replace("T", " ").slice(0, 19);
+      process.stdout.write(
+        `| ${h.cli.padEnd(7)} | ${h.short_id.padEnd(10)} | ${(h.cwd ?? "").padEnd(37)} | ${when.padEnd(19)} | ${h.snippet.padEnd(40)} |\n`
+      );
+    }
+    process.stdout.write("\nDrill in with `dotclaude handoff describe <cli> <short-uuid>`.\n");
+    process.exit(EXIT_CODES.OK);
   }
 
   // ---- top-level subs: push / pull / list --------------------------------
@@ -839,6 +1026,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 export {
   cliFromPath,
   collectSessionFiles,
+  decodeDescription,
   detectHost,
   encodeDescription,
   mechanicalSummary,
@@ -846,6 +1034,8 @@ export {
   nextStepFor,
   projectSlugFromCwd,
   requireTransportRepo,
+  searchSessions,
+  truncate,
   CLI_LAYOUTS,
   UUID_HEAD_RE,
 };

--- a/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
+++ b/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# Behavior tests for the binary-side port of `doctor`, `remote-list`,
+# and `search`. Before v0.9.0 these were skill-interpreted (Claude /
+# Copilot read SKILL.md and ran shell commands by hand); this suite
+# verifies the binary matches the documented contract so Codex can
+# invoke them directly.
+
+load helpers
+
+bats_require_minimum_version 1.5.0
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+
+  mkdir -p "$TEST_HOME/.claude/projects/-home-u-demo"
+  CLAUDE_FILE="$TEST_HOME/.claude/projects/-home-u-demo/aaaa1111-1111-1111-1111-111111111111.jsonl"
+  cat > "$CLAUDE_FILE" <<'EOF'
+{"type":"user","cwd":"/home/u/demo","sessionId":"aaaa1111-1111-1111-1111-111111111111","version":"2.1","message":{"content":"Fix the migration bug in the auth middleware"}}
+{"type":"user","cwd":"/home/u/demo","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"Run the suite"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"OK running now."}]}}
+{"type":"custom-title","customTitle":"my-feature","sessionId":"aaaa1111-1111-1111-1111-111111111111"}
+EOF
+
+  sleep 0.01
+  mkdir -p "$TEST_HOME/.codex/sessions/2026/04/18"
+  CODEX_FILE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T10-00-00-bbbb2222-2222-2222-2222-222222222222.jsonl"
+  cat > "$CODEX_FILE" <<'EOF'
+{"type":"session_meta","payload":{"id":"bbbb2222-2222-2222-2222-222222222222","cwd":"/work/demo","cli_version":"0.1"}}
+{"type":"event_msg","payload":{"thread_name":"my-codex-task","type":"thread_renamed"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"ship the migration bug fix"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"running"}]}}
+EOF
+
+  # Set up a bare git repo as the remote transport endpoint.
+  TRANSPORT_REPO=$(mktemp -d)
+  rm -rf "$TRANSPORT_REPO"
+  git init -q --bare "$TRANSPORT_REPO"
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+
+  export CLAUDE_FILE CODEX_FILE TRANSPORT_REPO
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+}
+
+# ---- doctor (binary wrapper around handoff-doctor.sh) ------------------
+
+@test "doctor: exit 0 when DOTCLAUDE_HANDOFF_REPO points at a reachable repo" {
+  run node "$BIN" doctor
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}
+
+@test "doctor: exit 1 with a remediation block when DOTCLAUDE_HANDOFF_REPO is unset" {
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" node "$BIN" doctor
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"Preflight failed: handoff-repo-unset"* ]]
+  [[ "$stderr" == *"DOTCLAUDE_HANDOFF_REPO"* ]]
+}
+
+# ---- remote-list -------------------------------------------------------
+
+@test "remote-list: empty transport exits 0 with 'No handoffs found'" {
+  run node "$BIN" remote-list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No handoffs found"* ]]
+}
+
+@test "remote-list: after pushes, returns a table with both branches" {
+  run node "$BIN" push my-feature
+  [ "$status" -eq 0 ]
+  run node "$BIN" push my-codex-task
+  [ "$status" -eq 0 ]
+  run node "$BIN" remote-list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"handoff/claude/aaaa1111"* ]]
+  [[ "$output" == *"handoff/codex/bbbb2222"* ]]
+}
+
+@test "remote-list --cli claude filters to claude-only" {
+  run node "$BIN" push my-feature
+  run node "$BIN" push my-codex-task
+  run node "$BIN" remote-list --cli claude
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"handoff/claude/aaaa1111"* ]]
+  [[ "$output" != *"handoff/codex/bbbb2222"* ]]
+}
+
+@test "remote-list --json emits a JSON array of handoff entries" {
+  run node "$BIN" push my-feature
+  run node "$BIN" --json remote-list
+  [ "$status" -eq 0 ]
+  # Parseable JSON and at least one entry with the expected fields.
+  [[ "$output" == *'"branch":'* ]]
+  [[ "$output" == *'"cli":'* ]]
+  [[ "$output" == *'"short_id":'* ]]
+}
+
+@test "remote-list --cli with an invalid value exits 64" {
+  run node "$BIN" remote-list --cli bogus
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"--cli must be one of"* ]]
+}
+
+# ---- search ------------------------------------------------------------
+
+@test "search <query> returns matching sessions across roots" {
+  run node "$BIN" search migration
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]] || [[ "$output" == *"bbbb2222"* ]]
+  [[ "$output" == *"migration"* ]]
+}
+
+@test "search --cli codex narrows to the codex root only" {
+  run node "$BIN" search migration --cli codex
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222"* ]]
+  [[ "$output" != *"aaaa1111"* ]]
+}
+
+@test "search with no match exits 0 with 'No sessions matching'" {
+  run node "$BIN" search absolutelynothingmatches
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No sessions matching"* ]]
+}
+
+@test "search missing <query> exits 64" {
+  run node "$BIN" search
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"search requires a <query>"* ]]
+}
+
+@test "search --cli bogus exits 64" {
+  run node "$BIN" search migration --cli bogus
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"--cli must be one of"* ]]
+}
+
+@test "search --since with an invalid date exits 64" {
+  run node "$BIN" search migration --since not-a-date
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"--since must be ISO-8601"* ]]
+}
+
+@test "search --json emits JSON parsable by callers" {
+  run node "$BIN" --json search migration
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"cli":'* ]]
+  [[ "$output" == *'"short_id":'* ]]
+  [[ "$output" == *'"snippet":'* ]]
+}


### PR DESCRIPTION
## Summary

- Ports the three skill-only sub-commands (`doctor`, `remote-list`, `search`) into the `dotclaude-handoff` binary so every agentic CLI — Claude Code, Copilot CLI, **and Codex** — can invoke them identically through `dotclaude handoff <sub>`.
- Adds two flags shared by `remote-list` and `search`: `--since <ISO>` (default 30 days) and `--cli <cli>` (filter to one source CLI).
- New file `plugins/dotclaude/tests/bats/handoff-binary-subs.bats` with 14 tests covering every success and usage-error path for the three new sub-commands.

## Why

Before this PR, those three sub-commands lived only in SKILL.md prose. Claude / Copilot read the steps and ran the shell commands by hand at skill-execution time. Codex doesn't load SKILL.md the same way, so it couldn't reach them at all (`dotclaude handoff doctor` exited with "unknown subcommand"). PR #68 closed the transport-side parity gap; this PR closes the sub-command-surface gap.

SKILL.md is not edited in this PR — the prose can collapse to a thin wrapper around `dotclaude handoff <sub> --help` once the binary surface is proven. That's the planned PR D in the v0.9.0 rollout.

## Implementation notes

- **`doctor`** — thin wrapper around `handoff-doctor.sh` (already argv-free since PR #68). Forwards stdout / stderr / exit code verbatim.
- **`remote-list`** — reuses `listRemoteCandidates`, `enrichWithDescriptions`, and `handoff-description.sh decode` so the description schema ownership stays in the shell script. Renders a markdown table; `--json` flag emits the same data as a JSON array.
- **`search`** — ports the algorithm documented in SKILL.md L258-324 to Node. Walks `CLI_LAYOUTS` roots, mtime-prefilters by `--since`, does a raw case-insensitive regex match against file content, then refines the hit against extracted user prompts so matches in tool-use / metadata noise are dropped. No `rg` dependency.

## Test plan

- [x] `npm test` — 23/23 vitest files, 265/265 tests pass
- [x] `npx bats plugins/dotclaude/tests/bats/*.bats` — 227/227 bats tests pass (213 existing + 14 new)
- [x] CI prettier + markdownlint + shellcheck — clean (verified locally with the same flag set CI uses)
- [x] `node plugins/dotclaude/bin/dotclaude-index.mjs --check` — index fresh
- [x] `npm run dogfood` — manifest valid, specs valid, instruction drift clean, spec coverage ok (0 protected files changed)
- [ ] After merge: smoke `dotclaude handoff doctor`, `dotclaude handoff remote-list`, `dotclaude handoff search <q>` from inside Codex's bash tool to confirm parity is reached.

## Spec ID

dotclaude-core
