### PR TITLE
docs: reposition dotclaude as a Claude Code toolkit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@
 >   That wires `commands/`, `skills/`, and this file into `~/.claude/` in one step.
 >   No npm required.
 > - **Want more:** Install `@dotclaude/dotclaude` for the full CLI — `dotclaude bootstrap`,
->   `sync`, `doctor`, `init`, drift detection, and the spec-governance validators.
+>   `dotclaude sync`, `dotclaude doctor`, `dotclaude init`, `dotclaude detect-drift`,
+>   and the spec-governance validators.
 >   See [README.md](./README.md) or [docs/quickstart.md](./docs/quickstart.md).
 >
 > **This file is for the bootstrap path.** It gets symlinked into `~/.claude/CLAUDE.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,9 @@
 > - **TL;DR — just want skills & commands:** Clone this repo and run `./bootstrap.sh`.
 >   That wires `commands/`, `skills/`, and this file into `~/.claude/` in one step.
 >   No npm required.
-> - **Want more flexibility:** Install `@dotclaude/dotclaude` for the full governance
->   CLI — `dotclaude bootstrap`, `dotclaude sync`, `dotclaude doctor`,
->   `dotclaude validate-specs`, and more. See [README.md](./README.md) or
->   [docs/quickstart.md](./docs/quickstart.md).
+> - **Want more:** Install `@dotclaude/dotclaude` for the full CLI — `dotclaude bootstrap`,
+>   `sync`, `doctor`, `init`, drift detection, and the spec-governance validators.
+>   See [README.md](./README.md) or [docs/quickstart.md](./docs/quickstart.md).
 >
 > **This file is for the bootstrap path.** It gets symlinked into `~/.claude/CLAUDE.md`
 > by `bootstrap.sh` and sets the global rule floor for every Claude Code session.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ governance CLI on top, for repos that want PR-time gates.
 
 **Who is this for?**
 
-| I am…            | I want…                                                                | Start here                                       |
-| ---------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
-| **Dotfile user** | The toolkit — skills, commands, and CLAUDE.md in every Claude session  | [Clone & bootstrap](#clone--bootstrap)           |
-| **Consumer**     | The CLI in my repo — bootstrap, doctor, drift, optional spec-gov gates | [Install the CLI](#install-the-cli)              |
-| **Library user** | Node API in my own tooling                                             | [docs/api-reference.md](./docs/api-reference.md) |
-| **Contributor**  | Dev workflow, local gates                                              | [CONTRIBUTING.md](./CONTRIBUTING.md)             |
+| I am…            | I want…                                                                          | Start here                                       |
+| ---------------- | -------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **Dotfile user** | The toolkit — skills, commands, and CLAUDE.md in every Claude session            | [Clone & bootstrap](#clone--bootstrap)           |
+| **Consumer**     | The CLI in my repo — bootstrap, doctor, drift detection, optional spec-gov gates | [Install the CLI](#install-the-cli)              |
+| **Library user** | Node API in my own tooling                                                       | [docs/api-reference.md](./docs/api-reference.md) |
+| **Contributor**  | Dev workflow, local gates                                                        | [CONTRIBUTING.md](./CONTRIBUTING.md)             |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,26 +6,28 @@
 
 > Maintained by [@kaiohenricunha](https://github.com/kaiohenricunha) · [Changelog](./CHANGELOG.md) · [Security](./SECURITY.md)
 
-Portable Claude Code plugin + zero-dependency npm package that bootstraps
-spec-driven-development governance into consumer repos.
+An opinionated Claude Code toolkit. Ships a curated library of skills,
+slash commands, and cloud/IaC specialists plus a global rule floor that
+hardens every Claude Code session — and an optional spec-driven-development
+governance CLI on top, for repos that want PR-time gates.
 
 **Who is this for?**
 
-| I am…            | I want…                                        | Start here                                       |
-| ---------------- | ---------------------------------------------- | ------------------------------------------------ |
-| **Dotfile user** | Skills & commands in every Claude Code session | [Clone & bootstrap](#clone--bootstrap)           |
-| **Consumer**     | Spec-governance CLI for my own repos           | [Install the CLI](#install-the-cli)              |
-| **Library user** | Node API in my own tooling                     | [docs/api-reference.md](./docs/api-reference.md) |
-| **Contributor**  | Dev workflow, local gates                      | [CONTRIBUTING.md](./CONTRIBUTING.md)             |
+| I am…            | I want…                                                                | Start here                                       |
+| ---------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| **Dotfile user** | The toolkit — skills, commands, and CLAUDE.md in every Claude session  | [Clone & bootstrap](#clone--bootstrap)           |
+| **Consumer**     | The CLI in my repo — bootstrap, doctor, drift, optional spec-gov gates | [Install the CLI](#install-the-cli)              |
+| **Library user** | Node API in my own tooling                                             | [docs/api-reference.md](./docs/api-reference.md) |
+| **Contributor**  | Dev workflow, local gates                                              | [CONTRIBUTING.md](./CONTRIBUTING.md)             |
 
 ---
 
 ## TL;DR — pick your path
 
-| What you want                                     | How                                                                                |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Skills & commands library wired into `~/.claude/` | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required           |
-| Spec-governance CLI for your own repos            | **[Install the CLI](#install-the-cli)** — see install section (Node ≥ 20 required) |
+| What you want                                                                | How                                                                                |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Skills & commands library wired into `~/.claude/`                            | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required           |
+| Governance CLI for your own repos (bootstrap + doctor + optional spec gates) | **[Install the CLI](#install-the-cli)** — see install section (Node ≥ 20 required) |
 
 Both paths are independent. You can use one or both.
 
@@ -114,7 +116,7 @@ or `dotclaude sync --help` for full options.
 | [`create-assessment`](commands/create-assessment.md) | `/create-assessment <target>`  | 0–10 graded assessment doc → `docs/assessments/`          |
 | [`markdown`](commands/markdown.md)                   | `/markdown <path>`             | Fix markdown formatting and structure                     |
 
-**Spec & governance:**
+**Spec & governance** — one optional pillar of the toolkit. Skip this section if you're not adopting spec-driven workflows.
 
 | Command / Skill                                    | Invoke                                                                                                                                | What it does                                    |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
@@ -161,8 +163,8 @@ Every command is context-aware — it reads your repo's files, history, and CI s
 
 ## Install the CLI
 
-Need spec-governance gates, CI integration, drift detection, or programmatic
-validation in your own projects? Install the CLI:
+Want the governance CLI in your own repos — bootstrap, doctor, drift detection,
+programmatic validation, and optional spec-governance gates? Install it:
 
 ```bash
 # One-liner (requires Node ≥ 20)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 _Last updated: v0.11.0_
 
 dotclaude is an opinionated Claude Code toolkit shipped as a portable
