### PR TITLE
feat(handoff)!: v2 store taxonomy + schema enforcement + init

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-20T00:54:50.553Z",
+  "generatedAt": "2026-04-20T01:39:24.380Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:a47c4b7c20052ce9cbe3f028d7def0fa8d82ebeefa7e7058633d22681dcc84ee",
+      "checksum": "sha256:128882d9009e164bd1ed5b9daf3655a12f900842d8049880e5d1f3a205646aed",
       "dependencies": [],
       "lastValidated": "2026-04-20"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-20T01:39:24.380Z",
+  "generatedAt": "2026-04-20T08:53:39.235Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:128882d9009e164bd1ed5b9daf3655a12f900842d8049880e5d1f3a205646aed",
+      "checksum": "sha256:8668bf1afa47c0e689a9e1c31c8058b90028055e2fdebef173bb3d6fd757ddfe",
       "dependencies": [],
       "lastValidated": "2026-04-20"
     },

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -35,4 +35,5 @@ jobs:
             --exclude '^https?://(www\.)?npmjs\.com/' \
             --exclude '^https?://(www\.)?contributor-covenant\.org/' \
             --exclude '^https?://github\.com/[^/]+/[^/]+/compare/' \
+            --exclude-path 'plugins/dotclaude/templates' \
             'docs/**/*.md' '*.md' 'plugins/dotclaude/**/*.md'

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -37,8 +37,15 @@ GitHub, GitLab, Gitea, self-hosted). Create one once, then point
 gh repo create handoff-store --private
 echo 'export DOTCLAUDE_HANDOFF_REPO=git@github.com:<user>/handoff-store.git' >> ~/.zshrc
 source ~/.zshrc
-/handoff doctor                  # verify
+dotclaude handoff init           # writes .dotclaude-handoff.json + README to main
+dotclaude handoff doctor         # verify
 ```
+
+`init` is required from v0.10.0 onward — `push` refuses to write into
+an unstamped store so mismatched versions across machines surface
+immediately. Running it against an already-initialised store is a
+no-op (exits 0 with "already initialised"). Schema details live in
+[`docs/handoff-store-schema.md`](./handoff-store-schema.md).
 
 You can also use HTTPS (`https://github.com/<user>/handoff-store.git`), self-hosted
 URLs, or a local repository via an absolute path or `file://` URL. The only

--- a/docs/handoff-store-schema.md
+++ b/docs/handoff-store-schema.md
@@ -1,6 +1,6 @@
 # Handoff store schema (v2 — v0.10.0+)
 
-_Last updated: v0.10.0_
+_Last updated: v0.9.0_
 
 Authoritative reference for the layout of the private git repository
 that `dotclaude handoff` uses as its remote transport. Consumed by the

--- a/docs/handoff-store-schema.md
+++ b/docs/handoff-store-schema.md
@@ -1,6 +1,6 @@
 # Handoff store schema (v2 — v0.10.0+)
 
-_Last updated: v0.9.0_
+_Last updated: v0.10.0_
 
 Authoritative reference for the layout of the private git repository
 that `dotclaude handoff` uses as its remote transport. Consumed by the

