### PR TITLE
fix(handoff): scrub every push and fail closed if scrubber cannot run

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,209 +1,209 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-20T19:18:27.828Z",
+  "generatedAt": "2026-04-21T23:53:00.211Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
       "checksum": "sha256:f7a8fa0598d7925de95ed3829ea677a2df58fa3db93e9ff290944bb686fad7d7",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
       "checksum": "sha256:cf3ac020cd3ce7d8fc11dbf4f5f5a2ffa5e1d6443e60cd10179b564bd77894cc",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
       "checksum": "sha256:cabbf4bfe2deff3a328f15e025dfc0d63369825c0c32574790251f2793e62aeb",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
       "checksum": "sha256:cf987369294337fff90fc62e1d73d235d35055055dc8e4fbfb33a492f7cd38b5",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
       "checksum": "sha256:50573c4199f27083286fdbc3760b2f684105b4a6df39b7cb47094d7c0e5327f7",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
       "checksum": "sha256:3f7b90b69172e29cdcf66713f2708f9741003d05cc12cf9d81ff79ff9c5b692c",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
       "checksum": "sha256:7d888f6964725d82687fb61b68ff961f041f95d2c9eef7b5282061229499ca90",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
       "checksum": "sha256:6ffc091e9bd421798c5b7990f21d095563d69c59c3e2bd10d35b554b3ec225d9",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
       "checksum": "sha256:d0bc84f956c0ee8c176cf76a79374e8defb0bd2487c8340a2e2a1d9e04d8a1cc",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
       "checksum": "sha256:52e610b195a43fdd460106c1bdf56b32803cb86d163a4303274773ea3900bf79",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2dc1c4213ab6650d685e7b2243ddda91fce2ceba224ca3da3951afeb37d12946",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:031aa7cfdebdc8c16be8c45ae20f0977a10a46a4bae1b4e95f32cc403a3fd7d7",
+      "checksum": "sha256:91adefd38f22c858e7d53d41638b6d7eebba5885d40628857db5f3052e2c3e0e",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "review-prs",
       "path": ".claude/commands/review-prs.md",
       "checksum": "sha256:e01a0432cd1a6cf6fe4a60cfc2b02f7cab3cde418062ca85beadc5491548bc71",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:347be395b0f8003816b4f3ed3bb777a63a3f9f7ae300d6f050b499ff66cfd3b0",
       "dependencies": [],
-      "lastValidated": "2026-04-20"
+      "lastValidated": "2026-04-21"
     }
   ]
 }

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -30,6 +30,7 @@
 
 import { parse, helpText } from "../src/lib/argv.mjs";
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { scrubDigest } from "../src/lib/handoff-scrub.mjs";
 import { version } from "../src/index.mjs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -676,6 +677,12 @@ async function pushRemote({ cli, path: sessionFile, tag }) {
   const toCli = meta.cli;
   const handoffBlock = renderHandoffBlock(meta, prompts, turns, toCli);
 
+  // Scrub before the digest ever leaves the machine. Thrown errors
+  // propagate out of pushRemote — the outer try/catch in main() maps
+  // them to `push failed: <message>` with exit 2, so an unscrubbed
+  // digest can never reach the remote.
+  const { scrubbed, count: scrubbedCount } = scrubDigest(handoffBlock);
+
   const shortId = meta.short_id ?? "unknown";
   const host = slugify(hostname());
   const project = projectSlugFromCwd(meta.cwd);
@@ -698,7 +705,7 @@ async function pushRemote({ cli, path: sessionFile, tag }) {
     month,
     hostname: host,
     created_at: new Date().toISOString(),
-    scrubbed_count: 0,
+    scrubbed_count: scrubbedCount,
     tag: tag || null,
   };
 
