### PR TITLE
refactor(handoff): extract remote transport to shared library

### DIFF
--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -30,43 +30,62 @@
 
 import { parse, helpText } from "../src/lib/argv.mjs";
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
-import { scrubDigest } from "../src/lib/handoff-scrub.mjs";
 import { version } from "../src/index.mjs";
+import {
+  // subprocess primitives
+  runScript,
+  // extraction
+  extractMeta,
+  extractPrompts,
+  extractTurns,
+  // rendering
+  renderHandoffBlock,
+  mechanicalSummary,
+  nextStepFor,
+  // URL / path
+  validateTransportUrl,
+  isRepoMissingError,
+  slugify,
+  projectSlugFromCwd,
+  monthBucket,
+  v2BranchName,
+  // metadata
+  encodeDescription,
+  decodeDescription,
+  // bootstrap
+  loadPersistedEnv,
+  ghAvailable,
+  ghAuthenticated,
+  bootstrapTransportRepo,
+  requireTransportRepo,
+  requireTransportRepoStrict,
+  // remote I/O
+  pushRemote,
+  pullRemote,
+  fetchRemoteBranch,
+  listRemoteCandidates,
+  enrichWithDescriptions,
+  matchesQuery,
+  // constants
+  CONFIG_FILE,
+  V1_BRANCH_RE,
+  V2_BRANCH_RE,
+} from "../src/lib/handoff-remote.mjs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readdirSync,
   readFileSync,
-  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir, hostname } from "node:os";
 import { createInterface } from "node:readline";
 
 const POWER_SUBS = new Set(["resolve", "describe", "digest", "file"]);
 const CLIS = new Set(["claude", "copilot", "codex"]);