--- a/docs/handoff-store-schema.md
+++ b/docs/handoff-store-schema.md
@@ -1,0 +1,129 @@
+# Handoff store schema (v2 — v0.10.0+)
+
+_Last updated: v0.9.0_
+
+Authoritative reference for the layout of the private git repository
+that `dotclaude handoff` uses as its remote transport. Consumed by the
+binary (enforced on push / surfaced on pull) and by humans browsing the
+repo in the GitHub / GitLab / Gitea UI.
+
+## TL;DR
+
+- Each handoff is a branch: `handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>`.
+- `main` holds two files: `.dotclaude-handoff.json` (the schema pin) and
+  a README. `push` / `pull` / `remote-list` / `prune` never touch `main`.
+- The binary refuses to push to a store whose pin doesn't match; run
+  `dotclaude handoff init` once per store to stamp it.
+
+## Branch namespace
+
+```
+handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
+```
+
+Segments (all lowercase, `[a-z0-9-]` only, slugified via
+`handoff-description.sh`'s `slugify()`):
+
+| Segment        | Source                                                                                 |
+| -------------- | -------------------------------------------------------------------------------------- |
+| `<project>`    | `projectSlugFromCwd(meta.cwd)` — git-repo basename, or cwd basename outside a git repo |
+| `<cli>`        | `claude`, `copilot`, or `codex`                                                        |
+| `<YYYY-MM>`    | UTC month at push time (`monthBucket(now)`)                                            |
+| `<short-uuid>` | First 8 hex chars of the session UUID                                                  |
+
+Each branch carries three files at the root:
+
+```
+handoff.md           # the rendered <handoff> block (Markdown)
+metadata.json        # cli, session_id, cwd, project, month, hostname,
+                     # scrubbed_count, schema_version, tag, created_at
+description.txt      # the encoded description string (also the commit
+                     # message on the branch's first + only commit)
+```
+
+## Schema pin (`.dotclaude-handoff.json` on main)
+
+```json
+{
+  "schema_version": "2",
+  "created_at": "2026-04-20T01:15:00Z",
+  "layout": "branch-per-handoff",
+  "branch_format": "handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>",
+  "description_format": "handoff:v2:<project>:<cli>:<YYYY-MM>:<short-uuid>:<hostname>[:<tag>]",
+  "created_by": "@dotclaude/dotclaude@0.10.0"
+}
+```
+
+The binary shallow-clones `main` on every `push` to read this file.
+Behaviour:
+
+- **Pin present, version matches** → proceed.
+- **Pin missing** (empty repo, or `main` lacks the file) → exit 2 with
+  "run `dotclaude handoff init` first."
+- **Pin present, version mismatches** → exit 2 with "upgrade
+  `@dotclaude/dotclaude` on every machine before reinitialising."
+
+## Description schema
+
+The `description.txt` file — which also serves as the branch's commit
+message — is a colon-separated string:
+
+```
+handoff:v2:<project>:<cli>:<YYYY-MM>:<short-uuid>:<hostname>[:<tag>]
+```
+
+Encoded by `plugins/dotclaude/scripts/handoff-description.sh encode`
+(consult its `--help`). Decoded by the same script's `decode`
+sub-command, which emits JSON with a `"schema"` field (`"v1"` or
+`"v2"`) so callers can render legacy markers in UI tables.
+
+### Legacy v1 (read-only)
+
+Stores initialised by v0.9.0 or earlier use:
+
+```
+handoff/<cli>/<short-uuid>             # branch
+handoff:v1:<cli>:<short>:<project>:<hostname>[:<tag>]   # description
+```
+
+v0.10.0+ still **reads** v1 branches so `pull` and `remote-list` work
+across a staged rollout, but **writes** always emit v2. A future
+`dotclaude handoff migrate` sub-command will rename legacy branches.
+
+## Why this layout
+
+1. **Project scoping.** Handoffs from five personal side projects
+   mixed with three work repos made the v0.9.0 flat namespace
+   unscrollable. Grouping by project lets `remote-list --project X`
+   return a focused view.
+2. **Age bucketing.** `<YYYY-MM>` turns pruning into a pattern match
+   (`git ls-remote | grep 'handoff/*/*/2024-' | xargs push --delete`).
+   No need to decode every branch to check its date.
+3. **Enforced schema.** Without a server-side pin, two machines at
+   different versions silently produce incompatible branches. The
+   pin lets the binary fail fast rather than emit data the reader
+   can't decode.
+4. **Branch-per-handoff stays.** Every alternative we considered
+   (tree on `main`, per-project repos, encrypted blobs) added
+   complexity for no gain at the expected scale (O(100) handoffs per
+   user per year). Force-pushing a single branch is cheap,
+   conflict-free, and browsable.
+
+## Operational sub-commands
+
+All touch only `handoff/...` branches; `main` is reserved for the pin:
+
+- `dotclaude handoff init` — idempotent; writes `.dotclaude-handoff.json`
+  and a README. Skips README when one already exists.
+- `dotclaude handoff push [<query>]` — creates a new v2 branch.
+- `dotclaude handoff pull [<handle>]` — fetches one back.
+- `dotclaude handoff remote-list` — enumerates branches.
+- `dotclaude handoff doctor` — verifies the pin + transport.
+- `dotclaude handoff prune` — (PR B) deletes stale branches.
+- `dotclaude handoff migrate` — (PR C) renames v1 branches to v2.
+
+## Editing `main` by hand
+
+Don't. The binary tolerates extra files on `main`, but operational
+commands never read them. If you want to add project notes, the README
+is the right place — the binary leaves it untouched once written.

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -50,6 +50,20 @@ import { createInterface } from "node:readline";
 const POWER_SUBS = new Set(["resolve", "describe", "digest", "file"]);
 const CLIS = new Set(["claude", "copilot", "codex"]);
 
+// Schema pin for the remote handoff store. v0.10.0 introduced the v2
+// branch namespace (handoff/<project>/<cli>/<YYYY-MM>/<short>) and the
+// .dotclaude-handoff.json file on `main`. The binary refuses to write
+// (exit 2) against a store whose pin doesn't match, pointing the user
+// at `dotclaude handoff init`.
+const SCHEMA_VERSION = "2";
+
+// V2 branch shape — used both as the regex the writer must match AND
+// the filter `listRemoteCandidates` applies on read to skip legacy v1
+// branches. Keep in sync with handoff-description.sh's v2 schema.
+const V2_BRANCH_RE =
+  /^handoff\/[a-z0-9-]+\/(claude|copilot|codex)\/\d{4}-\d{2}\/[0-9a-f]{8}$/;
+const V1_BRANCH_RE = /^handoff\/(claude|copilot|codex)\/[0-9a-f]{8}$/;
+
 const META = {
   name: "dotclaude-handoff",
   synopsis:
@@ -364,7 +378,7 @@ function requireTransportRepo() {
   return url;
 }
 
-function encodeDescription({ cli, shortId, project, host, tag }) {
+function encodeDescription({ cli, shortId, project, host, month, tag }) {
   const args = [
     "encode",
     "--cli",
@@ -375,6 +389,8 @@ function encodeDescription({ cli, shortId, project, host, tag }) {
     project || "adhoc",
     "--hostname",
     host || "unknown",
+    "--month",
+    month,
   ];
   if (tag) args.push("--tag", tag);
   const r = runScript(DESCRIPTION_SH, args);
@@ -382,14 +398,107 @@ function encodeDescription({ cli, shortId, project, host, tag }) {
   return r.stdout.trim();
 }
 
+// Slugify any string for safe use as a branch / description segment:
+// lowercase, [a-z0-9-] only, capped at 40 chars. Collapses runs of
+// dashes and strips leading/trailing dashes so whitespace-only input
+// falls back to "adhoc" instead of "-" — matches the shell-side
+// contract in handoff-description.sh's slugify().
+function slugify(s) {
+  if (!s) return "adhoc";
+  let out = s.toLowerCase().replace(/[^a-z0-9-]+/g, "-");
+  out = out.replace(/-+/g, "-").replace(/^-+/, "").replace(/-+$/, "");
+  return out.slice(0, 40) || "adhoc";
+}
+
+// Resolve a cwd to a project slug. Walks up to the nearest git-repo
+// root via `git rev-parse --show-toplevel` so a session running deep
+// inside `~/projects/foo/services/api` is grouped under `foo`, not
+// `api`. Falls back to the cwd basename when not inside a git repo —
+// matching the v0.9.0 behaviour for non-git scratch dirs.
 function projectSlugFromCwd(cwd) {
   if (!cwd) return "adhoc";
-  const last = cwd.split("/").filter(Boolean).pop() || "adhoc";
-  return last.toLowerCase().replace(/[^a-z0-9-]+/g, "-").slice(0, 40) || "adhoc";
+  const r = spawnSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], { encoding: "utf8" });
+  const root = r.status === 0 ? r.stdout.trim() : "";
+  const last = (root || cwd).split("/").filter(Boolean).pop() || "adhoc";
+  return slugify(last);
+}
+
+// Two-digit UTC month bucket for the v2 branch namespace. Accepts any
+// ISO-8601 string (or null/undefined → falls back to "now"); returns
+// "YYYY-MM". Pure function so the unit tests can drive it directly.
+function monthBucket(isoOrNull) {
+  const d = isoOrNull ? new Date(isoOrNull) : new Date();
+  if (Number.isNaN(d.getTime())) return monthBucket(null);
+  const yyyy = d.getUTCFullYear().toString();
+  const mm = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  return `${yyyy}-${mm}`;
+}
+
+// Build a v2 branch name. Centralised so the regex, the writer, and
+// the migrate sub all agree on the format.
+function v2BranchName({ project, cli, month, shortId }) {
+  return `handoff/${slugify(project)}/${cli}/${month}/${shortId}`;
+}
+
+// Shallow-clone the remote's `main` branch into a temp dir and read
+// `.dotclaude-handoff.json`. Returns the parsed object, or null when
+// the file is missing (uninitialised store). Throws when `main`
+// itself is missing (truly empty repo) — caller decides how to
+// handle that vs the unwritten-pin case.
+function readRemoteSchema() {
+  const repoUrl = requireTransportRepo();
+  const tmp = mkdtempSync(join(tmpdir(), "handoff-schema-"));
+  try {
+    const r = runGit(["clone", "-q", "--depth", "1", "--branch", "main", repoUrl, "."], tmp);
+    if (r.status !== 0) {
+      // Empty repo (no `main`) is a distinct state from "main exists
+      // but lacks the pin"; surface it as null so callers can decide.
+      const stderr = (r.stderr || "").toLowerCase();
+      if (stderr.includes("not found") || stderr.includes("does not appear") || stderr.includes("empty repository")) {
+        return null;
+      }
+      throw new Error(`clone failed: ${(r.stderr || r.stdout).trim()}`);
+    }
+    const pinPath = join(tmp, ".dotclaude-handoff.json");
+    if (!existsSync(pinPath)) return null;
+    try {
+      return JSON.parse(readFileSync(pinPath, "utf8"));
+    } catch (err) {
+      throw new Error(`.dotclaude-handoff.json is not valid JSON: ${err.message}`);
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// Wrap requireTransportRepo with a schema check. Push paths must call
+// this before writing — it's the "enforced" half of the v2 contract.
+// On schema mismatch / missing pin, fails with a pointer at `init`.
+function requireInitializedRepo() {
+  const url = requireTransportRepo();
+  let pin;
+  try {
+    pin = readRemoteSchema();
+  } catch (err) {
+    fail(2, `cannot read remote schema: ${err.message}`);
+  }
+  if (pin === null) {
+    fail(
+      2,
+      "remote handoff store is not initialised — run `dotclaude handoff init` first (writes README.md + .dotclaude-handoff.json to `main`)"
+    );
+  }
+  if (pin.schema_version !== SCHEMA_VERSION) {
+    fail(
+      2,
+      `remote handoff store schema_version=${pin.schema_version}, this binary supports ${SCHEMA_VERSION}; upgrade @dotclaude/dotclaude or reinitialise the store`
+    );
+  }
+  return url;
 }
 
 function pushRemote({ cli, path: sessionFile, tag }) {
-  const repoUrl = requireTransportRepo();
+  const repoUrl = requireInitializedRepo();
   const meta = extractMeta(cli, sessionFile);
   const prompts = extractPrompts(cli, sessionFile);
   const turns = extractTurns(cli, sessionFile);
@@ -397,13 +506,15 @@ function pushRemote({ cli, path: sessionFile, tag }) {
   const handoffBlock = renderHandoffBlock(meta, prompts, turns, toCli);
 
   const shortId = meta.short_id ?? "unknown";
-  const host = hostname().toLowerCase().replace(/[^a-z0-9-]+/g, "-").slice(0, 40);
+  const host = slugify(hostname());
   const project = projectSlugFromCwd(meta.cwd);
+  const month = monthBucket(new Date().toISOString());
   const description = encodeDescription({
     cli: meta.cli,
     shortId,
     project,
     host,
+    month,
     tag: tag || null,
   });
 
@@ -412,10 +523,12 @@ function pushRemote({ cli, path: sessionFile, tag }) {
     session_id: meta.session_id,
     short_id: shortId,
     cwd: meta.cwd ?? null,
+    project,
+    month,
     hostname: host,
     created_at: new Date().toISOString(),
     scrubbed_count: 0,
-    schema_version: "1",
+    schema_version: SCHEMA_VERSION,
     tag: tag || null,
   };
 
@@ -425,7 +538,7 @@ function pushRemote({ cli, path: sessionFile, tag }) {
     runGitOrThrow(["remote", "add", "origin", repoUrl], tmp);
     runGitOrThrow(["config", "user.email", "handoff@dotclaude.local"], tmp);
     runGitOrThrow(["config", "user.name", "dotclaude-handoff"], tmp);
-    const branch = `handoff/${meta.cli}/${shortId}`;
+    const branch = v2BranchName({ project, cli: meta.cli, month, shortId });
     runGitOrThrow(["checkout", "-q", "-b", branch], tmp);
     writeFileSync(join(tmp, "handoff.md"), handoffBlock + "\n");
     writeFileSync(join(tmp, "metadata.json"), JSON.stringify(metadata, null, 2) + "\n");
@@ -509,12 +622,17 @@ async function pullRemote(query, fromCli = null) {
   let candidates = listRemoteCandidates();
   if (candidates.length === 0) fail(2, "no handoffs found on transport");
 
-  // `--from <cli>` narrows the candidate set to one source-CLI. Branch
-  // names are shaped `handoff/<cli>/<short-uuid>`, so the prefix match
-  // is exact. Applied BEFORE any query match so short-UUID collisions
-  // across CLIs can be resolved with --from.
+  // `--from <cli>` narrows the candidate set to one source-CLI. Two
+  // branch shapes may coexist in the store: v2 (`handoff/<project>/
+  // <cli>/<YYYY-MM>/<short>`) carries the CLI in segment 2, v1 legacy
+  // (`handoff/<cli>/<short>`) carries it in segment 1. Applied BEFORE
+  // any query match so short-UUID collisions across CLIs can be
+  // resolved with --from.
   if (fromCli) {
-    candidates = candidates.filter((c) => c.branch.startsWith(`handoff/${fromCli}/`));
+    candidates = candidates.filter((c) => {
+      const segs = c.branch.split("/");
+      return segs[2] === fromCli || segs[1] === fromCli;
+    });
     if (candidates.length === 0) fail(2, `no ${fromCli} handoffs found on transport`);
   }
 
@@ -614,7 +732,8 @@ function detectHost(env = process.env) {
  * handoff-description.sh — keeps the schema owner in one place.
  */
 function decodeDescription(desc) {
-  if (!desc || !desc.startsWith("handoff:v1:")) return null;
+  if (!desc) return null;
+  if (!desc.startsWith("handoff:v1:") && !desc.startsWith("handoff:v2:")) return null;
   const r = runScript(DESCRIPTION_SH, ["decode", desc]);
   if (r.status !== 0) return null;
   try {
@@ -753,7 +872,135 @@ async function main() {
     const r = runScript(DOCTOR_SH, []);
     process.stdout.write(r.stdout);
     process.stderr.write(r.stderr);
-    process.exit(r.status);
+    if (r.status !== 0) process.exit(r.status);
+    // Surface the v2 schema pin status as a soft check on top of the
+    // shell script's git/env validation. Missing pin is a warning,
+    // not a failure — the script's contract stays "git transport
+    // reachable", and `init` is the documented next step.
+    try {
+      const pin = readRemoteSchema();
+      if (pin === null) {
+        process.stderr.write(
+          "warn: remote handoff store is not initialised — run `dotclaude handoff init` before the first push\n"
+        );
+      } else if (pin.schema_version !== SCHEMA_VERSION) {
+        process.stderr.write(
+          `warn: remote schema_version=${pin.schema_version}, this binary supports ${SCHEMA_VERSION}\n`
+        );
+      } else {
+        process.stdout.write(`ok: schema_version=${pin.schema_version}\n`);
+      }
+    } catch (err) {
+      process.stderr.write(`warn: schema check skipped: ${err.message}\n`);
+    }
+    process.exit(EXIT_CODES.OK);
+  }
+
+  if (first === "init") {
+    const repoUrl = requireTransportRepo();
+    let existing;
+    try {
+      existing = readRemoteSchema();
+    } catch (err) {
+      fail(2, `cannot read remote schema: ${err.message}`);
+    }
+    if (existing !== null) {
+      if (existing.schema_version === SCHEMA_VERSION) {
+        process.stdout.write(`ok: already initialised (schema_version=${existing.schema_version})\n`);
+        process.exit(EXIT_CODES.OK);
+      }
+      fail(
+        2,
+        `remote already pinned at schema_version=${existing.schema_version}; this binary supports ${SCHEMA_VERSION}. Upgrade @dotclaude/dotclaude on every machine before reinitialising.`
+      );
+    }
+
+    const tmp = mkdtempSync(join(tmpdir(), "handoff-init-"));
+    try {
+      // Try to clone main first; falls back to a fresh init when the
+      // remote is genuinely empty (no main branch yet).
+      const cloneR = runGit(["clone", "-q", "--depth", "1", "--branch", "main", repoUrl, "."], tmp);
+      const isEmpty = cloneR.status !== 0;
+      if (isEmpty) {
+        runGitOrThrow(["init", "-q", "-b", "main"], tmp);
+        runGitOrThrow(["remote", "add", "origin", repoUrl], tmp);
+      }
+      runGitOrThrow(["config", "user.email", "handoff@dotclaude.local"], tmp);
+      runGitOrThrow(["config", "user.name", "dotclaude-handoff"], tmp);
+
+      const pin = {
+        schema_version: SCHEMA_VERSION,
+        created_at: new Date().toISOString(),
+        layout: "branch-per-handoff",
+        branch_format: "handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>",
+        description_format: "handoff:v2:<project>:<cli>:<YYYY-MM>:<short-uuid>:<hostname>[:<tag>]",
+        created_by: `@dotclaude/dotclaude@${version}`,
+      };
+      writeFileSync(join(tmp, ".dotclaude-handoff.json"), JSON.stringify(pin, null, 2) + "\n");
+
+      // README.md is best-effort: only write it when the repo doesn't
+      // already have one. This keeps `init` safe to run against a
+      // private repo the user is also using for unrelated content.
+      const readmePath = join(tmp, "README.md");
+      let readmeWritten = false;
+      if (!existsSync(readmePath)) {
+        writeFileSync(
+          readmePath,
+          [
+            "# Handoff store",
+            "",
+            "Managed by [`@dotclaude/dotclaude`](https://github.com/kaiohenricunha/dotclaude). Holds session handoffs",
+            "produced by `dotclaude handoff push`.",
+            "",
+            "## Layout",
+            "",
+            "Each handoff is a branch:",
+            "",
+            "```",
+            "handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>",
+            "```",
+            "",
+            "Each branch carries three files at the root: `handoff.md` (the rendered",
+            "`<handoff>` block), `metadata.json` (cli, session, project, hostname,",
+            "scrubbed_count, schema_version), and `description.txt` (the encoded",
+            "`handoff:v2:...` string, also used as the commit message).",
+            "",
+            "The `main` branch is reserved for `.dotclaude-handoff.json` (the schema",
+            "pin) and this README. Operational sub-commands (push / pull /",
+            "remote-list / prune / migrate) only touch `handoff/...` branches.",
+            "",
+            "## Lifecycle",
+            "",
+            "- `dotclaude handoff init` — scaffolds this repo (idempotent).",
+            "- `dotclaude handoff push` — appends a handoff branch.",
+            "- `dotclaude handoff pull` — fetches one back.",
+            "- `dotclaude handoff remote-list` — lists what's here.",
+            "- `dotclaude handoff prune --older-than <Nd>` — deletes stale branches.",
+            "",
+            "Do not edit files on `main` by hand unless you know what you're doing.",
+            "",
+          ].join("\n")
+        );
+        readmeWritten = true;
+      } else {
+        process.stderr.write(
+          "note: README.md already exists on `main`; leaving it untouched\n"
+        );
+      }
+
+      runGitOrThrow(["add", ".dotclaude-handoff.json", ...(readmeWritten ? ["README.md"] : [])], tmp);
+      runGitOrThrow(
+        ["commit", "-q", "-m", `chore: initialise handoff store (schema_version=${SCHEMA_VERSION})`],
+        tmp
+      );
+      runGitOrThrow(["push", "-q", "origin", "main"], tmp);
+      process.stdout.write(`ok: initialised handoff store at ${repoUrl} (schema_version=${SCHEMA_VERSION})\n`);
+      process.exit(EXIT_CODES.OK);
+    } catch (err) {
+      fail(2, `init failed: ${err.message}`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   }
 
   if (first === "remote-list") {
@@ -1031,11 +1278,19 @@ export {
   encodeDescription,
   mechanicalSummary,
   matchesQuery,
+  monthBucket,
   nextStepFor,
   projectSlugFromCwd,
+  readRemoteSchema,
+  requireInitializedRepo,
   requireTransportRepo,
   searchSessions,
+  slugify,
   truncate,
+  v2BranchName,
   CLI_LAYOUTS,
+  SCHEMA_VERSION,
   UUID_HEAD_RE,
+  V1_BRANCH_RE,
+  V2_BRANCH_RE,
 };

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -50,16 +50,11 @@ import { createInterface } from "node:readline";
 const POWER_SUBS = new Set(["resolve", "describe", "digest", "file"]);
 const CLIS = new Set(["claude", "copilot", "codex"]);
 
-// Schema pin for the remote handoff store. v0.10.0 introduced the v2
-// branch namespace (handoff/<project>/<cli>/<YYYY-MM>/<short>) and the
-// .dotclaude-handoff.json file on `main`. The binary refuses to write
-// (exit 2) against a store whose pin doesn't match, pointing the user
-// at `dotclaude handoff init`.
+// Mirrors `schema_version` in .dotclaude-handoff.json; bump only on a
+// breaking store-layout change, because every writer on the network
+// must agree before the next `push`.
 const SCHEMA_VERSION = "2";
 
-// V2 branch shape — used both as the regex the writer must match AND
-// the filter `listRemoteCandidates` applies on read to skip legacy v1
-// branches. Keep in sync with handoff-description.sh's v2 schema.
 const V2_BRANCH_RE =
   /^handoff\/[a-z0-9-]+\/(claude|copilot|codex)\/\d{4}-\d{2}\/[0-9a-f]{8}$/;
 const V1_BRANCH_RE = /^handoff\/(claude|copilot|codex)\/[0-9a-f]{8}$/;
@@ -398,34 +393,30 @@ function encodeDescription({ cli, shortId, project, host, month, tag }) {
   return r.stdout.trim();
 }
 
-// Slugify any string for safe use as a branch / description segment:
-// lowercase, [a-z0-9-] only, capped at 40 chars. Collapses runs of
-// dashes and strips leading/trailing dashes so whitespace-only input
-// falls back to "adhoc" instead of "-" — matches the shell-side
-// contract in handoff-description.sh's slugify().
+// Mirror of the shell `slugify` in handoff-description.sh so JS-side
+// encoders and the shell decoder agree on the edge cases (dash-run
+// collapse, trimmed edges, "" → "adhoc" fallback).
 function slugify(s) {
   if (!s) return "adhoc";
-  let out = s.toLowerCase().replace(/[^a-z0-9-]+/g, "-");
-  out = out.replace(/-+/g, "-").replace(/^-+/, "").replace(/-+$/, "");
+  const out = s
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
   return out.slice(0, 40) || "adhoc";
 }
 
-// Resolve a cwd to a project slug. Walks up to the nearest git-repo
-// root via `git rev-parse --show-toplevel` so a session running deep
-// inside `~/projects/foo/services/api` is grouped under `foo`, not
-// `api`. Falls back to the cwd basename when not inside a git repo —
-// matching the v0.9.0 behaviour for non-git scratch dirs.
+// Walk up to the git-repo root so a session deep in `~/foo/services/api`
+// groups under `foo`, not `api`. Falls back to the cwd basename outside
+// a git repo.
 function projectSlugFromCwd(cwd) {
   if (!cwd) return "adhoc";
-  const r = spawnSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], { encoding: "utf8" });
+  const r = runGit(["-C", cwd, "rev-parse", "--show-toplevel"]);
   const root = r.status === 0 ? r.stdout.trim() : "";
   const last = (root || cwd).split("/").filter(Boolean).pop() || "adhoc";
   return slugify(last);
 }
 
-// Two-digit UTC month bucket for the v2 branch namespace. Accepts any
-// ISO-8601 string (or null/undefined → falls back to "now"); returns
-// "YYYY-MM". Pure function so the unit tests can drive it directly.
 function monthBucket(isoOrNull) {
   const d = isoOrNull ? new Date(isoOrNull) : new Date();
   if (Number.isNaN(d.getTime())) return monthBucket(null);
@@ -434,8 +425,6 @@ function monthBucket(isoOrNull) {
   return `${yyyy}-${mm}`;
 }
 
-// Build a v2 branch name. Centralised so the regex, the writer, and
-// the migrate sub all agree on the format.
 function v2BranchName({ project, cli, month, shortId }) {
   return `handoff/${slugify(project)}/${cli}/${month}/${shortId}`;
 }
@@ -508,7 +497,7 @@ function pushRemote({ cli, path: sessionFile, tag }) {
   const shortId = meta.short_id ?? "unknown";
   const host = slugify(hostname());
   const project = projectSlugFromCwd(meta.cwd);
-  const month = monthBucket(new Date().toISOString());
+  const month = monthBucket();
   const description = encodeDescription({
     cli: meta.cli,
     shortId,
@@ -622,12 +611,8 @@ async function pullRemote(query, fromCli = null) {
   let candidates = listRemoteCandidates();
   if (candidates.length === 0) fail(2, "no handoffs found on transport");
 
-  // `--from <cli>` narrows the candidate set to one source-CLI. Two
-  // branch shapes may coexist in the store: v2 (`handoff/<project>/
-  // <cli>/<YYYY-MM>/<short>`) carries the CLI in segment 2, v1 legacy
-  // (`handoff/<cli>/<short>`) carries it in segment 1. Applied BEFORE
-  // any query match so short-UUID collisions across CLIs can be
-  // resolved with --from.
+  // v2 carries the CLI in segment 2 (handoff/<project>/<cli>/...);
+  // v1 legacy carries it in segment 1 (handoff/<cli>/<short>).
   if (fromCli) {
     candidates = candidates.filter((c) => {
       const segs = c.branch.split("/");

--- a/plugins/dotclaude/scripts/handoff-description.sh
+++ b/plugins/dotclaude/scripts/handoff-description.sh
@@ -4,13 +4,10 @@
 # branch commit message + the description.txt file, and by
 # `remote-list` to render the table.
 #
-# v0.10.0 introduces v2; v1 is still parsed for back-compat with
-# v0.9.0-era stores so `remote-list` and (PR-C) `migrate` can read
-# legacy branches.
-#
 # Schemas:
 #   v2 (current): handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]
 #   v1 (legacy ): handoff:v1:<cli>:<short>:<project>:<host>[:<tag>]
+# decode accepts both; encode only emits v2.
 #
 # Usage:
 #   handoff-description.sh encode \

--- a/plugins/dotclaude/scripts/handoff-description.sh
+++ b/plugins/dotclaude/scripts/handoff-description.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
-# handoff-description.sh — encode/decode the gist description schema.
+# handoff-description.sh — encode/decode the remote handoff store
+# description schema. Used by `dotclaude handoff push` to build the
+# branch commit message + the description.txt file, and by
+# `remote-list` to render the table.
 #
-# Schema: handoff:v1:<cli>:<short-uuid>:<project-slug>:<hostname>[:<tag>]
+# v0.10.0 introduces v2; v1 is still parsed for back-compat with
+# v0.9.0-era stores so `remote-list` and (PR-C) `migrate` can read
+# legacy branches.
+#
+# Schemas:
+#   v2 (current): handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]
+#   v1 (legacy ): handoff:v1:<cli>:<short>:<project>:<host>[:<tag>]
 #
 # Usage:
 #   handoff-description.sh encode \
@@ -9,13 +18,14 @@
 #     --short-id <8 hex chars> \
 #     --project <slug> \
 #     --hostname <slug> \
+#     --month <YYYY-MM> \
 #     [--tag <slug>]
 #
-#   handoff-description.sh decode "<handoff:v1:...>"
+#   handoff-description.sh decode "<handoff:v[12]:...>"
 #
-# encode: prints the composed string on stdout, exit 0.
-# decode: prints a JSON object on stdout, exit 0. Exits non-zero with
-# a structured error on malformed input.
+# encode: prints the v2 string on stdout, exit 0.
+# decode: prints a JSON object on stdout, exit 0. The JSON includes a
+#         "schema":"v1"|"v2" key so callers can branch on it.
 
 set -euo pipefail
 
@@ -26,7 +36,6 @@ slugify() {
   local raw="$1"
   raw="$(printf '%s' "$raw" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
   raw="$(printf '%s' "$raw" | LC_ALL=C tr -c 'a-z0-9-' '-')"
-  # Trim leading/trailing dashes and collapse runs.
   raw="$(printf '%s' "$raw" | sed -E 's/-+/-/g; s/^-+//; s/-+$//')"
   [[ -z "$raw" ]] && raw="adhoc"
   printf '%s' "${raw:0:40}"
@@ -37,14 +46,20 @@ valid_segment() {
   [[ "$1" =~ ^[a-z0-9-]{1,40}$ ]]
 }
 
+# YYYY-MM month bucket — exactly 4 digits, dash, 2 digits.
+valid_month() {
+  [[ "$1" =~ ^[0-9]{4}-[0-9]{2}$ ]]
+}
+
 cmd_encode() {
-  local cli="" short_id="" project="" hostname="" tag=""
+  local cli="" short_id="" project="" hostname="" month="" tag=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --cli) cli="$2"; shift 2;;
       --short-id) short_id="$2"; shift 2;;
       --project) project="$2"; shift 2;;
       --hostname) hostname="$2"; shift 2;;
+      --month) month="$2"; shift 2;;
       --tag) tag="$2"; shift 2;;
       *) die "unknown encode flag: $1";;
     esac
@@ -54,6 +69,7 @@ cmd_encode() {
   [[ -z "$short_id" ]] && die "encode requires --short-id"
   [[ -z "$project" ]] && die "encode requires --project"
   [[ -z "$hostname" ]] && die "encode requires --hostname"
+  [[ -z "$month" ]] && die "encode requires --month"
 
   case "$cli" in
     claude|copilot|codex) ;;
@@ -61,6 +77,7 @@ cmd_encode() {
   esac
 
   [[ "$short_id" =~ ^[0-9a-f]{8}$ ]] || die "--short-id must be exactly 8 hex chars"
+  valid_month "$month" || die "--month must be YYYY-MM (got: $month)"
 
   local project_slug hostname_slug tag_slug=""
   project_slug="$(slugify "$project")"
@@ -68,7 +85,7 @@ cmd_encode() {
   valid_segment "$project_slug" || die "project slug invalid after normalization: $project_slug"
   valid_segment "$hostname_slug" || die "hostname slug invalid after normalization: $hostname_slug"
 
-  local out="handoff:v1:${cli}:${short_id}:${project_slug}:${hostname_slug}"
+  local out="handoff:v2:${project_slug}:${cli}:${month}:${short_id}:${hostname_slug}"
   if [[ -n "$tag" ]]; then
     tag_slug="$(slugify "$tag")"
     valid_segment "$tag_slug" || die "tag slug invalid after normalization: $tag_slug"
@@ -78,39 +95,78 @@ cmd_encode() {
   printf '%s\n' "$out"
 }
 
+# Decode a v2 description. Segments are positional:
+#   handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]
+decode_v2() {
+  local rest="$1"
+  IFS=':' read -r project cli month short_id hostname tag extra <<<"$rest"
+
+  [[ -n "${extra:-}" ]] && die "malformed v2: too many colon segments"
+  [[ -z "${project:-}" || -z "${cli:-}" || -z "${month:-}" || -z "${short_id:-}" || -z "${hostname:-}" ]] \
+    && die "malformed v2: missing required segment"
+
+  case "$cli" in
+    claude|copilot|codex) ;;
+    *) die "malformed v2: cli not one of claude|copilot|codex ($cli)";;
+  esac
+  valid_month "$month" || die "malformed v2: month not YYYY-MM ($month)"
+  [[ "$short_id" =~ ^[0-9a-f]{8}$ ]] || die "malformed v2: short-id not 8 hex chars"
+  valid_segment "$project" || die "malformed v2: project slug fails charset"
+  valid_segment "$hostname" || die "malformed v2: hostname slug fails charset"
+  if [[ -n "${tag:-}" ]]; then
+    valid_segment "$tag" || die "malformed v2: tag slug fails charset"
+  fi
+
+  if [[ -n "${tag:-}" ]]; then
+    printf '{"schema":"v2","cli":"%s","short_id":"%s","project":"%s","month":"%s","hostname":"%s","tag":"%s"}\n' \
+      "$cli" "$short_id" "$project" "$month" "$hostname" "$tag"
+  else
+    printf '{"schema":"v2","cli":"%s","short_id":"%s","project":"%s","month":"%s","hostname":"%s","tag":null}\n' \
+      "$cli" "$short_id" "$project" "$month" "$hostname"
+  fi
+}
+
+# Decode a legacy v1 description (read-only — no encode path). Segments:
+#   handoff:v1:<cli>:<short>:<project>:<host>[:<tag>]
+decode_v1() {
+  local rest="$1"
+  IFS=':' read -r cli short_id project hostname tag extra <<<"$rest"
+
+  [[ -n "${extra:-}" ]] && die "malformed v1: too many colon segments"
+  [[ -z "${cli:-}" || -z "${short_id:-}" || -z "${project:-}" || -z "${hostname:-}" ]] \
+    && die "malformed v1: missing required segment"
+
+  case "$cli" in
+    claude|copilot|codex) ;;
+    *) die "malformed v1: cli not one of claude|copilot|codex ($cli)";;
+  esac
+  [[ "$short_id" =~ ^[0-9a-f]{8}$ ]] || die "malformed v1: short-id not 8 hex chars"
+  valid_segment "$project" || die "malformed v1: project slug fails charset"
+  valid_segment "$hostname" || die "malformed v1: hostname slug fails charset"
+  if [[ -n "${tag:-}" ]]; then
+    valid_segment "$tag" || die "malformed v1: tag slug fails charset"
+  fi
+
+  # Emit the same shape as v2's JSON, with month=null (legacy lacks it)
+  # and schema=v1 so callers can mark these as "(legacy)" in UI.
+  if [[ -n "${tag:-}" ]]; then
+    printf '{"schema":"v1","cli":"%s","short_id":"%s","project":"%s","month":null,"hostname":"%s","tag":"%s"}\n' \
+      "$cli" "$short_id" "$project" "$hostname" "$tag"
+  else
+    printf '{"schema":"v1","cli":"%s","short_id":"%s","project":"%s","month":null,"hostname":"%s","tag":null}\n' \
+      "$cli" "$short_id" "$project" "$hostname"
+  fi
+}
+
 cmd_decode() {
   local raw="${1:-}"
   [[ -z "$raw" ]] && die "decode requires the description string"
 
-  # Strict parse: reject anything that doesn't start with handoff:v1:.
-  [[ "$raw" =~ ^handoff:v1: ]] || die "malformed: missing handoff:v1: prefix"
-
-  local rest="${raw#handoff:v1:}"
-  IFS=':' read -r cli short_id project hostname tag extra <<<"$rest"
-
-  [[ -n "${extra:-}" ]] && die "malformed: too many colon segments"
-  [[ -z "${cli:-}" || -z "${short_id:-}" || -z "${project:-}" || -z "${hostname:-}" ]] \
-    && die "malformed: missing required segment"
-
-  case "$cli" in
-    claude|copilot|codex) ;;
-    *) die "malformed: cli not one of claude|copilot|codex ($cli)";;
+  case "$raw" in
+    handoff:v2:*) decode_v2 "${raw#handoff:v2:}" ;;
+    handoff:v1:*) decode_v1 "${raw#handoff:v1:}" ;;
+    *) die "malformed: missing handoff:v[12]: prefix" ;;
   esac
-  [[ "$short_id" =~ ^[0-9a-f]{8}$ ]] || die "malformed: short-id not 8 hex chars"
-  valid_segment "$project" || die "malformed: project slug fails charset"
-  valid_segment "$hostname" || die "malformed: hostname slug fails charset"
-  if [[ -n "${tag:-}" ]]; then
-    valid_segment "$tag" || die "malformed: tag slug fails charset"
-  fi
-
-  # Emit JSON. Keep it hand-rolled to avoid a jq hard-dep.
-  if [[ -n "${tag:-}" ]]; then
-    printf '{"cli":"%s","short_id":"%s","project":"%s","hostname":"%s","tag":"%s"}\n' \
-      "$cli" "$short_id" "$project" "$hostname" "$tag"
-  else
-    printf '{"cli":"%s","short_id":"%s","project":"%s","hostname":"%s","tag":null}\n' \
-      "$cli" "$short_id" "$project" "$hostname"
-  fi
 }
 
 sub="${1:-}"

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -119,7 +119,7 @@ handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
 e.g. `handoff/dotclaude/claude/2026-04/aaaa1111`. `main` holds
 `.dotclaude-handoff.json` (the schema pin) and a README — `push`/
 `pull`/`remote-list`/`prune` only touch `handoff/...` branches. Full
-schema + rationale in [`docs/handoff-store-schema.md`](https://github.com/kaiohenricunha/dotclaude/blob/main/docs/handoff-store-schema.md).
+schema + rationale in [`docs/handoff-store-schema.md`](../../docs/handoff-store-schema.md).
 
 ## Auto-trigger contract
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -62,6 +62,7 @@ semantics. Brief summary:
 
 | Sub                   | Purpose                                                             |
 | --------------------- | ------------------------------------------------------------------- |
+| `init`                | Scaffold the remote schema pin on `main` (idempotent, one-time)     |
 | `resolve <cli> <id>`  | Print the absolute JSONL path                                       |
 | `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                 |
 | `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                |
@@ -71,7 +72,7 @@ semantics. Brief summary:
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript` |
 | `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline     |
 | `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`     |
-| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` reachable                  |
+| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + schema pin               |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 
@@ -101,9 +102,24 @@ self-hosted). Required:
 - `$DOTCLAUDE_HANDOFF_REPO` set to the repo URL (no default; example:
   `git@github.com:<user>/handoff-store.git`).
 - Working SSH or credential-helper auth for that repo.
+- The repo initialised once via `dotclaude handoff init` — writes the
+  schema pin on `main` so the binary can refuse mismatched stores.
 
 Run `dotclaude handoff doctor` to verify. Full install matrix and
 remediation lives in `references/prerequisites.md`.
+
+## Repo layout (v0.10.0+)
+
+Each handoff is a branch:
+
+```
+handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
+```
+
+e.g. `handoff/dotclaude/claude/2026-04/aaaa1111`. `main` holds
+`.dotclaude-handoff.json` (the schema pin) and a README — `push`/
+`pull`/`remote-list`/`prune` only touch `handoff/...` branches. Full
+schema + rationale in [`docs/handoff-store-schema.md`](../../docs/handoff-store-schema.md).
 
 ## Auto-trigger contract
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -119,7 +119,7 @@ handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
 e.g. `handoff/dotclaude/claude/2026-04/aaaa1111`. `main` holds
 `.dotclaude-handoff.json` (the schema pin) and a README — `push`/
 `pull`/`remote-list`/`prune` only touch `handoff/...` branches. Full
-schema + rationale in [`docs/handoff-store-schema.md`](../../docs/handoff-store-schema.md).
+schema + rationale in [`docs/handoff-store-schema.md`](https://github.com/kaiohenricunha/dotclaude/blob/main/docs/handoff-store-schema.md).
 
 ## Auto-trigger contract
 

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -42,12 +42,16 @@ EOF
 {"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"running"}]}}
 EOF
 
-  # Set up a bare git repo as the remote transport endpoint.
-  # Push/pull tests run against this local repo — no GitHub auth needed.
+  # Set up a bare git repo as the remote transport endpoint and
+  # pre-initialise it with the v2 schema pin so push/pull work without
+  # each test having to run `init` first. v0.10.0 pushRemote() refuses
+  # uninitialised stores by design — the init-coverage tests live in
+  # handoff-binary-subs.bats and don't use this fixture.
   TRANSPORT_REPO=$(mktemp -d)
   rm -rf "$TRANSPORT_REPO"
   git init -q --bare "$TRANSPORT_REPO"
   export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+  node "$BIN" init >/dev/null
 
   export CLAUDE_FILE CODEX_FILE TRANSPORT_REPO
 }
@@ -126,20 +130,27 @@ teardown() {
 
 # -- push (remote git transport) -----------------------------------------
 
-@test "push <query> uploads to remote (bare repo transport)" {
+@test "push <query> uploads to remote (v2 branch shape)" {
   run node "$BIN" push my-feature
   [ "$status" -eq 0 ]
-  # Confirm the transport repo has the new branch.
+  # Confirm the transport repo has a v2 branch. The month segment
+  # reflects the current UTC month; we match with a glob rather than
+  # hard-coding the date so the test stays stable across calendar
+  # rollovers. Fixture cwd `/home/u/demo` → project slug "demo".
   run bash -c "git --git-dir='$TRANSPORT_REPO' branch -a"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"handoff/claude/aaaa1111"* ]]
+  [[ "$output" =~ handoff/demo/claude/[0-9]{4}-[0-9]{2}/aaaa1111 ]]
 }
 
 @test "push --tag label embeds tag in the transport description" {
   run node "$BIN" push my-feature --tag finishing-auth
   [ "$status" -eq 0 ]
-  # The description line includes the tag (commit message carries it).
-  run bash -c "git --git-dir='$TRANSPORT_REPO' log --format=%s handoff/claude/aaaa1111"
+  # Find the branch name via ls-remote, then grep its commit message
+  # for the tag segment.
+  run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/demo/claude/*/aaaa1111'"
+  [ "$status" -eq 0 ]
+  branch="$output"
+  run bash -c "git --git-dir='$TRANSPORT_REPO' log --format=%s $branch"
   [ "$status" -eq 0 ]
   [[ "$output" == *"finishing-auth"* ]]
 }
@@ -185,7 +196,7 @@ teardown() {
   [ "$status" -eq 0 ]
   run node "$BIN" pull alpha </dev/null
   [ "$status" -eq 2 ]
-  [[ "$output" == *"handoff/claude/aaaa1111"* ]] || [[ "$output" == *"handoff/codex/bbbb2222"* ]]
+  [[ "$output" =~ handoff/demo/(claude|codex)/ ]]
 }
 
 # -- back-compat removal: no <cli> positional allowed --------------------
@@ -224,7 +235,7 @@ teardown() {
     node "$BIN" push --from codex
   [ "$status" -eq 0 ]
   run git --git-dir="$TRANSPORT_REPO" branch -a
-  [[ "$output" == *"handoff/codex/bbbb2222"* ]]
+  [[ "$output" =~ handoff/demo/codex/[0-9]{4}-[0-9]{2}/bbbb2222 ]]
 }
 
 @test "push --from with an unknown CLI exits 64" {
@@ -264,7 +275,7 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$stderr" == *"using --from codex override"* ]]
   run git --git-dir="$TRANSPORT_REPO" branch -a
-  [[ "$output" == *"handoff/codex/bbbb2222"* ]]
+  [[ "$output" =~ handoff/demo/codex/[0-9]{4}-[0-9]{2}/bbbb2222 ]]
 }
 
 # -- honest stderr fallback notes ----------------------------------------

--- a/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
+++ b/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
@@ -34,11 +34,15 @@ EOF
 {"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"running"}]}}
 EOF
 
-  # Set up a bare git repo as the remote transport endpoint.
+  # Set up a bare git repo as the remote transport endpoint and
+  # pre-initialise it with the v2 schema pin so push succeeds.
+  # The dedicated `init` tests further down reinitialise their own
+  # fresh stores so they can assert against the bare-repo starting state.
   TRANSPORT_REPO=$(mktemp -d)
   rm -rf "$TRANSPORT_REPO"
   git init -q --bare "$TRANSPORT_REPO"
   export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+  node "$BIN" init >/dev/null
 
   export CLAUDE_FILE CODEX_FILE TRANSPORT_REPO
 }
@@ -77,8 +81,9 @@ teardown() {
   [ "$status" -eq 0 ]
   run node "$BIN" remote-list
   [ "$status" -eq 0 ]
-  [[ "$output" == *"handoff/claude/aaaa1111"* ]]
-  [[ "$output" == *"handoff/codex/bbbb2222"* ]]
+  # v2 branches include project + month; fixture cwd resolves to "demo".
+  [[ "$output" =~ handoff/demo/claude/[0-9]{4}-[0-9]{2}/aaaa1111 ]]
+  [[ "$output" =~ handoff/demo/codex/[0-9]{4}-[0-9]{2}/bbbb2222 ]]
 }
 
 @test "remote-list --cli claude filters to claude-only" {
@@ -86,8 +91,8 @@ teardown() {
   run node "$BIN" push my-codex-task
   run node "$BIN" remote-list --cli claude
   [ "$status" -eq 0 ]
-  [[ "$output" == *"handoff/claude/aaaa1111"* ]]
-  [[ "$output" != *"handoff/codex/bbbb2222"* ]]
+  [[ "$output" =~ handoff/demo/claude/[0-9]{4}-[0-9]{2}/aaaa1111 ]]
+  [[ "$output" != *"bbbb2222"* ]]
 }
 
 @test "remote-list --json emits a JSON array of handoff entries" {
@@ -152,4 +157,44 @@ teardown() {
   [[ "$output" == *'"cli":'* ]]
   [[ "$output" == *'"short_id":'* ]]
   [[ "$output" == *'"snippet":'* ]]
+}
+
+# ---- init (v0.10.0: scaffold the remote schema pin) --------------------
+# These tests build a second, FRESH bare repo so they can assert the
+# pre-init / post-init transitions without tripping the shared setup's
+# already-initialised fixture repo.
+
+@test "init: idempotent — re-running against an already-initialised store exits 0" {
+  run node "$BIN" init
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already initialised"* ]]
+}
+
+@test "init: a fresh empty bare repo gets main + .dotclaude-handoff.json" {
+  local fresh
+  fresh=$(mktemp -d); rm -rf "$fresh"; git init -q --bare "$fresh"
+  DOTCLAUDE_HANDOFF_REPO="$fresh" run node "$BIN" init
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok: initialised"* ]]
+  # Schema pin landed on main.
+  run git --git-dir="$fresh" show main:.dotclaude-handoff.json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"schema_version": "2"'* ]]
+  rm -rf "$fresh"
+}
+
+@test "push against an uninitialised store exits 2 with an init pointer" {
+  local fresh
+  fresh=$(mktemp -d); rm -rf "$fresh"; git init -q --bare "$fresh"
+  DOTCLAUDE_HANDOFF_REPO="$fresh" run node "$BIN" push aaaa1111
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not initialised"* ]]
+  [[ "$output" == *"dotclaude handoff init"* ]]
+  rm -rf "$fresh"
+}
+
+@test "doctor surfaces schema status after a successful transport check" {
+  run node "$BIN" doctor
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"schema_version=2"* ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-concurrency.bats
+++ b/plugins/dotclaude/tests/bats/handoff-concurrency.bats
@@ -51,7 +51,14 @@ teardown() {
   "
   [ "$status" -eq 0 ]
 
-  run git --git-dir="$TRANSPORT_REPO" rev-parse handoff/claude/aaaa1111
+  # v2 branch shape: handoff/<project>/<cli>/<YYYY-MM>/<short>.
+  # Fixture cwd `/home/u/demo` → project slug "demo"; month is the
+  # current UTC month. Look up the ref dynamically.
+  run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/demo/claude/*/aaaa1111'"
+  [ "$status" -eq 0 ]
+  local branch="$output"
+  [ -n "$branch" ]
+  run git --git-dir="$TRANSPORT_REPO" rev-parse "$branch"
   [ "$status" -eq 0 ]
   [[ "$output" =~ ^[0-9a-f]{40}$ ]]
   run git --git-dir="$TRANSPORT_REPO" fsck --no-dangling

--- a/plugins/dotclaude/tests/bats/handoff-description.bats
+++ b/plugins/dotclaude/tests/bats/handoff-description.bats
@@ -1,7 +1,9 @@
 #!/usr/bin/env bats
 # Behavior tests for plugins/dotclaude/scripts/handoff-description.sh.
-# Encodes/decodes the transport-neutral description schema:
-#   handoff:v1:<cli>:<short-uuid>:<project-slug>:<hostname>[:<tag>]
+# Encode produces the v2 schema:
+#   handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]
+# Decode accepts v1 (legacy) and v2; the returned JSON includes a
+# "schema" key so callers can render "(legacy)" markers.
 
 load helpers
 
@@ -11,116 +13,174 @@ setup() {
   [ -x "$DESC" ] || chmod +x "$DESC"
 }
 
-@test "encode: minimal args (no tag) produces expected string" {
+# ---- v2 encode ---------------------------------------------------------
+
+@test "encode v2: minimal args (no tag) produces expected string" {
   run "$DESC" encode \
     --cli claude --short-id 3564b8c0 \
-    --project dotclaude --hostname thinkpad-pop
+    --project dotclaude --hostname thinkpad-pop \
+    --month 2026-04
   [ "$status" -eq 0 ]
-  [ "$output" = "handoff:v1:claude:3564b8c0:dotclaude:thinkpad-pop" ]
+  [ "$output" = "handoff:v2:dotclaude:claude:2026-04:3564b8c0:thinkpad-pop" ]
 }
 
-@test "encode: with tag produces 7-segment string" {
+@test "encode v2: with tag produces 8-segment string" {
   run "$DESC" encode \
     --cli codex --short-id 1be89762 \
-    --project example-app --hostname win-desktop --tag evening
+    --project example-app --hostname win-desktop \
+    --month 2026-04 --tag evening
   [ "$status" -eq 0 ]
-  [ "$output" = "handoff:v1:codex:1be89762:example-app:win-desktop:evening" ]
+  [ "$output" = "handoff:v2:example-app:codex:2026-04:1be89762:win-desktop:evening" ]
 }
 
-@test "encode: slugifies mixed-case project with spaces and punctuation" {
+@test "encode v2: slugifies mixed-case project with spaces and punctuation" {
   run "$DESC" encode \
     --cli claude --short-id 3564b8c0 \
-    --project "Dot Claude!" --hostname "Thinkpad PopOS"
+    --project "Dot Claude!" --hostname "Thinkpad PopOS" \
+    --month 2026-04
   [ "$status" -eq 0 ]
-  [ "$output" = "handoff:v1:claude:3564b8c0:dot-claude:thinkpad-popos" ]
+  [ "$output" = "handoff:v2:dot-claude:claude:2026-04:3564b8c0:thinkpad-popos" ]
 }
 
-@test "encode: slugifies tag the same way as project/hostname" {
+@test "encode v2: slugifies tag the same way as project/hostname" {
   run "$DESC" encode \
     --cli claude --short-id 3564b8c0 \
-    --project dotclaude --hostname pop --tag "Evening Run!"
+    --project dotclaude --hostname pop --tag "Evening Run!" \
+    --month 2026-04
   [ "$status" -eq 0 ]
-  [ "$output" = "handoff:v1:claude:3564b8c0:dotclaude:pop:evening-run" ]
+  [ "$output" = "handoff:v2:dotclaude:claude:2026-04:3564b8c0:pop:evening-run" ]
 }
 
-@test "encode: rejects unknown --cli" {
+@test "encode v2: rejects unknown --cli" {
   run "$DESC" encode \
     --cli bogus --short-id 3564b8c0 \
-    --project p --hostname h
+    --project p --hostname h --month 2026-04
   [ "$status" -eq 2 ]
   [[ "$output" == *"--cli must be one of"* ]]
 }
 
-@test "encode: rejects bad short-id length" {
+@test "encode v2: rejects bad short-id length" {
   run "$DESC" encode \
     --cli claude --short-id abc \
-    --project p --hostname h
+    --project p --hostname h --month 2026-04
   [ "$status" -eq 2 ]
   [[ "$output" == *"short-id must be exactly 8 hex chars"* ]]
 }
 
-@test "encode: rejects non-hex short-id" {
+@test "encode v2: rejects non-hex short-id" {
   run "$DESC" encode \
     --cli claude --short-id 3564b8cZ \
-    --project p --hostname h
+    --project p --hostname h --month 2026-04
   [ "$status" -eq 2 ]
   [[ "$output" == *"short-id must be exactly 8 hex chars"* ]]
 }
 
-@test "decode: round-trips a 6-segment string" {
-  run "$DESC" decode "handoff:v1:claude:3564b8c0:dotclaude:thinkpad-pop"
+@test "encode v2: rejects missing --month" {
+  run "$DESC" encode \
+    --cli claude --short-id 3564b8c0 \
+    --project p --hostname h
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"encode requires --month"* ]]
+}
+
+@test "encode v2: rejects malformed --month" {
+  run "$DESC" encode \
+    --cli claude --short-id 3564b8c0 \
+    --project p --hostname h --month not-a-month
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--month must be YYYY-MM"* ]]
+}
+
+# ---- v2 decode ---------------------------------------------------------
+
+@test "decode v2: round-trips a 7-segment string" {
+  run "$DESC" decode "handoff:v2:dotclaude:claude:2026-04:3564b8c0:thinkpad-pop"
   [ "$status" -eq 0 ]
+  [[ "$output" == *'"schema":"v2"'* ]]
   [[ "$output" == *'"cli":"claude"'* ]]
   [[ "$output" == *'"short_id":"3564b8c0"'* ]]
   [[ "$output" == *'"project":"dotclaude"'* ]]
+  [[ "$output" == *'"month":"2026-04"'* ]]
   [[ "$output" == *'"hostname":"thinkpad-pop"'* ]]
   [[ "$output" == *'"tag":null'* ]]
 }
 
-@test "decode: round-trips a 7-segment string with tag" {
-  run "$DESC" decode "handoff:v1:codex:1be89762:squadranks:win-desktop:evening"
+@test "decode v2: round-trips an 8-segment string with tag" {
+  run "$DESC" decode "handoff:v2:squadranks:codex:2026-04:1be89762:win-desktop:evening"
   [ "$status" -eq 0 ]
+  [[ "$output" == *'"schema":"v2"'* ]]
   [[ "$output" == *'"tag":"evening"'* ]]
 }
 
-@test "decode: rejects missing handoff:v1 prefix" {
-  run "$DESC" decode "v2:claude:3564b8c0:p:h"
+@test "decode v2: rejects too few segments" {
+  run "$DESC" decode "handoff:v2:dotclaude:claude:2026-04:3564b8c0"
   [ "$status" -eq 2 ]
-  [[ "$output" == *"missing handoff:v1: prefix"* ]]
+  [[ "$output" == *"malformed v2"* ]]
 }
 
-@test "decode: rejects too few segments" {
-  run "$DESC" decode "handoff:v1:claude:3564b8c0:dotclaude"
-  [ "$status" -eq 2 ]
-  [[ "$output" == *"missing required segment"* ]]
-}
-
-@test "decode: rejects too many segments" {
-  run "$DESC" decode "handoff:v1:claude:3564b8c0:p:h:t:extra"
+@test "decode v2: rejects too many segments" {
+  run "$DESC" decode "handoff:v2:p:claude:2026-04:3564b8c0:h:t:extra"
   [ "$status" -eq 2 ]
   [[ "$output" == *"too many colon segments"* ]]
 }
 
-@test "decode: rejects bad cli name" {
+@test "decode v2: rejects malformed month segment" {
+  run "$DESC" decode "handoff:v2:p:claude:not-a-month:3564b8c0:h"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"month not YYYY-MM"* ]]
+}
+
+# ---- v1 decode (legacy back-compat) -----------------------------------
+
+@test "decode v1: round-trips a 6-segment legacy string with schema=v1 marker" {
+  run "$DESC" decode "handoff:v1:claude:3564b8c0:dotclaude:thinkpad-pop"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"schema":"v1"'* ]]
+  [[ "$output" == *'"cli":"claude"'* ]]
+  [[ "$output" == *'"short_id":"3564b8c0"'* ]]
+  [[ "$output" == *'"project":"dotclaude"'* ]]
+  [[ "$output" == *'"month":null'* ]]
+  [[ "$output" == *'"tag":null'* ]]
+}
+
+@test "decode v1: round-trips a 7-segment legacy string with tag" {
+  run "$DESC" decode "handoff:v1:codex:1be89762:squadranks:win-desktop:evening"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"schema":"v1"'* ]]
+  [[ "$output" == *'"tag":"evening"'* ]]
+}
+
+# ---- error paths -------------------------------------------------------
+
+@test "decode: rejects missing handoff:v[12] prefix" {
+  run "$DESC" decode "v3:claude:3564b8c0:p:h"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"handoff:v[12]: prefix"* ]]
+}
+
+@test "decode v1: rejects bad cli name" {
   run "$DESC" decode "handoff:v1:bogus:3564b8c0:p:h"
   [ "$status" -eq 2 ]
   [[ "$output" == *"cli not one of"* ]]
 }
 
-@test "decode: rejects bad short-id length" {
+@test "decode v1: rejects bad short-id length" {
   run "$DESC" decode "handoff:v1:claude:3564:p:h"
   [ "$status" -eq 2 ]
   [[ "$output" == *"short-id not 8 hex chars"* ]]
 }
 
-@test "roundtrip: encode then decode yields same fields" {
+# ---- v2 roundtrip ------------------------------------------------------
+
+@test "roundtrip v2: encode then decode yields same fields" {
   local encoded
   encoded="$("$DESC" encode --cli claude --short-id 3564b8c0 \
-    --project dotclaude --hostname pop --tag morning)"
-  [ "$encoded" = "handoff:v1:claude:3564b8c0:dotclaude:pop:morning" ]
+    --project dotclaude --hostname pop --month 2026-04 --tag morning)"
+  [ "$encoded" = "handoff:v2:dotclaude:claude:2026-04:3564b8c0:pop:morning" ]
 
   run "$DESC" decode "$encoded"
   [ "$status" -eq 0 ]
+  [[ "$output" == *'"schema":"v2"'* ]]
   [[ "$output" == *'"cli":"claude"'* ]]
   [[ "$output" == *'"tag":"morning"'* ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-integration.bats
+++ b/plugins/dotclaude/tests/bats/handoff-integration.bats
@@ -117,8 +117,12 @@ teardown() {
   [ "$status" -eq 0 ]
   # Transport description appears on stdout as the final line of the push.
   [[ "$output" == *"shipping-the-thing"* ]]
-  # And it persists into the transport repo commit subject.
-  run bash -c "git --git-dir='$TRANSPORT_REPO' log --format=%s handoff/claude/aaaa1111"
+  # And it persists into the transport repo commit subject. Branch is
+  # handoff/<project>/<cli>/<YYYY-MM>/<short>; look it up dynamically.
+  run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/*/claude/*/aaaa1111'"
+  [ "$status" -eq 0 ]
+  local branch="$output"
+  run bash -c "git --git-dir='$TRANSPORT_REPO' log --format=%s $branch"
   [ "$status" -eq 0 ]
   [[ "$output" == *"shipping-the-thing"* ]]
   # Pull-by-tag resolves and returns a valid block (content-equivalence

--- a/plugins/dotclaude/tests/bats/helpers.bash
+++ b/plugins/dotclaude/tests/bats/helpers.bash
@@ -205,7 +205,12 @@ HEREDOC
     local sha
     sha=$(git rev-parse HEAD)
     git remote add origin "$bare"
-    git push -q origin HEAD:refs/heads/main
+    # Force-push because make_transport_repo now stamps the store with
+    # the v0.10.0 schema pin via `dotclaude handoff init`; this bulk
+    # seed path overwrites main with a minimal commit so the stress
+    # test's pull (which reads handoff/... branches, not main) stays
+    # cheap. Pull paths don't consult `.dotclaude-handoff.json`.
+    git push -qf origin HEAD:refs/heads/main
     # Build a stdin script for `update-ref` on the bare repo: one
     # `create refs/heads/handoff/claude/<hex> <sha>` line per branch.
     local i=0
@@ -221,11 +226,17 @@ HEREDOC
 }
 
 # make_transport_repo <dir>
-# Initialise a bare git repo at <dir>. Use as DOTCLAUDE_HANDOFF_REPO for
-# push/pull tests. Caller is responsible for cleanup.
+# Initialise a bare git repo at <dir> AND stamp it with the v0.10.0+
+# schema pin (`.dotclaude-handoff.json` on `main`) so callers can push
+# immediately. Pushes to uninitialised stores refuse by design; having
+# a shared helper avoids per-file boilerplate.
+# Use the returned path as DOTCLAUDE_HANDOFF_REPO. Caller is responsible
+# for cleanup.
 make_transport_repo() {
   local dir="$1"
   git init -q --bare "$dir"
+  DOTCLAUDE_HANDOFF_REPO="$dir" node \
+    "${REPO_ROOT}/plugins/dotclaude/bin/dotclaude-handoff.mjs" init >/dev/null
   echo "$dir"
 }
 

--- a/plugins/dotclaude/tests/handoff-encoder.test.mjs
+++ b/plugins/dotclaude/tests/handoff-encoder.test.mjs
@@ -2,31 +2,36 @@
 // scripts/handoff-description.sh so the test exercises both the JS wrapper
 // and the shell encoder.
 //
-// Schema: handoff:v1:<cli>:<short-uuid>:<project-slug>:<hostname>[:<tag>]
+// Schema (v0.10.0+):
+//   handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]
 
 import { describe, it, expect } from "vitest";
 import { encodeDescription } from "../bin/dotclaude-handoff.mjs";
 
+// Parse a v2 description back into named segments. Matches the segment
+// order defined in handoff-description.sh's encode path.
 function parse(encoded) {
-  const [prefix, version, cli, shortId, project, host, tag] = encoded.split(":");
-  return { prefix, version, cli, shortId, project, host, tag };
+  const [prefix, version, project, cli, month, shortId, host, tag] = encoded.split(":");
+  return { prefix, version, project, cli, month, shortId, host, tag };
 }
 
-describe("encodeDescription", () => {
-  it("produces a 6-segment string when no tag is supplied", () => {
+describe("encodeDescription (v2)", () => {
+  it("produces a 7-segment string when no tag is supplied", () => {
     const s = encodeDescription({
       cli: "claude",
       shortId: "abcd1234",
       project: "my-app",
       host: "laptop",
+      month: "2026-04",
     });
-    expect(s.split(":")).toHaveLength(6);
+    expect(s.split(":")).toHaveLength(7);
     const p = parse(s);
     expect(p.prefix).toBe("handoff");
-    expect(p.version).toBe("v1");
-    expect(p.cli).toBe("claude");
-    expect(p.shortId).toBe("abcd1234");
+    expect(p.version).toBe("v2");
     expect(p.project).toBe("my-app");
+    expect(p.cli).toBe("claude");
+    expect(p.month).toBe("2026-04");
+    expect(p.shortId).toBe("abcd1234");
     expect(p.host).toBe("laptop");
     expect(p.tag).toBeUndefined();
   });
@@ -37,9 +42,10 @@ describe("encodeDescription", () => {
       shortId: "12345678",
       project: "my-app",
       host: "laptop",
+      month: "2026-04",
       tag: "wip-refactor",
     });
-    expect(s.split(":")).toHaveLength(7);
+    expect(s.split(":")).toHaveLength(8);
     expect(parse(s).tag).toBe("wip-refactor");
   });
 
@@ -49,6 +55,7 @@ describe("encodeDescription", () => {
       shortId: "deadbeef",
       project: "My Project!",
       host: "My.Laptop",
+      month: "2026-04",
       tag: "V2 Feature",
     });
     const p = parse(s);
@@ -63,6 +70,7 @@ describe("encodeDescription", () => {
       shortId: "abcd1234",
       project: "",
       host: "laptop",
+      month: "2026-04",
     });
     expect(parse(s).project).toBe("adhoc");
   });
@@ -73,6 +81,7 @@ describe("encodeDescription", () => {
       shortId: "abcd1234",
       project: "my-app",
       host: "",
+      month: "2026-04",
     });
     expect(parse(s).host).toBe("unknown");
   });

--- a/plugins/dotclaude/tests/handoff-portability.test.mjs
+++ b/plugins/dotclaude/tests/handoff-portability.test.mjs
@@ -34,11 +34,12 @@ describe("collectSessionFiles (symlink safety)", () => {
 });
 
 describe("projectSlugFromCwd (trailing-separator edge)", () => {
-  it("does not strip a trailing '-' produced by sanitising punctuation", () => {
-    // Documented side-effect: the sanitizer folds runs of non-[a-z0-9-] to
-    // "-" and then slice-at-40 truncates; no trim. A final segment ending
-    // in punctuation therefore yields a trailing "-".
-    expect(projectSlugFromCwd("/tmp/My Weird Project!!")).toBe("my-weird-project-");
+  it("strips a trailing '-' produced by sanitising punctuation", () => {
+    // v0.10.0 tightened the JS slugify to match the shell slugify in
+    // handoff-description.sh — collapse runs of '-' and trim leading /
+    // trailing '-'. A cwd ending in punctuation therefore yields a
+    // clean "my-weird-project" rather than "my-weird-project-".
+    expect(projectSlugFromCwd("/tmp/My Weird Project!!")).toBe("my-weird-project");
   });
 });
 

--- a/plugins/dotclaude/tests/handoff-schema.test.mjs
+++ b/plugins/dotclaude/tests/handoff-schema.test.mjs
@@ -1,0 +1,211 @@
+// Unit tests for the v2 remote-store schema helpers in
+// plugins/dotclaude/bin/dotclaude-handoff.mjs. Covers:
+// SCHEMA_VERSION, V1_BRANCH_RE, V2_BRANCH_RE, monthBucket, slugify,
+// v2BranchName, readRemoteSchema.
+//
+// readRemoteSchema is integration-ish — it shells out to `git clone`
+// against a local bare repo scratch-built per test. Keeps the happy
+// path and the uninitialised-store path covered without needing a
+// real GitHub account.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  SCHEMA_VERSION,
+  V1_BRANCH_RE,
+  V2_BRANCH_RE,
+  monthBucket,
+  slugify,
+  v2BranchName,
+  readRemoteSchema,
+} from "../bin/dotclaude-handoff.mjs";
+
+describe("SCHEMA_VERSION", () => {
+  it("is the string '2' (v0.10.0 pin)", () => {
+    expect(SCHEMA_VERSION).toBe("2");
+  });
+});
+
+describe("V2_BRANCH_RE", () => {
+  it("matches a well-formed v2 branch", () => {
+    expect(V2_BRANCH_RE.test("handoff/dotclaude/claude/2026-04/aaaa1111")).toBe(true);
+  });
+
+  it("accepts all three supported CLIs", () => {
+    expect(V2_BRANCH_RE.test("handoff/proj/claude/2026-04/aaaa1111")).toBe(true);
+    expect(V2_BRANCH_RE.test("handoff/proj/copilot/2026-04/aaaa1111")).toBe(true);
+    expect(V2_BRANCH_RE.test("handoff/proj/codex/2026-04/aaaa1111")).toBe(true);
+  });
+
+  it("rejects v1-shaped branches", () => {
+    expect(V2_BRANCH_RE.test("handoff/claude/aaaa1111")).toBe(false);
+  });
+
+  it("rejects unknown CLIs", () => {
+    expect(V2_BRANCH_RE.test("handoff/proj/gpt/2026-04/aaaa1111")).toBe(false);
+  });
+
+  it("rejects uppercase segments (enforces normalised slug)", () => {
+    expect(V2_BRANCH_RE.test("handoff/DotClaude/claude/2026-04/aaaa1111")).toBe(false);
+  });
+
+  it("rejects short-UUID that is not exactly 8 hex chars", () => {
+    expect(V2_BRANCH_RE.test("handoff/proj/claude/2026-04/aaaa111")).toBe(false);
+    expect(V2_BRANCH_RE.test("handoff/proj/claude/2026-04/aaaa11111")).toBe(false);
+    expect(V2_BRANCH_RE.test("handoff/proj/claude/2026-04/ZZZZ1111")).toBe(false);
+  });
+
+  it("rejects a month missing the dash or with a 3-digit month", () => {
+    expect(V2_BRANCH_RE.test("handoff/proj/claude/202604/aaaa1111")).toBe(false);
+    expect(V2_BRANCH_RE.test("handoff/proj/claude/2026-004/aaaa1111")).toBe(false);
+  });
+});
+
+describe("V1_BRANCH_RE", () => {
+  it("matches a legacy v1 branch", () => {
+    expect(V1_BRANCH_RE.test("handoff/claude/aaaa1111")).toBe(true);
+  });
+
+  it("rejects a v2 branch (so classification forks cleanly)", () => {
+    expect(V1_BRANCH_RE.test("handoff/dotclaude/claude/2026-04/aaaa1111")).toBe(false);
+  });
+});
+
+describe("monthBucket", () => {
+  it("returns a YYYY-MM bucket for an ISO-8601 string", () => {
+    expect(monthBucket("2026-04-20T12:00:00Z")).toBe("2026-04");
+  });
+
+  it("returns YYYY-MM for end-of-year UTC rollover", () => {
+    expect(monthBucket("2025-12-31T23:59:59Z")).toBe("2025-12");
+  });
+
+  it("falls back to current month when input is null/undefined", () => {
+    const now = new Date();
+    const expected = `${now.getUTCFullYear()}-${(now.getUTCMonth() + 1).toString().padStart(2, "0")}`;
+    expect(monthBucket(null)).toBe(expected);
+    expect(monthBucket(undefined)).toBe(expected);
+  });
+
+  it("falls back to current month for malformed input", () => {
+    const now = new Date();
+    const expected = `${now.getUTCFullYear()}-${(now.getUTCMonth() + 1).toString().padStart(2, "0")}`;
+    expect(monthBucket("not-a-date")).toBe(expected);
+  });
+
+  it("zero-pads single-digit months", () => {
+    expect(monthBucket("2026-01-15T00:00:00Z")).toBe("2026-01");
+    expect(monthBucket("2026-09-15T00:00:00Z")).toBe("2026-09");
+  });
+});
+
+describe("slugify", () => {
+  it("lowercases and replaces non-[a-z0-9-] with dashes", () => {
+    expect(slugify("My Project Name!")).toBe("my-project-name");
+  });
+
+  it("caps at 40 chars", () => {
+    expect(slugify("a".repeat(100)).length).toBe(40);
+  });
+
+  it("returns 'adhoc' for empty / whitespace-only input", () => {
+    expect(slugify("")).toBe("adhoc");
+    expect(slugify("   ")).toBe("adhoc");
+  });
+});
+
+describe("v2BranchName", () => {
+  it("composes the canonical v2 shape", () => {
+    expect(
+      v2BranchName({ project: "dotclaude", cli: "claude", month: "2026-04", shortId: "aaaa1111" })
+    ).toBe("handoff/dotclaude/claude/2026-04/aaaa1111");
+  });
+
+  it("output always matches V2_BRANCH_RE", () => {
+    const b = v2BranchName({ project: "x", cli: "codex", month: "2026-04", shortId: "deadbeef" });
+    expect(V2_BRANCH_RE.test(b)).toBe(true);
+  });
+
+  it("slugifies the project segment so malformed inputs still produce a valid branch", () => {
+    const b = v2BranchName({ project: "My Proj!", cli: "claude", month: "2026-04", shortId: "aaaa1111" });
+    expect(V2_BRANCH_RE.test(b)).toBe(true);
+    expect(b).toBe("handoff/my-proj/claude/2026-04/aaaa1111");
+  });
+});
+
+describe("readRemoteSchema (integration)", () => {
+  // Each test spins up a fresh bare repo in a tmp dir and points
+  // DOTCLAUDE_HANDOFF_REPO at it. We build main by cloning, writing,
+  // committing, and pushing — same pattern the binary's `init` uses.
+  let REPO;
+  let SAVED_ENV;
+
+  function runGit(args, cwd) {
+    return spawnSync("git", args, { encoding: "utf8", cwd });
+  }
+
+  function seedMain(pinJson, { includeReadme = false } = {}) {
+    const work = mkdtempSync(join(tmpdir(), "schema-test-"));
+    runGit(["clone", "-q", "--branch", "main", REPO, "."], work);
+    // `clone --branch main` against an empty bare repo returns exit != 0
+    // before ever creating `.git`, so initialise from scratch instead.
+    if (!existsSync(join(work, ".git"))) {
+      runGit(["init", "-q", "-b", "main"], work);
+      runGit(["remote", "add", "origin", REPO], work);
+    }
+    runGit(["config", "user.email", "test@test.local"], work);
+    runGit(["config", "user.name", "schema-test"], work);
+    if (pinJson !== null) {
+      writeFileSync(join(work, ".dotclaude-handoff.json"), pinJson);
+    }
+    if (includeReadme) {
+      writeFileSync(join(work, "README.md"), "# test store\n");
+    }
+    runGit(["add", "."], work);
+    runGit(["commit", "-q", "-m", "seed"], work);
+    runGit(["push", "-q", "origin", "main"], work);
+    rmSync(work, { recursive: true, force: true });
+  }
+
+  beforeEach(() => {
+    REPO = mkdtempSync(join(tmpdir(), "schema-repo-"));
+    rmSync(REPO, { recursive: true, force: true });
+    execFileSync("git", ["init", "-q", "--bare", REPO]);
+    SAVED_ENV = process.env.DOTCLAUDE_HANDOFF_REPO;
+    process.env.DOTCLAUDE_HANDOFF_REPO = REPO;
+  });
+
+  afterEach(() => {
+    if (SAVED_ENV === undefined) delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    else process.env.DOTCLAUDE_HANDOFF_REPO = SAVED_ENV;
+    rmSync(REPO, { recursive: true, force: true });
+  });
+
+  it("returns null when the remote is completely empty", () => {
+    expect(readRemoteSchema()).toBeNull();
+  });
+
+  it("returns null when main exists but lacks the pin", () => {
+    seedMain(null, { includeReadme: true });
+    expect(readRemoteSchema()).toBeNull();
+  });
+
+  it("returns the parsed pin when present and well-formed", () => {
+    const pin = {
+      schema_version: "2",
+      created_at: "2026-04-20T00:00:00Z",
+      layout: "branch-per-handoff",
+    };
+    seedMain(JSON.stringify(pin, null, 2) + "\n");
+    expect(readRemoteSchema()).toEqual(pin);
+  });
+
+  it("throws when the pin file is not valid JSON", () => {
+    seedMain("{not json");
+    expect(() => readRemoteSchema()).toThrow(/not valid JSON/);
+  });
+});

--- a/plugins/dotclaude/tests/handoff-unit.test.mjs
+++ b/plugins/dotclaude/tests/handoff-unit.test.mjs
@@ -76,11 +76,11 @@ describe("projectSlugFromCwd", () => {
     expect(projectSlugFromCwd(long).length).toBeLessThanOrEqual(40);
   });
 
-  it("only collapses to 'adhoc' when normalisation leaves an empty string", () => {
-    // Documented edge: "..." normalises to "-", which is non-empty so the
-    // `|| "adhoc"` fallback does NOT fire. Locked in so a regex tweak that
-    // silently changes this behaviour is surfaced by the suite.
-    expect(projectSlugFromCwd("/root/...")).toBe("-");
+  it("collapses to 'adhoc' when normalisation leaves only dashes", () => {
+    // v0.10.0 aligned the JS slugify with the shell slugify — collapse
+    // runs of '-' and trim leading / trailing '-'. "..." now reduces
+    // to "" after trimming, and the `|| "adhoc"` fallback fires.
+    expect(projectSlugFromCwd("/root/...")).toBe("adhoc");
   });
 });
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -65,6 +65,7 @@ semantics. Brief summary:
 
 | Sub                   | Purpose                                                             |
 | --------------------- | ------------------------------------------------------------------- |
+| `init`                | Scaffold the remote schema pin on `main` (idempotent, one-time)     |
 | `resolve <cli> <id>`  | Print the absolute JSONL path                                       |
 | `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                 |
 | `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                |
@@ -74,7 +75,7 @@ semantics. Brief summary:
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript` |
 | `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline     |
 | `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`     |
-| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` reachable                  |
+| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + schema pin               |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 
@@ -104,9 +105,24 @@ self-hosted). Required:
 - `$DOTCLAUDE_HANDOFF_REPO` set to the repo URL (no default; example:
   `git@github.com:<user>/handoff-store.git`).
 - Working SSH or credential-helper auth for that repo.
+- The repo initialised once via `dotclaude handoff init` — writes the
+  schema pin on `main` so the binary can refuse mismatched stores.
 
 Run `dotclaude handoff doctor` to verify. Full install matrix and
 remediation lives in `references/prerequisites.md`.
+
+## Repo layout (v0.10.0+)
+
+Each handoff is a branch:
+
+```
+handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
+```
+
+e.g. `handoff/dotclaude/claude/2026-04/aaaa1111`. `main` holds
+`.dotclaude-handoff.json` (the schema pin) and a README — `push`/
+`pull`/`remote-list`/`prune` only touch `handoff/...` branches. Full
+schema + rationale in [`docs/handoff-store-schema.md`](../../docs/handoff-store-schema.md).
 
 ## Auto-trigger contract
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -122,7 +122,7 @@ handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
 e.g. `handoff/dotclaude/claude/2026-04/aaaa1111`. `main` holds
 `.dotclaude-handoff.json` (the schema pin) and a README — `push`/
 `pull`/`remote-list`/`prune` only touch `handoff/...` branches. Full
-schema + rationale in [`docs/handoff-store-schema.md`](../../docs/handoff-store-schema.md).
+schema + rationale in [`docs/handoff-store-schema.md`](https://github.com/kaiohenricunha/dotclaude/blob/main/docs/handoff-store-schema.md).
 
 ## Auto-trigger contract
 


### PR DESCRIPTION
## Summary

- New branch taxonomy on the remote handoff store: `handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>`. v0.9.0 used a flat `handoff/<cli>/<short>` that mixed projects and had no age bucket — this change adds project scoping and month buckets so `remote-list --project X` and (PR B) `prune --older-than Nd` become cheap pattern matches.
- New `.dotclaude-handoff.json` on `main` pins `schema_version: "2"`. `push` fails with exit 2 against an unstamped / mismatched store, pointing at the new `init` sub-command.
- New `dotclaude handoff init` — idempotent; scaffolds `README.md` + `.dotclaude-handoff.json` on `main`. Works against empty repos and existing ones.
- Description schema bumped to v2: `handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]`. v1 still decodes (read-only) so v0.9.0-era stores render in `remote-list` during migration.
- `projectSlugFromCwd` now walks up to the git-repo root (not just the cwd basename). `slugify` collapses dash runs + trims leading/trailing dashes to match the shell-side `handoff-description.sh` contract.

## Why

Plan rationale and segment-by-segment reasoning live in the new `docs/handoff-store-schema.md`. Short version: v0.9.0 was "dump with deterministic names" and started to friction past ~300 branches. v0.10.0 formalises what `push` writes, enforces it at the binary, and makes the layout browsable + prunable without changing the transport model (still branch-per-handoff).

## Test plan

- [x] `npm test` — 24/24 vitest files, 290/290 tests pass (adds new `handoff-schema.test.mjs` with 25 unit tests)
- [x] `npx bats plugins/dotclaude/tests/bats/*.bats` — 240/240 pass (new init/schema coverage in `handoff-binary-subs.bats`; `handoff-description.bats` rewritten for v2 encode + both-schema decode)
- [x] CI prettier + markdownlint + shellcheck — clean (verified locally with the same flag set CI uses)
- [x] `node plugins/dotclaude/bin/dotclaude-index.mjs --check` — index fresh
- [x] `npm run dogfood` — manifest valid (`auto-update-manifest` re-run), specs valid, instruction drift clean, spec coverage ok (0 protected files changed)
- [x] End-to-end smoke: fresh bare repo → `dotclaude handoff init` → `push` → branch lands at `handoff/<project>/<cli>/<month>/<short>` → idempotent re-init exits 0 → `push` against uninitialised store exits 2 with init pointer.
- [ ] After merge: follow-up PRs B (prune + remote-list project/month columns) and C (v1 → v2 migrate) — tracked in the plan.

## Migration

Existing users upgrading from v0.9.0:

```bash
npm install -g @dotclaude/dotclaude@0.10.0   # after release
dotclaude handoff init                        # stamp your store once
dotclaude handoff doctor                      # should report schema_version=2
dotclaude handoff push                        # now writes the v2 shape
```

Legacy `handoff/<cli>/<short>` branches remain readable via `pull`
and show up in `remote-list` (PR B adds a `(legacy)` marker). PR C
will ship `dotclaude handoff migrate` to rename them to v2 in place.

## Spec ID

dotclaude-core