-plugin + zero-dependency npm package. It curates a library of skills,
+npm package + Claude Code plugin. It curates a library of skills,
 slash commands, and cloud/IaC specialists, hardens every Claude Code
 session via a global rule floor, and adds an optional spec-driven-development
 governance CLI on top — Node API, umbrella CLI, gold-standard shell
@@ -39,8 +39,8 @@ settings validator, and a destructive-git PreToolUse hook.
   `--no-color` on every bin.
 - **Named exit codes.** `{OK:0, VALIDATION:1, ENV:2, USAGE:64}` — `64`
   mirrors BSD `sysexits.h`.
-- **Zero runtime dependencies.** Plain Node 20+, no bundler, no type system
-  runtime cost.
+- **Minimal runtime footprint.** Plain Node 20+, no bundler, no TypeScript
+  runtime — three small JSON/YAML utility dependencies (ajv, ajv-formats, js-yaml).
 
 ## Governance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,12 @@
 
 _Last updated: v0.11.0_
 
-dotclaude is a portable npm package + Claude Code plugin that bootstraps
-spec-driven-development governance into consumer repos. It ships a
-zero-dependency Node API, an umbrella CLI, a gold-standard shell settings
-validator, and a destructive-git PreToolUse hook.
+dotclaude is an opinionated Claude Code toolkit shipped as a portable
+plugin + zero-dependency npm package. It curates a library of skills,
+slash commands, and cloud/IaC specialists, hardens every Claude Code
+session via a global rule floor, and adds an optional spec-driven-development
+governance CLI on top — Node API, umbrella CLI, gold-standard shell
+settings validator, and a destructive-git PreToolUse hook.
 
 ## Start here
 

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -5,13 +5,13 @@ _Last updated: v0.11.0_
 This repo is a dual-purpose checkout. Three distinct audiences consume
 parts of it. Pick yours, then follow the "Start here" column.
 
