### PR TITLE
fix(handoff): sort pull candidates by committer date (#90 Gap 2)

### DIFF
--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -648,22 +648,22 @@ export async function pushRemote({ cli, path: sessionFile, tag, verify = false, 
  *
  * If the sort fetch fails (network blip, auth hiccup between the
  * ls-remote that built `candidates` and this call), emit a stderr
- * warning and return the input unchanged. Preserving availability
- * beats picking a deterministic-but-wrong answer — the caller can
- * still pull by id.
+ * warning and return null. The caller falls back to the pre-fix
+ * selection (last ls-remote entry) so the degraded path is stable.
  *
  * @param {Array<{branch: string, commit: string, description: string}>} candidates
  * @param {string} repoUrl
- * @returns {Array<{branch: string, commit: string, description: string}>}
+ * @returns {Array<{branch: string, commit: string, description: string}>|null}
  */
 function sortByCommitterDate(candidates, repoUrl) {
   if (candidates.length <= 1) return candidates;
   const tmp = mkdtempSync(join(tmpdir(), "handoff-sort-"));
   const warnAndFallback = (reason) => {
+    const msg = String(reason).trim().replace(/\s+/gu, " ") || "unknown error";
     process.stderr.write(
-      `dotclaude-handoff: committer-date sort skipped (${reason}); using ls-remote order\n`,
+      `dotclaude-handoff: committer-date sort skipped (${msg}); using ls-remote order\n`,
     );
-    return candidates;
+    return null;
   };
   try {
     const init = runGit(["init", "-q", "--bare"], tmp);
@@ -804,7 +804,7 @@ export async function pullRemote(query, fromCli = null, { verify = false, verbos
   // transient failure with a stderr warning.
   if (!query) {
     const sorted = sortByCommitterDate(candidates, repoUrl);
-    return sorted[0];
+    return sorted ? sorted[0] : candidates[candidates.length - 1];
   }
 
   // Cheap pass: filter by branch name.

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -636,6 +636,82 @@ export async function pushRemote({ cli, path: sessionFile, tag, verify = false, 
 }
 
 /**
+ * Sort remote handoff candidates newest-first by commit date.
+ *
+ * `git ls-remote --sort=committerdate` is documented to fail with
+ * "missing object" for refs whose objects have not yet been fetched
+ * (see git-ls-remote(1)), so we can't sort server-side. Instead, do
+ * one bulk shallow fetch into a throwaway bare repo and run
+ * `for-each-ref --sort=-committerdate` locally.
+ *
+ * Cost: one `fetch --depth=1` round-trip; O(N) commit-tip objects.
+ *
+ * If the sort fetch fails (network blip, auth hiccup between the
+ * ls-remote that built `candidates` and this call), emit a stderr
+ * warning and return the input unchanged. Preserving availability
+ * beats picking a deterministic-but-wrong answer — the caller can
+ * still pull by id.
+ *
+ * @param {Array<{branch: string, commit: string, description: string}>} candidates
+ * @param {string} repoUrl
+ * @returns {Array<{branch: string, commit: string, description: string}>}
+ */
+function sortByCommitterDate(candidates, repoUrl) {
+  if (candidates.length <= 1) return candidates;
+  const tmp = mkdtempSync(join(tmpdir(), "handoff-sort-"));
+  const warnAndFallback = (reason) => {
+    process.stderr.write(
+      `dotclaude-handoff: committer-date sort skipped (${reason}); using ls-remote order\n`,
+    );
+    return candidates;
+  };
+  try {
+    const init = runGit(["init", "-q", "--bare"], tmp);
+    if (init.status !== 0) {
+      return warnAndFallback(`git init failed: ${init.stderr.trim()}`);
+    }
+    const refspecs = candidates.map(
+      (c) => `+refs/heads/${c.branch}:refs/heads/${c.branch}`,
+    );
+    const fetched = runGit(
+      ["fetch", "--depth=1", "--no-tags", "-q", repoUrl, ...refspecs],
+      tmp,
+    );
+    if (fetched.status !== 0) {
+      return warnAndFallback(`fetch failed: ${fetched.stderr.trim()}`);
+    }
+    const fer = runGit(
+      [
+        "for-each-ref",
+        "--sort=-committerdate",
+        "--format=%(refname:short)",
+        "refs/heads/handoff/",
+      ],
+      tmp,
+    );
+    if (fer.status !== 0) {
+      return warnAndFallback(`for-each-ref failed: ${fer.stderr.trim()}`);
+    }
+    const byBranch = new Map(candidates.map((c) => [c.branch, c]));
+    const sorted = [];
+    for (const line of fer.stdout.split("\n")) {
+      const ref = line.trim();
+      if (!ref) continue;
+      const c = byBranch.get(ref);
+      if (c) sorted.push(c);
+    }
+    if (sorted.length !== candidates.length) {
+      return warnAndFallback(
+        `partial sort (${sorted.length}/${candidates.length} refs resolved)`,
+      );
+    }
+    return sorted;
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
  * List handoff branches on the remote as candidate objects.
  * Returns [{branch, description, commit}] — no content fetched.
  */
@@ -720,13 +796,15 @@ export async function pullRemote(query, fromCli = null, { verify = false, verbos
     if (candidates.length === 0) fail(2, `no ${fromCli} handoffs found on transport`);
   }
 
-  // Bare: pick the newest. We don't have a reliable remote mtime, so
-  // fall back to the lexically last branch, which is typically the
-  // most recent since short IDs hash-distribute. The caller re-fetches
-  // the branch contents via fetchRemoteBranch, so skipping the
-  // enrichment pass saves N shallow clones.
+  // Bare: pick the newest by commit date. Short UUIDs are 8 hex chars
+  // of a v4 random UUID, so lexical order is random with respect to
+  // push time — the previous implementation could return a stale
+  // branch silently. sortByCommitterDate pays one shallow fetch to
+  // get a correct answer, and falls back to ls-remote order on
+  // transient failure with a stderr warning.
   if (!query) {
-    return candidates[candidates.length - 1];
+    const sorted = sortByCommitterDate(candidates, repoUrl);
+    return sorted[0];
   }
 
   // Cheap pass: filter by branch name.

--- a/plugins/dotclaude/tests/bats/handoff-pull-latest.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-latest.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# `pull` with no query must return the branch with the newest commit date,
+# not the lexically-last short UUID. Issue #90 Gap 2.
+#
+# Exercises the real `pullRemote` against a local bare repo — no network.
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+# Seed a Claude session at $TEST_HOME/.claude/projects/<slug>/<uuid>.jsonl
+# whose first user prompt carries the marker string $2. Per-uuid slug keeps
+# each session distinct for the resolver.
+seed_session() {
+  local uuid="$1" marker="$2"
+  local slug="-home-u-pull-latest-${uuid%%-*}"
+  local dir="$TEST_HOME/.claude/projects/$slug"
+  mkdir -p "$dir"
+  cat > "$dir/$uuid.jsonl" <<EOF
+{"type":"user","cwd":"/home/u/pull-latest/${uuid%%-*}","sessionId":"$uuid","version":"2.1","message":{"content":"$marker"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}
+EOF
+}
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  TRANSPORT_REPO=$(make_transport_repo "$(mktemp -d)")
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+
+  # Short UUIDs chosen so that lexical order of branches is the OPPOSITE
+  # of push order. With this setup, the pre-fix code's
+  # `candidates[candidates.length - 1]` returns the oldest-committed
+  # branch (fffffff0), while the fix must return the newest (00000001).
+  UUID_OLD="fffffff0-1111-1111-1111-111111111111"
+  UUID_MID="77777777-1111-1111-1111-111111111111"
+  UUID_NEW="00000001-1111-1111-1111-111111111111"
+  seed_session "$UUID_OLD" "marker-oldest"
+  seed_session "$UUID_MID" "marker-middle"
+  seed_session "$UUID_NEW" "marker-newest"
+
+  export UUID_OLD UUID_MID UUID_NEW
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+}
+
+@test "pull (bare): returns newest-committed branch, not lex-last" {
+  # Push oldest → middle → newest, >1s apart so the committer dates are
+  # strictly increasing and reflect push order.
+  run node "$BIN" push fffffff0
+  [ "$status" -eq 0 ]
+  sleep 1.1
+  run node "$BIN" push 77777777
+  [ "$status" -eq 0 ]
+  sleep 1.1
+  run node "$BIN" push 00000001
+  [ "$status" -eq 0 ]
+
+  run node "$BIN" pull
+  [ "$status" -eq 0 ]
+  # Pulled branch must be the newest (marker-newest). If the bug is
+  # still present, the lex-last branch (fffffff0 / marker-oldest) is
+  # returned instead.
+  [[ "$output" == *"marker-newest"* ]]
+  [[ "$output" != *"marker-oldest"* ]]
+  [[ "$output" != *"marker-middle"* ]]
+}
+
+@test "pull --from claude (no query): still returns newest by commit date" {
+  # Same ordering as above; verify the fromCli-scoped path also sorts
+  # correctly — the filter runs before the sort, so all three remain in
+  # the candidate set.
+  run node "$BIN" push fffffff0
+  [ "$status" -eq 0 ]
+  sleep 1.1
+  run node "$BIN" push 77777777
+  [ "$status" -eq 0 ]
+  sleep 1.1
+  run node "$BIN" push 00000001
+  [ "$status" -eq 0 ]
+
+  run node "$BIN" pull --from claude
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"marker-newest"* ]]
+  [[ "$output" != *"marker-oldest"* ]]
+}
+
+@test "pull (bare) with a single branch: no sort attempted, fast path" {
+  # Single-candidate short-circuit. If this regresses to unconditional
+  # fetch-for-sort, the test is still green but would be slower — we
+  # pin correctness, not cost.
+  run node "$BIN" push fffffff0
+  [ "$status" -eq 0 ]
+  run node "$BIN" pull
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"marker-oldest"* ]]
+}

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -770,10 +770,10 @@ describe("pullRemote", () => {
   //
   // Each test below mocks an ls-remote with 2–3 candidates, then queues
   // spawnSync returns for `git init` / `git fetch` / `git for-each-ref`
-  // in that exact order. On fallback, sortByCommitterDate returns the
-  // candidates unchanged (ls-remote order) and pullRemote returns
-  // sorted[0] — i.e. the first ls-remote candidate. The stderr warning
-  // is what signals the user that the pick is best-effort.
+  // in that exact order. On fallback, sortByCommitterDate returns null
+  // and pullRemote falls back to candidates[candidates.length - 1] —
+  // the last ls-remote entry, preserving pre-fix selection semantics.
+  // The stderr warning signals the user that the pick is best-effort.
 
   function mockLsRemoteMulti(...shortIds) {
     const lines = shortIds
@@ -806,7 +806,7 @@ describe("pullRemote", () => {
     mockLsRemoteMulti("aaaaaaaa", "bbbbbbbb");
     spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "init denied" });
     const result = await lib.pullRemote(null);
-    expect(result.branch).toBe("handoff/proj/claude/2026-04/aaaaaaaa");
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/bbbbbbbb");
   });
 
   it("falls back to ls-remote order when the shallow fetch fails during sort", async () => {
@@ -814,7 +814,7 @@ describe("pullRemote", () => {
     spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
     spawnSync.mockReturnValueOnce({ status: 128, stdout: "", stderr: "remote hung up" });
     const result = await lib.pullRemote(null);
-    expect(result.branch).toBe("handoff/proj/claude/2026-04/aaaaaaaa");
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/bbbbbbbb");
   });
 
   it("falls back to ls-remote order when `for-each-ref` fails during sort", async () => {
@@ -823,7 +823,7 @@ describe("pullRemote", () => {
     spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // fetch
     spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "bad ref" });
     const result = await lib.pullRemote(null);
-    expect(result.branch).toBe("handoff/proj/claude/2026-04/aaaaaaaa");
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/bbbbbbbb");
   });
 
   it("falls back when for-each-ref returns fewer refs than candidates (partial)", async () => {
@@ -836,7 +836,7 @@ describe("pullRemote", () => {
       stderr: "",
     });
     const result = await lib.pullRemote(null);
-    expect(result.branch).toBe("handoff/proj/claude/2026-04/aaaaaaaa");
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/bbbbbbbb");
   });
 
   it("exits 2 when no candidates exist", async () => {

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -760,10 +760,83 @@ describe("pullRemote", () => {
     delete process.env.DOTCLAUDE_HANDOFF_REPO;
   });
 
-  it("returns the last candidate when query is null (no enrichment)", async () => {
+  it("returns the single candidate when query is null (sort short-circuits on N=1)", async () => {
     mockLsRemote("handoff/proj/claude/2026-04/abc12345");
     const result = await lib.pullRemote(null);
     expect(result.branch).toBe("handoff/proj/claude/2026-04/abc12345");
+  });
+
+  // ---- sortByCommitterDate via bare pullRemote ----
+  //
+  // Each test below mocks an ls-remote with 2–3 candidates, then queues
+  // spawnSync returns for `git init` / `git fetch` / `git for-each-ref`
+  // in that exact order. On fallback, sortByCommitterDate returns the
+  // candidates unchanged (ls-remote order) and pullRemote returns
+  // sorted[0] — i.e. the first ls-remote candidate. The stderr warning
+  // is what signals the user that the pick is best-effort.
+
+  function mockLsRemoteMulti(...shortIds) {
+    const lines = shortIds
+      .map((s, i) => `c${i}  refs/heads/handoff/proj/claude/2026-04/${s}`)
+      .join("\n") + "\n";
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: lines, stderr: "" });
+  }
+
+  it("sorts bare pull candidates by committer date (newest first)", async () => {
+    mockLsRemoteMulti("aaaaaaaa", "bbbbbbbb", "cccccccc");
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // fetch
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout:
+        [
+          "handoff/proj/claude/2026-04/bbbbbbbb",
+          "handoff/proj/claude/2026-04/aaaaaaaa",
+          "handoff/proj/claude/2026-04/cccccccc",
+        ].join("\n") + "\n",
+      stderr: "",
+    }); // for-each-ref: bbb is newest
+    const result = await lib.pullRemote(null);
+    // Pre-fix would return 'cccccccc' (lex-last); the fix returns the
+    // first entry of for-each-ref --sort=-committerdate output.
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/bbbbbbbb");
+  });
+
+  it("falls back to ls-remote order when `git init` fails during sort", async () => {
+    mockLsRemoteMulti("aaaaaaaa", "bbbbbbbb");
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "init denied" });
+    const result = await lib.pullRemote(null);
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/aaaaaaaa");
+  });
+
+  it("falls back to ls-remote order when the shallow fetch fails during sort", async () => {
+    mockLsRemoteMulti("aaaaaaaa", "bbbbbbbb");
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
+    spawnSync.mockReturnValueOnce({ status: 128, stdout: "", stderr: "remote hung up" });
+    const result = await lib.pullRemote(null);
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/aaaaaaaa");
+  });
+
+  it("falls back to ls-remote order when `for-each-ref` fails during sort", async () => {
+    mockLsRemoteMulti("aaaaaaaa", "bbbbbbbb");
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // fetch
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "bad ref" });
+    const result = await lib.pullRemote(null);
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/aaaaaaaa");
+  });
+
+  it("falls back when for-each-ref returns fewer refs than candidates (partial)", async () => {
+    mockLsRemoteMulti("aaaaaaaa", "bbbbbbbb");
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // fetch
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "handoff/proj/claude/2026-04/aaaaaaaa\n", // only one of two
+      stderr: "",
+    });
+    const result = await lib.pullRemote(null);
+    expect(result.branch).toBe("handoff/proj/claude/2026-04/aaaaaaaa");
   });
 
   it("exits 2 when no candidates exist", async () => {


### PR DESCRIPTION
## Summary

- Closes #90 Gap 2. `pullRemote` with no query returned `candidates[candidates.length - 1]`, but short UUIDs are 8 hex chars of a v4 UUID — lexical order is random with respect to push time. Bare `pull` could silently return a stale branch.
- New `sortByCommitterDate` does one bulk `git fetch --depth=1` into a throwaway bare repo, then `for-each-ref --sort=-committerdate`. Server-side `ls-remote --sort=committerdate` is ruled out by `git-ls-remote(1)` — it errors on unfetched objects.
- On transient fetch failure the helper emits a stderr warning and returns ls-remote order so the pull still resolves; availability wins over picking a deterministic-but-wrong answer.

## Test plan

- [x] New bats suite `handoff-pull-latest.bats` — 3 pushes with short UUIDs chosen so lex-last is the oldest commit. Confirmed failing on `main`, passing after the fix.
- [x] Full bats suite: `npx bats plugins/dotclaude/tests/bats/` — 248/248 pass.
- [x] Full vitest suite: `npm test` — 457/457 pass across 29 files.
- [x] Single-candidate fast-path pinned (no sort fetch when N≤1).
- [x] Reviewer: eyeball `sortByCommitterDate` fallback path — a CI env without outbound git access will exercise the warn-and-return-unsorted branch.

## Notes

- Gaps 1, 4, 5 of #90 are already resolved on `main` (see [status comment](https://github.com/kaiohenricunha/dotclaude/issues/90#issuecomment-4297476829)). Gap 3 (force-push overwrites) is still open and will ship as a separate PR since it warrants a deliberate branch/tag scheme change.
- The scratch bare repo is cleaned up via `rmSync({ force: true })` in the `finally` block.

## Spec ID

dotclaude-core