### PR TITLE
fix(handoff): digest prompts group by message, not by line (#84)

### DIFF
--- a/plugins/dotclaude/scripts/handoff-extract.sh
+++ b/plugins/dotclaude/scripts/handoff-extract.sh
@@ -131,23 +131,26 @@ prompts_claude() {
         elif $a == null or ($a.a // "") == "" then $n.n
         else "\($n.n) \($a.a)"
         end;
-    [inputs | select(.type == "user")]
-    | reduce .[] as $r (
-        {out: [], prevWasCommand: false, prevPid: null};
+    foreach (inputs | select(.type == "user")) as $r (
+        {emit: null, prevWasCommand: false, prevPid: null};
         ($r.message.content | text_of) as $t
         | ($r.promptId // "") as $pid
-        | if $t == "" or ($t | is_noise) then .
+        | if $t == "" or ($t | is_noise) then
+            .emit = null
           elif ($t | is_command_wrapper) then
-            .out += [$t | compact_command]
+            .emit = ($t | compact_command)
             | .prevWasCommand = true
             | .prevPid = $pid
           elif .prevWasCommand and .prevPid == $pid then
-            .prevWasCommand = false
+            .emit = null
+            | .prevWasCommand = false
           else
-            .out += [$t] | .prevWasCommand = false | .prevPid = $pid
-          end
+            .emit = $t
+            | .prevWasCommand = false
+            | .prevPid = $pid
+          end;
+        .emit | select(. != null)
       )
-    | .out[]
   ' "$file" 2>/dev/null
 }
 

--- a/plugins/dotclaude/scripts/handoff-extract.sh
+++ b/plugins/dotclaude/scripts/handoff-extract.sh
@@ -89,12 +89,21 @@ meta_claude() {
 }
 
 # Claude user prompts, scrubbed of system/command/tool noise.
-# Content may be string OR array of content blocks.
-# Noise filtering is done in jq on the full prompt text (not line-by-line)
-# so multi-line synthetic records are correctly dropped at the record level.
+#
+# Output: one JSON-encoded string per line (jq -c). Multi-line prompts stay
+# atomic as `"line one\nline two"`; the consumer parses each line via
+# JSON.parse. This is what fixes the "digest splits by line, not by message"
+# bug — the old jq -r contract emitted raw bytes and multi-line skill-body
+# messages turned into N bogus "prompts".
+#
+# Slash-command handling: a `<command-name>/X</command-name>` wrapper is
+# rendered as compact `/X <args>` form, and the immediately-following
+# skill body (same promptId) is dropped. This requires a single-pass
+# slurp + reduce so we can track "previous record was a command wrapper"
+# across the input stream.
 prompts_claude() {
   local file="$1"
-  jq -r '
+  jq -c -n '
     def text_of:
       if type == "string" then .
       else (map(select(.type == "text") | .text) | join("\n"))
@@ -102,9 +111,7 @@ prompts_claude() {
     def is_noise:
       ltrimstr(" ") | ltrimstr("\t") | ltrimstr("\n") |
       ( startswith("<local-command-caveat>")
-        or startswith("<command-name>")
-        or startswith("<command-message>")
-        or startswith("<command-args>")
+        or startswith("<local-command-stdout>")
         or startswith("<stdin>")
         or startswith("<system-reminder>")
         or startswith("<user-prompt-submit-hook>")
@@ -115,18 +122,39 @@ prompts_claude() {
         or startswith("<event>")
         or startswith("If this event is something the user")
       );
-    select(.type == "user")
-    | .message.content
-    | text_of
-    | select(length > 0)
-    | select(is_noise | not)
+    def is_command_wrapper:
+      test("<command-name>") or test("<command-message>");
+    def compact_command:
+      (capture("<command-name>\\s*(?<n>[^<]+?)\\s*</command-name>") // null) as $n
+      | (capture("<command-args>\\s*(?<a>[^<]*?)\\s*</command-args>") // null) as $a
+      | if $n == null then "/unknown"
+        elif $a == null or ($a.a // "") == "" then $n.n
+        else "\($n.n) \($a.a)"
+        end;
+    [inputs | select(.type == "user")]
+    | reduce .[] as $r (
+        {out: [], prevWasCommand: false, prevPid: null};
+        ($r.message.content | text_of) as $t
+        | ($r.promptId // "") as $pid
+        | if $t == "" or ($t | is_noise) then .
+          elif ($t | is_command_wrapper) then
+            .out += [$t | compact_command]
+            | .prevWasCommand = true
+            | .prevPid = $pid
+          elif .prevWasCommand and .prevPid == $pid then
+            .prevWasCommand = false
+          else
+            .out += [$t] | .prevWasCommand = false | .prevPid = $pid
+          end
+      )
+    | .out[]
   ' "$file" 2>/dev/null
 }
 
 turns_claude() {
   local file="$1"
   local limit="${2:-20}"
-  jq -r '
+  jq -c '
     select(.type == "assistant")
     | .message.content
     | (map(select(.type == "text") | .text) | join("\n"))
@@ -184,9 +212,10 @@ meta_copilot() {
 
 # Always prefer .data.content (the raw user text) over .data.transformedContent
 # (which wraps the prompt in system-reminder boilerplate).
+# Output: one JSON-encoded string per line so multi-line prompts stay atomic.
 prompts_copilot() {
   local file="$1"
-  jq -r '
+  jq -c '
     select(.type == "user.message")
     | .data.content // ""
     | select(length > 0)
@@ -196,7 +225,7 @@ prompts_copilot() {
 turns_copilot() {
   local file="$1"
   local limit="${2:-20}"
-  jq -r '
+  jq -c '
     select(.type == "assistant.message")
     | (.data.content // .data.text // "")
     | select(length > 0)
@@ -229,7 +258,8 @@ prompts_codex() {
   local file="$1"
   # The first user message in every Codex session is an <environment_context>
   # block. Filter it out; every other user turn stays.
-  jq -r '
+  # Output: one JSON-encoded string per line so multi-line prompts stay atomic.
+  jq -c '
     select(.type == "response_item"
            and .payload.type == "message"
            and .payload.role == "user")
@@ -242,7 +272,7 @@ prompts_codex() {
 turns_codex() {
   local file="$1"
   local limit="${2:-20}"
-  jq -r '
+  jq -c '
     select(.type == "response_item"
            and .payload.type == "message"
            and .payload.role == "assistant")

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -108,7 +108,15 @@ export function extractMeta(cli, file) {
   }
 }
 
-/** Extract newline-delimited output via handoff-extract.sh <sub>. */
+/**
+ * Extract JSON-encoded-per-line output via handoff-extract.sh <sub>.
+ *
+ * `prompts` and `turns` emit one JSON-encoded string per line so that
+ * multi-line messages stay atomic — splitting on `\n` here would
+ * regress #84 by turning one skill-body message into N bogus "prompts".
+ * Lines that fail to parse are skipped (defensive — the script owns the
+ * contract).
+ */
 export function extractLines(sub, cli, file, extra = []) {
   const r = runScript(EXTRACT_SH, [sub, cli, file, ...extra]);
   if (r.status !== 0) {
@@ -116,7 +124,17 @@ export function extractLines(sub, cli, file, extra = []) {
       process.stderr.write(`dotclaude-handoff: ${sub}: ${r.stderr.trim()}\n`);
     return [];
   }
-  return r.stdout.split("\n").filter((line) => line.trim().length > 0);
+  const out = [];
+  for (const line of r.stdout.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const v = JSON.parse(line);
+      if (typeof v === "string" && v.length > 0) out.push(v);
+    } catch {
+      // Script contract broken — skip the line rather than crash the digest.
+    }
+  }
+  return out;
 }
 
 /** Extract user prompt lines from a session file. */

--- a/plugins/dotclaude/tests/bats/handoff-extract.bats
+++ b/plugins/dotclaude/tests/bats/handoff-extract.bats
@@ -14,14 +14,23 @@ setup() {
   TEST_DIR=$(mktemp -d)
 
   # --- Claude fixture: mix of real prompts + noise records ---
+  # promptId groups model Claude Code's real transcript shape:
+  #   - p-caveat: synthetic noise only
+  #   - p-typed:  real typed user prompts (one multi-line)
+  #   - p-slash:  a typed prompt + a /slash invocation + its skill body
   CLAUDE_FILE="$TEST_DIR/claude.jsonl"
   cat > "$CLAUDE_FILE" <<'EOF'
-{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","version":"2.1","message":{"content":"<local-command-caveat>Caveat: this was auto-generated</local-command-caveat>"}}
-{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"<command-name>/clear</command-name>"}}
-{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"Actually fix the retry loop"}}
-{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":[{"type":"tool_result","content":"file contents"}]}}
-{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":[{"type":"text","text":"<system-reminder>do not respond to this</system-reminder>"}]}}
-{"type":"user","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":[{"type":"text","text":"Run the full suite and report results"}]}}
+{"type":"user","promptId":"p-caveat","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","version":"2.1","message":{"content":"<local-command-caveat>Caveat: this was auto-generated</local-command-caveat>"}}
+{"type":"user","promptId":"p-typed","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"Actually fix the retry loop"}}
+{"type":"user","promptId":"p-typed","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":[{"type":"tool_result","content":"file contents"}]}}
+{"type":"user","promptId":"p-typed","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":[{"type":"text","text":"<system-reminder>do not respond to this</system-reminder>"}]}}
+{"type":"user","promptId":"p-typed","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":[{"type":"text","text":"Run the full suite and report\nevery failure with its stack trace"}]}}
+{"type":"user","promptId":"p-slash","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"oPEN pr"}}
+{"type":"user","promptId":"p-slash","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"<command-message>simplify</command-message>\n<command-name>/simplify</command-name>"}}
+{"type":"user","promptId":"p-slash","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"# Simplify: Code Review and Cleanup\n\nReview all changed files.\nEnd of skill body."}}
+{"type":"user","promptId":"p-slash","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"<command-message>review-pr</command-message>\n<command-name>/review-pr</command-name>\n<command-args>#80</command-args>"}}
+{"type":"user","promptId":"p-slash","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"Review a pull request: fetch comments, apply fixes.\nARGUMENTS: #80"}}
+{"type":"user","promptId":"p-bare","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"<command-name>/clear</command-name>"}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"Sure, running tests now."}]}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"All 205 tests passed."}]}}
 EOF
@@ -35,6 +44,7 @@ EOF
 {"type":"user.message","data":{"content":"First user prompt"}}
 {"type":"assistant.message","data":{"content":"First assistant reply"}}
 {"type":"user.message","data":{"content":"Second prompt","transformedContent":"<wrapped><system-reminder>ignore</system-reminder>Second prompt</wrapped>"}}
+{"type":"user.message","data":{"content":"Multi-line prompt\nwith two lines"}}
 EOF
   cat > "$COPILOT_DIR/workspace.yaml" <<'EOF'
 id: cccc3333-3333-3333-3333-333333333333
@@ -51,6 +61,7 @@ EOF
 {"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"Improve documentation in @README.md"}]}}
 {"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"I'll read README.md first."}]}}
 {"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"Go ahead"}]}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"Refactor this:\n- step one\n- step two"}]}}
 {"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"Done."}]}}
 EOF
 
@@ -91,25 +102,53 @@ teardown() {
 
 # -- prompts --------------------------------------------------------------
 
-@test "prompts claude excludes local-command-caveat, command-name, tool_result, system-reminder" {
+@test "prompts claude excludes local-command-caveat, tool_result, system-reminder, and raw command-wrapper tags" {
   run "$EX" prompts claude "$CLAUDE_FILE"
   [ "$status" -eq 0 ]
   # Real prompts present:
   [[ "$output" == *"Actually fix the retry loop"* ]]
-  [[ "$output" == *"Run the full suite and report results"* ]]
+  [[ "$output" == *"Run the full suite and report"* ]]
+  [[ "$output" == *"oPEN pr"* ]]
   # Noise excluded:
   [[ "$output" != *"<local-command-caveat>"* ]]
   [[ "$output" != *"<command-name>"* ]]
+  [[ "$output" != *"<command-message>"* ]]
+  [[ "$output" != *"<command-args>"* ]]
   [[ "$output" != *"<system-reminder>"* ]]
   [[ "$output" != *"file contents"* ]]
 }
 
-@test "prompts claude count is 2 on the fixture (6 user records, 4 noisy)" {
+@test "prompts claude emits one JSON-encoded string per message (not per line)" {
   run "$EX" prompts claude "$CLAUDE_FILE"
   [ "$status" -eq 0 ]
+  # Real prompts (3) + compact slash forms (3) = 6 records.
   local n
   n=$(printf '%s\n' "$output" | grep -cv '^$')
-  [ "$n" -eq 2 ]
+  [ "$n" -eq 6 ]
+}
+
+@test "prompts claude keeps multi-line messages atomic (not split by line)" {
+  run "$EX" prompts claude "$CLAUDE_FILE"
+  [ "$status" -eq 0 ]
+  # JSON-encoded two-line message — newline is escaped as \n inside one quoted string.
+  [[ "$output" == *'"Run the full suite and report\nevery failure with its stack trace"'* ]]
+}
+
+@test "prompts claude renders /slash commands in compact form with args" {
+  run "$EX" prompts claude "$CLAUDE_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"/simplify"'* ]]
+  [[ "$output" == *'"/review-pr #80"'* ]]
+  [[ "$output" == *'"/clear"'* ]]
+}
+
+@test "prompts claude drops skill body that follows a command wrapper" {
+  run "$EX" prompts claude "$CLAUDE_FILE"
+  [ "$status" -eq 0 ]
+  # Skill body content must not leak into the prompt list.
+  [[ "$output" != *"End of skill body"* ]]
+  [[ "$output" != *"Simplify: Code Review"* ]]
+  [[ "$output" != *"ARGUMENTS: #80"* ]]
 }
 
 @test "prompts copilot extracts .data.content (not transformedContent)" {
@@ -121,12 +160,30 @@ teardown() {
   [[ "$output" != *"<wrapped>"* ]]
 }
 
+@test "prompts copilot keeps multi-line messages atomic" {
+  run "$EX" prompts copilot "$COPILOT_FILE"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(printf '%s\n' "$output" | grep -cv '^$')
+  [ "$n" -eq 3 ]
+  [[ "$output" == *'"Multi-line prompt\nwith two lines"'* ]]
+}
+
 @test "prompts codex excludes environment_context" {
   run "$EX" prompts codex "$CODEX_FILE"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Improve documentation in @README.md"* ]]
   [[ "$output" == *"Go ahead"* ]]
   [[ "$output" != *"<environment_context>"* ]]
+}
+
+@test "prompts codex keeps multi-line messages atomic" {
+  run "$EX" prompts codex "$CODEX_FILE"
+  [ "$status" -eq 0 ]
+  local n
+  n=$(printf '%s\n' "$output" | grep -cv '^$')
+  [ "$n" -eq 3 ]
+  [[ "$output" == *'"Refactor this:\n- step one\n- step two"'* ]]
 }
 
 # -- turns (assistant tail) -----------------------------------------------

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -126,9 +126,22 @@ describe("extractMeta", () => {
 // ---- extractLines / extractPrompts / extractTurns ----------------------
 
 describe("extractLines", () => {
-  it("returns non-empty lines on success", () => {
-    spawnSync.mockReturnValueOnce({ status: 0, stdout: "line1\nline2\n\n", stderr: "" });
-    expect(lib.extractLines("prompts", "claude", "/f")).toEqual(["line1", "line2"]);
+  it("parses JSON-encoded strings, one per line, preserving embedded newlines", () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '"line1"\n"multi\\nline"\n\n',
+      stderr: "",
+    });
+    expect(lib.extractLines("prompts", "claude", "/f")).toEqual(["line1", "multi\nline"]);
+  });
+
+  it("skips malformed lines without crashing", () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '"ok"\nnot-json\n"also-ok"\n',
+      stderr: "",
+    });
+    expect(lib.extractLines("prompts", "claude", "/f")).toEqual(["ok", "also-ok"]);
   });
 
   it("returns [] on non-zero exit", () => {
@@ -147,19 +160,19 @@ describe("extractLines", () => {
 
 describe("extractPrompts", () => {
   it("delegates to extractLines with sub=prompts", () => {
-    spawnSync.mockReturnValueOnce({ status: 0, stdout: "user said hi\n", stderr: "" });
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: '"user said hi"\n', stderr: "" });
     expect(lib.extractPrompts("claude", "/f")).toEqual(["user said hi"]);
   });
 });
 
 describe("extractTurns", () => {
   it("delegates to extractLines with sub=turns (no limit)", () => {
-    spawnSync.mockReturnValueOnce({ status: 0, stdout: "assistant replied\n", stderr: "" });
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: '"assistant replied"\n', stderr: "" });
     expect(lib.extractTurns("claude", "/f")).toEqual(["assistant replied"]);
   });
 
   it("passes limit as extra arg when provided", () => {
-    spawnSync.mockReturnValueOnce({ status: 0, stdout: "t1\nt2\n", stderr: "" });
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: '"t1"\n"t2"\n', stderr: "" });
     lib.extractTurns("claude", "/f", 5);
     expect(spawnSync).toHaveBeenCalledWith(
       expect.any(String),


### PR DESCRIPTION
## Summary

- `handoff digest` "User prompts (last 10)" was splitting on `\n`, so in skill-heavy sessions the list collapsed into the last 10 *lines of a skill body* instead of 10 real user turns (issue #84).
- Extractor now emits one JSON-encoded string per line (`jq -c`) so multi-line messages stay atomic; `extractLines` parses each line with `JSON.parse` and preserves embedded newlines.
- Claude extractor renders `<command-name>/X</command-name>` wrappers as compact `/X <args>` and drops the skill body that follows in the same promptId — verified against real session `3668f1d7` where the digest now shows actual prompts like `/handoff push --tag "..."` instead of doc fragments.

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/handoff-extract.bats` — new tests cover multi-line atomicity, compact `/slash` rendering, skill-body drop, and Copilot/Codex atomicity (19/19)
- [x] `npx bats plugins/dotclaude/tests/bats/` — full bats suite (258/258)
- [x] `npm test` — full vitest suite (480/480, +1 new extractLines malformed-line test)
- [x] `npm run coverage` — branches 80.79% (clears 80% threshold)
- [x] Dogfood: `node plugins/dotclaude/bin/dotclaude-handoff.mjs digest claude 3668f1d7` — prompts list shows real user turns, not skill-body fragments

## Spec ID

dotclaude-core