-| Persona                                                           | What you want                                              | Start here                                                                                                          |
-| ----------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Consumer** — installing the plugin to govern your own repo      | Install, scaffold, run validators, wire CI                 | [quickstart.md](./quickstart.md) → [cli-reference.md](./cli-reference.md)                                           |
-| **Library user** — importing the Node API into your own tooling   | Import, typed signatures, error codes                      | [api-reference.md](./api-reference.md)                                                                              |
-| **Dotfile user** — personal Claude Code config via `bootstrap.sh` | Symlink into `~/.claude/`, manage your own commands/skills | [dotfile-quickstart.md](./dotfile-quickstart.md) — start here, then [../CLAUDE.md](../CLAUDE.md) for the full rules |
-| **Contributor** — sending PRs to this repo                        | Dev workflow, local gates, spec discipline                 | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                                                            |
-| **Security researcher**                                           | Private disclosure, threat model                           | [../SECURITY.md](../SECURITY.md)                                                                                    |
+| Persona                                                                                     | What you want                                              | Start here                                                                                                          |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Dotfile user** — personal Claude Code config via `bootstrap.sh`                           | Symlink into `~/.claude/`, manage your own commands/skills | [dotfile-quickstart.md](./dotfile-quickstart.md) — start here, then [../CLAUDE.md](../CLAUDE.md) for the full rules |
+| **Consumer** — installing the CLI for bootstrap, doctor, drift, and optional spec-gov gates | Install, scaffold, run validators, wire CI                 | [quickstart.md](./quickstart.md) → [cli-reference.md](./cli-reference.md)                                           |
+| **Library user** — importing the Node API into your own tooling                             | Import, typed signatures, error codes                      | [api-reference.md](./api-reference.md)                                                                              |
+| **Contributor** — sending PRs to this repo                                                  | Dev workflow, local gates, spec discipline                 | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                                                            |
+| **Security researcher**                                                                     | Private disclosure, threat model                           | [../SECURITY.md](../SECURITY.md)                                                                                    |
 
 ## Where the split happens
 

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -5,13 +5,13 @@ _Last updated: v0.11.0_
 This repo is a dual-purpose checkout. Three distinct audiences consume
 parts of it. Pick yours, then follow the "Start here" column.
 