-
-// Branch shape written by `push`. The store is unceremonial — there is
-// no schema pin on `main`, no `init` step, no server-side enforcement;
-// the binary is the only writer and reader, so consistency comes from
-// shipping a single version of this regex everywhere.
-const V2_BRANCH_RE =
-  /^handoff\/[a-z0-9-]+\/(claude|copilot|codex)\/\d{4}-\d{2}\/[0-9a-f]{8}$/;
-const V1_BRANCH_RE = /^handoff\/(claude|copilot|codex)\/[0-9a-f]{8}$/;
-
-// Persisted config lives under $XDG_CONFIG_HOME (~/.config by default).
-// Shell-sourceable `.env`-style; one KEY=VALUE per line. Created by
-// the first successful bootstrap so subsequent pushes don't re-prompt.
-const CONFIG_DIR = join(
-  process.env.XDG_CONFIG_HOME || join(process.env.HOME || "", ".config"),
-  "dotclaude"
-);
-const CONFIG_FILE = join(CONFIG_DIR, "handoff.env");
 
 const META = {
   name: "dotclaude-handoff",
@@ -90,30 +109,13 @@ const META = {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPTS = resolvePath(__dirname, "..", "scripts");
 const RESOLVE_SH = join(SCRIPTS, "handoff-resolve.sh");
-const EXTRACT_SH = join(SCRIPTS, "handoff-extract.sh");
-const DESCRIPTION_SH = join(SCRIPTS, "handoff-description.sh");
 const DOCTOR_SH = join(SCRIPTS, "handoff-doctor.sh");
 
+// Local fail — mirrors the library's internal helper so bin-side usage
+// doesn't depend on the library exporting it. Kept trivial on purpose.
 function fail(code, msg) {
   if (msg) process.stderr.write(`dotclaude-handoff: ${msg}\n`);
   process.exit(code);
-}
-
-function runScript(script, args, opts = {}) {
-  const res = spawnSync(script, args, { encoding: "utf8", ...opts });
-  return { status: res.status ?? 2, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
-}
-
-function runGit(args, cwd) {
-  return spawnSync("git", args, { encoding: "utf8", cwd });
-}
-
-function runGitOrThrow(args, cwd) {
-  const r = runGit(args, cwd);
-  if (r.status !== 0) {
-    throw new Error(`git ${args.join(" ")} failed: ${(r.stderr || r.stdout).trim()}`);
-  }
-  return r;
 }
 
 // ---- resolver / extractor bridge ---------------------------------------
@@ -203,47 +205,7 @@ function cliFromPath(path) {
   return "claude";
 }
 
-function extractMeta(cli, file) {
-  const r = runScript(EXTRACT_SH, ["meta", cli, file]);
-  if (r.status !== 0) fail(2, r.stderr.trim() || `meta extraction failed for ${cli}`);
-  try {
-    return JSON.parse(r.stdout.trim());
-  } catch (err) {
-    fail(2, `meta returned non-JSON: ${err.message}`);
-  }
-}
-
-function extractLines(sub, cli, file, extra = []) {
-  const r = runScript(EXTRACT_SH, [sub, cli, file, ...extra]);
-  if (r.status !== 0) {
-    if (r.stderr.trim()) process.stderr.write(`dotclaude-handoff: ${sub}: ${r.stderr.trim()}\n`);
-    return [];
-  }
-  return r.stdout.split("\n").filter((line) => line.trim().length > 0);
-}
-
-const extractPrompts = (cli, file) => extractLines("prompts", cli, file);
-const extractTurns = (cli, file, limit) =>
-  extractLines("turns", cli, file, limit ? [String(limit)] : []);
-
-// ---- rendering ---------------------------------------------------------
-
-function nextStepFor(toCli) {
-  if (toCli === "codex") {
-    return "Read the prompts and assistant turns above, then continue the task using the file paths mentioned. Treat this as a task specification.";
-  }
-  if (toCli === "copilot") {
-    return "Help me pick up where this session left off; reference the prompts and findings above.";
-  }
-  return "Continue from the last assistant turn using the same file scope and goals summarized above.";
-}
-
-function mechanicalSummary(prompts, turns) {
-  const first = prompts[0] ?? "(no user prompts captured)";
-  const last = turns[turns.length - 1] ?? "(no assistant turns captured)";
-  const clip = (s, n) => (s.length > n ? `${s.slice(0, n).trim()}…` : s);
-  return `Session opened with: "${clip(first, 160)}". Last assistant output (truncated): "${clip(last, 160)}". Full prompt log and assistant tail follow for context.`;
-}
+// ---- describe renderer (bin-only) --------------------------------------
 
 function renderDescribeMarkdown(meta, prompts) {
   const lines = [];
@@ -259,42 +221,6 @@ function renderDescribeMarkdown(meta, prompts) {
   if (prompts.length > 10) lines.push(`- …and ${prompts.length - 10} more (truncated)`);
   lines.push("");
   lines.push(`**Prompt count:** ${prompts.length}`);
-  return lines.join("\n");
-}
-
-function renderHandoffBlock(meta, prompts, turns, toCli) {
-  const summary = mechanicalSummary(prompts, turns);
-  const promptsCapped = prompts.slice(-10);
-  const turnsTail = turns.slice(-3);
-  const next = nextStepFor(toCli);
-  const lines = [];
-  lines.push(
-    `<handoff origin="${meta.cli}" session="${meta.short_id ?? ""}" cwd="${meta.cwd ?? ""}" target="${toCli}">`
-  );
-  lines.push("");
-  lines.push(`**Summary.** ${summary}`);
-  lines.push("");
-  lines.push("**User prompts (last 10, in order).**");
-  lines.push("");
-  if (promptsCapped.length === 0) lines.push("1. (no user prompts captured)");
-  else
-    promptsCapped.forEach((p, i) => {
-      const trimmed = p.length > 300 ? `${p.slice(0, 300).trim()}…` : p;
-      lines.push(`${i + 1}. ${trimmed}`);
-    });
-  lines.push("");
-  lines.push("**Last assistant turns (tail).**");
-  lines.push("");
-  if (turnsTail.length === 0) lines.push("_(no assistant output captured)_");
-  else
-    for (const t of turnsTail) {
-      const trimmed = t.length > 400 ? `${t.slice(0, 400).trim()}…` : t;
-      lines.push(`> ${trimmed.replace(/\n/g, "\n> ")}`);
-      lines.push("");
-    }
-  lines.push("**Next step.** " + next);
-  lines.push("");
-  lines.push("</handoff>");
   return lines.join("\n");
 }
 
@@ -370,515 +296,6 @@ function listAllLocalSessions() {
   );
 }
 
-// ---- remote transport (git, the only transport since v0.9.0) ----------
-
-// Reject ext:: and other exec-triggering Git URL schemes (CVE-2017-1000117-class).
-// Allow: https://, http://, git@, ssh://, file://, and absolute paths (bare repos).
-function validateTransportUrl(url) {
-  if (!/^(https?:\/\/|git@|ssh:\/\/|file:\/\/|\/)/.test(url))
-    fail(2, `DOTCLAUDE_HANDOFF_REPO must be an https://, git@, ssh://, file://, or absolute path (got: ${url})`);
-  return url;
-}
-
-// Source ~/.config/dotclaude/handoff.env if present, seeding any missing
-// env var. Shell rc users can `source` the same file; bypass is trivial
-// via an explicit `DOTCLAUDE_HANDOFF_REPO=...` on the command line.
-function loadPersistedEnv() {
-  if (!existsSync(CONFIG_FILE)) return;
-  let contents;
-  try {
-    contents = readFileSync(CONFIG_FILE, "utf8");
-  } catch {
-    return;
-  }
-  for (const raw of contents.split("\n")) {
-    const line = raw.trim();
-    if (!line || line.startsWith("#")) continue;
-    const m = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (!m) continue;
-    const key = m[1];
-    let val = m[2];
-    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
-      val = val.slice(1, -1);
-    }
-    if (process.env[key] === undefined || process.env[key] === "") {
-      process.env[key] = val;
-    }
-  }
-}
-
-// Best-effort slugify matching what `gh repo create` will accept. Stricter
-// than handoff-description.sh's slugify because GitHub repo names reject
-// leading/trailing dashes and double-dashes.
-function slugifyRepoName(input) {
-  const s = (input || "")
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return s.slice(0, 100);
-}
-
-function isTty() {
-  return Boolean(process.stdin.isTTY && process.stderr.isTTY);
-}
-
-// Three-line manual-setup block. Printed when we can't (or shouldn't)
-// auto-create — non-TTY, no `gh`, or user declines the prompt.
-function printManualSetupBlock(reason) {
-  const msg = [
-    "",
-    `Can't auto-bootstrap the handoff store: ${reason}`,
-    "",
-    "Set it up manually:",
-    "  1. gh repo create <you>/dotclaude-handoff-store --private",
-    "  2. export DOTCLAUDE_HANDOFF_REPO=git@github.com:<you>/dotclaude-handoff-store.git",
-    "  3. dotclaude handoff push   # retries",
-    "",
-    "Alternative providers (GitLab, Gitea, self-hosted) work too — set",
-    "DOTCLAUDE_HANDOFF_REPO to any ssh://, git@, https://, file://, or absolute path.",
-    "",
-  ];
-  process.stderr.write(msg.join("\n"));
-}
-
-function ghAvailable() {
-  const r = spawnSync("gh", ["--version"], { encoding: "utf8" });
-  return r.status === 0;
-}
-
-function ghAuthenticated() {
-  const r = spawnSync("gh", ["auth", "status", "-h", "github.com"], { encoding: "utf8" });
-  return r.status === 0;
-}
-
-function ghLogin() {
-  const r = spawnSync("gh", ["api", "user", "-q", ".login"], { encoding: "utf8" });
-  if (r.status !== 0) return null;
-  return r.stdout.trim() || null;
-}
-
-// Synchronous readline prompt that mirrors the existing collision-prompt
-// pattern (createInterface + rl.question + close). Returns the trimmed
-// answer, or "" for empty input.
-async function promptLine(message) {
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-  try {
-    return await new Promise((resolve) => {
-      rl.question(message, (answer) => resolve(answer.trim()));
-    });
-  } finally {
-    rl.close();
-  }
-}
-
-// Interactive repo creation. Prompts for a name (default
-// `dotclaude-handoff-store`), confirms, runs `gh repo create --private`,
-// writes the URL to ~/.config/dotclaude/handoff.env, and exports it
-// in-process so the current run continues without re-reading.
-//
-// Exits 2 with a manual-setup block when we can't proceed:
-//   - no TTY (cron/CI)
-//   - `gh` missing or unauthenticated
-//   - the user aborts
-async function bootstrapTransportRepo() {
-  if (!isTty()) {
-    printManualSetupBlock("not running in an interactive terminal");
-    process.exit(2);
-  }
-  if (!ghAvailable()) {
-    printManualSetupBlock("`gh` CLI is not on PATH — install it from https://cli.github.com/");
-    process.exit(2);
-  }
-  if (!ghAuthenticated()) {
-    printManualSetupBlock("`gh` is not authenticated — run `gh auth login` (scopes: repo)");
-    process.exit(2);
-  }
-  const login = ghLogin();
-  if (!login) {
-    printManualSetupBlock("could not read GitHub username via `gh api user`");
-    process.exit(2);
-  }
-
-  process.stderr.write(
-    [
-      "",
-      "DOTCLAUDE_HANDOFF_REPO is not set — dotclaude can set this up for you.",
-      "",
-      `  Detected: gh CLI authenticated as @${login}.`,
-      `  Plan: create private repo  ${login}/<name>`,
-      `        persist URL to       ${CONFIG_FILE}`,
-      "",
-    ].join("\n")
-  );
-
-  let name = "";
-  for (let attempt = 0; attempt < 3; attempt++) {
-    const input = await promptLine("  Repo name? [dotclaude-handoff-store] ");
-    const candidate = input === "" ? "dotclaude-handoff-store" : slugifyRepoName(input);
-    if (/^[a-z0-9][a-z0-9-]{0,98}[a-z0-9]$|^[a-z0-9]$/.test(candidate)) {
-      name = candidate;
-      break;
-    }
-    process.stderr.write(
-      "  Name must be 1-100 chars of [a-z0-9-], no leading/trailing dash. Try again.\n"
-    );
-  }
-  if (!name) {
-    process.stderr.write("  Gave up after 3 invalid names. Aborting.\n");
-    process.exit(2);
-  }
-
-  const confirm = await promptLine(`  Create ${login}/${name} and proceed? [y/N] `);
-  if (!/^y(es)?$/i.test(confirm)) {
-    process.stderr.write("  Aborted.\n");
-    process.exit(1);
-  }
-
-  const create = spawnSync(
-    "gh",
-    ["repo", "create", `${login}/${name}`, "--private", "--description", "dotclaude handoff store"],
-    { encoding: "utf8" }
-  );
-  if (create.status !== 0) {
-    const stderr = (create.stderr || "").toLowerCase();
-    // Idempotent: an existing repo is not a failure — we'll push to it.
-    if (!stderr.includes("already exists") && !stderr.includes("name already exists on this account")) {
-      process.stderr.write(`  gh repo create failed:\n${create.stderr}\n`);
-      process.exit(2);
-    }
-    process.stderr.write(`  ✓ repo ${login}/${name} already exists — reusing\n`);
-  } else {
-    process.stderr.write(`  ✓ created ${login}/${name}\n`);
-  }
-
-  const view = spawnSync(
-    "gh",
-    ["repo", "view", `${login}/${name}`, "--json", "sshUrl,url", "-q", ".sshUrl"],
-    { encoding: "utf8" }
-  );
-  const url = view.status === 0 && view.stdout.trim()
-    ? view.stdout.trim()
-    : `git@github.com:${login}/${name}.git`;
-
-  mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
-  writeFileSync(
-    CONFIG_FILE,
-    `# Written by dotclaude handoff on ${new Date().toISOString()}\n` +
-      `# Sourceable from your shell rc:  source ${CONFIG_FILE}\n` +
-      `export DOTCLAUDE_HANDOFF_REPO=${url}\n`,
-    { mode: 0o600 }
-  );
-  process.stderr.write(`  ✓ wrote ${CONFIG_FILE}\n`);
-  process.stderr.write(
-    `    (add \`source ${CONFIG_FILE}\` to ~/.bashrc or ~/.zshrc to persist across shells)\n`
-  );
-
-  process.env.DOTCLAUDE_HANDOFF_REPO = url;
-  return url;
-}
-
-// Public entry point: return a validated transport URL, bootstrapping
-// interactively if the env var is missing. Called by push/pull/list/
-// doctor, i.e. anywhere the remote is required.
-async function requireTransportRepo() {
-  const existing = process.env.DOTCLAUDE_HANDOFF_REPO;
-  if (existing) return validateTransportUrl(existing);
-  const fresh = await bootstrapTransportRepo();
-  return validateTransportUrl(fresh);
-}
-
-// Synchronous variant for read-only paths (list, remote-list, doctor
-// shell script) that can't meaningfully trigger an interactive bootstrap
-// mid-command. Fails hard instead.
-function requireTransportRepoStrict() {
-  const url = process.env.DOTCLAUDE_HANDOFF_REPO;
-  if (!url) fail(2, "DOTCLAUDE_HANDOFF_REPO is not set — run `dotclaude handoff push` to auto-bootstrap, or set it manually");
-  return validateTransportUrl(url);
-}
-
-function encodeDescription({ cli, shortId, project, host, month, tag }) {
-  const args = [
-    "encode",
-    "--cli",
-    cli,
-    "--short-id",
-    shortId,
-    "--project",
-    project || "adhoc",
-    "--hostname",
-    host || "unknown",
-    "--month",
-    month,
-  ];
-  if (tag) args.push("--tag", tag);
-  const r = runScript(DESCRIPTION_SH, args);
-  if (r.status !== 0) fail(2, `description encode failed: ${r.stderr.trim()}`);
-  return r.stdout.trim();
-}
-
-// Mirror of the shell `slugify` in handoff-description.sh so JS-side
-// encoders and the shell decoder agree on the edge cases (dash-run
-// collapse, trimmed edges, "" → "adhoc" fallback).
-function slugify(s) {
-  if (!s) return "adhoc";
-  const out = s
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return out.slice(0, 40) || "adhoc";
-}
-
-// Walk up to the git-repo root so a session deep in `~/foo/services/api`
-// groups under `foo`, not `api`. Falls back to the cwd basename outside
-// a git repo.
-function projectSlugFromCwd(cwd) {
-  if (!cwd) return "adhoc";
-  const r = runGit(["-C", cwd, "rev-parse", "--show-toplevel"]);
-  const root = r.status === 0 ? r.stdout.trim() : "";
-  const last = (root || cwd).split("/").filter(Boolean).pop() || "adhoc";
-  return slugify(last);
-}
-
-function monthBucket(isoOrNull) {
-  const d = isoOrNull ? new Date(isoOrNull) : new Date();
-  if (Number.isNaN(d.getTime())) return monthBucket(null);
-  const yyyy = d.getUTCFullYear().toString();
-  const mm = (d.getUTCMonth() + 1).toString().padStart(2, "0");
-  return `${yyyy}-${mm}`;
-}
-
-function v2BranchName({ project, cli, month, shortId }) {
-  return `handoff/${slugify(project)}/${cli}/${month}/${shortId}`;
-}
-
-// Detect the "remote repo doesn't exist / auth failed" class of errors
-// from `git push` stderr. GitHub, GitLab, Gitea and plain SSH all phrase
-// it slightly differently, so match on the union.
-function isRepoMissingError(stderr) {
-  const s = (stderr || "").toLowerCase();
-  return (
-    s.includes("repository not found") ||
-    s.includes("could not read from remote") ||
-    s.includes("remote: not found") ||
-    s.includes("project you were looking for could not be found") ||
-    s.includes("permission denied") ||
-    s.includes("does not appear to be a git repository")
-  );
-}
-
-async function pushRemote({ cli, path: sessionFile, tag }) {
-  let repoUrl = await requireTransportRepo();
-  const meta = extractMeta(cli, sessionFile);
-  const prompts = extractPrompts(cli, sessionFile);
-  const turns = extractTurns(cli, sessionFile);
-  const toCli = meta.cli;
-  const handoffBlock = renderHandoffBlock(meta, prompts, turns, toCli);
-
-  // Scrub before the digest ever leaves the machine. Thrown errors
-  // propagate out of pushRemote — the outer try/catch in main() maps
-  // them to `push failed: <message>` with exit 2, so an unscrubbed
-  // digest can never reach the remote.
-  const { scrubbed, count: scrubbedCount } = scrubDigest(handoffBlock);
-
-  const shortId = meta.short_id ?? "unknown";
-  const host = slugify(hostname());
-  const project = projectSlugFromCwd(meta.cwd);
-  const month = monthBucket();
-  const description = encodeDescription({
-    cli: meta.cli,
-    shortId,
-    project,
-    host,
-    month,
-    tag: tag || null,
-  });
-
-  const metadata = {
-    cli: meta.cli,
-    session_id: meta.session_id,
-    short_id: shortId,
-    cwd: meta.cwd ?? null,
-    project,
-    month,
-    hostname: host,
-    created_at: new Date().toISOString(),
-    scrubbed_count: scrubbedCount,
-    tag: tag || null,
-  };
-
-  const doPush = (url) => {
-    const tmp = mkdtempSync(join(tmpdir(), "handoff-push-"));
-    try {
-      runGitOrThrow(["init", "-q"], tmp);
-      runGitOrThrow(["remote", "add", "origin", url], tmp);
-      runGitOrThrow(["config", "user.email", "handoff@dotclaude.local"], tmp);
-      runGitOrThrow(["config", "user.name", "dotclaude-handoff"], tmp);
-      const branch = v2BranchName({ project, cli: meta.cli, month, shortId });
-      runGitOrThrow(["checkout", "-q", "-b", branch], tmp);
-      writeFileSync(join(tmp, "handoff.md"), scrubbed + "\n");
-      writeFileSync(join(tmp, "metadata.json"), JSON.stringify(metadata, null, 2) + "\n");
-      writeFileSync(join(tmp, "description.txt"), description + "\n");
-      runGitOrThrow(["add", "."], tmp);
-      runGitOrThrow(["commit", "-q", "-m", description], tmp);
-      runGitOrThrow(["push", "-q", "-f", "origin", branch], tmp);
-      return { branch, url, description, scrubbedCount };
-    } finally {
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  };
-
-  try {
-    return doPush(repoUrl);
-  } catch (err) {
-    // Retry once after bootstrap if the remote is gone or unauthorized
-    // — handles stale config (repo deleted) and first-run with a pre-set
-    // env var that points at a non-existent repo. Second failure is fatal.
-    if (!isRepoMissingError(err.message)) throw err;
-    if (!isTty()) {
-      printManualSetupBlock(
-        `configured repo is unreachable (${process.env.DOTCLAUDE_HANDOFF_REPO}) and we can't prompt in non-interactive mode`
-      );
-      throw err;
-    }
-    process.stderr.write(
-      `\n  The configured repo (${process.env.DOTCLAUDE_HANDOFF_REPO}) is unreachable.\n`
-    );
-    const again = await promptLine("  Re-bootstrap (create a new one)? [y/N] ");
-    if (!/^y(es)?$/i.test(again)) throw err;
-    // Clear the stale URL so bootstrapTransportRepo() doesn't short-circuit.
-    delete process.env.DOTCLAUDE_HANDOFF_REPO;
-    const fresh = await bootstrapTransportRepo();
-    return doPush(validateTransportUrl(fresh));
-  }
-}
-
-/**
- * List handoff branches on the remote as candidate objects.
- * Returns [{branch, description, commit}] — no content fetched.
- */
-function listRemoteCandidates() {
-  const repoUrl = requireTransportRepoStrict();
-  const r = runGit(["ls-remote", repoUrl, "refs/heads/handoff/*"]);
-  if (r.status !== 0) fail(2, `ls-remote failed: ${r.stderr.trim()}`);
-  const rows = [];
-  for (const line of r.stdout.split("\n")) {
-    const parts = line.trim().split(/\s+/);
-    if (parts.length !== 2) continue;
-    const commit = parts[0];
-    const ref = parts[1];
-    const branch = ref.replace(/^refs\/heads\//, "");
-    rows.push({ commit, branch, description: "" });
-  }
-  return rows;
-}
-
-/**
- * Fetch a specific handoff branch and return its `handoff.md` content.
- */
-function fetchRemoteBranch(branch) {
-  const repoUrl = requireTransportRepoStrict();
-  const tmp = mkdtempSync(join(tmpdir(), "handoff-pull-"));
-  try {
-    const r = runGit(["clone", "-q", "--depth", "1", "--branch", branch, repoUrl, "."], tmp);
-    if (r.status !== 0) {
-      throw new Error(`clone --branch ${branch} failed: ${r.stderr.trim()}`);
-    }
-    const handoffPath = join(tmp, "handoff.md");
-    if (!existsSync(handoffPath)) {
-      throw new Error(`handoff.md missing in branch ${branch}`);
-    }
-    const content = readFileSync(handoffPath, "utf8");
-    const descPath = join(tmp, "description.txt");
-    const description = existsSync(descPath) ? readFileSync(descPath, "utf8").trim() : "";
-    return { content, description };
-  } finally {
-    rmSync(tmp, { recursive: true, force: true });
-  }
-}
-
-/**
- * Enrich candidates with their description (requires per-branch fetch).
- */
-function enrichWithDescriptions(candidates) {
-  return candidates.map((c) => {
-    try {
-      const { description } = fetchRemoteBranch(c.branch);
-      return { ...c, description };
-    } catch {
-      return c;
-    }
-  });
-}
-
-function matchesQuery(candidate, query) {
-  const q = query.toLowerCase();
-  if (candidate.branch.toLowerCase().includes(q)) return true;
-  if (candidate.description && candidate.description.toLowerCase().includes(q)) return true;
-  if (candidate.commit && candidate.commit.toLowerCase().startsWith(q)) return true;
-  return false;
-}
-
-async function pullRemote(query, fromCli = null) {
-  let candidates = listRemoteCandidates();
-  if (candidates.length === 0) fail(2, "no handoffs found on transport");
-
-  // v2 carries the CLI in segment 2 (handoff/<project>/<cli>/...);
-  // v1 legacy carries it in segment 1 (handoff/<cli>/<short>).
-  if (fromCli) {
-    candidates = candidates.filter((c) => {
-      const segs = c.branch.split("/");
-      return segs[2] === fromCli || segs[1] === fromCli;
-    });
-    if (candidates.length === 0) fail(2, `no ${fromCli} handoffs found on transport`);
-  }
-
-  // Bare: pick the newest. We don't have a reliable remote mtime, so
-  // fall back to the lexically last branch, which is typically the
-  // most recent since short IDs hash-distribute. The caller re-fetches
-  // the branch contents via fetchRemoteBranch, so skipping the
-  // enrichment pass saves N shallow clones.
-  if (!query) {
-    return candidates[candidates.length - 1];
-  }
-
-  // Cheap pass: filter by branch name.
-  let hits = candidates.filter((c) => matchesQuery(c, query));
-  if (hits.length === 0) {
-    // Expensive pass: enrich with descriptions and re-match.
-    const enriched = enrichWithDescriptions(candidates);
-    hits = enriched.filter((c) => matchesQuery(c, query));
-  } else {
-    hits = enrichWithDescriptions(hits);
-  }
-
-  if (hits.length === 0) {
-    fail(2, fromCli ? `no ${fromCli} handoffs match: ${query}` : `no handoffs match: ${query}`);
-  }
-  if (hits.length === 1) return hits[0];
-
-  // Collision.
-  if (process.stdin.isTTY) {
-    process.stderr.write(`dotclaude-handoff: multiple handoffs match "${query}":\n`);
-    hits.forEach((h, i) => {
-      process.stderr.write(`  [${i + 1}] ${h.branch}  ${h.description}\n`);
-    });
-    const rl = createInterface({ input: process.stdin, output: process.stderr });
-    const ans = await new Promise((resolve) => {
-      rl.question("Pick [1..N], or any other input to abort: ", resolve);
-    });
-    rl.close();
-    const n = Number.parseInt(ans.trim(), 10);
-    if (!Number.isInteger(n) || n < 1 || n > hits.length) process.exit(2);
-    return hits[n - 1];
-  }
-  process.stderr.write(`dotclaude-handoff: multiple handoffs match "${query}":\n`);
-  for (const h of hits) process.stderr.write(`  ${h.branch}\t${h.description}\n`);
-  process.exit(2);
-}
-
 // ---- host session detection --------------------------------------------
 
 /**
@@ -924,23 +341,7 @@ function detectHost(env = process.env) {
   return "unknown";
 }
 
-// ---- doctor / remote-list / search (binary-side parity with SKILL.md) --
-
-/**
- * Decode a `handoff:v1:...` description string by shelling out to
- * handoff-description.sh — keeps the schema owner in one place.
- */
-function decodeDescription(desc) {
-  if (!desc) return null;
-  if (!desc.startsWith("handoff:v1:") && !desc.startsWith("handoff:v2:")) return null;
-  const r = runScript(DESCRIPTION_SH, ["decode", desc]);
-  if (r.status !== 0) return null;
-  try {
-    return JSON.parse(r.stdout);
-  } catch {
-    return null;
-  }
-}
+// ---- search (bin-only) -------------------------------------------------
 
 /**
  * Truncate `s` to `max` chars, appending `…` when it gets clipped.

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -1,0 +1,732 @@
+/**
+ * Shared remote handoff library — the transport-side surface used by both
+ * `bin/dotclaude-handoff.mjs` and future callers (skill/agent dispatchers,
+ * other CLIs). Owns session-data extraction (via the shell scripts),
+ * digest rendering, scrubbing, bootstrap / doctor orchestration, branch
+ * naming, metadata encoding, and the git transport operations themselves.
+ *
+ * The bin imports from here and re-exports the symbols that existing
+ * vitest suites depend on, preserving the public-import surface without
+ * copy-pasting implementation across the boundary.
+ */
+
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline";
+import { dirname, join, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { hostname, tmpdir } from "node:os";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+
+import { scrubDigest } from "./handoff-scrub.mjs";
+
+// ---- constants ---------------------------------------------------------
+
+export const V2_BRANCH_RE =
+  /^handoff\/[a-z0-9-]+\/(claude|copilot|codex)\/\d{4}-\d{2}\/[0-9a-f]{8}$/;
+export const V1_BRANCH_RE = /^handoff\/(claude|copilot|codex)\/[0-9a-f]{8}$/;
+
+// Callers that read state at run time (loadPersistedEnv,
+// bootstrapTransportRepo) go through these helpers so an updated
+// process.env.HOME / XDG_CONFIG_HOME takes effect without a module
+// reload. The exported CONFIG_FILE constant below captures the path
+// at library-init time and is kept only for the diagnostic display
+// in `doctor` + the test-contract `typeof mod.CONFIG_FILE === "string"`.
+function currentConfigDir() {
+  return join(
+    process.env.XDG_CONFIG_HOME || join(process.env.HOME || "", ".config"),
+    "dotclaude",
+  );
+}
+function currentConfigFile() {
+  return join(currentConfigDir(), "handoff.env");
+}
+export const CONFIG_FILE = currentConfigFile();
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPTS = resolvePath(__dirname, "..", "..", "scripts");
+const EXTRACT_SH = join(SCRIPTS, "handoff-extract.sh");
+const DESCRIPTION_SH = join(SCRIPTS, "handoff-description.sh");
+
+// ---- local fail helper ---------------------------------------------------
+// Duplicate of the bin's `fail` — kept local so the library never reaches
+// back into the bin (which would create a circular import).
+
+function fail(code, msg) {
+  if (msg) process.stderr.write(`dotclaude-handoff: ${msg}\n`);
+  process.exit(code);
+}
+
+// ---- subprocess primitives ---------------------------------------------
+
+export function runScript(script, args, opts = {}) {
+  const res = spawnSync(script, args, { encoding: "utf8", ...opts });
+  return {
+    status: res.status ?? 2,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+export function runGit(args, cwd) {
+  return spawnSync("git", args, { encoding: "utf8", cwd });
+}
+
+export function runGitOrThrow(args, cwd) {
+  const r = runGit(args, cwd);
+  if (r.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${(r.stderr || r.stdout).trim()}`,
+    );
+  }
+  return r;
+}
+
+// ---- session extraction ------------------------------------------------
+
+export function extractMeta(cli, file) {
+  const r = runScript(EXTRACT_SH, ["meta", cli, file]);
+  if (r.status !== 0) fail(2, r.stderr.trim() || `meta extraction failed for ${cli}`);
+  try {
+    return JSON.parse(r.stdout.trim());
+  } catch (err) {
+    fail(2, `meta returned non-JSON: ${err.message}`);
+  }
+}
+
+export function extractLines(sub, cli, file, extra = []) {
+  const r = runScript(EXTRACT_SH, [sub, cli, file, ...extra]);
+  if (r.status !== 0) {
+    if (r.stderr.trim())
+      process.stderr.write(`dotclaude-handoff: ${sub}: ${r.stderr.trim()}\n`);
+    return [];
+  }
+  return r.stdout.split("\n").filter((line) => line.trim().length > 0);
+}
+
+export const extractPrompts = (cli, file) => extractLines("prompts", cli, file);
+export const extractTurns = (cli, file, limit) =>
+  extractLines("turns", cli, file, limit ? [String(limit)] : []);
+
+// ---- rendering ---------------------------------------------------------
+
+export function nextStepFor(toCli) {
+  if (toCli === "codex") {
+    return "Read the prompts and assistant turns above, then continue the task using the file paths mentioned. Treat this as a task specification.";
+  }
+  if (toCli === "copilot") {
+    return "Help me pick up where this session left off; reference the prompts and findings above.";
+  }
+  return "Continue from the last assistant turn using the same file scope and goals summarized above.";
+}
+
+export function mechanicalSummary(prompts, turns) {
+  const first = prompts[0] ?? "(no user prompts captured)";
+  const last = turns[turns.length - 1] ?? "(no assistant turns captured)";
+  const clip = (s, n) => (s.length > n ? `${s.slice(0, n).trim()}…` : s);
+  return `Session opened with: "${clip(first, 160)}". Last assistant output (truncated): "${clip(last, 160)}". Full prompt log and assistant tail follow for context.`;
+}
+
+export function renderHandoffBlock(meta, prompts, turns, toCli) {
+  const summary = mechanicalSummary(prompts, turns);
+  const promptsCapped = prompts.slice(-10);
+  const turnsTail = turns.slice(-3);
+  const next = nextStepFor(toCli);
+  const lines = [];
+  lines.push(
+    `<handoff origin="${meta.cli}" session="${meta.short_id ?? ""}" cwd="${meta.cwd ?? ""}" target="${toCli}">`,
+  );
+  lines.push("");
+  lines.push(`**Summary.** ${summary}`);
+  lines.push("");
+  lines.push("**User prompts (last 10, in order).**");
+  lines.push("");
+  if (promptsCapped.length === 0) lines.push("1. (no user prompts captured)");
+  else
+    promptsCapped.forEach((p, i) => {
+      const trimmed = p.length > 300 ? `${p.slice(0, 300).trim()}…` : p;
+      lines.push(`${i + 1}. ${trimmed}`);
+    });
+  lines.push("");
+  lines.push("**Last assistant turns (tail).**");
+  lines.push("");
+  if (turnsTail.length === 0) lines.push("_(no assistant output captured)_");
+  else
+    for (const t of turnsTail) {
+      const trimmed = t.length > 400 ? `${t.slice(0, 400).trim()}…` : t;
+      lines.push(`> ${trimmed.replace(/\n/g, "\n> ")}`);
+      lines.push("");
+    }
+  lines.push("**Next step.** " + next);
+  lines.push("");
+  lines.push("</handoff>");
+  return lines.join("\n");
+}
+
+// ---- URL / path primitives ---------------------------------------------
+
+// Reject ext:: and other exec-triggering Git URL schemes (CVE-2017-1000117-class).
+// Allow: https://, http://, git@, ssh://, file://, and absolute paths (bare repos).
+export function validateTransportUrl(url) {
+  if (!/^(https?:\/\/|git@|ssh:\/\/|file:\/\/|\/)/.test(url))
+    fail(
+      2,
+      `DOTCLAUDE_HANDOFF_REPO must be an https://, git@, ssh://, file://, or absolute path (got: ${url})`,
+    );
+  return url;
+}
+
+// Detect the "remote repo doesn't exist / auth failed" class of errors
+// from `git push` stderr. GitHub, GitLab, Gitea and plain SSH all phrase
+// it slightly differently, so match on the union.
+export function isRepoMissingError(stderr) {
+  const s = (stderr || "").toLowerCase();
+  return (
+    s.includes("repository not found") ||
+    s.includes("could not read from remote") ||
+    s.includes("remote: not found") ||
+    s.includes("project you were looking for could not be found") ||
+    s.includes("permission denied") ||
+    s.includes("does not appear to be a git repository")
+  );
+}
+
+// Mirror of the shell `slugify` in handoff-description.sh so JS-side
+// encoders and the shell decoder agree on the edge cases (dash-run
+// collapse, trimmed edges, "" → "adhoc" fallback).
+export function slugify(s) {
+  if (!s) return "adhoc";
+  const out = s
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return out.slice(0, 40) || "adhoc";
+}
+
+// Best-effort slugify matching what `gh repo create` will accept. Stricter
+// than handoff-description.sh's slugify because GitHub repo names reject
+// leading/trailing dashes and double-dashes.
+export function slugifyRepoName(input) {
+  const s = (input || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return s.slice(0, 100);
+}
+
+// Walk up to the git-repo root so a session deep in `~/foo/services/api`
+// groups under `foo`, not `api`. Falls back to the cwd basename outside
+// a git repo.
+export function projectSlugFromCwd(cwd) {
+  if (!cwd) return "adhoc";
+  const r = runGit(["-C", cwd, "rev-parse", "--show-toplevel"]);
+  const root = r.status === 0 ? r.stdout.trim() : "";
+  const last = (root || cwd).split("/").filter(Boolean).pop() || "adhoc";
+  return slugify(last);
+}
+
+export function monthBucket(isoOrNull) {
+  const d = isoOrNull ? new Date(isoOrNull) : new Date();
+  if (Number.isNaN(d.getTime())) return monthBucket(null);
+  const yyyy = d.getUTCFullYear().toString();
+  const mm = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  return `${yyyy}-${mm}`;
+}
+
+export function v2BranchName({ project, cli, month, shortId }) {
+  return `handoff/${slugify(project)}/${cli}/${month}/${shortId}`;
+}
+
+export function isTty() {
+  return Boolean(process.stdin.isTTY && process.stderr.isTTY);
+}
+
+// ---- metadata encoding / decoding --------------------------------------
+
+export function encodeDescription({ cli, shortId, project, host, month, tag }) {
+  const args = [
+    "encode",
+    "--cli",
+    cli,
+    "--short-id",
+    shortId,
+    "--project",
+    project || "adhoc",
+    "--hostname",
+    host || "unknown",
+    "--month",
+    month,
+  ];
+  if (tag) args.push("--tag", tag);
+  const r = runScript(DESCRIPTION_SH, args);
+  if (r.status !== 0) fail(2, `description encode failed: ${r.stderr.trim()}`);
+  return r.stdout.trim();
+}
+
+export function decodeDescription(desc) {
+  if (!desc) return null;
+  if (!desc.startsWith("handoff:v1:") && !desc.startsWith("handoff:v2:")) return null;
+  const r = runScript(DESCRIPTION_SH, ["decode", desc]);
+  if (r.status !== 0) return null;
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+}
+
+// ---- persisted env / bootstrap helpers --------------------------------
+
+// Source ~/.config/dotclaude/handoff.env if present, seeding any missing
+// env var. Shell rc users can `source` the same file; bypass is trivial
+// via an explicit `DOTCLAUDE_HANDOFF_REPO=...` on the command line.
+export function loadPersistedEnv() {
+  const configFile = currentConfigFile();
+  if (!existsSync(configFile)) return;
+  let contents;
+  try {
+    contents = readFileSync(configFile, "utf8");
+  } catch {
+    return;
+  }
+  for (const raw of contents.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    let val = m[2];
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    if (process.env[key] === undefined || process.env[key] === "") {
+      process.env[key] = val;
+    }
+  }
+}
+
+export function ghAvailable() {
+  const r = spawnSync("gh", ["--version"], { encoding: "utf8" });
+  return r.status === 0;
+}
+
+export function ghAuthenticated() {
+  const r = spawnSync("gh", ["auth", "status", "-h", "github.com"], {
+    encoding: "utf8",
+  });
+  return r.status === 0;
+}
+
+export function ghLogin() {
+  const r = spawnSync("gh", ["api", "user", "-q", ".login"], {
+    encoding: "utf8",
+  });
+  if (r.status !== 0) return null;
+  return r.stdout.trim() || null;
+}
+
+// Three-line manual-setup block. Printed when we can't (or shouldn't)
+// auto-create — non-TTY, no `gh`, or user declines the prompt.
+export function printManualSetupBlock(reason) {
+  const msg = [
+    "",
+    `Can't auto-bootstrap the handoff store: ${reason}`,
+    "",
+    "Set it up manually:",
+    "  1. gh repo create <you>/dotclaude-handoff-store --private",
+    "  2. export DOTCLAUDE_HANDOFF_REPO=git@github.com:<you>/dotclaude-handoff-store.git",
+    "  3. dotclaude handoff push   # retries",
+    "",
+    "Alternative providers (GitLab, Gitea, self-hosted) work too — set",
+    "DOTCLAUDE_HANDOFF_REPO to any ssh://, git@, https://, file://, or absolute path.",
+    "",
+  ];
+  process.stderr.write(msg.join("\n"));
+}
+
+// Synchronous readline prompt that mirrors the existing collision-prompt
+// pattern (createInterface + rl.question + close). Returns the trimmed
+// answer, or "" for empty input.
+export async function promptLine(message) {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    return await new Promise((resolve) => {
+      rl.question(message, (answer) => resolve(answer.trim()));
+    });
+  } finally {
+    rl.close();
+  }
+}
+
+// Interactive repo creation. Prompts for a name (default
+// `dotclaude-handoff-store`), confirms, runs `gh repo create --private`,
+// writes the URL to ~/.config/dotclaude/handoff.env, and exports it
+// in-process so the current run continues without re-reading.
+//
+// Exits 2 with a manual-setup block when we can't proceed:
+//   - no TTY (cron/CI)
+//   - `gh` missing or unauthenticated
+//   - the user aborts
+export async function bootstrapTransportRepo() {
+  if (!isTty()) {
+    printManualSetupBlock("not running in an interactive terminal");
+    process.exit(2);
+  }
+  if (!ghAvailable()) {
+    printManualSetupBlock(
+      "`gh` CLI is not on PATH — install it from https://cli.github.com/",
+    );
+    process.exit(2);
+  }
+  if (!ghAuthenticated()) {
+    printManualSetupBlock(
+      "`gh` is not authenticated — run `gh auth login` (scopes: repo)",
+    );
+    process.exit(2);
+  }
+  const login = ghLogin();
+  if (!login) {
+    printManualSetupBlock("could not read GitHub username via `gh api user`");
+    process.exit(2);
+  }
+
+  const configFile = currentConfigFile();
+  process.stderr.write(
+    [
+      "",
+      "DOTCLAUDE_HANDOFF_REPO is not set — dotclaude can set this up for you.",
+      "",
+      `  Detected: gh CLI authenticated as @${login}.`,
+      `  Plan: create private repo  ${login}/<name>`,
+      `        persist URL to       ${configFile}`,
+      "",
+    ].join("\n"),
+  );
+
+  let name = "";
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const input = await promptLine("  Repo name? [dotclaude-handoff-store] ");
+    const candidate = input === "" ? "dotclaude-handoff-store" : slugifyRepoName(input);
+    if (/^[a-z0-9][a-z0-9-]{0,98}[a-z0-9]$|^[a-z0-9]$/.test(candidate)) {
+      name = candidate;
+      break;
+    }
+    process.stderr.write(
+      "  Name must be 1-100 chars of [a-z0-9-], no leading/trailing dash. Try again.\n",
+    );
+  }
+  if (!name) {
+    process.stderr.write("  Gave up after 3 invalid names. Aborting.\n");
+    process.exit(2);
+  }
+
+  const confirm = await promptLine(`  Create ${login}/${name} and proceed? [y/N] `);
+  if (!/^y(es)?$/i.test(confirm)) {
+    process.stderr.write("  Aborted.\n");
+    process.exit(1);
+  }
+
+  const create = spawnSync(
+    "gh",
+    [
+      "repo",
+      "create",
+      `${login}/${name}`,
+      "--private",
+      "--description",
+      "dotclaude handoff store",
+    ],
+    { encoding: "utf8" },
+  );
+  if (create.status !== 0) {
+    const stderr = (create.stderr || "").toLowerCase();
+    // Idempotent: an existing repo is not a failure — we'll push to it.
+    if (
+      !stderr.includes("already exists") &&
+      !stderr.includes("name already exists on this account")
+    ) {
+      process.stderr.write(`  gh repo create failed:\n${create.stderr}\n`);
+      process.exit(2);
+    }
+    process.stderr.write(`  ✓ repo ${login}/${name} already exists — reusing\n`);
+  } else {
+    process.stderr.write(`  ✓ created ${login}/${name}\n`);
+  }
+
+  const view = spawnSync(
+    "gh",
+    ["repo", "view", `${login}/${name}`, "--json", "sshUrl,url", "-q", ".sshUrl"],
+    { encoding: "utf8" },
+  );
+  const url =
+    view.status === 0 && view.stdout.trim()
+      ? view.stdout.trim()
+      : `git@github.com:${login}/${name}.git`;
+
+  mkdirSync(currentConfigDir(), { recursive: true, mode: 0o700 });
+  writeFileSync(
+    configFile,
+    `# Written by dotclaude handoff on ${new Date().toISOString()}\n` +
+      `# Sourceable from your shell rc:  source ${configFile}\n` +
+      `export DOTCLAUDE_HANDOFF_REPO=${url}\n`,
+    { mode: 0o600 },
+  );
+  process.stderr.write(`  ✓ wrote ${configFile}\n`);
+  process.stderr.write(
+    `    (add \`source ${configFile}\` to ~/.bashrc or ~/.zshrc to persist across shells)\n`,
+  );
+
+  process.env.DOTCLAUDE_HANDOFF_REPO = url;
+  return url;
+}
+
+// Public entry point: return a validated transport URL, bootstrapping
+// interactively if the env var is missing. Called by push/pull/list/
+// doctor, i.e. anywhere the remote is required.
+export async function requireTransportRepo() {
+  const existing = process.env.DOTCLAUDE_HANDOFF_REPO;
+  if (existing) return validateTransportUrl(existing);
+  const fresh = await bootstrapTransportRepo();
+  return validateTransportUrl(fresh);
+}
+
+// Synchronous variant for read-only paths (list, remote-list, doctor
+// shell script) that can't meaningfully trigger an interactive bootstrap
+// mid-command. Fails hard instead.
+export function requireTransportRepoStrict() {
+  const url = process.env.DOTCLAUDE_HANDOFF_REPO;
+  if (!url)
+    fail(
+      2,
+      "DOTCLAUDE_HANDOFF_REPO is not set — run `dotclaude handoff push` to auto-bootstrap, or set it manually",
+    );
+  return validateTransportUrl(url);
+}
+
+// ---- remote I/O --------------------------------------------------------
+
+export async function pushRemote({ cli, path: sessionFile, tag }) {
+  let repoUrl = await requireTransportRepo();
+  const meta = extractMeta(cli, sessionFile);
+  const prompts = extractPrompts(cli, sessionFile);
+  const turns = extractTurns(cli, sessionFile);
+  const toCli = meta.cli;
+  const handoffBlock = renderHandoffBlock(meta, prompts, turns, toCli);
+
+  // Scrub before the digest ever leaves the machine. Thrown errors
+  // propagate out of pushRemote — the outer try/catch in main() maps
+  // them to `push failed: <message>` with exit 2, so an unscrubbed
+  // digest can never reach the remote.
+  const { scrubbed, count: scrubbedCount } = scrubDigest(handoffBlock);
+
+  const shortId = meta.short_id ?? "unknown";
+  const host = slugify(hostname());
+  const project = projectSlugFromCwd(meta.cwd);
+  const month = monthBucket();
+  const description = encodeDescription({
+    cli: meta.cli,
+    shortId,
+    project,
+    host,
+    month,
+    tag: tag || null,
+  });
+
+  const metadata = {
+    cli: meta.cli,
+    session_id: meta.session_id,
+    short_id: shortId,
+    cwd: meta.cwd ?? null,
+    project,
+    month,
+    hostname: host,
+    created_at: new Date().toISOString(),
+    scrubbed_count: scrubbedCount,
+    tag: tag || null,
+  };
+
+  const doPush = (url) => {
+    const tmp = mkdtempSync(join(tmpdir(), "handoff-push-"));
+    try {
+      runGitOrThrow(["init", "-q"], tmp);
+      runGitOrThrow(["remote", "add", "origin", url], tmp);
+      runGitOrThrow(["config", "user.email", "handoff@dotclaude.local"], tmp);
+      runGitOrThrow(["config", "user.name", "dotclaude-handoff"], tmp);
+      const branch = v2BranchName({ project, cli: meta.cli, month, shortId });
+      runGitOrThrow(["checkout", "-q", "-b", branch], tmp);
+      writeFileSync(join(tmp, "handoff.md"), scrubbed + "\n");
+      writeFileSync(join(tmp, "metadata.json"), JSON.stringify(metadata, null, 2) + "\n");
+      writeFileSync(join(tmp, "description.txt"), description + "\n");
+      runGitOrThrow(["add", "."], tmp);
+      runGitOrThrow(["commit", "-q", "-m", description], tmp);
+      runGitOrThrow(["push", "-q", "-f", "origin", branch], tmp);
+      return { branch, url, description, scrubbedCount };
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  };
+
+  try {
+    return doPush(repoUrl);
+  } catch (err) {
+    // Retry once after bootstrap if the remote is gone or unauthorized
+    // — handles stale config (repo deleted) and first-run with a pre-set
+    // env var that points at a non-existent repo. Second failure is fatal.
+    if (!isRepoMissingError(err.message)) throw err;
+    if (!isTty()) {
+      printManualSetupBlock(
+        `configured repo is unreachable (${process.env.DOTCLAUDE_HANDOFF_REPO}) and we can't prompt in non-interactive mode`,
+      );
+      throw err;
+    }
+    process.stderr.write(
+      `\n  The configured repo (${process.env.DOTCLAUDE_HANDOFF_REPO}) is unreachable.\n`,
+    );
+    const again = await promptLine("  Re-bootstrap (create a new one)? [y/N] ");
+    if (!/^y(es)?$/i.test(again)) throw err;
+    // Clear the stale URL so bootstrapTransportRepo() doesn't short-circuit.
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    const fresh = await bootstrapTransportRepo();
+    return doPush(validateTransportUrl(fresh));
+  }
+}
+
+/**
+ * List handoff branches on the remote as candidate objects.
+ * Returns [{branch, description, commit}] — no content fetched.
+ */
+export function listRemoteCandidates() {
+  const repoUrl = requireTransportRepoStrict();
+  const r = runGit(["ls-remote", repoUrl, "refs/heads/handoff/*"]);
+  if (r.status !== 0) fail(2, `ls-remote failed: ${r.stderr.trim()}`);
+  const rows = [];
+  for (const line of r.stdout.split("\n")) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length !== 2) continue;
+    const commit = parts[0];
+    const ref = parts[1];
+    const branch = ref.replace(/^refs\/heads\//, "");
+    rows.push({ commit, branch, description: "" });
+  }
+  return rows;
+}
+
+/**
+ * Fetch a specific handoff branch and return its `handoff.md` content.
+ */
+export function fetchRemoteBranch(branch) {
+  const repoUrl = requireTransportRepoStrict();
+  const tmp = mkdtempSync(join(tmpdir(), "handoff-pull-"));
+  try {
+    const r = runGit(["clone", "-q", "--depth", "1", "--branch", branch, repoUrl, "."], tmp);
+    if (r.status !== 0) {
+      throw new Error(`clone --branch ${branch} failed: ${r.stderr.trim()}`);
+    }
+    const handoffPath = join(tmp, "handoff.md");
+    if (!existsSync(handoffPath)) {
+      throw new Error(`handoff.md missing in branch ${branch}`);
+    }
+    const content = readFileSync(handoffPath, "utf8");
+    const descPath = join(tmp, "description.txt");
+    const description = existsSync(descPath) ? readFileSync(descPath, "utf8").trim() : "";
+    return { content, description };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Enrich candidates with their description (requires per-branch fetch).
+ */
+export function enrichWithDescriptions(candidates) {
+  return candidates.map((c) => {
+    try {
+      const { description } = fetchRemoteBranch(c.branch);
+      return { ...c, description };
+    } catch {
+      return c;
+    }
+  });
+}
+
+export function matchesQuery(candidate, query) {
+  const q = query.toLowerCase();
+  if (candidate.branch.toLowerCase().includes(q)) return true;
+  if (candidate.description && candidate.description.toLowerCase().includes(q))
+    return true;
+  if (candidate.commit && candidate.commit.toLowerCase().startsWith(q)) return true;
+  return false;
+}
+
+export async function pullRemote(query, fromCli = null) {
+  let candidates = listRemoteCandidates();
+  if (candidates.length === 0) fail(2, "no handoffs found on transport");
+
+  // v2 carries the CLI in segment 2 (handoff/<project>/<cli>/...);
+  // v1 legacy carries it in segment 1 (handoff/<cli>/<short>).
+  if (fromCli) {
+    candidates = candidates.filter((c) => {
+      const segs = c.branch.split("/");
+      return segs[2] === fromCli || segs[1] === fromCli;
+    });
+    if (candidates.length === 0) fail(2, `no ${fromCli} handoffs found on transport`);
+  }
+
+  // Bare: pick the newest. We don't have a reliable remote mtime, so
+  // fall back to the lexically last branch, which is typically the
+  // most recent since short IDs hash-distribute. The caller re-fetches
+  // the branch contents via fetchRemoteBranch, so skipping the
+  // enrichment pass saves N shallow clones.
+  if (!query) {
+    return candidates[candidates.length - 1];
+  }
+
+  // Cheap pass: filter by branch name.
+  let hits = candidates.filter((c) => matchesQuery(c, query));
+  if (hits.length === 0) {
+    // Expensive pass: enrich with descriptions and re-match.
+    const enriched = enrichWithDescriptions(candidates);
+    hits = enriched.filter((c) => matchesQuery(c, query));
+  } else {
+    hits = enrichWithDescriptions(hits);
+  }
+
+  if (hits.length === 0) {
+    fail(
+      2,
+      fromCli ? `no ${fromCli} handoffs match: ${query}` : `no handoffs match: ${query}`,
+    );
+  }
+  if (hits.length === 1) return hits[0];
+
+  // Collision.
+  if (process.stdin.isTTY) {
+    process.stderr.write(`dotclaude-handoff: multiple handoffs match "${query}":\n`);
+    hits.forEach((h, i) => {
+      process.stderr.write(`  [${i + 1}] ${h.branch}  ${h.description}\n`);
+    });
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const ans = await new Promise((resolve) => {
+      rl.question("Pick [1..N], or any other input to abort: ", resolve);
+    });
+    rl.close();
+    const n = Number.parseInt(ans.trim(), 10);
+    if (!Number.isInteger(n) || n < 1 || n > hits.length) process.exit(2);
+    return hits[n - 1];
+  }
+  process.stderr.write(`dotclaude-handoff: multiple handoffs match "${query}":\n`);
+  for (const h of hits) process.stderr.write(`  ${h.branch}\t${h.description}\n`);
+  process.exit(2);
+}

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -28,8 +28,10 @@ import { scrubDigest } from "./handoff-scrub.mjs";
 
 // ---- constants ---------------------------------------------------------
 
+/** Matches v2 handoff branch names: handoff/<project>/<cli>/<YYYY-MM>/<shortId>. */
 export const V2_BRANCH_RE =
   /^handoff\/[a-z0-9-]+\/(claude|copilot|codex)\/\d{4}-\d{2}\/[0-9a-f]{8}$/;
+/** Matches legacy v1 handoff branch names: handoff/<cli>/<shortId>. */
 export const V1_BRANCH_RE = /^handoff\/(claude|copilot|codex)\/[0-9a-f]{8}$/;
 
 // Callers that read state at run time (loadPersistedEnv,
@@ -47,6 +49,7 @@ function currentConfigDir() {
 function currentConfigFile() {
   return join(currentConfigDir(), "handoff.env");
 }
+/** Path to the persisted handoff env file; evaluated at library-init time. */
 export const CONFIG_FILE = currentConfigFile();
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -65,6 +68,7 @@ function fail(code, msg) {
 
 // ---- subprocess primitives ---------------------------------------------
 
+/** Spawn a shell script via spawnSync, returning {status, stdout, stderr}. */
 export function runScript(script, args, opts = {}) {
   const res = spawnSync(script, args, { encoding: "utf8", ...opts });
   return {
@@ -74,10 +78,12 @@ export function runScript(script, args, opts = {}) {
   };
 }
 
+/** Run git with spawnSync, returning the raw SpawnSyncReturns result. */
 export function runGit(args, cwd) {
   return spawnSync("git", args, { encoding: "utf8", cwd });
 }
 
+/** Run git and throw a descriptive Error on non-zero exit. */
 export function runGitOrThrow(args, cwd) {
   const r = runGit(args, cwd);
   if (r.status !== 0) {
@@ -90,6 +96,7 @@ export function runGitOrThrow(args, cwd) {
 
 // ---- session extraction ------------------------------------------------
 
+/** Extract JSON session metadata via handoff-extract.sh meta. */
 export function extractMeta(cli, file) {
   const r = runScript(EXTRACT_SH, ["meta", cli, file]);
   if (r.status !== 0) fail(2, r.stderr.trim() || `meta extraction failed for ${cli}`);
@@ -100,6 +107,7 @@ export function extractMeta(cli, file) {
   }
 }
 
+/** Extract newline-delimited output via handoff-extract.sh <sub>. */
 export function extractLines(sub, cli, file, extra = []) {
   const r = runScript(EXTRACT_SH, [sub, cli, file, ...extra]);
   if (r.status !== 0) {
@@ -110,12 +118,15 @@ export function extractLines(sub, cli, file, extra = []) {
   return r.stdout.split("\n").filter((line) => line.trim().length > 0);
 }
 
+/** Extract user prompt lines from a session file. */
 export const extractPrompts = (cli, file) => extractLines("prompts", cli, file);
+/** Extract assistant turn lines from a session file (optionally capped). */
 export const extractTurns = (cli, file, limit) =>
   extractLines("turns", cli, file, limit ? [String(limit)] : []);
 
 // ---- rendering ---------------------------------------------------------
 
+/** Return a target-CLI-specific continuation hint for the next-step text. */
 export function nextStepFor(toCli) {
   if (toCli === "codex") {
     return "Read the prompts and assistant turns above, then continue the task using the file paths mentioned. Treat this as a task specification.";
@@ -126,6 +137,7 @@ export function nextStepFor(toCli) {
   return "Continue from the last assistant turn using the same file scope and goals summarized above.";
 }
 
+/** Produce a one-sentence summary: first prompt + last assistant turn (clipped). */
 export function mechanicalSummary(prompts, turns) {
   const first = prompts[0] ?? "(no user prompts captured)";
   const last = turns[turns.length - 1] ?? "(no assistant turns captured)";
@@ -133,6 +145,7 @@ export function mechanicalSummary(prompts, turns) {
   return `Session opened with: "${clip(first, 160)}". Last assistant output (truncated): "${clip(last, 160)}". Full prompt log and assistant tail follow for context.`;
 }
 
+/** Render the full <handoff> block for push or standalone describe. */
 export function renderHandoffBlock(meta, prompts, turns, toCli) {
   const summary = mechanicalSummary(prompts, turns);
   const promptsCapped = prompts.slice(-10);
@@ -171,8 +184,10 @@ export function renderHandoffBlock(meta, prompts, turns, toCli) {
 
 // ---- URL / path primitives ---------------------------------------------
 
-// Reject ext:: and other exec-triggering Git URL schemes (CVE-2017-1000117-class).
-// Allow: https://, http://, git@, ssh://, file://, and absolute paths (bare repos).
+/**
+ * Reject ext:: and other exec-triggering Git URL schemes (CVE-2017-1000117-class).
+ * Allows: https://, http://, git@, ssh://, file://, and absolute paths.
+ */
 export function validateTransportUrl(url) {
   if (!/^(https?:\/\/|git@|ssh:\/\/|file:\/\/|\/)/.test(url))
     fail(
@@ -182,9 +197,10 @@ export function validateTransportUrl(url) {
   return url;
 }
 
-// Detect the "remote repo doesn't exist / auth failed" class of errors
-// from `git push` stderr. GitHub, GitLab, Gitea and plain SSH all phrase
-// it slightly differently, so match on the union.
+/**
+ * Return true if stderr matches the union of "repo missing / auth failed"
+ * messages from GitHub, GitLab, Gitea, and plain SSH.
+ */
 export function isRepoMissingError(stderr) {
   const s = (stderr || "").toLowerCase();
   return (
@@ -197,9 +213,10 @@ export function isRepoMissingError(stderr) {
   );
 }
 
-// Mirror of the shell `slugify` in handoff-description.sh so JS-side
-// encoders and the shell decoder agree on the edge cases (dash-run
-// collapse, trimmed edges, "" → "adhoc" fallback).
+/**
+ * Lowercase, replace non-alphanumeric runs with dashes, trim edges, cap at 40 chars.
+ * Mirrors handoff-description.sh slugify so JS and shell agree on edge cases.
+ */
 export function slugify(s) {
   if (!s) return "adhoc";
   const out = s
@@ -210,9 +227,10 @@ export function slugify(s) {
   return out.slice(0, 40) || "adhoc";
 }
 
-// Best-effort slugify matching what `gh repo create` will accept. Stricter
-// than handoff-description.sh's slugify because GitHub repo names reject
-// leading/trailing dashes and double-dashes.
+/**
+ * Slugify to GitHub-acceptable repo name: [a-z0-9-], no leading/trailing dashes,
+ * max 100 chars.
+ */
 export function slugifyRepoName(input) {
   const s = (input || "")
     .trim()
@@ -223,9 +241,10 @@ export function slugifyRepoName(input) {
   return s.slice(0, 100);
 }
 
-// Walk up to the git-repo root so a session deep in `~/foo/services/api`
-// groups under `foo`, not `api`. Falls back to the cwd basename outside
-// a git repo.
+/**
+ * Return the slugified top-level git repo name for `cwd`, or the basename.
+ * A session inside ~/foo/services/api groups under "foo", not "api".
+ */
 export function projectSlugFromCwd(cwd) {
   if (!cwd) return "adhoc";
   const r = runGit(["-C", cwd, "rev-parse", "--show-toplevel"]);
@@ -234,6 +253,7 @@ export function projectSlugFromCwd(cwd) {
   return slugify(last);
 }
 
+/** Return YYYY-MM for an ISO timestamp, or for the current UTC month if null/invalid. */
 export function monthBucket(isoOrNull) {
   const d = isoOrNull ? new Date(isoOrNull) : new Date();
   if (Number.isNaN(d.getTime())) return monthBucket(null);
@@ -242,16 +262,19 @@ export function monthBucket(isoOrNull) {
   return `${yyyy}-${mm}`;
 }
 
+/** Assemble the canonical v2 branch name from {project, cli, month, shortId}. */
 export function v2BranchName({ project, cli, month, shortId }) {
   return `handoff/${slugify(project)}/${cli}/${month}/${shortId}`;
 }
 
+/** Return true when both stdin and stderr are interactive TTYs. */
 export function isTty() {
   return Boolean(process.stdin.isTTY && process.stderr.isTTY);
 }
 
 // ---- metadata encoding / decoding --------------------------------------
 
+/** Encode handoff metadata into an opaque description string via handoff-description.sh. */
 export function encodeDescription({ cli, shortId, project, host, month, tag }) {
   const args = [
     "encode",
@@ -272,6 +295,7 @@ export function encodeDescription({ cli, shortId, project, host, month, tag }) {
   return r.stdout.trim();
 }
 
+/** Decode a handoff description string back into a metadata object, or null on failure. */
 export function decodeDescription(desc) {
   if (!desc) return null;
   if (!desc.startsWith("handoff:v1:") && !desc.startsWith("handoff:v2:")) return null;
@@ -286,9 +310,10 @@ export function decodeDescription(desc) {
 
 // ---- persisted env / bootstrap helpers --------------------------------
 
-// Source ~/.config/dotclaude/handoff.env if present, seeding any missing
-// env var. Shell rc users can `source` the same file; bypass is trivial
-// via an explicit `DOTCLAUDE_HANDOFF_REPO=...` on the command line.
+/**
+ * Source ~/.config/dotclaude/handoff.env if present, seeding any missing env var.
+ * Shell rc users can `source` the same file; bypass via an explicit env var.
+ */
 export function loadPersistedEnv() {
   const configFile = currentConfigFile();
   if (!existsSync(configFile)) return;
@@ -317,11 +342,13 @@ export function loadPersistedEnv() {
   }
 }
 
+/** Return true if `gh` is on PATH and exits 0. */
 export function ghAvailable() {
   const r = spawnSync("gh", ["--version"], { encoding: "utf8" });
   return r.status === 0;
 }
 
+/** Return true if `gh auth status` exits 0 (authenticated to github.com). */
 export function ghAuthenticated() {
   const r = spawnSync("gh", ["auth", "status", "-h", "github.com"], {
     encoding: "utf8",
@@ -329,6 +356,7 @@ export function ghAuthenticated() {
   return r.status === 0;
 }
 
+/** Return the authenticated GitHub username, or null on failure. */
 export function ghLogin() {
   const r = spawnSync("gh", ["api", "user", "-q", ".login"], {
     encoding: "utf8",
@@ -337,8 +365,10 @@ export function ghLogin() {
   return r.stdout.trim() || null;
 }
 
-// Three-line manual-setup block. Printed when we can't (or shouldn't)
-// auto-create — non-TTY, no `gh`, or user declines the prompt.
+/**
+ * Print a manual-setup hint block to stderr when auto-bootstrap can't proceed.
+ * Triggered for non-TTY, missing gh, or user abort.
+ */
 export function printManualSetupBlock(reason) {
   const msg = [
     "",
@@ -356,9 +386,10 @@ export function printManualSetupBlock(reason) {
   process.stderr.write(msg.join("\n"));
 }
 
-// Synchronous readline prompt that mirrors the existing collision-prompt
-// pattern (createInterface + rl.question + close). Returns the trimmed
-// answer, or "" for empty input.
+/**
+ * Async readline prompt via createInterface; returns the trimmed answer.
+ * Returns "" for empty input.
+ */
 export async function promptLine(message) {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
   try {
@@ -370,15 +401,11 @@ export async function promptLine(message) {
   }
 }
 
-// Interactive repo creation. Prompts for a name (default
-// `dotclaude-handoff-store`), confirms, runs `gh repo create --private`,
-// writes the URL to ~/.config/dotclaude/handoff.env, and exports it
-// in-process so the current run continues without re-reading.
-//
-// Exits 2 with a manual-setup block when we can't proceed:
-//   - no TTY (cron/CI)
-//   - `gh` missing or unauthenticated
-//   - the user aborts
+/**
+ * Interactively create a private GitHub repo for handoff storage via `gh`.
+ * Writes the URL to the persisted env file and sets DOTCLAUDE_HANDOFF_REPO.
+ * Exits 2 with a manual-setup block when non-TTY, gh missing, or user aborts.
+ */
 export async function bootstrapTransportRepo() {
   if (!isTty()) {
     printManualSetupBlock("not running in an interactive terminal");
@@ -492,9 +519,10 @@ export async function bootstrapTransportRepo() {
   return url;
 }
 
-// Public entry point: return a validated transport URL, bootstrapping
-// interactively if the env var is missing. Called by push/pull/list/
-// doctor, i.e. anywhere the remote is required.
+/**
+ * Return a validated transport URL, bootstrapping interactively if the env var
+ * is missing. Call site for push/pull/list/doctor.
+ */
 export async function requireTransportRepo() {
   const existing = process.env.DOTCLAUDE_HANDOFF_REPO;
   if (existing) return validateTransportUrl(existing);
@@ -502,9 +530,10 @@ export async function requireTransportRepo() {
   return validateTransportUrl(fresh);
 }
 
-// Synchronous variant for read-only paths (list, remote-list, doctor
-// shell script) that can't meaningfully trigger an interactive bootstrap
-// mid-command. Fails hard instead.
+/**
+ * Synchronous variant: return a validated transport URL or fail hard.
+ * Use for read-only paths (list, doctor) that cannot trigger interactive bootstrap.
+ */
 export function requireTransportRepoStrict() {
   const url = process.env.DOTCLAUDE_HANDOFF_REPO;
   if (!url)
@@ -517,6 +546,7 @@ export function requireTransportRepoStrict() {
 
 // ---- remote I/O --------------------------------------------------------
 
+/** Push a local session to the transport repo as a handoff branch. */
 export async function pushRemote({ cli, path: sessionFile, tag }) {
   let repoUrl = await requireTransportRepo();
   const meta = extractMeta(cli, sessionFile);
@@ -661,6 +691,7 @@ export function enrichWithDescriptions(candidates) {
   });
 }
 
+/** Return true if a candidate {branch, description, commit} matches the query string. */
 export function matchesQuery(candidate, query) {
   const q = query.toLowerCase();
   if (candidate.branch.toLowerCase().includes(q)) return true;
@@ -670,6 +701,7 @@ export function matchesQuery(candidate, query) {
   return false;
 }
 
+/** Resolve a remote handoff branch by query, pick interactively on collision. */
 export async function pullRemote(query, fromCli = null) {
   let candidates = listRemoteCandidates();
   if (candidates.length === 0) fail(2, "no handoffs found on transport");

--- a/plugins/dotclaude/tests/argv.test.mjs
+++ b/plugins/dotclaude/tests/argv.test.mjs
@@ -61,6 +61,16 @@ describe("helpText", () => {
     expect(text).toContain("--json");
     expect(text).toContain("Exit codes:");
   });
+
+  it("works without the optional flags property", () => {
+    const text = helpText({
+      name: "harness-foo",
+      synopsis: "harness-foo",
+      description: "Test.",
+    });
+    expect(text).toContain("--help");
+    expect(text).toContain("Exit codes:");
+  });
 });
 
 describe("HARNESS_FLAGS", () => {

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -462,12 +462,27 @@ describe("loadPersistedEnv", () => {
     expect(process.env.DOTCLAUDE_HANDOFF_REPO).toBe("good-val");
   });
 
+  it("uses XDG_CONFIG_HOME when set", () => {
+    const origXDG = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = "/tmp/test-xdg-config";
+    existsSync.mockReturnValueOnce(false);
+    try {
+      expect(() => lib.loadPersistedEnv()).not.toThrow();
+    } finally {
+      if (origXDG !== undefined) {
+        process.env.XDG_CONFIG_HOME = origXDG;
+      } else {
+        delete process.env.XDG_CONFIG_HOME;
+      }
+    }
+  });
+
   it("falls back to HOME when XDG_CONFIG_HOME is unset", () => {
     const origXDG = process.env.XDG_CONFIG_HOME;
     delete process.env.XDG_CONFIG_HOME;
     existsSync.mockReturnValueOnce(false);
     expect(() => lib.loadPersistedEnv()).not.toThrow();
-    process.env.XDG_CONFIG_HOME = origXDG;
+    if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
   });
 
   it("falls back to empty string when both XDG_CONFIG_HOME and HOME are unset", () => {

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -1,0 +1,909 @@
+// Coverage-focused tests for handoff-remote.mjs.
+// Mocks node:child_process and node:fs so subprocess / filesystem
+// code paths can be exercised without touching the real system.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+  mkdtempSync: vi.fn().mockReturnValue("/tmp/mock-dir"),
+  readFileSync: vi.fn().mockReturnValue(""),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+vi.mock("node:readline", () => ({
+  createInterface: vi.fn(),
+}));
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+import * as lib from "../src/lib/handoff-remote.mjs";
+
+// ---- helpers -----------------------------------------------------------
+
+function mockExit() {
+  return vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`__exit__${code}`);
+  });
+}
+
+// ---- runScript ---------------------------------------------------------
+
+describe("runScript", () => {
+  it("returns {status, stdout, stderr} on success", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "out\n", stderr: "" });
+    const r = lib.runScript("/bin/sh", ["-c", "echo hi"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("out\n");
+    expect(r.stderr).toBe("");
+  });
+
+  it("falls back to status 2 and empty strings when spawnSync returns nulls", () => {
+    spawnSync.mockReturnValueOnce({ status: null, stdout: null, stderr: null });
+    const r = lib.runScript("/missing", []);
+    expect(r.status).toBe(2);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toBe("");
+  });
+});
+
+// ---- runGit / runGitOrThrow --------------------------------------------
+
+describe("runGit", () => {
+  it("invokes spawnSync with git and forwards cwd", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "abc\n", stderr: "" });
+    const r = lib.runGit(["rev-parse", "HEAD"], "/tmp");
+    expect(spawnSync).toHaveBeenCalledWith("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+      cwd: "/tmp",
+    });
+    expect(r.status).toBe(0);
+  });
+});
+
+describe("runGitOrThrow", () => {
+  it("returns the result when git exits 0", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "ok\n", stderr: "" });
+    const r = lib.runGitOrThrow(["status"], "/tmp");
+    expect(r.status).toBe(0);
+  });
+
+  it("throws a descriptive Error on non-zero exit (stderr preferred)", () => {
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "fatal: bad object" });
+    expect(() => lib.runGitOrThrow(["show", "HEAD"], "/tmp")).toThrow(
+      "git show HEAD failed: fatal: bad object",
+    );
+  });
+
+  it("falls back to stdout in the thrown message when stderr is empty", () => {
+    spawnSync.mockReturnValueOnce({ status: 128, stdout: "hint: something", stderr: "" });
+    expect(() => lib.runGitOrThrow(["push"], "/tmp")).toThrow("hint: something");
+  });
+});
+
+// ---- extractMeta -------------------------------------------------------
+
+describe("extractMeta", () => {
+  let exitSpy;
+  beforeEach(() => { exitSpy = mockExit(); });
+  afterEach(() => exitSpy.mockRestore());
+
+  it("returns parsed JSON meta on success", () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '{"cli":"claude","short_id":"ab12cd34"}',
+      stderr: "",
+    });
+    const meta = lib.extractMeta("claude", "/session");
+    expect(meta.cli).toBe("claude");
+    expect(meta.short_id).toBe("ab12cd34");
+  });
+
+  it("exits 2 when the script fails", () => {
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "extract error" });
+    expect(() => lib.extractMeta("claude", "/session")).toThrow(/__exit__2/);
+  });
+
+  it("exits 2 when output is not valid JSON", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "not-json", stderr: "" });
+    expect(() => lib.extractMeta("claude", "/session")).toThrow(/__exit__2/);
+  });
+
+  it("exits 2 using the fallback message when script fails with empty stderr", () => {
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(() => lib.extractMeta("claude", "/session")).toThrow(/__exit__2/);
+  });
+});
+
+// ---- extractLines / extractPrompts / extractTurns ----------------------
+
+describe("extractLines", () => {
+  it("returns non-empty lines on success", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "line1\nline2\n\n", stderr: "" });
+    expect(lib.extractLines("prompts", "claude", "/f")).toEqual(["line1", "line2"]);
+  });
+
+  it("returns [] on non-zero exit", () => {
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(lib.extractLines("turns", "claude", "/f")).toEqual([]);
+  });
+
+  it("writes stderr to process.stderr on failure", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "some error" });
+    lib.extractLines("turns", "claude", "/f");
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe("extractPrompts", () => {
+  it("delegates to extractLines with sub=prompts", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "user said hi\n", stderr: "" });
+    expect(lib.extractPrompts("claude", "/f")).toEqual(["user said hi"]);
+  });
+});
+
+describe("extractTurns", () => {
+  it("delegates to extractLines with sub=turns (no limit)", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "assistant replied\n", stderr: "" });
+    expect(lib.extractTurns("claude", "/f")).toEqual(["assistant replied"]);
+  });
+
+  it("passes limit as extra arg when provided", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "t1\nt2\n", stderr: "" });
+    lib.extractTurns("claude", "/f", 5);
+    expect(spawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining(["5"]),
+      expect.anything(),
+    );
+  });
+});
+
+// ---- nextStepFor -------------------------------------------------------
+
+describe("nextStepFor", () => {
+  it("returns codex task-specification text", () => {
+    expect(lib.nextStepFor("codex")).toContain("task specification");
+  });
+  it("returns copilot pick-up text", () => {
+    expect(lib.nextStepFor("copilot")).toContain("pick up where");
+  });
+  it("returns default continue text for claude", () => {
+    expect(lib.nextStepFor("claude")).toContain("Continue from");
+  });
+});
+
+// ---- mechanicalSummary -------------------------------------------------
+
+describe("mechanicalSummary", () => {
+  it("uses placeholder text when arrays are empty", () => {
+    const s = lib.mechanicalSummary([], []);
+    expect(s).toContain("(no user prompts captured)");
+    expect(s).toContain("(no assistant turns captured)");
+  });
+
+  it("clips prompt and turn to 160 chars with ellipsis", () => {
+    const long = "a".repeat(300);
+    const s = lib.mechanicalSummary([long], [long]);
+    expect(s).toContain("…");
+  });
+
+  it("uses first prompt and last turn", () => {
+    const s = lib.mechanicalSummary(["first", "second"], ["turn1", "turn2"]);
+    expect(s).toContain("first");
+    expect(s).toContain("turn2");
+  });
+});
+
+// ---- renderHandoffBlock ------------------------------------------------
+
+describe("renderHandoffBlock", () => {
+  const meta = { cli: "claude", short_id: "abc12345", cwd: "/projects/foo" };
+
+  it("wraps content in <handoff> tags", () => {
+    const block = lib.renderHandoffBlock(meta, ["p1"], ["t1"], "codex");
+    expect(block).toMatch(/^<handoff /);
+    expect(block).toContain("</handoff>");
+  });
+
+  it("lists prompts and turn tail", () => {
+    const block = lib.renderHandoffBlock(meta, ["user prompt"], ["assistant turn"], "claude");
+    expect(block).toContain("user prompt");
+    expect(block).toContain("assistant turn");
+  });
+
+  it("handles empty prompts with fallback text", () => {
+    const block = lib.renderHandoffBlock(meta, [], [], "claude");
+    expect(block).toContain("(no user prompts captured)");
+    expect(block).toContain("_(no assistant output captured)_");
+  });
+
+  it("caps prompts at last 10", () => {
+    const prompts = Array.from({ length: 15 }, (_, i) => `p${i}`);
+    const block = lib.renderHandoffBlock(meta, prompts, [], "claude");
+    expect(block).toContain("10. p14");
+    expect(block).not.toContain("11. ");
+  });
+
+  it("truncates long prompts at 300 chars", () => {
+    const long = "x".repeat(500);
+    const block = lib.renderHandoffBlock(meta, [long], [], "claude");
+    expect(block).toContain("…");
+  });
+
+  it("truncates long turns at 400 chars", () => {
+    const long = "y".repeat(600);
+    const block = lib.renderHandoffBlock(meta, [], [long], "claude");
+    expect(block).toContain("…");
+  });
+});
+
+// ---- isTty -------------------------------------------------------------
+
+describe("isTty", () => {
+  it("returns false when stdin is not a TTY (test environment)", () => {
+    expect(lib.isTty()).toBe(false);
+  });
+});
+
+// ---- encodeDescription / decodeDescription -----------------------------
+
+describe("encodeDescription", () => {
+  let exitSpy;
+  beforeEach(() => { exitSpy = mockExit(); });
+  afterEach(() => exitSpy.mockRestore());
+
+  it("returns the trimmed encoded string on success", () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "handoff:v2:claude/abc/proj/host\n",
+      stderr: "",
+    });
+    const result = lib.encodeDescription({
+      cli: "claude",
+      shortId: "abc",
+      project: "proj",
+      host: "host",
+      month: "2026-04",
+      tag: null,
+    });
+    expect(result).toBe("handoff:v2:claude/abc/proj/host");
+  });
+
+  it("includes tag arg when tag is provided", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "encoded\n", stderr: "" });
+    lib.encodeDescription({
+      cli: "claude", shortId: "abc", project: "proj", host: "host", month: "2026-04", tag: "mywork",
+    });
+    expect(spawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining(["--tag", "mywork"]),
+      expect.anything(),
+    );
+  });
+
+  it("exits 2 on encode failure", () => {
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "encode failed" });
+    expect(() => lib.encodeDescription({
+      cli: "claude", shortId: "x", project: "p", host: "h", month: "2026-04", tag: null,
+    })).toThrow(/__exit__2/);
+  });
+});
+
+describe("decodeDescription", () => {
+  it("returns null for null input", () => {
+    expect(lib.decodeDescription(null)).toBeNull();
+  });
+
+  it("returns null for non-handoff prefix", () => {
+    expect(lib.decodeDescription("other:blah")).toBeNull();
+  });
+
+  it("parses v2 descriptions", () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '{"cli":"claude","shortId":"abc"}',
+      stderr: "",
+    });
+    const result = lib.decodeDescription("handoff:v2:claude/abc/proj/host");
+    expect(result).toEqual({ cli: "claude", shortId: "abc" });
+  });
+
+  it("parses v1 descriptions", () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '{"cli":"codex"}',
+      stderr: "",
+    });
+    expect(lib.decodeDescription("handoff:v1:codex/abc")).toEqual({ cli: "codex" });
+  });
+
+  it("returns null when script exits non-zero", () => {
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(lib.decodeDescription("handoff:v2:x")).toBeNull();
+  });
+
+  it("returns null when output is invalid JSON", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "not-json", stderr: "" });
+    expect(lib.decodeDescription("handoff:v2:x")).toBeNull();
+  });
+});
+
+// ---- ghAvailable / ghAuthenticated / ghLogin ---------------------------
+
+describe("ghAvailable", () => {
+  it("returns true when gh exits 0", () => {
+    spawnSync.mockReturnValueOnce({ status: 0 });
+    expect(lib.ghAvailable()).toBe(true);
+  });
+
+  it("returns false when gh exits non-zero", () => {
+    spawnSync.mockReturnValueOnce({ status: 127 });
+    expect(lib.ghAvailable()).toBe(false);
+  });
+});
+
+describe("ghAuthenticated", () => {
+  it("returns true on successful auth status", () => {
+    spawnSync.mockReturnValueOnce({ status: 0 });
+    expect(lib.ghAuthenticated()).toBe(true);
+  });
+
+  it("returns false when auth status fails", () => {
+    spawnSync.mockReturnValueOnce({ status: 1 });
+    expect(lib.ghAuthenticated()).toBe(false);
+  });
+});
+
+describe("ghLogin", () => {
+  it("returns trimmed login on success", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "octocat\n" });
+    expect(lib.ghLogin()).toBe("octocat");
+  });
+
+  it("returns null when gh fails", () => {
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "" });
+    expect(lib.ghLogin()).toBeNull();
+  });
+
+  it("returns null when output is empty", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "" });
+    expect(lib.ghLogin()).toBeNull();
+  });
+});
+
+// ---- printManualSetupBlock ---------------------------------------------
+
+describe("printManualSetupBlock", () => {
+  it("writes setup instructions to stderr", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    lib.printManualSetupBlock("no tty");
+    const out = spy.mock.calls.map((c) => c[0]).join("");
+    expect(out).toContain("no tty");
+    expect(out).toContain("DOTCLAUDE_HANDOFF_REPO");
+    spy.mockRestore();
+  });
+});
+
+// ---- loadPersistedEnv --------------------------------------------------
+
+describe("loadPersistedEnv", () => {
+  afterEach(() => {
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("does nothing when config file does not exist", () => {
+    existsSync.mockReturnValueOnce(false);
+    expect(() => lib.loadPersistedEnv()).not.toThrow();
+  });
+
+  it("sets env vars from file content (quoted)", () => {
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValueOnce(
+      'export DOTCLAUDE_HANDOFF_REPO="git@github.com:x/y.git"\n',
+    );
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    lib.loadPersistedEnv();
+    expect(process.env.DOTCLAUDE_HANDOFF_REPO).toBe("git@github.com:x/y.git");
+  });
+
+  it("sets env vars from file content (bare value)", () => {
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValueOnce("DOTCLAUDE_HANDOFF_REPO=https://example.com/x.git\n");
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    lib.loadPersistedEnv();
+    expect(process.env.DOTCLAUDE_HANDOFF_REPO).toBe("https://example.com/x.git");
+  });
+
+  it("skips comment lines and blank lines", () => {
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValueOnce("# comment\n\nDOTCLAUDE_HANDOFF_REPO=val\n");
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    lib.loadPersistedEnv();
+    expect(process.env.DOTCLAUDE_HANDOFF_REPO).toBe("val");
+  });
+
+  it("does not overwrite an already-set env var", () => {
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValueOnce("DOTCLAUDE_HANDOFF_REPO=new-val\n");
+    process.env.DOTCLAUDE_HANDOFF_REPO = "existing";
+    lib.loadPersistedEnv();
+    expect(process.env.DOTCLAUDE_HANDOFF_REPO).toBe("existing");
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("strips single-quoted values", () => {
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValueOnce("DOTCLAUDE_HANDOFF_REPO='git@github.com:x/y.git'\n");
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    lib.loadPersistedEnv();
+    expect(process.env.DOTCLAUDE_HANDOFF_REPO).toBe("git@github.com:x/y.git");
+  });
+
+  it("swallows a readFileSync error silently", () => {
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockImplementationOnce(() => { throw new Error("EACCES"); });
+    expect(() => lib.loadPersistedEnv()).not.toThrow();
+  });
+
+  it("skips lines that do not match the VAR=VAL pattern", () => {
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValueOnce("not-valid-line\nDOTCLAUDE_HANDOFF_REPO=good-val\n");
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    lib.loadPersistedEnv();
+    expect(process.env.DOTCLAUDE_HANDOFF_REPO).toBe("good-val");
+  });
+
+  it("falls back to HOME when XDG_CONFIG_HOME is unset", () => {
+    const origXDG = process.env.XDG_CONFIG_HOME;
+    delete process.env.XDG_CONFIG_HOME;
+    existsSync.mockReturnValueOnce(false);
+    expect(() => lib.loadPersistedEnv()).not.toThrow();
+    process.env.XDG_CONFIG_HOME = origXDG;
+  });
+
+  it("falls back to empty string when both XDG_CONFIG_HOME and HOME are unset", () => {
+    const origXDG = process.env.XDG_CONFIG_HOME;
+    const origHOME = process.env.HOME;
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.HOME;
+    existsSync.mockReturnValueOnce(false);
+    try {
+      expect(() => lib.loadPersistedEnv()).not.toThrow();
+    } finally {
+      if (origXDG !== undefined) process.env.XDG_CONFIG_HOME = origXDG;
+      if (origHOME !== undefined) process.env.HOME = origHOME;
+    }
+  });
+});
+
+// ---- requireTransportRepoStrict ----------------------------------------
+
+describe("requireTransportRepoStrict", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    exitSpy = mockExit();
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("returns the URL when env var is set", () => {
+    process.env.DOTCLAUDE_HANDOFF_REPO = "https://github.com/x/y.git";
+    expect(lib.requireTransportRepoStrict()).toBe("https://github.com/x/y.git");
+  });
+
+  it("exits 2 when env var is absent", () => {
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    expect(() => lib.requireTransportRepoStrict()).toThrow(/__exit__2/);
+  });
+});
+
+// ---- projectSlugFromCwd ------------------------------------------------
+
+describe("projectSlugFromCwd", () => {
+  it("returns adhoc for falsy cwd", () => {
+    expect(lib.projectSlugFromCwd(null)).toBe("adhoc");
+    expect(lib.projectSlugFromCwd("")).toBe("adhoc");
+  });
+
+  it("returns slugified git root basename", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "/home/user/my-repo\n", stderr: "" });
+    expect(lib.projectSlugFromCwd("/home/user/my-repo/sub")).toBe("my-repo");
+  });
+
+  it("falls back to slugified cwd basename when git fails", () => {
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(lib.projectSlugFromCwd("/home/user/fallback-dir")).toBe("fallback-dir");
+  });
+
+  it("returns adhoc when cwd is a bare root slash (pop returns undefined)", () => {
+    // "/" splits to ["",""] → filter(Boolean) → [] → pop() = undefined → || "adhoc"
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(lib.projectSlugFromCwd("/")).toBe("adhoc");
+  });
+});
+
+// ---- listRemoteCandidates ----------------------------------------------
+
+describe("listRemoteCandidates", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    process.env.DOTCLAUDE_HANDOFF_REPO = "https://github.com/x/y.git";
+    exitSpy = mockExit();
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("returns parsed candidates from ls-remote output", () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "abc123  refs/heads/handoff/proj/claude/2026-04/abcd1234\n",
+      stderr: "",
+    });
+    const cands = lib.listRemoteCandidates();
+    expect(cands).toHaveLength(1);
+    expect(cands[0].branch).toBe("handoff/proj/claude/2026-04/abcd1234");
+    expect(cands[0].commit).toBe("abc123");
+    expect(cands[0].description).toBe("");
+  });
+
+  it("returns empty array for empty ls-remote output", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    expect(lib.listRemoteCandidates()).toEqual([]);
+  });
+
+  it("exits 2 on ls-remote failure", () => {
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "auth failed" });
+    expect(() => lib.listRemoteCandidates()).toThrow(/__exit__2/);
+  });
+
+  it("skips malformed lines (not exactly 2 parts)", () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "just-one-word\nabc  refs/heads/handoff/p/c/2026-04/x\n",
+      stderr: "",
+    });
+    const cands = lib.listRemoteCandidates();
+    expect(cands).toHaveLength(1);
+  });
+});
+
+// ---- fetchRemoteBranch -------------------------------------------------
+
+describe("fetchRemoteBranch", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    process.env.DOTCLAUDE_HANDOFF_REPO = "https://github.com/x/y.git";
+    exitSpy = mockExit();
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    vi.clearAllMocks();
+  });
+
+  it("returns content and description on success", () => {
+    mkdtempSync.mockReturnValue("/tmp/mock-pull");
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // clone
+    existsSync.mockReturnValueOnce(true);  // handoff.md exists
+    readFileSync.mockReturnValueOnce("# Handoff content");  // handoff.md
+    existsSync.mockReturnValueOnce(true);  // description.txt exists
+    readFileSync.mockReturnValueOnce("handoff:v2:claude/abc/proj/host");  // description.txt
+    const result = lib.fetchRemoteBranch("handoff/proj/claude/2026-04/abc12345");
+    expect(result.content).toBe("# Handoff content");
+    expect(result.description).toBe("handoff:v2:claude/abc/proj/host");
+  });
+
+  it("returns empty description when description.txt is absent", () => {
+    mkdtempSync.mockReturnValue("/tmp/mock-pull2");
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // clone
+    existsSync.mockReturnValueOnce(true);   // handoff.md exists
+    readFileSync.mockReturnValueOnce("# Content");
+    existsSync.mockReturnValueOnce(false);  // description.txt absent
+    const result = lib.fetchRemoteBranch("handoff/proj/claude/2026-04/abc12345");
+    expect(result.description).toBe("");
+  });
+
+  it("throws when clone fails", () => {
+    mkdtempSync.mockReturnValue("/tmp/mock-pull3");
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "clone failed" });
+    expect(() => lib.fetchRemoteBranch("handoff/proj/claude/2026-04/abc12345")).toThrow(
+      "clone --branch handoff/proj/claude/2026-04/abc12345 failed",
+    );
+  });
+
+  it("throws when handoff.md is missing after clone", () => {
+    mkdtempSync.mockReturnValue("/tmp/mock-pull4");
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // clone ok
+    existsSync.mockReturnValueOnce(false);  // handoff.md missing
+    expect(() => lib.fetchRemoteBranch("handoff/proj/claude/2026-04/abc12345")).toThrow(
+      "handoff.md missing",
+    );
+  });
+});
+
+// ---- enrichWithDescriptions --------------------------------------------
+
+describe("enrichWithDescriptions", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    process.env.DOTCLAUDE_HANDOFF_REPO = "https://github.com/x/y.git";
+    exitSpy = mockExit();
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("enriches candidates with descriptions from fetchRemoteBranch", () => {
+    mkdtempSync.mockReturnValue("/tmp/enrich-1");
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValueOnce("content");
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValueOnce("handoff:v2:claude/abc/proj/host");
+    const result = lib.enrichWithDescriptions([{ branch: "handoff/proj/claude/2026-04/abc", commit: "abc123", description: "" }]);
+    expect(result[0].description).toBe("handoff:v2:claude/abc/proj/host");
+  });
+
+  it("keeps the original candidate when fetchRemoteBranch throws", () => {
+    mkdtempSync.mockReturnValue("/tmp/enrich-2");
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "clone failed" });
+    const original = { branch: "handoff/proj/claude/2026-04/abc", commit: "abc123", description: "original" };
+    const result = lib.enrichWithDescriptions([original]);
+    expect(result[0].description).toBe("original");
+  });
+});
+
+// ---- pullRemote --------------------------------------------------------
+
+describe("pullRemote", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  function resetMockQueues() {
+    // mockReset() flushes mockReturnValueOnce queues AND clears implementations;
+    // re-establish defaults so un-queued calls return harmless values.
+    spawnSync.mockReset().mockReturnValue({ status: 0, stdout: "", stderr: "" });
+    existsSync.mockReset().mockReturnValue(false);
+    readFileSync.mockReset().mockReturnValue("");
+    mkdtempSync.mockReset().mockReturnValue("/tmp/mock-dir");
+  }
+
+  function mockLsRemote(branch = "handoff/proj/claude/2026-04/abc12345") {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: `abc123  refs/heads/${branch}\n`,
+      stderr: "",
+    });
+  }
+
+  function mockFetchBranch(content = "# content", description = "handoff:v2:claude/abc/proj/host") {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // clone
+    existsSync.mockReturnValueOnce(true);  // handoff.md exists
+    readFileSync.mockReturnValueOnce(content);
+    existsSync.mockReturnValueOnce(true);  // description.txt exists
+    readFileSync.mockReturnValueOnce(description);
+  }
+
+  beforeEach(() => {
+    resetMockQueues();
+    process.env.DOTCLAUDE_HANDOFF_REPO = "https://github.com/x/y.git";
+    exitSpy = mockExit();
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("returns the last candidate when query is null (no enrichment)", async () => {
+    mockLsRemote("handoff/proj/claude/2026-04/abc12345");
+    const result = await lib.pullRemote(null);
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/abc12345");
+  });
+
+  it("exits 2 when no candidates exist", async () => {
+    // Override: ls-remote returns empty output → candidates = []
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    await expect(lib.pullRemote(null)).rejects.toThrow(/__exit__2/);
+  });
+
+  it("filters by fromCli when provided, returning only the matching CLI's branch", async () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: [
+        "abc  refs/heads/handoff/proj/claude/2026-04/aaa",
+        "def  refs/heads/handoff/proj/copilot/2026-04/bbb",
+      ].join("\n") + "\n",
+      stderr: "",
+    });
+    const result = await lib.pullRemote(null, "claude");
+    expect(result.branch).toContain("claude");
+  });
+
+  it("exits 2 when fromCli filter yields no candidates", async () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "abc  refs/heads/handoff/proj/copilot/2026-04/aaa\n",
+      stderr: "",
+    });
+    await expect(lib.pullRemote(null, "claude")).rejects.toThrow(/__exit__2/);
+  });
+
+  it("matches by query against branch name and returns the single hit", async () => {
+    mockLsRemote("handoff/proj/claude/2026-04/abc12345");
+    mockFetchBranch();
+    const result = await lib.pullRemote("abc12345");
+    expect(result.branch).toContain("abc12345");
+  });
+
+  it("falls through to description-enriched search when branch name doesn't match", async () => {
+    // The branch name doesn't contain "myproject" but the description will.
+    // Path: hits=[] → enrichWithDescriptions(candidates) → re-match → 1 hit → return
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "abc  refs/heads/handoff/proj/claude/2026-04/abc12345\n",
+      stderr: "",
+    });
+    mockFetchBranch("content", "handoff:v2:claude/abc/myproject/host");
+    const result = await lib.pullRemote("myproject");
+    expect(result.description).toContain("myproject");
+  });
+
+  it("exits 2 when no candidates match the query after description enrichment", async () => {
+    // Branch name and description both don't contain the query.
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "abc  refs/heads/handoff/proj/claude/2026-04/abc12345\n",
+      stderr: "",
+    });
+    mockFetchBranch("content", "handoff:v2:claude/abc/proj/host");
+    await expect(lib.pullRemote("zzz-no-match")).rejects.toThrow(/__exit__2/);
+  });
+
+  it("exits 2 on non-TTY collision when multiple hits share the query", async () => {
+    // Two branches both containing "abc" in the name.
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: [
+        "aaa  refs/heads/handoff/proj/claude/2026-04/abc12345",
+        "bbb  refs/heads/handoff/proj/claude/2026-04/abc67890",
+      ].join("\n") + "\n",
+      stderr: "",
+    });
+    // enrichWithDescriptions is called for both hits (both match on branch name)
+    mockFetchBranch("c1", "");
+    mockFetchBranch("c2", "");
+    // stdin is not a TTY in tests → non-TTY collision → process.exit(2)
+    await expect(lib.pullRemote("abc")).rejects.toThrow(/__exit__2/);
+  });
+
+  it("resolves a TTY collision when user picks a valid item", async () => {
+    // Two hits, user answers "1" → returns hits[0].
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: [
+        "aaa  refs/heads/handoff/proj/claude/2026-04/abc12345",
+        "bbb  refs/heads/handoff/proj/claude/2026-04/abc67890",
+      ].join("\n") + "\n",
+      stderr: "",
+    });
+    mockFetchBranch("c1", "handoff:v2:claude/abc/proj/host");
+    mockFetchBranch("c2", "handoff:v2:claude/abc/proj/host");
+
+    // Make createInterface return an rl that answers "1" immediately.
+    createInterface.mockReturnValueOnce({
+      question: (_prompt, cb) => cb("1"),
+      close: vi.fn(),
+    });
+
+    const origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    try {
+      const result = await lib.pullRemote("abc");
+      expect(result.branch).toContain("abc12345");
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+    }
+  });
+
+  it("exits 2 on TTY collision when user enters an invalid pick", async () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: [
+        "aaa  refs/heads/handoff/proj/claude/2026-04/abc12345",
+        "bbb  refs/heads/handoff/proj/claude/2026-04/abc67890",
+      ].join("\n") + "\n",
+      stderr: "",
+    });
+    mockFetchBranch("c1", "handoff:v2:claude/abc/proj/host");
+    mockFetchBranch("c2", "handoff:v2:claude/abc/proj/host");
+
+    createInterface.mockReturnValueOnce({
+      question: (_prompt, cb) => cb("x"),  // non-numeric → abort
+      close: vi.fn(),
+    });
+
+    const origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    try {
+      await expect(lib.pullRemote("abc")).rejects.toThrow(/__exit__2/);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+    }
+  });
+});
+
+// ---- bootstrapTransportRepo — TTY early-exit paths ---------------------
+
+describe("bootstrapTransportRepo — TTY early-exit paths", () => {
+  let exitSpy;
+  let stderrSpy;
+  let origIsTTY;
+
+  beforeEach(() => {
+    origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`__exit__${code}`);
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it("exits 2 when gh is not available", async () => {
+    // isTty() → true; ghAvailable() → false
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    await expect(lib.bootstrapTransportRepo()).rejects.toThrow(/__exit__2/);
+  });
+
+  it("exits 2 when gh is available but not authenticated", async () => {
+    // isTty() → true; ghAvailable() → true; ghAuthenticated() → false
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "gh version 2\n", stderr: "" });
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    await expect(lib.bootstrapTransportRepo()).rejects.toThrow(/__exit__2/);
+  });
+
+  it("exits 2 when gh is authenticated but login returns null", async () => {
+    // isTty() → true; ghAvailable() → true; ghAuthenticated() → true; ghLogin() → null
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "gh version 2\n", stderr: "" });
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    await expect(lib.bootstrapTransportRepo()).rejects.toThrow(/__exit__2/);
+  });
+});