@@ -711,13 +718,13 @@ async function pushRemote({ cli, path: sessionFile, tag }) {
       runGitOrThrow(["config", "user.name", "dotclaude-handoff"], tmp);
       const branch = v2BranchName({ project, cli: meta.cli, month, shortId });
       runGitOrThrow(["checkout", "-q", "-b", branch], tmp);
-      writeFileSync(join(tmp, "handoff.md"), handoffBlock + "\n");
+      writeFileSync(join(tmp, "handoff.md"), scrubbed + "\n");
       writeFileSync(join(tmp, "metadata.json"), JSON.stringify(metadata, null, 2) + "\n");
       writeFileSync(join(tmp, "description.txt"), description + "\n");
       runGitOrThrow(["add", "."], tmp);
       runGitOrThrow(["commit", "-q", "-m", description], tmp);
       runGitOrThrow(["push", "-q", "-f", "origin", branch], tmp);
-      return { branch, url, description };
+      return { branch, url, description, scrubbedCount };
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -1249,7 +1256,9 @@ async function main() {
     const tag = argv.flags.tag ? String(argv.flags.tag) : null;
     try {
       const result = await pushRemote({ cli: sessionHit.cli, path: sessionHit.path, tag });
-      process.stdout.write(`${result.branch}\n${result.url}\n${result.description}\n`);
+      process.stdout.write(
+        `${result.branch}\n${result.url}\n${result.description}\n[scrubbed ${result.scrubbedCount} secrets]\n`,
+      );
       process.exit(EXIT_CODES.OK);
     } catch (err) {
       fail(2, `push failed: ${err.message}`);

--- a/plugins/dotclaude/src/lib/handoff-scrub.mjs
+++ b/plugins/dotclaude/src/lib/handoff-scrub.mjs
@@ -1,19 +1,4 @@
-/**
- * Node-side wrapper around `plugins/dotclaude/scripts/handoff-scrub.sh`.
- *
- * The shell script is a stdin→stdout filter that prints `scrubbed:N` to
- * stderr and exits 0 on success. This wrapper feeds a digest string to it,
- * captures the redacted output, parses the count, and fails closed on any
- * deviation from that contract. Callers on a push path must propagate the
- * throw so the remote upload does not proceed with unscrubbed content.
- *
- * The three-state signal the remote binary emits (`[scrubbed N secrets]`,
- * `[scrubbed 0 secrets]`, `[scrub not applied]`) lives in the caller —
- * this module only distinguishes "scrubbed with count N" from "throw".
- */
-
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
 import { dirname, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -27,6 +12,12 @@ export const DEFAULT_SCRUB_SCRIPT = resolvePath(
   "scripts",
   "handoff-scrub.sh",
 );
+
+/**
+ * Message prefix on every throw from this module. Callers (and tests) match
+ * on it to recognise fail-closed failures before surfacing them to the user.
+ */
+export const SCRUB_ERROR_PREFIX = "scrub not applied";
 
 const COUNT_LINE_RE = /^scrubbed:(\d+)$/m;
 
@@ -48,12 +39,6 @@ const COUNT_LINE_RE = /^scrubbed:(\d+)$/m;
 export function scrubDigest(text, opts = {}) {
   const scriptPath = opts.scriptPath ?? DEFAULT_SCRUB_SCRIPT;
 
-  if (!existsSync(scriptPath)) {
-    throw new Error(
-      `scrub not applied: handoff-scrub.sh missing at ${scriptPath}`,
-    );
-  }
-
   const res = spawnSync(scriptPath, [], {
     input: text,
     encoding: "utf8",
@@ -62,26 +47,26 @@ export function scrubDigest(text, opts = {}) {
   });
 
   if (res.error) {
-    throw new Error(`scrub not applied: ${res.error.message}`);
+    throw new Error(`${SCRUB_ERROR_PREFIX}: ${res.error.message}`);
   }
   if (typeof res.status !== "number" || res.status !== 0) {
     const stderr = (res.stderr ?? "").trim();
     throw new Error(
-      `scrub not applied: handoff-scrub.sh exited ${res.status}${stderr ? `: ${stderr}` : ""}`,
+      `${SCRUB_ERROR_PREFIX}: handoff-scrub.sh exited ${res.status}${stderr ? `: ${stderr}` : ""}`,
     );
   }
 
   const match = (res.stderr ?? "").match(COUNT_LINE_RE);
   if (!match) {
     throw new Error(
-      "scrub not applied: handoff-scrub.sh did not report a `scrubbed:N` count on stderr",
+      `${SCRUB_ERROR_PREFIX}: handoff-scrub.sh did not report a \`scrubbed:N\` count on stderr`,
     );
   }
 
   const count = Number(match[1]);
   if (!Number.isInteger(count) || count < 0) {
     throw new Error(
-      `scrub not applied: unparseable scrubbed count ${JSON.stringify(match[1])}`,
+      `${SCRUB_ERROR_PREFIX}: unparseable scrubbed count ${JSON.stringify(match[1])}`,
     );
   }
 

--- a/plugins/dotclaude/src/lib/handoff-scrub.mjs
+++ b/plugins/dotclaude/src/lib/handoff-scrub.mjs
@@ -1,0 +1,89 @@
+/**
+ * Node-side wrapper around `plugins/dotclaude/scripts/handoff-scrub.sh`.
+ *
+ * The shell script is a stdin→stdout filter that prints `scrubbed:N` to
+ * stderr and exits 0 on success. This wrapper feeds a digest string to it,
+ * captures the redacted output, parses the count, and fails closed on any
+ * deviation from that contract. Callers on a push path must propagate the
+ * throw so the remote upload does not proceed with unscrubbed content.
+ *
+ * The three-state signal the remote binary emits (`[scrubbed N secrets]`,
+ * `[scrubbed 0 secrets]`, `[scrub not applied]`) lives in the caller —
+ * this module only distinguishes "scrubbed with count N" from "throw".
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the shell script. Resolved once at module load. */
+export const DEFAULT_SCRUB_SCRIPT = resolvePath(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "handoff-scrub.sh",
+);
+
+const COUNT_LINE_RE = /^scrubbed:(\d+)$/m;
+
+/**
+ * @typedef {object} ScrubResult
+ * @property {string} scrubbed   The redacted text. Equal to input when count is 0.
+ * @property {number} count      Number of redactions the scrubber applied.
+ */
+
+/**
+ * Pipe `text` through handoff-scrub.sh and return the scrubbed output plus
+ * redaction count. Throws if the script is missing, exits non-zero, or
+ * violates the stderr contract — callers must treat those as push-blocking.
+ *
+ * @param {string} text
+ * @param {{ scriptPath?: string }} [opts]
+ * @returns {ScrubResult}
+ */
+export function scrubDigest(text, opts = {}) {
+  const scriptPath = opts.scriptPath ?? DEFAULT_SCRUB_SCRIPT;
+
+  if (!existsSync(scriptPath)) {
+    throw new Error(
+      `scrub not applied: handoff-scrub.sh missing at ${scriptPath}`,
+    );
+  }
+
+  const res = spawnSync(scriptPath, [], {
+    input: text,
+    encoding: "utf8",
+    // No shell: direct exec avoids quoting hazards with the stdin payload.
+    shell: false,
+  });
+
+  if (res.error) {
+    throw new Error(`scrub not applied: ${res.error.message}`);
+  }
+  if (typeof res.status !== "number" || res.status !== 0) {
+    const stderr = (res.stderr ?? "").trim();
+    throw new Error(
+      `scrub not applied: handoff-scrub.sh exited ${res.status}${stderr ? `: ${stderr}` : ""}`,
+    );
+  }
+
+  const match = (res.stderr ?? "").match(COUNT_LINE_RE);
+  if (!match) {
+    throw new Error(
+      "scrub not applied: handoff-scrub.sh did not report a `scrubbed:N` count on stderr",
+    );
+  }
+
+  const count = Number(match[1]);
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error(
+      `scrub not applied: unparseable scrubbed count ${JSON.stringify(match[1])}`,
+    );
+  }
+
+  return { scrubbed: res.stdout ?? "", count };
+}

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -145,9 +145,12 @@ question before proceeding.
   prevents unintended cross-session execution.
 - **End-to-end encryption.** The git transport is access-controlled
   by the host (private repo + push-side auth), but content is stored
-  in plaintext on the remote. Do not push transcripts containing
-  secrets you rely on scrubbing to catch. Scrubbing is a best-effort
-  pattern pass (see `references/redaction.md`).
+  in plaintext on the remote. Every `push` runs the scrubber before
+  uploading and reports `[scrubbed N secrets]` as the final stdout
+  line; the push fails closed (exit 2, no commit written) if the
+  scrubber cannot run. Scrubbing is a best-effort pattern pass (see
+  `references/redaction.md`) — do not rely on it to catch bespoke
+  or obfuscated secrets.
 - **Fuzzy or semantic search.** `search` is substring/regex only.
 - **Persistent indexing.** Grep-at-query-time is fast enough for
   local session volumes; revisit only if p95 exceeds ~2s.

--- a/plugins/dotclaude/tests/bats/handoff-scrub-push.bats
+++ b/plugins/dotclaude/tests/bats/handoff-scrub-push.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# End-to-end: `dotclaude handoff push` must scrub the digest before writing
+# it to the remote. Ensures parity with the skill-driven github path, which
+# has always scrubbed via handoff-scrub.sh. Issue #90 Gap 1.
+#
+# Exercises the real `pushRemote` against a local bare repo — no network.
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+SCRUB="$REPO_ROOT/plugins/dotclaude/scripts/handoff-scrub.sh"
+BAIT_GH_TOKEN="ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456"
+
+setup() {
+  [ -x "$SCRUB" ] || chmod +x "$SCRUB"
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+
+  # Seed a Claude session whose prompts carry a bait GitHub token. The
+  # digest renderer pulls prompts straight out, so the token lands in
+  # handoff.md unless pushRemote() scrubs first.
+  CLAUDE_UUID="aaaa1111-1111-1111-1111-111111111111"
+  CLAUDE_DIR="$TEST_HOME/.claude/projects/-home-u-scrubdemo"
+  mkdir -p "$CLAUDE_DIR"
+  CLAUDE_FILE="$CLAUDE_DIR/$CLAUDE_UUID.jsonl"
+  cat > "$CLAUDE_FILE" <<EOF
+{"type":"user","cwd":"/home/u/scrubdemo","sessionId":"$CLAUDE_UUID","version":"2.1","message":{"content":"deploy with $BAIT_GH_TOKEN"}}
+{"type":"user","cwd":"/home/u/scrubdemo","sessionId":"$CLAUDE_UUID","message":{"content":"second prompt"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}
+EOF
+
+  TRANSPORT_REPO=$(make_transport_repo "$(mktemp -d)")
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+  export CLAUDE_UUID CLAUDE_FILE TRANSPORT_REPO BAIT_GH_TOKEN
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+}
+
+@test "push: stdout emits [scrubbed N secrets] as a fourth line" {
+  run node "$BIN" push aaaa1111
+  [ "$status" -eq 0 ]
+  # Fourth line is the scrub-state line.
+  local fourth
+  fourth="$(printf '%s\n' "$output" | sed -n '4p')"
+  [[ "$fourth" =~ ^\[scrubbed\ [0-9]+\ secrets\]$ ]]
+  # Seeded one bait token → count must be at least 1.
+  local count
+  count="$(printf '%s\n' "$fourth" | sed -E 's/^\[scrubbed ([0-9]+) secrets\]$/\1/')"
+  [ "$count" -ge 1 ]
+}
+
+@test "push: pushed handoff.md does not contain the bait token" {
+  run node "$BIN" push aaaa1111
+  [ "$status" -eq 0 ]
+  # Look up the branch written by push (handoff/<project>/claude/<month>/aaaa1111).
+  run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/*/claude/*/aaaa1111'"
+  [ "$status" -eq 0 ]
+  local branch="$output"
+  [ -n "$branch" ]
+  run bash -c "git --git-dir='$TRANSPORT_REPO' show '$branch:handoff.md'"
+  [ "$status" -eq 0 ]
+  # Bait must be gone; replacement marker must be present.
+  [[ "$output" != *"$BAIT_GH_TOKEN"* ]]
+  [[ "$output" == *"<redacted:github-token>"* ]]
+}
+
+@test "push: metadata.json.scrubbed_count matches the stdout count" {
+  run node "$BIN" push aaaa1111
+  [ "$status" -eq 0 ]
+  local fourth count_stdout
+  fourth="$(printf '%s\n' "$output" | sed -n '4p')"
+  count_stdout="$(printf '%s\n' "$fourth" | sed -E 's/^\[scrubbed ([0-9]+) secrets\]$/\1/')"
+
+  run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/*/claude/*/aaaa1111'"
+  [ "$status" -eq 0 ]
+  local branch="$output"
+  run bash -c "git --git-dir='$TRANSPORT_REPO' show '$branch:metadata.json' | jq -r .scrubbed_count"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$count_stdout" ]
+}
+
+@test "push: clean session records scrubbed_count 0, stdout says [scrubbed 0 secrets]" {
+  # Overwrite the session with a token-free payload. Scrubber runs but finds nothing.
+  cat > "$CLAUDE_FILE" <<EOF
+{"type":"user","cwd":"/home/u/scrubdemo","sessionId":"$CLAUDE_UUID","version":"2.1","message":{"content":"plain prose no secrets"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}
+EOF
+  run node "$BIN" push aaaa1111
+  [ "$status" -eq 0 ]
+  local fourth
+  fourth="$(printf '%s\n' "$output" | sed -n '4p')"
+  [ "$fourth" = "[scrubbed 0 secrets]" ]
+}
+
+@test "push: fail-closed when scrubber is missing (no branch written)" {
+  # Temporarily rename the real scrubber so the module's existsSync check
+  # trips. This is the fail-closed baseline: if the scrubber cannot run,
+  # the push must not commit anything to the remote.
+  local backup="$SCRUB.bak.$$"
+  mv "$SCRUB" "$backup"
+
+  run node "$BIN" push aaaa1111
+  local push_status="$status"
+  local push_output="$output"
+
+  # Restore before any assertion can short-circuit the test.
+  mv "$backup" "$SCRUB"
+
+  [ "$push_status" -eq 2 ]
+  [[ "$push_output" == *"scrub not applied"* ]]
+
+  # Remote must carry no branch for this session.
+  run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/*/claude/*/aaaa1111'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/plugins/dotclaude/tests/bats/handoff-scrub-push.bats
+++ b/plugins/dotclaude/tests/bats/handoff-scrub-push.bats
@@ -11,6 +11,21 @@ BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
 SCRUB="$REPO_ROOT/plugins/dotclaude/scripts/handoff-scrub.sh"
 BAIT_GH_TOKEN="ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456"
 
+# Emits the short-ref name of the session's pushed branch, or empty if none.
+# Call against $TRANSPORT_REPO. Scoped by short-UUID suffix.
+handoff_branch_for() {
+  local short_uuid="$1"
+  git --git-dir="$TRANSPORT_REPO" for-each-ref \
+    --format='%(refname:short)' \
+    "refs/heads/handoff/*/claude/*/$short_uuid"
+}
+
+# Parses the `[scrubbed N secrets]` line from `$output` into a bare integer.
+# Assumes the state line is the fourth line of `push` stdout.
+scrub_count_from_output() {
+  printf '%s\n' "$output" | sed -n '4p' | sed -E 's/^\[scrubbed ([0-9]+) secrets\]$/\1/'
+}
+
 setup() {
   [ -x "$SCRUB" ] || chmod +x "$SCRUB"
   TEST_HOME=$(mktemp -d)
@@ -41,27 +56,23 @@ teardown() {
 @test "push: stdout emits [scrubbed N secrets] as a fourth line" {
   run node "$BIN" push aaaa1111
   [ "$status" -eq 0 ]
-  # Fourth line is the scrub-state line.
   local fourth
   fourth="$(printf '%s\n' "$output" | sed -n '4p')"
   [[ "$fourth" =~ ^\[scrubbed\ [0-9]+\ secrets\]$ ]]
   # Seeded one bait token → count must be at least 1.
   local count
-  count="$(printf '%s\n' "$fourth" | sed -E 's/^\[scrubbed ([0-9]+) secrets\]$/\1/')"
+  count="$(scrub_count_from_output)"
   [ "$count" -ge 1 ]
 }
 
 @test "push: pushed handoff.md does not contain the bait token" {
   run node "$BIN" push aaaa1111
   [ "$status" -eq 0 ]
-  # Look up the branch written by push (handoff/<project>/claude/<month>/aaaa1111).
-  run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/*/claude/*/aaaa1111'"
-  [ "$status" -eq 0 ]
-  local branch="$output"
+  local branch
+  branch="$(handoff_branch_for aaaa1111)"
   [ -n "$branch" ]
-  run bash -c "git --git-dir='$TRANSPORT_REPO' show '$branch:handoff.md'"
+  run git --git-dir="$TRANSPORT_REPO" show "$branch:handoff.md"
   [ "$status" -eq 0 ]
-  # Bait must be gone; replacement marker must be present.
   [[ "$output" != *"$BAIT_GH_TOKEN"* ]]
   [[ "$output" == *"<redacted:github-token>"* ]]
 }
@@ -69,13 +80,10 @@ teardown() {
 @test "push: metadata.json.scrubbed_count matches the stdout count" {
   run node "$BIN" push aaaa1111
   [ "$status" -eq 0 ]
-  local fourth count_stdout
-  fourth="$(printf '%s\n' "$output" | sed -n '4p')"
-  count_stdout="$(printf '%s\n' "$fourth" | sed -E 's/^\[scrubbed ([0-9]+) secrets\]$/\1/')"
+  local count_stdout branch
+  count_stdout="$(scrub_count_from_output)"
+  branch="$(handoff_branch_for aaaa1111)"
 
-  run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/*/claude/*/aaaa1111'"
-  [ "$status" -eq 0 ]
-  local branch="$output"
   run bash -c "git --git-dir='$TRANSPORT_REPO' show '$branch:metadata.json' | jq -r .scrubbed_count"
   [ "$status" -eq 0 ]
   [ "$output" = "$count_stdout" ]
@@ -112,7 +120,7 @@ EOF
   [[ "$push_output" == *"scrub not applied"* ]]
 
   # Remote must carry no branch for this session.
-  run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/*/claude/*/aaaa1111'"
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
+  local branch
+  branch="$(handoff_branch_for aaaa1111)"
+  [ -z "$branch" ]
 }

--- a/plugins/dotclaude/tests/handoff-scrub-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-scrub-lib.test.mjs
@@ -1,8 +1,9 @@
 // Unit tests for the scrubDigest helper that wraps handoff-scrub.sh.
-// The sibling bats suite (tests/bats/handoff-scrub.bats) exercises the shell
-// script itself; this file pins the Node-side contract: stdin→stdout streaming,
-// the `scrubbed:N` stderr-count parse, and the fail-closed behavior that
-// pushRemote() relies on to avoid uploading unscrubbed content.
+// The sibling bats suite
+// (plugins/dotclaude/tests/bats/handoff-scrub.bats) exercises the shell
+// script itself; this file pins the Node-side contract: full-input scrubbed
+// output, the `scrubbed:N` stderr-count parse, and the fail-closed behavior
+// that pushRemote() relies on to avoid uploading unscrubbed content.
 
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";

--- a/plugins/dotclaude/tests/handoff-scrub-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-scrub-lib.test.mjs
@@ -1,0 +1,91 @@
+// Unit tests for the scrubDigest helper that wraps handoff-scrub.sh.
+// The sibling bats suite (tests/bats/handoff-scrub.bats) exercises the shell
+// script itself; this file pins the Node-side contract: stdin→stdout streaming,
+// the `scrubbed:N` stderr-count parse, and the fail-closed behavior that
+// pushRemote() relies on to avoid uploading unscrubbed content.
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scrubDigest } from "../src/lib/handoff-scrub.mjs";
+
+/**
+ * Build a temporary stub script that mimics handoff-scrub.sh's contract
+ * (stdin→stdout, `scrubbed:N` on stderr, exit 0) or any corruption of it
+ * the caller wants to simulate. Returns the absolute path.
+ */
+function stubScript(body) {
+  const dir = mkdtempSync(join(tmpdir(), "scrub-stub-"));
+  const path = join(dir, "handoff-scrub.sh");
+  writeFileSync(path, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+  chmodSync(path, 0o755);
+  return { dir, path };
+}
+
+describe("scrubDigest", () => {
+  it("returns the real scrubber's output with an accurate count for clean input", () => {
+    // No stub — use the real script. Clean prose should emit count 0 and
+    // round-trip unchanged.
+    const text = "Plain prose with no tokens, numbers 1234 and /tmp/foo.";
+    const result = scrubDigest(text);
+    expect(result.count).toBe(0);
+    expect(result.scrubbed).toBe(text);
+  });
+
+  it("redacts a seeded github token and reports count 1", () => {
+    const text = "pre ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456 post";
+    const result = scrubDigest(text);
+    expect(result.count).toBe(1);
+    expect(result.scrubbed).not.toContain("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456");
+    expect(result.scrubbed).toContain("<redacted:github-token>");
+  });
+
+  it("counts multi-match inputs faithfully", () => {
+    const text = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456\nAKIAIOSFODNN7EXAMPLE\n";
+    const result = scrubDigest(text);
+    expect(result.count).toBe(2);
+  });
+
+  it("throws when the scrubber script is missing", () => {
+    expect(() =>
+      scrubDigest("any input", { scriptPath: "/nonexistent/handoff-scrub.sh" }),
+    ).toThrow(/scrub not applied/);
+  });
+
+  it("throws when the scrubber exits non-zero (fail-closed contract)", () => {
+    const { dir, path } = stubScript("exit 3");
+    try {
+      expect(() => scrubDigest("any input", { scriptPath: path })).toThrow(
+        /scrub not applied/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when stderr lacks the scrubbed:N line", () => {
+    // Exits 0 and echoes stdin to stdout but never writes the count line.
+    const { dir, path } = stubScript("cat");
+    try {
+      expect(() => scrubDigest("any input", { scriptPath: path })).toThrow(
+        /scrub not applied/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when stderr reports a non-numeric count", () => {
+    const { dir, path } = stubScript(
+      "cat\nprintf 'scrubbed:abc\\n' >&2",
+    );
+    try {
+      expect(() => scrubDigest("any input", { scriptPath: path })).toThrow(
+        /scrub not applied/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/dotclaude/tests/handoff-scrub-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-scrub-lib.test.mjs
@@ -8,7 +8,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { scrubDigest } from "../src/lib/handoff-scrub.mjs";
+import { scrubDigest, SCRUB_ERROR_PREFIX } from "../src/lib/handoff-scrub.mjs";
 
 /**
  * Build a temporary stub script that mimics handoff-scrub.sh's contract
@@ -50,14 +50,14 @@ describe("scrubDigest", () => {
   it("throws when the scrubber script is missing", () => {
     expect(() =>
       scrubDigest("any input", { scriptPath: "/nonexistent/handoff-scrub.sh" }),
-    ).toThrow(/scrub not applied/);
+    ).toThrow(SCRUB_ERROR_PREFIX);
   });
 
   it("throws when the scrubber exits non-zero (fail-closed contract)", () => {
     const { dir, path } = stubScript("exit 3");
     try {
       expect(() => scrubDigest("any input", { scriptPath: path })).toThrow(
-        /scrub not applied/,
+        SCRUB_ERROR_PREFIX,
       );
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -69,7 +69,7 @@ describe("scrubDigest", () => {
     const { dir, path } = stubScript("cat");
     try {
       expect(() => scrubDigest("any input", { scriptPath: path })).toThrow(
-        /scrub not applied/,
+        SCRUB_ERROR_PREFIX,
       );
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -82,7 +82,7 @@ describe("scrubDigest", () => {
     );
     try {
       expect(() => scrubDigest("any input", { scriptPath: path })).toThrow(
-        /scrub not applied/,
+        SCRUB_ERROR_PREFIX,
       );
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -148,9 +148,12 @@ question before proceeding.
   prevents unintended cross-session execution.
 - **End-to-end encryption.** The git transport is access-controlled
   by the host (private repo + push-side auth), but content is stored
-  in plaintext on the remote. Do not push transcripts containing
-  secrets you rely on scrubbing to catch. Scrubbing is a best-effort
-  pattern pass (see `references/redaction.md`).
+  in plaintext on the remote. Every `push` runs the scrubber before
+  uploading and reports `[scrubbed N secrets]` as the final stdout
+  line; the push fails closed (exit 2, no commit written) if the
+  scrubber cannot run. Scrubbing is a best-effort pattern pass (see
+  `references/redaction.md`) — do not rely on it to catch bespoke
+  or obfuscated secrets.
 - **Fuzzy or semantic search.** `search` is substring/regex only.
 - **Persistent indexing.** Grep-at-query-time is fast enough for
   local session volumes; revisit only if p95 exceeds ~2s.


### PR DESCRIPTION
## Summary

- `dotclaude handoff push` now pipes the rendered digest through `handoff-scrub.sh` before writing to the transport, reports the real count in `metadata.scrubbed_count`, and appends `[scrubbed N secrets]` as a fourth stdout line — closing the parity gap where binary pushes (Codex path) uploaded unredacted content while the skill's github path always scrubbed.
- Fails closed: if the scrubber is missing, exits non-zero, or violates its `scrubbed:N` stderr contract, `push` aborts with exit 2 and no commit reaches the remote.
- First of four PRs against #90. See `docs/plans/handoff-issue-rollout.md` for the full sequence.

## Test plan

- [x] `npx vitest run plugins/dotclaude/tests/handoff-scrub-lib.test.mjs` — 7/7 pass (clean input, seeded `ghp_` token, multi-match, missing script, non-zero exit, missing stderr line, non-numeric count).
- [x] `npx bats plugins/dotclaude/tests/bats/handoff-scrub-push.bats` — 5/5 pass (stdout shape, bait redaction in pushed `handoff.md`, metadata/stdout count agreement, clean-session `[scrubbed 0 secrets]`, fail-closed with no branch written).
- [x] `npx bats plugins/dotclaude/tests/bats/` — 240/240 pass, no regressions.
- [x] `npx vitest run` — 284/284 pass.
- [x] `npm run dogfood` — manifest, skills, agents, specs, drift, coverage all clean (`.claude/skills-manifest.json` refreshed via `npx dotclaude-validate-skills --update`).
- [x] Manual verification that the pre-existing `prettier` warning on `CHANGELOG.md` and `shellcheck` info on unchanged `.sh` files survive `git stash` — unrelated to this change.

## Spec ID

dotclaude-core