-| Persona                                                                                     | What you want                                              | Start here                                                                                                          |
-| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Dotfile user** — personal Claude Code config via `bootstrap.sh`                           | Symlink into `~/.claude/`, manage your own commands/skills | [dotfile-quickstart.md](./dotfile-quickstart.md) — start here, then [../CLAUDE.md](../CLAUDE.md) for the full rules |
-| **Consumer** — installing the CLI for bootstrap, doctor, drift, and optional spec-gov gates | Install, scaffold, run validators, wire CI                 | [quickstart.md](./quickstart.md) → [cli-reference.md](./cli-reference.md)                                           |
-| **Library user** — importing the Node API into your own tooling                             | Import, typed signatures, error codes                      | [api-reference.md](./api-reference.md)                                                                              |
-| **Contributor** — sending PRs to this repo                                                  | Dev workflow, local gates, spec discipline                 | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                                                            |
-| **Security researcher**                                                                     | Private disclosure, threat model                           | [../SECURITY.md](../SECURITY.md)                                                                                    |
+| Persona                                                                                               | What you want                                              | Start here                                                                                                          |
+| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Dotfile user** — personal Claude Code config via `bootstrap.sh`                                     | Symlink into `~/.claude/`, manage your own commands/skills | [dotfile-quickstart.md](./dotfile-quickstart.md) — start here, then [../CLAUDE.md](../CLAUDE.md) for the full rules |
+| **Consumer** — installing the CLI for bootstrap, doctor, drift detection, and optional spec-gov gates | Install, scaffold, run validators, wire CI                 | [quickstart.md](./quickstart.md) → [cli-reference.md](./cli-reference.md)                                           |
+| **Library user** — importing the Node API into your own tooling                                       | Import, typed signatures, error codes                      | [api-reference.md](./api-reference.md)                                                                              |
+| **Contributor** — sending PRs to this repo                                                            | Dev workflow, local gates, spec discipline                 | [../CONTRIBUTING.md](../CONTRIBUTING.md)                                                                            |
+| **Security researcher**                                                                               | Private disclosure, threat model                           | [../SECURITY.md](../SECURITY.md)                                                                                    |
 
 ## Where the split happens
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,10 +4,10 @@ _Last updated: v0.11.0_
 
 **Two paths — pick yours:**
 
-| I want…                                          | Path                                                                           |
-| ------------------------------------------------ | ------------------------------------------------------------------------------ |
-| Skills & commands in every Claude Code session   | **[Dotfile bootstrap](./dotfile-quickstart.md)** — 30 seconds, no npm required |
-| Spec-governance CLI and CI gates for my own repo | **This page** — 10 minutes, Node ≥ 20 required                                 |
+| I want…                                                                 | Path                                                                           |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Skills & commands in every Claude Code session                          | **[Dotfile bootstrap](./dotfile-quickstart.md)** — 30 seconds, no npm required |
+| Governance CLI for my own repo (bootstrap, doctor, optional spec gates) | **This page** — 10 minutes, Node ≥ 20 required                                 |
 
 ---
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -33,4 +33,4 @@ docs/specs/
 1. Draft → `status: draft`; no CI enforcement yet.
 2. Approve → `status: approved`; files in `linked_paths` now require this spec (or a `No-spec rationale`) in any PR that touches them.
 3. Implement → `status: implementing`; work in progress, same gating.