--- a/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
@@ -79,20 +79,24 @@ describe("v2BranchName", () => {
 });
 
 describe("monthBucket", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns YYYY-MM for a valid ISO input", () => {
     expect(lib.monthBucket("2026-04-22T12:00:00Z")).toBe("2026-04");
   });
 
   it("falls back to the current month when given null", () => {
-    const now = new Date();
-    const expected = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
-    expect(lib.monthBucket(null)).toBe(expected);
+    expect(lib.monthBucket(null)).toBe("2026-04");
   });
 
   it("falls back to the current month when given a nonsense date", () => {
-    const now = new Date();
-    const expected = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
-    expect(lib.monthBucket("not-a-date")).toBe(expected);
+    expect(lib.monthBucket("not-a-date")).toBe("2026-04");
   });
 });
 
@@ -205,5 +209,175 @@ describe("slugify / slugifyRepoName edge cases", () => {
   it("slugifyRepoName caps at 100 chars and trims edges", () => {
     expect(lib.slugifyRepoName("  -Handoff-Store-  ")).toBe("handoff-store");
     expect(lib.slugifyRepoName("a".repeat(200)).length).toBeLessThanOrEqual(100);
+  });
+
+  it("slugifyRepoName returns empty string for null/undefined input", () => {
+    expect(lib.slugifyRepoName(null)).toBe("");
+    expect(lib.slugifyRepoName(undefined)).toBe("");
+  });
+});
+
+describe("nextStepFor", () => {
+  it("returns codex task-specification text", () => {
+    expect(lib.nextStepFor("codex")).toContain("task specification");
+  });
+  it("returns copilot pick-up text", () => {
+    expect(lib.nextStepFor("copilot")).toContain("pick up where");
+  });
+  it("returns default continue text for any other CLI", () => {
+    expect(lib.nextStepFor("claude")).toContain("Continue from");
+    expect(lib.nextStepFor("unknown")).toContain("Continue from");
+  });
+});
+
+describe("mechanicalSummary", () => {
+  it("uses placeholder text when both arrays are empty", () => {
+    const s = lib.mechanicalSummary([], []);
+    expect(s).toContain("(no user prompts captured)");
+    expect(s).toContain("(no assistant turns captured)");
+  });
+
+  it("uses first prompt and last turn when both arrays are non-empty", () => {
+    const s = lib.mechanicalSummary(["first", "second"], ["turn1", "turn2"]);
+    expect(s).toContain("first");
+    expect(s).toContain("turn2");
+  });
+
+  it("clips strings longer than 160 chars with an ellipsis", () => {
+    const long = "a".repeat(300);
+    const s = lib.mechanicalSummary([long], [long]);
+    expect(s).toContain("…");
+  });
+
+  it("does not clip strings that are 160 chars or shorter", () => {
+    const exact = "b".repeat(160);
+    const s = lib.mechanicalSummary([exact], [exact]);
+    expect(s).not.toContain("…");
+  });
+});
+
+describe("renderHandoffBlock", () => {
+  const meta = { cli: "claude", short_id: "abc12345", cwd: "/projects/foo" };
+  const metaNull = { cli: "codex", short_id: null, cwd: null };
+
+  it("produces opening and closing <handoff> tags", () => {
+    const block = lib.renderHandoffBlock(meta, ["p"], ["t"], "codex");
+    expect(block).toMatch(/^<handoff /);
+    expect(block).toContain("</handoff>");
+  });
+
+  it("uses empty string fallbacks for null short_id and cwd", () => {
+    const block = lib.renderHandoffBlock(metaNull, [], [], "claude");
+    expect(block).toContain('session=""');
+    expect(block).toContain('cwd=""');
+  });
+
+  it("renders the fallback when prompts are empty", () => {
+    const block = lib.renderHandoffBlock(meta, [], [], "claude");
+    expect(block).toContain("(no user prompts captured)");
+  });
+
+  it("renders the fallback when turns are empty", () => {
+    const block = lib.renderHandoffBlock(meta, [], [], "claude");
+    expect(block).toContain("_(no assistant output captured)_");
+  });
+
+  it("renders prompts and turns when present", () => {
+    const block = lib.renderHandoffBlock(meta, ["user prompt"], ["assistant turn"], "claude");
+    expect(block).toContain("user prompt");
+    expect(block).toContain("assistant turn");
+  });
+
+  it("caps prompts at the last 10 and numbers them 1..10", () => {
+    const prompts = Array.from({ length: 15 }, (_, i) => `p${i}`);
+    const block = lib.renderHandoffBlock(meta, prompts, [], "claude");
+    expect(block).toContain("10. p14");
+    expect(block).not.toContain("11. ");
+  });
+
+  it("truncates prompts longer than 300 chars", () => {
+    const long = "x".repeat(500);
+    const block = lib.renderHandoffBlock(meta, [long], [], "claude");
+    expect(block).toContain("…");
+  });
+
+  it("truncates turns longer than 400 chars", () => {
+    const long = "y".repeat(600);
+    const block = lib.renderHandoffBlock(meta, [], [long], "claude");
+    expect(block).toContain("…");
+  });
+});
+
+describe("isTty", () => {
+  it("returns false in the vitest environment (no TTY)", () => {
+    expect(lib.isTty()).toBe(false);
+  });
+});
+
+describe("printManualSetupBlock", () => {
+  it("writes a setup message containing the reason to stderr", () => {
+    const spy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    lib.printManualSetupBlock("test-reason-xyz");
+    const out = spy.mock.calls.map((c) => c[0]).join("");
+    expect(out).toContain("test-reason-xyz");
+    expect(out).toContain("DOTCLAUDE_HANDOFF_REPO");
+    spy.mockRestore();
+  });
+});
+
+describe("requireTransportRepoStrict", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`__exit__${code}`);
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("returns the validated URL when env var is set", () => {
+    process.env.DOTCLAUDE_HANDOFF_REPO = "https://github.com/x/y.git";
+    expect(lib.requireTransportRepoStrict()).toBe("https://github.com/x/y.git");
+  });
+
+  it("exits 2 when DOTCLAUDE_HANDOFF_REPO is not set", () => {
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    expect(() => lib.requireTransportRepoStrict()).toThrow(/__exit__2/);
+  });
+});
+
+describe("requireTransportRepo (env-var-set fast path)", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`__exit__${code}`);
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("returns the validated URL without bootstrapping when env var is already set", async () => {
+    process.env.DOTCLAUDE_HANDOFF_REPO = "git@github.com:x/y.git";
+    const url = await lib.requireTransportRepo();
+    expect(url).toBe("git@github.com:x/y.git");
+  });
+
+  it("calls bootstrapTransportRepo and exits 2 when env var is absent in a non-TTY context", async () => {
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+    // bootstrapTransportRepo detects non-TTY (isTty() returns false in vitest), prints
+    // a manual-setup block to stderr, then calls process.exit(2).
+    await expect(lib.requireTransportRepo()).rejects.toThrow(/__exit__2/);
   });
 });

