### PR TITLE
feat(handoff): auto-preflight caching for push/pull (#91 gap 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@dotclaude/dotclaude` land here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows
 [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- **handoff:** push/pull now auto-run preflight on first use within a 5-minute window; `--verify` forces re-run. `doctor` verb unchanged.
+
 ## [0.11.0](https://github.com/kaiohenricunha/dotclaude/compare/v0.10.0...v0.11.0) (2026-04-20)
 
 

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -90,9 +90,9 @@ const CLIS = new Set(["claude", "copilot", "codex"]);
 const META = {
   name: "dotclaude-handoff",
   synopsis:
-    "dotclaude handoff [<query>|push|pull|list|doctor|remote-list|search] [args...] [--from <cli>] [--to <cli>] [--tag <label>] [--cli <cli>] [--since <ISO>] [--limit <N>]",
+    "dotclaude handoff [<query>|push|pull|list|doctor|remote-list|search] [args...] [--from <cli>] [--to <cli>] [--tag <label>] [--cli <cli>] [--since <ISO>] [--limit <N>] [--verify]",
   description:
-    "Cross-agent and cross-machine session handoff. Bare <query> emits a <handoff> block for local cross-agent. push/pull/list handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO).",
+    "Cross-agent and cross-machine session handoff. Bare <query> emits a <handoff> block for local cross-agent. push/pull/list handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO). push/pull auto-run a preflight check (cached 5 min); --verify forces re-run.",
   flags: {
     tag: { type: "string" },
     from: { type: "string" },
@@ -103,6 +103,7 @@ const META = {
     "out-dir": { type: "string" },
     local: { type: "boolean" },
     remote: { type: "boolean" },
+    verify: { type: "boolean" },
   },
 };
 
@@ -655,8 +656,16 @@ async function main() {
     if (fallbackNote) process.stderr.write(fallbackNote + "\n");
 
     const tag = argv.flags.tag ? String(argv.flags.tag) : null;
+    const verify = Boolean(argv.flags.verify);
+    const verbose = Boolean(argv.verbose);
     try {
-      const result = await pushRemote({ cli: sessionHit.cli, path: sessionHit.path, tag });
+      const result = await pushRemote({
+        cli: sessionHit.cli,
+        path: sessionHit.path,
+        tag,
+        verify,
+        verbose,
+      });
       process.stdout.write(
         `${result.branch}\n${result.url}\n${result.description}\n[scrubbed ${result.scrubbedCount} secrets]\n`,
       );
@@ -667,8 +676,10 @@ async function main() {
   }
 
   if (first === "pull") {
+    const verify = Boolean(argv.flags.verify);
+    const verbose = Boolean(argv.verbose);
     try {
-      const hit = await pullRemote(second, fromCli);
+      const hit = await pullRemote(second, fromCli, { verify, verbose });
       const { content } = fetchRemoteBranch(hit.branch);
       process.stdout.write(content.endsWith("\n") ? content : content + "\n");
       process.exit(EXIT_CODES.OK);

--- a/plugins/dotclaude/src/lib/handoff-preflight.mjs
+++ b/plugins/dotclaude/src/lib/handoff-preflight.mjs
@@ -1,0 +1,155 @@
+/**
+ * Auto-preflight caching for handoff push/pull.
+ *
+ * Wraps the existing `plugins/dotclaude/scripts/handoff-doctor.sh` script with
+ * a 5-minute TTL cache so users don't pay the preflight cost on every push and
+ * so `push`/`pull` fail early with the doctor's structured remediation block
+ * on misconfiguration, instead of emitting a cryptic `gh` / `git` error.
+ *
+ * Cache file: `$XDG_CACHE_HOME/dotclaude/handoff-doctor.json` (fallback
+ * `$HOME/.cache/dotclaude/handoff-doctor.json`). Invalidated when the recorded
+ * `repo` no longer matches `process.env.DOTCLAUDE_HANDOFF_REPO`, when the TTL
+ * has expired, when the cache schema version differs, when the file is
+ * corrupt or missing, or when the caller passes `verify: true`.
+ *
+ * The `doctor` verb still invokes the shell script directly for on-demand
+ * diagnostics — it does not read or write this cache.
+ */
+
+import { dirname, join, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+
+import { runScript } from "./handoff-remote.mjs";
+
+/** Schema version for the handoff-doctor cache entry. Bumped on breaking changes. */
+export const CACHE_SCHEMA_VERSION = 1;
+
+/** Cache time-to-live in milliseconds. 5 minutes per rollout-doc acceptance. */
+export const DOCTOR_CACHE_TTL_MS = 5 * 60 * 1000;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPTS = resolvePath(__dirname, "..", "..", "scripts");
+/** Absolute path to the handoff-doctor.sh shell script. */
+export const DOCTOR_SH = join(SCRIPTS, "handoff-doctor.sh");
+
+/**
+ * Resolve the doctor script to run. Honors `DOTCLAUDE_DOCTOR_SH` so the bats
+ * suite can swap in a counter-shim without patching the shipped script. Any
+ * production path leaves this unset and gets the bundled `handoff-doctor.sh`.
+ */
+function resolveDoctorScript() {
+  const override = process.env.DOTCLAUDE_DOCTOR_SH;
+  return override && override.length > 0 ? override : DOCTOR_SH;
+}
+
+/** Resolve the active cache directory (honors XDG_CACHE_HOME, falls back to $HOME/.cache). */
+export function currentCacheDir() {
+  return join(
+    process.env.XDG_CACHE_HOME || join(process.env.HOME || "", ".cache"),
+    "dotclaude",
+  );
+}
+
+/** Resolve the active cache file path. */
+export function currentCacheFile() {
+  return join(currentCacheDir(), "handoff-doctor.json");
+}
+
+/** Read and parse the preflight cache entry, returning `null` on any failure (treated as miss). */
+export function readCache() {
+  const file = currentCacheFile();
+  if (!existsSync(file)) return null;
+  try {
+    const raw = readFileSync(file, "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Return true if a cache entry is usable for `repo` at time `now`. */
+export function isFresh(entry, repo, now) {
+  if (!entry || typeof entry !== "object") return false;
+  if (entry.version !== CACHE_SCHEMA_VERSION) return false;
+  if (entry.repo !== repo) return false;
+  if (entry.status !== "ok") return false;
+  const ts = Date.parse(entry.timestamp);
+  if (!Number.isFinite(ts)) return false;
+  return now - ts <= DOCTOR_CACHE_TTL_MS;
+}
+
+/**
+ * Atomically write a cache entry. Writes to a sibling tmp file and renames
+ * into place so a concurrent reader never sees a half-written JSON blob.
+ */
+export function writeCacheAtomic(entry) {
+  const dir = currentCacheDir();
+  mkdirSync(dir, { recursive: true });
+  const final = currentCacheFile();
+  const tmp = `${final}.${process.pid}.tmp`;
+  try {
+    writeFileSync(tmp, JSON.stringify(entry) + "\n", "utf8");
+    renameSync(tmp, final);
+  } catch (err) {
+    // Best-effort cleanup of the stray tmp file. A failure here is not fatal:
+    // the next successful preflight will overwrite it.
+    try {
+      if (existsSync(tmp)) unlinkSync(tmp);
+    } catch {
+      // ignore
+    }
+    throw err;
+  }
+}
+
+/**
+ * Auto-preflight before a push/pull. Returns silently when the cache is warm
+ * (one informational line to stderr under `verbose`). Runs `handoff-doctor.sh`
+ * otherwise; on failure, streams the doctor's remediation block to stderr
+ * and throws. Throwing lets the bin's existing catch map it to exit 2.
+ *
+ * @param {{ repo: string, verify?: boolean, verbose?: boolean }} opts
+ */
+export function autoPreflight({ repo, verify = false, verbose = false }) {
+  if (!verify) {
+    const entry = readCache();
+    const now = Date.now();
+    if (isFresh(entry, repo, now)) {
+      if (verbose) {
+        const ageSec = Math.floor((now - Date.parse(entry.timestamp)) / 1000);
+        process.stderr.write(`preflight: cache hit (age ${ageSec}s)\n`);
+      }
+      return;
+    }
+  }
+
+  if (verbose) process.stderr.write("preflight: running handoff-doctor.sh\n");
+  const r = runScript(resolveDoctorScript(), []);
+
+  if (r.status !== 0) {
+    // Always surface the remediation block — that's the whole point of doctor.
+    if (r.stdout) process.stdout.write(r.stdout);
+    if (r.stderr) process.stderr.write(r.stderr);
+    throw new Error("preflight failed");
+  }
+
+  if (verbose) {
+    if (r.stdout) process.stdout.write(r.stdout);
+    if (r.stderr) process.stderr.write(r.stderr);
+  }
+
+  writeCacheAtomic({
+    version: CACHE_SCHEMA_VERSION,
+    timestamp: new Date().toISOString(),
+    repo,
+    status: "ok",
+  });
+}

--- a/plugins/dotclaude/src/lib/handoff-preflight.mjs
+++ b/plugins/dotclaude/src/lib/handoff-preflight.mjs
@@ -29,6 +29,7 @@ import {
 import { runScript } from "./handoff-remote.mjs";
 import { debug } from "./debug.mjs";
 
+/** Cache schema version — increment to invalidate all existing entries. */
 export const CACHE_SCHEMA_VERSION = 1;
 
 /** 5 minutes per rollout-doc acceptance (docs/plans/handoff-issue-rollout.md). */
@@ -39,6 +40,7 @@ export const DOCTOR_CACHE_TTL_MS = 5 * 60 * 1000;
 // without hitting a cyclic-init TDZ error.
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPTS = resolvePath(__dirname, "..", "..", "scripts");
+/** Absolute path to the bundled `handoff-doctor.sh` preflight script. */
 export const DOCTOR_SH = join(SCRIPTS, "handoff-doctor.sh");
 
 /**
@@ -51,6 +53,7 @@ function resolveDoctorScript() {
   return override && override.length > 0 ? override : DOCTOR_SH;
 }
 
+/** Returns the directory that holds the preflight cache, honoring XDG_CACHE_HOME. */
 export function currentCacheDir() {
   return join(
     process.env.XDG_CACHE_HOME || join(process.env.HOME || "", ".cache"),
@@ -58,6 +61,7 @@ export function currentCacheDir() {
   );
 }
 
+/** Returns the absolute path to the preflight cache file. */
 export function currentCacheFile() {
   return join(currentCacheDir(), "handoff-doctor.json");
 }
@@ -73,6 +77,12 @@ export function readCache() {
   }
 }
 
+/**
+ * Returns true when a cache entry is valid and within the TTL window.
+ * @param {unknown} entry - parsed JSON from the cache file, or null
+ * @param {string} repo - the current transport repo URL
+ * @param {number} now - `Date.now()` at call time
+ */
 export function isFresh(entry, repo, now) {
   if (!entry || typeof entry !== "object") return false;
   if (entry.version !== CACHE_SCHEMA_VERSION) return false;

--- a/plugins/dotclaude/src/lib/handoff-preflight.mjs
+++ b/plugins/dotclaude/src/lib/handoff-preflight.mjs
@@ -19,7 +19,6 @@
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  existsSync,
   mkdirSync,
   readFileSync,
   renameSync,
@@ -28,16 +27,18 @@ import {
 } from "node:fs";
 
 import { runScript } from "./handoff-remote.mjs";
+import { debug } from "./debug.mjs";
 
-/** Schema version for the handoff-doctor cache entry. Bumped on breaking changes. */
 export const CACHE_SCHEMA_VERSION = 1;
 
-/** Cache time-to-live in milliseconds. 5 minutes per rollout-doc acceptance. */
+/** 5 minutes per rollout-doc acceptance (docs/plans/handoff-issue-rollout.md). */
 export const DOCTOR_CACHE_TTL_MS = 5 * 60 * 1000;
 
+// SCRIPTS is duplicated from handoff-remote.mjs on purpose: handoff-remote.mjs
+// imports from this module, so we can't import a non-hoisted `const` back
+// without hitting a cyclic-init TDZ error.
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPTS = resolvePath(__dirname, "..", "..", "scripts");
-/** Absolute path to the handoff-doctor.sh shell script. */
 export const DOCTOR_SH = join(SCRIPTS, "handoff-doctor.sh");
 
 /**
@@ -50,7 +51,6 @@ function resolveDoctorScript() {
   return override && override.length > 0 ? override : DOCTOR_SH;
 }
 
-/** Resolve the active cache directory (honors XDG_CACHE_HOME, falls back to $HOME/.cache). */
 export function currentCacheDir() {
   return join(
     process.env.XDG_CACHE_HOME || join(process.env.HOME || "", ".cache"),
@@ -58,24 +58,21 @@ export function currentCacheDir() {
   );
 }
 
-/** Resolve the active cache file path. */
 export function currentCacheFile() {
   return join(currentCacheDir(), "handoff-doctor.json");
 }
 
-/** Read and parse the preflight cache entry, returning `null` on any failure (treated as miss). */
+/** Returns `null` on any failure (missing, unreadable, unparseable) — treated as miss. */
 export function readCache() {
-  const file = currentCacheFile();
-  if (!existsSync(file)) return null;
   try {
-    const raw = readFileSync(file, "utf8");
+    const raw = readFileSync(currentCacheFile(), "utf8");
     return JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    if (err?.code !== "ENOENT") debug("preflight:readCache", err);
     return null;
   }
 }
 
-/** Return true if a cache entry is usable for `repo` at time `now`. */
 export function isFresh(entry, repo, now) {
   if (!entry || typeof entry !== "object") return false;
   if (entry.version !== CACHE_SCHEMA_VERSION) return false;
@@ -87,24 +84,23 @@ export function isFresh(entry, repo, now) {
 }
 
 /**
- * Atomically write a cache entry. Writes to a sibling tmp file and renames
- * into place so a concurrent reader never sees a half-written JSON blob.
+ * Writes to a sibling tmp file and renames into place so a concurrent reader
+ * never sees a half-written JSON blob.
  */
 export function writeCacheAtomic(entry) {
-  const dir = currentCacheDir();
-  mkdirSync(dir, { recursive: true });
   const final = currentCacheFile();
+  mkdirSync(currentCacheDir(), { recursive: true });
   const tmp = `${final}.${process.pid}.tmp`;
   try {
     writeFileSync(tmp, JSON.stringify(entry) + "\n", "utf8");
     renameSync(tmp, final);
   } catch (err) {
-    // Best-effort cleanup of the stray tmp file. A failure here is not fatal:
-    // the next successful preflight will overwrite it.
+    // Best-effort cleanup. Stray tmp files are self-healing — the next
+    // successful preflight overwrites them.
     try {
-      if (existsSync(tmp)) unlinkSync(tmp);
-    } catch {
-      // ignore
+      unlinkSync(tmp);
+    } catch (cleanupErr) {
+      if (cleanupErr?.code !== "ENOENT") debug("preflight:writeCacheAtomic:cleanup", cleanupErr);
     }
     throw err;
   }

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -25,6 +25,7 @@ import {
 } from "node:fs";
 
 import { scrubDigest } from "./handoff-scrub.mjs";
+import { autoPreflight } from "./handoff-preflight.mjs";
 
 // ---- constants ---------------------------------------------------------
 
@@ -547,8 +548,9 @@ export function requireTransportRepoStrict() {
 // ---- remote I/O --------------------------------------------------------
 
 /** Push a local session to the transport repo as a handoff branch. */
-export async function pushRemote({ cli, path: sessionFile, tag }) {
+export async function pushRemote({ cli, path: sessionFile, tag, verify = false, verbose = false }) {
   let repoUrl = await requireTransportRepo();
+  autoPreflight({ repo: repoUrl, verify, verbose });
   const meta = extractMeta(cli, sessionFile);
   const prompts = extractPrompts(cli, sessionFile);
   const turns = extractTurns(cli, sessionFile);
@@ -702,7 +704,9 @@ export function matchesQuery(candidate, query) {
 }
 
 /** Resolve a remote handoff branch by query, pick interactively on collision. */
-export async function pullRemote(query, fromCli = null) {
+export async function pullRemote(query, fromCli = null, { verify = false, verbose = false } = {}) {
+  const repoUrl = requireTransportRepoStrict();
+  autoPreflight({ repo: repoUrl, verify, verbose });
   let candidates = listRemoteCandidates();
   if (candidates.length === 0) fail(2, "no handoffs found on transport");
 

--- a/plugins/dotclaude/tests/bats/handoff-preflight.bats
+++ b/plugins/dotclaude/tests/bats/handoff-preflight.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# Auto-preflight caching — covers the contract in docs/plans/handoff-issue-rollout.md:
+#
+#   - First push on a cold cache runs preflight.
+#   - Subsequent pushes within 5 min skip it (cache hit).
+#   - `--verify` forces a re-run.
+#   - Changing DOTCLAUDE_HANDOFF_REPO invalidates the cache.
+#   - `doctor` verb remains on-demand (never consults the cache).
+#
+# Uses DOTCLAUDE_DOCTOR_SH to swap in a counter-shim so we can measure the
+# number of doctor invocations without patching the shipped script.
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+REAL_DOCTOR="$REPO_ROOT/plugins/dotclaude/scripts/handoff-doctor.sh"
+
+setup() {
+  TEST_HOME=$(make_tmp_home)
+  export HOME="$TEST_HOME"
+  # XDG_CACHE_HOME defaults to $HOME/.cache → the preflight cache lands
+  # inside TEST_HOME, so each test has an isolated cache.
+  unset XDG_CACHE_HOME
+
+  # Seed a real claude session so `push` has something to digest before it
+  # reaches the remote transport.
+  CLAUDE_UUID="aaaa1111-1111-1111-1111-111111111111"
+  CLAUDE_DIR="$TEST_HOME/.claude/projects/-home-u-demo"
+  mkdir -p "$CLAUDE_DIR"
+  cat > "$CLAUDE_DIR/$CLAUDE_UUID.jsonl" <<EOF
+{"type":"user","cwd":"/home/u/demo","sessionId":"$CLAUDE_UUID","version":"2.1","message":{"content":"hello"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}
+EOF
+
+  TRANSPORT_REPO=$(make_transport_repo "$(mktemp -d)")
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+
+  # Counter-shim that delegates to the real doctor and increments a file.
+  COUNTER_FILE="$TEST_HOME/doctor-calls"
+  SHIM_DOCTOR="$TEST_HOME/doctor-shim.sh"
+  cat > "$SHIM_DOCTOR" <<EOF
+#!/usr/bin/env bash
+n=\$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+echo \$((n + 1)) > "$COUNTER_FILE"
+exec "$REAL_DOCTOR" "\$@"
+EOF
+  chmod +x "$SHIM_DOCTOR"
+  export DOTCLAUDE_DOCTOR_SH="$SHIM_DOCTOR"
+  printf 0 > "$COUNTER_FILE"
+
+  export CLAUDE_UUID TRANSPORT_REPO COUNTER_FILE SHIM_DOCTOR
+}
+
+teardown() {
+  unset DOTCLAUDE_DOCTOR_SH
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+}
+
+counter() { cat "$COUNTER_FILE"; }
+
+# --- push: cold cache runs doctor; warm cache skips it ------------------
+
+@test "push: first push on cold cache runs preflight (counter=1)" {
+  run node "$BIN" push --from claude "$CLAUDE_UUID"
+  [ "$status" -eq 0 ]
+  [ "$(counter)" -eq 1 ]
+}
+
+@test "push: second push within TTL reuses cache (counter still 1)" {
+  run node "$BIN" push --from claude "$CLAUDE_UUID"
+  [ "$status" -eq 0 ]
+  [ "$(counter)" -eq 1 ]
+
+  run node "$BIN" push --from claude "$CLAUDE_UUID"
+  [ "$status" -eq 0 ]
+  [ "$(counter)" -eq 1 ]
+}
+
+# --- --verify forces a re-run regardless of cache state -----------------
+
+@test "push --verify: forces doctor to run even with a warm cache" {
+  run node "$BIN" push --from claude "$CLAUDE_UUID"
+  [ "$status" -eq 0 ]
+  [ "$(counter)" -eq 1 ]
+
+  run node "$BIN" push --verify --from claude "$CLAUDE_UUID"
+  [ "$status" -eq 0 ]
+  [ "$(counter)" -eq 2 ]
+}
+
+# --- transport-config change invalidates the cache ----------------------
+
+@test "push: switching DOTCLAUDE_HANDOFF_REPO re-runs preflight" {
+  run node "$BIN" push --from claude "$CLAUDE_UUID"
+  [ "$status" -eq 0 ]
+  [ "$(counter)" -eq 1 ]
+
+  # Point at a brand-new bare repo. Same cache file, but entry.repo now
+  # mismatches → isFresh() must refuse the entry and re-run doctor.
+  local second_repo
+  second_repo=$(make_transport_repo "$(mktemp -d)")
+  export DOTCLAUDE_HANDOFF_REPO="$second_repo"
+
+  run node "$BIN" push --from claude "$CLAUDE_UUID"
+  [ "$status" -eq 0 ]
+  [ "$(counter)" -eq 2 ]
+
+  rm -rf "$second_repo"
+}
+
+# --- doctor verb bypasses the cache entirely ----------------------------
+
+@test "doctor verb: invokes the real script every time (never consults cache)" {
+  # Warm the cache via one push (counter=1 from auto-preflight).
+  run node "$BIN" push --from claude "$CLAUDE_UUID"
+  [ "$status" -eq 0 ]
+  [ "$(counter)" -eq 1 ]
+
+  # `doctor` shells out to handoff-doctor.sh directly — it never reads the
+  # preflight cache. The shim is NOT wired into the doctor verb (which
+  # invokes the real script via an absolute path from the bin), so we
+  # assert behavioral equivalence instead: doctor exits 0 against a valid
+  # transport even though cache would have let the bin skip the call.
+  run node "$BIN" doctor
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+  [[ "$output" == *"DOTCLAUDE_HANDOFF_REPO"* ]]
+
+  # Counter is unchanged: the doctor verb shells to the real script via
+  # absolute path and never consults the shim.
+  [ "$(counter)" -eq 1 ]
+}

--- a/plugins/dotclaude/tests/handoff-preflight-wiring.test.mjs
+++ b/plugins/dotclaude/tests/handoff-preflight-wiring.test.mjs
@@ -1,0 +1,120 @@
+// Asserts that pushRemote and pullRemote invoke autoPreflight with the resolved
+// repo URL and the {verify, verbose} opts, before any transport I/O. Mocks
+// autoPreflight to short-circuit so we don't need to stub git/fs.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/lib/handoff-preflight.mjs", () => ({
+  autoPreflight: vi.fn(),
+  // Re-export constants the consumer module reads at import time (none today,
+  // but keep the mock complete so future additions don't silently regress).
+  CACHE_SCHEMA_VERSION: 1,
+  DOCTOR_CACHE_TTL_MS: 5 * 60 * 1000,
+  DOCTOR_SH: "/unused-in-tests",
+  currentCacheDir: vi.fn(() => "/tmp/unused"),
+  currentCacheFile: vi.fn(() => "/tmp/unused/handoff-doctor.json"),
+  isFresh: vi.fn(() => false),
+  readCache: vi.fn(() => null),
+  writeCacheAtomic: vi.fn(),
+}));
+
+import { autoPreflight } from "../src/lib/handoff-preflight.mjs";
+import * as lib from "../src/lib/handoff-remote.mjs";
+
+const REPO_URL = "https://github.com/x/y.git";
+
+describe("pushRemote wires autoPreflight", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    autoPreflight.mockReset();
+    // Short-circuit pushRemote right after preflight by throwing a sentinel.
+    autoPreflight.mockImplementation(() => {
+      throw new Error("__preflight_short_circuit__");
+    });
+    process.env.DOTCLAUDE_HANDOFF_REPO = REPO_URL;
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`__exit__${code}`);
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("calls autoPreflight with the resolved repo URL before any transport I/O", async () => {
+    await expect(
+      lib.pushRemote({ cli: "claude", path: "/tmp/nonexistent" }),
+    ).rejects.toThrow("__preflight_short_circuit__");
+
+    expect(autoPreflight).toHaveBeenCalledTimes(1);
+    const call = autoPreflight.mock.calls[0][0];
+    expect(call.repo).toBe(REPO_URL);
+    expect(call.verify).toBe(false);
+    expect(call.verbose).toBe(false);
+  });
+
+  it("forwards verify:true and verbose:true to autoPreflight", async () => {
+    await expect(
+      lib.pushRemote({
+        cli: "claude",
+        path: "/tmp/nonexistent",
+        verify: true,
+        verbose: true,
+      }),
+    ).rejects.toThrow("__preflight_short_circuit__");
+
+    const call = autoPreflight.mock.calls[0][0];
+    expect(call.verify).toBe(true);
+    expect(call.verbose).toBe(true);
+  });
+});
+
+describe("pullRemote wires autoPreflight", () => {
+  let exitSpy;
+  let stderrSpy;
+
+  beforeEach(() => {
+    autoPreflight.mockReset();
+    autoPreflight.mockImplementation(() => {
+      throw new Error("__preflight_short_circuit__");
+    });
+    process.env.DOTCLAUDE_HANDOFF_REPO = REPO_URL;
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`__exit__${code}`);
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    delete process.env.DOTCLAUDE_HANDOFF_REPO;
+  });
+
+  it("calls autoPreflight with the resolved repo URL before listing candidates", async () => {
+    await expect(lib.pullRemote(null)).rejects.toThrow(
+      "__preflight_short_circuit__",
+    );
+
+    expect(autoPreflight).toHaveBeenCalledTimes(1);
+    const call = autoPreflight.mock.calls[0][0];
+    expect(call.repo).toBe(REPO_URL);
+    expect(call.verify).toBe(false);
+    expect(call.verbose).toBe(false);
+  });
+
+  it("forwards verify:true and verbose:true to autoPreflight", async () => {
+    await expect(
+      lib.pullRemote(null, null, { verify: true, verbose: true }),
+    ).rejects.toThrow("__preflight_short_circuit__");
+
+    const call = autoPreflight.mock.calls[0][0];
+    expect(call.verify).toBe(true);
+    expect(call.verbose).toBe(true);
+  });
+});

--- a/plugins/dotclaude/tests/handoff-preflight.test.mjs
+++ b/plugins/dotclaude/tests/handoff-preflight.test.mjs
@@ -1,0 +1,323 @@
+// Unit tests for plugins/dotclaude/src/lib/handoff-preflight.mjs.
+//
+// Strategy: use a real hermetic tempdir for cache file I/O (the point of the
+// module) and mock only `spawnSync` so we don't actually spawn the doctor
+// shell script. Mocking spawnSync cascades through `runScript` in
+// handoff-remote.mjs — which is what autoPreflight invokes.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+import { spawnSync } from "node:child_process";
+
+import {
+  autoPreflight,
+  CACHE_SCHEMA_VERSION,
+  DOCTOR_CACHE_TTL_MS,
+  DOCTOR_SH,
+  currentCacheDir,
+  currentCacheFile,
+  isFresh,
+  readCache,
+  writeCacheAtomic,
+} from "../src/lib/handoff-preflight.mjs";
+
+const REPO = "git@github.com:me/handoff-store.git";
+
+let tempRoot;
+let origXdg;
+let origHome;
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), "preflight-test-"));
+  origXdg = process.env.XDG_CACHE_HOME;
+  origHome = process.env.HOME;
+  process.env.XDG_CACHE_HOME = tempRoot;
+  delete process.env.HOME; // force tests to rely on XDG
+  spawnSync.mockReset();
+});
+
+afterEach(() => {
+  if (origXdg !== undefined) process.env.XDG_CACHE_HOME = origXdg;
+  else delete process.env.XDG_CACHE_HOME;
+  if (origHome !== undefined) process.env.HOME = origHome;
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
+function mockDoctor(status, { stdout = "", stderr = "" } = {}) {
+  spawnSync.mockReturnValueOnce({ status, stdout, stderr });
+}
+
+// ---- constants / path helpers -------------------------------------------
+
+describe("constants and path helpers", () => {
+  it("exposes CACHE_SCHEMA_VERSION = 1", () => {
+    expect(CACHE_SCHEMA_VERSION).toBe(1);
+  });
+
+  it("exposes DOCTOR_CACHE_TTL_MS = 5 * 60 * 1000", () => {
+    expect(DOCTOR_CACHE_TTL_MS).toBe(5 * 60 * 1000);
+  });
+
+  it("DOCTOR_SH points at the real shell script path", () => {
+    expect(DOCTOR_SH).toMatch(/scripts\/handoff-doctor\.sh$/);
+  });
+
+  it("currentCacheDir honors XDG_CACHE_HOME", () => {
+    expect(currentCacheDir()).toBe(join(tempRoot, "dotclaude"));
+  });
+
+  it("currentCacheDir falls back to $HOME/.cache when XDG is unset", () => {
+    delete process.env.XDG_CACHE_HOME;
+    process.env.HOME = "/tmp/fakehome";
+    expect(currentCacheDir()).toBe("/tmp/fakehome/.cache/dotclaude");
+  });
+
+  it("currentCacheDir tolerates both env vars being unset", () => {
+    delete process.env.XDG_CACHE_HOME;
+    delete process.env.HOME;
+    // The function should not throw; the resulting path is something
+    // unusable but callers will get an fs error on write, not a crash here.
+    expect(() => currentCacheDir()).not.toThrow();
+  });
+
+  it("currentCacheFile appends handoff-doctor.json", () => {
+    expect(currentCacheFile()).toBe(join(tempRoot, "dotclaude", "handoff-doctor.json"));
+  });
+});
+
+// ---- isFresh -------------------------------------------------------------
+
+describe("isFresh", () => {
+  const now = 1_700_000_000_000;
+  const fresh = {
+    version: 1,
+    timestamp: new Date(now - 60_000).toISOString(),
+    repo: REPO,
+    status: "ok",
+  };
+
+  it("returns true for a fresh entry within TTL", () => {
+    expect(isFresh(fresh, REPO, now)).toBe(true);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isFresh(null, REPO, now)).toBe(false);
+    expect(isFresh(undefined, REPO, now)).toBe(false);
+  });
+
+  it("returns false for non-object entry", () => {
+    expect(isFresh("ok", REPO, now)).toBe(false);
+    expect(isFresh(42, REPO, now)).toBe(false);
+  });
+
+  it("returns false when repo differs", () => {
+    expect(isFresh(fresh, "git@other:me/x.git", now)).toBe(false);
+  });
+
+  it("returns false when status is not 'ok'", () => {
+    expect(isFresh({ ...fresh, status: "fail" }, REPO, now)).toBe(false);
+  });
+
+  it("returns false when schema version mismatches", () => {
+    expect(isFresh({ ...fresh, version: 99 }, REPO, now)).toBe(false);
+  });
+
+  it("returns false when timestamp is unparseable", () => {
+    expect(isFresh({ ...fresh, timestamp: "not-a-date" }, REPO, now)).toBe(false);
+  });
+
+  it("returns false past TTL", () => {
+    const stale = { ...fresh, timestamp: new Date(now - DOCTOR_CACHE_TTL_MS - 1).toISOString() };
+    expect(isFresh(stale, REPO, now)).toBe(false);
+  });
+
+  it("returns true exactly at TTL boundary", () => {
+    const boundary = { ...fresh, timestamp: new Date(now - DOCTOR_CACHE_TTL_MS).toISOString() };
+    expect(isFresh(boundary, REPO, now)).toBe(true);
+  });
+});
+
+// ---- readCache / writeCacheAtomic ---------------------------------------
+
+describe("readCache and writeCacheAtomic", () => {
+  it("readCache returns null when file does not exist", () => {
+    expect(readCache()).toBeNull();
+  });
+
+  it("readCache returns null when file contents are not JSON", () => {
+    writeCacheAtomic({ version: 1, timestamp: new Date().toISOString(), repo: REPO, status: "ok" });
+    writeFileSync(currentCacheFile(), "{not json", "utf8");
+    expect(readCache()).toBeNull();
+  });
+
+  it("writeCacheAtomic creates the directory and writes the file", () => {
+    expect(existsSync(currentCacheDir())).toBe(false);
+    const entry = { version: 1, timestamp: new Date().toISOString(), repo: REPO, status: "ok" };
+    writeCacheAtomic(entry);
+    expect(existsSync(currentCacheFile())).toBe(true);
+    const round = JSON.parse(readFileSync(currentCacheFile(), "utf8"));
+    expect(round).toEqual(entry);
+  });
+
+  it("round-trips through readCache", () => {
+    const entry = { version: 1, timestamp: new Date().toISOString(), repo: REPO, status: "ok" };
+    writeCacheAtomic(entry);
+    expect(readCache()).toEqual(entry);
+  });
+
+  it("writeCacheAtomic leaves no tmp file behind after success", () => {
+    writeCacheAtomic({ version: 1, timestamp: new Date().toISOString(), repo: REPO, status: "ok" });
+    const tmp = `${currentCacheFile()}.${process.pid}.tmp`;
+    expect(existsSync(tmp)).toBe(false);
+  });
+});
+
+// ---- autoPreflight -------------------------------------------------------
+
+describe("autoPreflight", () => {
+  it("runs doctor on cold cache, writes cache, silent on success", () => {
+    mockDoctor(0, { stdout: "ok\n" });
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      autoPreflight({ repo: REPO });
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+      expect(spawnSync.mock.calls[0][0]).toBe(DOCTOR_SH);
+      expect(stdoutSpy).not.toHaveBeenCalled();
+      expect(stderrSpy).not.toHaveBeenCalled();
+      const entry = readCache();
+      expect(entry.version).toBe(1);
+      expect(entry.repo).toBe(REPO);
+      expect(entry.status).toBe("ok");
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("skips doctor on warm cache within TTL", () => {
+    writeCacheAtomic({
+      version: 1,
+      timestamp: new Date().toISOString(),
+      repo: REPO,
+      status: "ok",
+    });
+    autoPreflight({ repo: REPO });
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("runs doctor when cache is stale past TTL", () => {
+    writeCacheAtomic({
+      version: 1,
+      timestamp: new Date(Date.now() - DOCTOR_CACHE_TTL_MS - 1000).toISOString(),
+      repo: REPO,
+      status: "ok",
+    });
+    mockDoctor(0, { stdout: "ok\n" });
+    autoPreflight({ repo: REPO });
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs doctor when repo arg differs from cached repo (env-change invalidation)", () => {
+    writeCacheAtomic({
+      version: 1,
+      timestamp: new Date().toISOString(),
+      repo: "git@github.com:me/old-store.git",
+      status: "ok",
+    });
+    mockDoctor(0, { stdout: "ok\n" });
+    autoPreflight({ repo: REPO });
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+    // Cache should now reflect the NEW repo.
+    expect(readCache().repo).toBe(REPO);
+  });
+
+  it("bypasses cache when verify: true is passed", () => {
+    writeCacheAtomic({
+      version: 1,
+      timestamp: new Date().toISOString(),
+      repo: REPO,
+      status: "ok",
+    });
+    mockDoctor(0, { stdout: "ok\n" });
+    autoPreflight({ repo: REPO, verify: true });
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs doctor when cached schema version mismatches", () => {
+    // Write a version-99 entry directly; writeCacheAtomic always stamps v1.
+    mkdirSync(currentCacheDir(), { recursive: true });
+    writeFileSync(
+      currentCacheFile(),
+      JSON.stringify({ version: 99, timestamp: new Date().toISOString(), repo: REPO, status: "ok" }),
+      "utf8",
+    );
+    mockDoctor(0, { stdout: "ok\n" });
+    autoPreflight({ repo: REPO });
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws 'preflight failed' when doctor exits non-zero, does NOT write cache", () => {
+    mockDoctor(1, { stderr: "Preflight failed: handoff-repo-unreachable\n" });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      expect(() => autoPreflight({ repo: REPO })).toThrow(/preflight failed/);
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Preflight failed: handoff-repo-unreachable"),
+      );
+      expect(existsSync(currentCacheFile())).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("emits 'cache hit' line to stderr under verbose when warm", () => {
+    writeCacheAtomic({
+      version: 1,
+      timestamp: new Date().toISOString(),
+      repo: REPO,
+      status: "ok",
+    });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      autoPreflight({ repo: REPO, verbose: true });
+      expect(spawnSync).not.toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringMatching(/preflight: cache hit \(age \d+s\)/));
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("streams doctor stdout/stderr under verbose on success", () => {
+    mockDoctor(0, { stdout: "ok\n", stderr: "info: something\n" });
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      autoPreflight({ repo: REPO, verbose: true });
+      expect(stdoutSpy).toHaveBeenCalledWith("ok\n");
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("info: something"));
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("always streams doctor failure block, even when verbose is false", () => {
+    mockDoctor(1, { stdout: "", stderr: "Preflight failed: git-missing\n" });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      expect(() => autoPreflight({ repo: REPO, verbose: false })).toThrow();
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Preflight failed: git-missing"),
+      );
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -12,7 +12,9 @@ vi.mock("node:fs", () => ({
   mkdirSync: vi.fn(),
   mkdtempSync: vi.fn().mockReturnValue("/tmp/mock-dir"),
   readFileSync: vi.fn().mockReturnValue(""),
+  renameSync: vi.fn(),
   rmSync: vi.fn(),
+  unlinkSync: vi.fn(),
   writeFileSync: vi.fn(),
 }));
 vi.mock("node:readline", () => ({
@@ -730,11 +732,27 @@ describe("pullRemote", () => {
     readFileSync.mockReturnValueOnce(description);
   }
 
+  // Preflight runs first on pullRemote and reads the doctor cache via
+  // existsSync + readFileSync. Prime a cache-hit so preflight returns silently
+  // and does not consume any spawnSync mock that was queued for ls-remote.
+  function primePreflightCacheHit() {
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValueOnce(
+      JSON.stringify({
+        version: 1,
+        timestamp: new Date().toISOString(),
+        repo: "https://github.com/x/y.git",
+        status: "ok",
+      }),
+    );
+  }
+
   beforeEach(() => {
     resetMockQueues();
     process.env.DOTCLAUDE_HANDOFF_REPO = "https://github.com/x/y.git";
     exitSpy = mockExit();
     stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    primePreflightCacheHit();
   });
   afterEach(() => {
     exitSpy.mockRestore();


### PR DESCRIPTION
## Summary

- Auto-run `handoff-doctor.sh` on first `push`/`pull` per 5-minute TTL window; subsequent calls reuse the cached result, so users no longer discover misconfiguration only via a cryptic `gh` / `git` error.
- `--verify` on `push` / `pull` forces a fresh preflight; the `doctor` verb stays on-demand and never consults the cache.
- Cache lives at `$XDG_CACHE_HOME/dotclaude/handoff-doctor.json` (falls back to `$HOME/.cache`); invalidated on TTL expiry, schema-version bump, or when `DOTCLAUDE_HANDOFF_REPO` changes.

## Test plan

- [x] `npx vitest run plugins/dotclaude/tests/handoff-preflight.test.mjs` — 31/31 pass
- [x] `npx vitest run plugins/dotclaude/tests/handoff-preflight-wiring.test.mjs` — 4/4 pass
- [x] `npx vitest run --coverage` — 457/457 pass, branches 80.86% ≥ 80%
- [x] `npx bats plugins/dotclaude/tests/bats/handoff-preflight.bats` — 5/5 pass
- [x] `npx bats plugins/dotclaude/tests/bats/` — 245/245 pass
- [x] `npm run dogfood` — manifest / agents / specs / drift / coverage all green
- [x] Manual smoke: first push runs doctor, second push silent, `push --verify` re-runs, `doctor` verb still prints `ok` + enrichment lines

## Scope / rollout

Closes step 3 of `docs/plans/handoff-issue-rollout.md` (issue #91 gap 2). Out of scope and deferred to later gaps:

- Error-shape normalization `{stage, cause, fix, retry}` — Gap 3
- `--dry-run` / prune / tag polish — Gaps 4–6
- Transport backend split — Gap 8

No change to `handoff-doctor.sh`, `listRemoteCandidates`, or `fetchRemoteBranch`.

## Implementation notes

- New module `plugins/dotclaude/src/lib/handoff-preflight.mjs` owns the cache concern — keeps `handoff-remote.mjs` focused and makes the branch-coverage floor achievable without bloating the remote-lib suite.
- `pushRemote({ cli, path, tag, verify, verbose })` and `pullRemote(query, fromCli, { verify, verbose })` are additive — existing callers pass undefined and get the default non-verify behavior.
- `DOTCLAUDE_DOCTOR_SH` env override lets the bats counter-shim measure doctor invocations without patching the shipped script; production paths leave it unset and get the bundled `handoff-doctor.sh`.
- Atomic cache writes via `writeFileSync(tmp)` + `renameSync(tmp, final)` so concurrent readers never see a half-written JSON blob.

## Spec ID

dotclaude-core