-4. Done → `status: done`; spec remains as governance over linked_paths (Böckeler's "spec-anchored" mode).
+4. Done → `status: done`; spec remains as governance over linked_paths (Böckeler's "spec-anchored" mode — an opt-in steady state for repos that want long-lived PR-time gates, not the default for casual feature work).

--- a/docs/specs/dotclaude-core/spec.md
+++ b/docs/specs/dotclaude-core/spec.md
@@ -4,12 +4,18 @@ Status: **done** (v0.2.0 productization landing across PRs 1–7)
 
 ## Context
 
-`@dotclaude/dotclaude` is a portable npm package + Claude Code plugin that
-bootstraps spec-driven-development governance into consumer repos. It ships a
-CLI surface (`dotclaude`, `dotclaude-doctor`, `dotclaude-validate-skills`, …), a
-programmatic Node API (`import { validateSpecs, createHarnessContext, … }`),
-a gold-standard shell settings validator, and a destructive-git PreToolUse
-guard hook.
+`@dotclaude/dotclaude` is an opinionated Claude Code toolkit, shipped as a
+portable npm package + Claude Code plugin. It bundles a curated library of
+skills, slash commands, and cloud/IaC specialists; a global `CLAUDE.md` rule
+floor; an umbrella CLI surface (`dotclaude`, `dotclaude-doctor`,
+`dotclaude-validate-skills`, …); a programmatic Node API
+(`import { validateSpecs, createHarnessContext, … }`); a gold-standard shell
+settings validator; and a destructive-git PreToolUse guard hook.
+
+Spec-driven-development governance is one consumer-facing module of that
+toolkit — repos that want PR-time spec gates can opt in via
+`dotclaude-validate-specs` and `dotclaude-check-spec-coverage`; the rest of
+the toolkit works without it.
 
 This repository — `dotclaude` — is the canonical checkout. It
 dogfoods its own validators on every push (dogfood.yml in PR 7) and ships the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dotclaude/dotclaude",
   "version": "0.11.0",
-  "description": "dotclaude — portable SDD validators and Claude Code governance for any project.",
+  "description": "An opinionated Claude Code toolkit: skills, slash commands, cloud/IaC specialists, and an optional spec-governance CLI.",
   "type": "module",
   "main": "plugins/dotclaude/src/index.mjs",
   "exports": {
@@ -75,6 +75,10 @@
   },
   "keywords": [
     "claude-code",
+    "claude-code-toolkit",
+    "skills",
+    "slash-commands",
+    "cloud-specialists",
     "claude",
     "dotclaude",
     "sdd",

--- a/plugins/dotclaude/bin/dotclaude.mjs
+++ b/plugins/dotclaude/bin/dotclaude.mjs
@@ -41,7 +41,7 @@ const SUBCOMMANDS = [
 function printUsage() {
   process.stdout.write(
     [
-      "dotclaude — structured-error-emitting CLI for @dotclaude/dotclaude",
+      "dotclaude — Claude Code toolkit CLI (bootstrap, doctor, validators, governance)",
       "",
       "Usage:",
       "  dotclaude <subcommand> [options]",


### PR DESCRIPTION
## Summary

- Repositions dotclaude's top-of-funnel messaging from "spec-driven-development governance for consumer repos" to "an opinionated Claude Code toolkit (skills, slash commands, cloud/IaC specialists, global rule floor) — with optional spec-governance CLI on top." The toolkit was always the larger surface; the framing now matches what the project actually ships.
- Two commits, no behavior change. Tier 1 hits the high-impact surfaces (`package.json` description + keywords, `README.md` lede + persona/TL;DR tables + intros, `CLAUDE.md` setup blockquote). Tier 2 propagates the same framing through the docs tree (`docs/index.md`, `docs/quickstart.md`, `docs/personas.md`, `docs/specs/README.md`, `docs/specs/dotclaude-core/spec.md`) and rewrites the umbrella dispatcher's help banner (`plugins/dotclaude/bin/dotclaude.mjs`).
- Out of scope and intentionally untouched: ADRs (purely technical or about monorepo layout, not SDD framing); `docs/api-reference.md`, `docs/cli-reference.md`, `docs/architecture.md`, `docs/troubleshooting.md`, `docs/upgrade-guide.md` (already toolkit-neutral); `install.sh`, `bootstrap.sh`, `sync.sh` (operational); all other CLI bins and `plugins/dotclaude/src/**` (function-scoped, no project framing). The npm slug, GitHub repo URL, and `dotclaude-*` bin names are immovable; rebrand is messaging-only at those layers.

## Test plan

- [x] `npm run lint` (CI-style with both `.gitignore` and `.prettierignore`) — prettier clean, markdownlint 0 errors, jsdoc coverage ok (15 files)
- [x] `npm run dogfood` — manifest valid (29 skills), agents valid, 3 specs valid, instruction files match repo facts, spec coverage ok (2 protected files changed; `Spec ID: dotclaude-core` carried below)
- [x] `npm test` — 277/277 vitest passing across 24 files; no snapshot pinned the dispatcher banner
- [x] `node plugins/dotclaude/bin/dotclaude.mjs --help` — new banner renders, subcommand list intact
- [x] CI green on this PR

## Spec ID

dotclaude-core