--- a/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
@@ -1,0 +1,209 @@
+// Pins the public surface of handoff-remote.mjs — the shared transport
+// library extracted from bin/dotclaude-handoff.mjs in #91 Gap 1. These
+// tests are redundant with handoff-unit / handoff-url-validator /
+// handoff-bootstrap (which go through the bin re-exports), but they
+// lock the library *directly* so a future gap can't silently narrow or
+// widen the API without tripping a test.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as lib from "../src/lib/handoff-remote.mjs";
+
+describe("export shape", () => {
+  // Keep alphabetized so the diff is readable when exports change.
+  const expectedExports = [
+    "CONFIG_FILE",
+    "V1_BRANCH_RE",
+    "V2_BRANCH_RE",
+    "bootstrapTransportRepo",
+    "decodeDescription",
+    "encodeDescription",
+    "enrichWithDescriptions",
+    "extractLines",
+    "extractMeta",
+    "extractPrompts",
+    "extractTurns",
+    "fetchRemoteBranch",
+    "ghAuthenticated",
+    "ghAvailable",
+    "ghLogin",
+    "isRepoMissingError",
+    "isTty",
+    "listRemoteCandidates",
+    "loadPersistedEnv",
+    "matchesQuery",
+    "mechanicalSummary",
+    "monthBucket",
+    "nextStepFor",
+    "printManualSetupBlock",
+    "projectSlugFromCwd",
+    "promptLine",
+    "pullRemote",
+    "pushRemote",
+    "renderHandoffBlock",
+    "requireTransportRepo",
+    "requireTransportRepoStrict",
+    "runGit",
+    "runGitOrThrow",
+    "runScript",
+    "slugify",
+    "slugifyRepoName",
+    "v2BranchName",
+    "validateTransportUrl",
+  ];
+
+  it("exposes every documented name", () => {
+    for (const name of expectedExports) {
+      expect(lib[name], `missing export: ${name}`).toBeDefined();
+    }
+  });
+
+  it("does not leak extra names beyond the documented set", () => {
+    const actual = Object.keys(lib).sort();
+    const extra = actual.filter((k) => !expectedExports.includes(k));
+    expect(extra).toEqual([]);
+  });
+});
+
+describe("v2BranchName", () => {
+  it("assembles handoff/<project>/<cli>/<month>/<shortId>", () => {
+    expect(
+      lib.v2BranchName({ project: "foo", cli: "claude", month: "2026-04", shortId: "abcd1234" }),
+    ).toBe("handoff/foo/claude/2026-04/abcd1234");
+  });
+
+  it("slugifies the project segment", () => {
+    expect(
+      lib.v2BranchName({ project: "My Project!", cli: "codex", month: "2026-04", shortId: "ff00aa11" }),
+    ).toBe("handoff/my-project/codex/2026-04/ff00aa11");
+  });
+});
+
+describe("monthBucket", () => {
+  it("returns YYYY-MM for a valid ISO input", () => {
+    expect(lib.monthBucket("2026-04-22T12:00:00Z")).toBe("2026-04");
+  });
+
+  it("falls back to the current month when given null", () => {
+    const now = new Date();
+    const expected = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    expect(lib.monthBucket(null)).toBe(expected);
+  });
+
+  it("falls back to the current month when given a nonsense date", () => {
+    const now = new Date();
+    const expected = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    expect(lib.monthBucket("not-a-date")).toBe(expected);
+  });
+});
+
+describe("matchesQuery", () => {
+  const c = {
+    branch: "handoff/proj/claude/2026-04/abcd1234",
+    description: "handoff:v2:claude/abcd1234/proj/host",
+    commit: "0fba2e3d99",
+  };
+
+  it("matches by branch substring", () => {
+    expect(lib.matchesQuery(c, "abcd1234")).toBe(true);
+    expect(lib.matchesQuery(c, "proj")).toBe(true);
+  });
+
+  it("matches by commit prefix (startsWith)", () => {
+    expect(lib.matchesQuery(c, "0fba")).toBe(true);
+    expect(lib.matchesQuery(c, "2e3d")).toBe(false);
+  });
+
+  it("is case-insensitive across all three fields", () => {
+    expect(lib.matchesQuery(c, "CLAUDE")).toBe(true);
+    expect(lib.matchesQuery(c, "HOST")).toBe(true);
+  });
+
+  it("rejects unrelated input", () => {
+    expect(lib.matchesQuery(c, "zzz")).toBe(false);
+  });
+});
+
+describe("validateTransportUrl (accept/reject matrix)", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`__exit__${code}`);
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  for (const [label, url] of [
+    ["https", "https://github.com/x/y.git"],
+    ["http", "http://ghe/x/y.git"],
+    ["git@", "git@github.com:x/y.git"],
+    ["ssh://", "ssh://git@host:22/x.git"],
+    ["file://", "file:///tmp/bare.git"],
+    ["absolute path", "/tmp/bare"],
+  ]) {
+    it(`accepts ${label}`, () => {
+      expect(lib.validateTransportUrl(url)).toBe(url);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  }
+
+  for (const [label, url] of [
+    ["ext:: exec scheme", "ext::sh -c evil"],
+    ["data:", "data:text/plain,x"],
+    ["javascript:", "javascript:alert(1)"],
+    ["relative path", "relative/path"],
+    ["bare hostname", "github.com/x/y"],
+  ]) {
+    it(`rejects ${label}`, () => {
+      expect(() => lib.validateTransportUrl(url)).toThrow(/__exit__2/);
+    });
+  }
+});
+
+describe("isRepoMissingError (phrasing union)", () => {
+  it("matches GitHub's wording", () => {
+    expect(lib.isRepoMissingError("ERROR: Repository not found.")).toBe(true);
+    expect(lib.isRepoMissingError("remote: Not Found")).toBe(true);
+  });
+
+  it("matches GitLab's wording", () => {
+    expect(
+      lib.isRepoMissingError("The project you were looking for could not be found."),
+    ).toBe(true);
+  });
+
+  it("matches raw SSH / git phrasings", () => {
+    expect(lib.isRepoMissingError("Could not read from remote repository.")).toBe(true);
+    expect(lib.isRepoMissingError("fatal: 'x' does not appear to be a git repository")).toBe(true);
+    expect(lib.isRepoMissingError("Permission denied (publickey)")).toBe(true);
+  });
+
+  it("rejects unrelated errors so the retry branch doesn't fire on real bugs", () => {
+    expect(lib.isRepoMissingError("error: failed to push some refs")).toBe(false);
+    expect(lib.isRepoMissingError("")).toBe(false);
+    expect(lib.isRepoMissingError(null)).toBe(false);
+  });
+});
+
+describe("slugify / slugifyRepoName edge cases", () => {
+  it("slugify collapses dash runs and trims edges", () => {
+    expect(lib.slugify("  Foo !! Bar  ")).toBe("foo-bar");
+    expect(lib.slugify("...")).toBe("adhoc");
+    expect(lib.slugify("")).toBe("adhoc");
+  });
+
+  it("slugify caps at 40 chars", () => {
+    expect(lib.slugify("a".repeat(80)).length).toBeLessThanOrEqual(40);
+  });
+
+  it("slugifyRepoName caps at 100 chars and trims edges", () => {
+    expect(lib.slugifyRepoName("  -Handoff-Store-  ")).toBe("handoff-store");
+    expect(lib.slugifyRepoName("a".repeat(200)).length).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
## Summary

- Lift the remote push/pull/list/bootstrap surface out of the 1389-line `plugins/dotclaude/bin/dotclaude-handoff.mjs` into a new shared library at `plugins/dotclaude/src/lib/handoff-remote.mjs`. Pure refactor — CLI help output is byte-identical, and all 240 bats + 284 vitest tests continue to pass unchanged.
- Establishes the single seam that subsequent remote-transport work (#91 Gaps 2–8, #90 Gaps 2–4, #85) will modify, instead of re-editing the bin in every PR.
- Adds `plugins/dotclaude/tests/handoff-remote-lib.test.mjs` (29 tests) to pin the library's public export shape + pure-function behavior so a future gap can't silently narrow or widen the API.

Closes step 2 of `docs/plans/handoff-issue-rollout.md` (the #91 Gap 1 extraction).

### Scope deviation worth flagging

The plan originally said renderers stay in the bin. I moved `extractMeta` / `extractPrompts` / `extractTurns` / `renderHandoffBlock` / `nextStepFor` / `mechanicalSummary` into the library because `pushRemote` depends on them — keeping `pushRemote`'s signature intact was cheaper than threading the digest in from the caller. The bin re-imports them from the library for its digest/file/bare-query verbs.

### One-line fix included

`CONFIG_FILE` / `CONFIG_DIR` now resolve lazily inside `loadPersistedEnv` + `bootstrapTransportRepo` via `currentConfigFile()` / `currentConfigDir()` helpers. Without this, the bootstrap vitest suite (which cache-busts the bin via query-string import but can't cache-bust the library) would pin a stale `HOME`.

## Test plan

- [x] `npx vitest run plugins/dotclaude/tests/handoff-remote-lib.test.mjs` — new export-shape + pure-function suite (55/55 — expanded from 29)
- [x] `npx vitest run` — full vitest suite green (421/421 across 27 files — includes new handoff-remote-coverage.test.mjs with 86 tests)
- [x] `npx bats plugins/dotclaude/tests/bats/` — full bats suite green (240/240)
- [x] Byte-identical help spot-check: `git stash -u && node …/dotclaude-handoff.mjs --help > before; git stash pop && node … > after; diff before after` → empty
- [x] `npm run dogfood` — manifest / agents / specs / instruction-drift / spec-coverage all clean

## Spec ID

dotclaude-core