### PR TITLE
fix(handoff): drop bare /handoff zero-arg alias (#86)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T18:19:22.536Z",
+  "generatedAt": "2026-04-22T18:46:21.641Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:10d1a55e165d1f57a31ef011035532e64bba3673319f674d6b7ae1979ed83aa9",
+      "checksum": "sha256:f979fed5d364d36e999f21411455c4931d7ee4f8ecbec1d47ef61e0ea5b3cf52",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,209 +1,209 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-21T23:53:00.211Z",
+  "generatedAt": "2026-04-22T18:19:22.536Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
       "checksum": "sha256:f7a8fa0598d7925de95ed3829ea677a2df58fa3db93e9ff290944bb686fad7d7",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
       "checksum": "sha256:cf3ac020cd3ce7d8fc11dbf4f5f5a2ffa5e1d6443e60cd10179b564bd77894cc",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
       "checksum": "sha256:cabbf4bfe2deff3a328f15e025dfc0d63369825c0c32574790251f2793e62aeb",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
       "checksum": "sha256:cf987369294337fff90fc62e1d73d235d35055055dc8e4fbfb33a492f7cd38b5",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
       "checksum": "sha256:50573c4199f27083286fdbc3760b2f684105b4a6df39b7cb47094d7c0e5327f7",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
       "checksum": "sha256:3f7b90b69172e29cdcf66713f2708f9741003d05cc12cf9d81ff79ff9c5b692c",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
       "checksum": "sha256:7d888f6964725d82687fb61b68ff961f041f95d2c9eef7b5282061229499ca90",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
       "checksum": "sha256:6ffc091e9bd421798c5b7990f21d095563d69c59c3e2bd10d35b554b3ec225d9",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
       "checksum": "sha256:d0bc84f956c0ee8c176cf76a79374e8defb0bd2487c8340a2e2a1d9e04d8a1cc",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
       "checksum": "sha256:52e610b195a43fdd460106c1bdf56b32803cb86d163a4303274773ea3900bf79",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2dc1c4213ab6650d685e7b2243ddda91fce2ceba224ca3da3951afeb37d12946",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:91adefd38f22c858e7d53d41638b6d7eebba5885d40628857db5f3052e2c3e0e",
+      "checksum": "sha256:10d1a55e165d1f57a31ef011035532e64bba3673319f674d6b7ae1979ed83aa9",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "review-prs",
       "path": ".claude/commands/review-prs.md",
       "checksum": "sha256:e01a0432cd1a6cf6fe4a60cfc2b02f7cab3cde418062ca85beadc5491548bc71",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:347be395b0f8003816b4f3ed3bb777a63a3f9f7ae300d6f050b499ff66cfd3b0",
       "dependencies": [],
-      "lastValidated": "2026-04-21"
+      "lastValidated": "2026-04-22"
     }
   ]
 }

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T18:46:21.641Z",
+  "generatedAt": "2026-04-22T18:56:13.788Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:f979fed5d364d36e999f21411455c4931d7ee4f8ecbec1d47ef61e0ea5b3cf52",
+      "checksum": "sha256:988bcbf5d5a8afd612f5161d3ef5a76216dd59ede85ef9823de70809219ecbf1",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -458,11 +458,6 @@ function shortIdFromPath(path) {
 }
 
 async function main() {
-  // Issue #86: bare `dotclaude handoff` (no positionals, no flags that
-  // already short-circuited) prints usage and exits 0. The previous
-  // behavior — silently pushing the host's latest session — carried two
-  // contradictory SKILL.md contracts and mutated remote state as a
-  // zero-arg default, which is unsafe. Every other verb is explicit.
   if (argv.positional.length === 0) {
     process.stdout.write(helpText(META) + "\n");
     process.exit(EXIT_CODES.OK);
@@ -630,8 +625,6 @@ async function main() {
     process.exit(EXIT_CODES.OK);
   }
 
-  // `push` is the only path to remote-mutation now (#86 removed the
-  // zero-arg alias). Everything below this guard handles the push flow.
   if (first === "push") {
     const explicitQuery = second ?? null;
     let sessionHit;

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -3,7 +3,7 @@
  * dotclaude-handoff — five-form cross-agent / cross-machine handoff.
  *
  * Usage:
- *   dotclaude handoff                              push host's latest session
+ *   dotclaude handoff                              print usage and exit 0 (#86)
  *   dotclaude handoff <query>                      local cross-agent: emit <handoff> block
  *   dotclaude handoff push [<query>] [--tag <label>]
  *   dotclaude handoff pull [<query>]
@@ -458,6 +458,16 @@ function shortIdFromPath(path) {
 }
 
 async function main() {
+  // Issue #86: bare `dotclaude handoff` (no positionals, no flags that
+  // already short-circuited) prints usage and exits 0. The previous
+  // behavior — silently pushing the host's latest session — carried two
+  // contradictory SKILL.md contracts and mutated remote state as a
+  // zero-arg default, which is unsafe. Every other verb is explicit.
+  if (argv.positional.length === 0) {
+    process.stdout.write(helpText(META) + "\n");
+    process.exit(EXIT_CODES.OK);
+  }
+
   // ---- breaking-change shim ---------------------------------------------
   // A lone CLI name is never a valid query under the new surface, so
   // catch `push/pull claude|copilot|codex` (with or without a trailing
@@ -620,12 +630,10 @@ async function main() {
     process.exit(EXIT_CODES.OK);
   }
 
-  // Bare `dotclaude-handoff` (no positionals) is an alias for `push`.
-  // Aligns the binary with SKILL.md's "zero-arg = push host's latest
-  // session" contract.
-  const isPush = first === "push" || argv.positional.length === 0;
-  if (isPush) {
-    const explicitQuery = first === "push" ? second : null;
+  // `push` is the only path to remote-mutation now (#86 removed the
+  // zero-arg alias). Everything below this guard handles the push flow.
+  if (first === "push") {
+    const explicitQuery = second ?? null;
     let sessionHit;
     let fallbackNote;
     if (explicitQuery) {

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -36,15 +36,17 @@ document the public surface in one place. Every form below also works
 verbatim as `!dotclaude handoff …` from any shell — including Codex's
 bash tool.
 
-## The five forms
+## The four forms
 
 ```
-/handoff                              push host's latest session
 /handoff <query>                      local cross-agent: emit <handoff>
 /handoff push [<query>] [--tag <l>]   upload to transport
 /handoff pull [<query>]               fetch from transport
 /handoff list [--local|--remote]      unified table
 ```
+
+A bare `/handoff` with no arguments prints usage and exits 0. Every
+remote verb is explicit.
 
 `<query>` auto-detects across `~/.claude/projects`,
 `~/.copilot/session-state`, and `~/.codex/sessions`. Accepted forms:

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -39,10 +39,10 @@ bash tool.
 ## The four forms
 
 ```
-/handoff <query>                      local cross-agent: emit <handoff>
-/handoff push [<query>] [--tag <l>]   upload to transport
-/handoff pull [<query>]               fetch from transport
-/handoff list [--local|--remote]      unified table
+/handoff <query>                          local cross-agent: emit <handoff>
+/handoff push [<query>] [--tag <label>]   upload to transport
+/handoff pull [<query>]                   fetch from transport
+/handoff list [--local|--remote]          unified table
 ```
 
 A bare `/handoff` with no arguments prints usage and exits 0. Every

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
@@ -48,19 +48,14 @@ teardown() {
   [[ "$output" == *"list"* ]]
 }
 
-# Issue #86: bare invocation no longer aliases `push`. A zero-arg call
-# prints usage and exits 0. Silent-pushing-the-latest-session was too
-# ambiguous (two SKILL.md definitions) and too unsafe (mutates remote,
-# needs transport config) to be the default.
 @test "bare dotclaude-handoff prints usage and exits 0 (no push)" {
   run node "$BIN"
   [ "$status" -eq 0 ]
-  # Same synopsis as --help: mentions every verb.
   [[ "$output" == *"push"* ]]
   [[ "$output" == *"pull"* ]]
   [[ "$output" == *"list"* ]]
-  # Guardrail: must not have executed a push. A successful push emits
-  # the `[scrubbed N secrets]` line and a `handoff/<cli>/...` branch.
+  # Guardrail: a successful push would emit `[scrubbed N secrets]` and
+  # a `handoff/<cli>/...` branch name. Neither may appear.
   [[ "$output" != *"scrubbed"* ]]
   [[ "$output" != *"handoff/dotclaude/"* ]]
 }

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
@@ -48,6 +48,23 @@ teardown() {
   [[ "$output" == *"list"* ]]
 }
 
+# Issue #86: bare invocation no longer aliases `push`. A zero-arg call
+# prints usage and exits 0. Silent-pushing-the-latest-session was too
+# ambiguous (two SKILL.md definitions) and too unsafe (mutates remote,
+# needs transport config) to be the default.
+@test "bare dotclaude-handoff prints usage and exits 0 (no push)" {
+  run node "$BIN"
+  [ "$status" -eq 0 ]
+  # Same synopsis as --help: mentions every verb.
+  [[ "$output" == *"push"* ]]
+  [[ "$output" == *"pull"* ]]
+  [[ "$output" == *"list"* ]]
+  # Guardrail: must not have executed a push. A successful push emits
+  # the `[scrubbed N secrets]` line and a `handoff/<cli>/...` branch.
+  [[ "$output" != *"scrubbed"* ]]
+  [[ "$output" != *"handoff/dotclaude/"* ]]
+}
+
 @test "resolve missing args exits 64" {
   run node "$BIN" resolve
   [ "$status" -eq 64 ]

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -42,10 +42,10 @@ bash tool.
 ## The four forms
 
 ```
-/handoff <query>                      local cross-agent: emit <handoff>
-/handoff push [<query>] [--tag <l>]   upload to transport
-/handoff pull [<query>]               fetch from transport
-/handoff list [--local|--remote]      unified table
+/handoff <query>                          local cross-agent: emit <handoff>
+/handoff push [<query>] [--tag <label>]   upload to transport
+/handoff pull [<query>]                   fetch from transport
+/handoff list [--local|--remote]          unified table
 ```
 
 A bare `/handoff` with no arguments prints usage and exits 0. Every

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -48,10 +48,8 @@ bash tool.
 /handoff list [--local|--remote]      unified table
 ```
 
-A bare `/handoff` with no arguments prints usage and exits 0. The
-previous zero-arg alias for `push` was ambiguous (two SKILL.md contracts
-claimed it) and unsafe (it mutated remote state without explicit intent).
-Every remote verb is now explicit.
+A bare `/handoff` with no arguments prints usage and exits 0. Every
+remote verb is explicit.
 
 `<query>` auto-detects across `~/.claude/projects`,
 `~/.copilot/session-state`, and `~/.codex/sessions`. Accepted forms:

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -39,15 +39,19 @@ document the public surface in one place. Every form below also works
 verbatim as `!dotclaude handoff …` from any shell — including Codex's
 bash tool.
 
-## The five forms
+## The four forms
 
 ```
-/handoff                              push host's latest session
 /handoff <query>                      local cross-agent: emit <handoff>
 /handoff push [<query>] [--tag <l>]   upload to transport
 /handoff pull [<query>]               fetch from transport
 /handoff list [--local|--remote]      unified table
 ```
+
+A bare `/handoff` with no arguments prints usage and exits 0. The
+previous zero-arg alias for `push` was ambiguous (two SKILL.md contracts
+claimed it) and unsafe (it mutated remote state without explicit intent).
+Every remote verb is now explicit.
 
 `<query>` auto-detects across `~/.claude/projects`,
 `~/.copilot/session-state`, and `~/.codex/sessions`. Accepted forms:


### PR DESCRIPTION
## Summary

- Bare `dotclaude handoff` (no positionals) no longer aliases `push`. It now prints usage and exits 0, matching every other verb's explicit-intent contract.
- Removes the "zero-arg = push host's latest session" contract from `skills/handoff/SKILL.md` (the five forms are now four), and rewords the header to reflect that. The auto-trigger contract is untouched — it only ever routed through the bare `<query>` form.
- Adds a bats test that asserts the zero-arg call prints the help synopsis and does **not** execute a push (no `[scrubbed N secrets]`, no `handoff/...` branch).

Fixes #86.

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/` — 254/254 green (adds the new `bare dotclaude-handoff` case)
- [x] `npm test` from `plugins/dotclaude/` — 479/479 green
- [x] `npm run coverage` — branches 80.67% (≥ 80% threshold)
- [x] Manual: `node plugins/dotclaude/bin/dotclaude-handoff.mjs` prints the synopsis and exits 0

## Spec ID

dotclaude-core
