### PR TITLE
fix(handoff): host-scope `latest` in bare <query> path (#85)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T19:22:55.143Z",
+  "generatedAt": "2026-04-22T19:23:00.873Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:9e65b2ef9921d9217dfa330c06973848a8448be14c8ca1c2e2125006ebd52647",
+      "checksum": "sha256:4fdf77f0a676ff0750e4a7f1488cb18cf04db6070b2cf8350f42477f7cfba9c9",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T18:56:13.788Z",
+  "generatedAt": "2026-04-22T19:22:55.143Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:988bcbf5d5a8afd612f5161d3ef5a76216dd59ede85ef9823de70809219ecbf1",
+      "checksum": "sha256:9e65b2ef9921d9217dfa330c06973848a8448be14c8ca1c2e2125006ebd52647",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -763,7 +763,29 @@ async function main() {
 
   // ---- bare <query>: local cross-agent (implicit digest) -----------------
   const query = first;
-  const hit = await resolveAny(query);
+  // Host-scoping rule (#85): when query == "latest" we respect --from
+  // and the detected host so the resolver picks the newest session on
+  // THIS agent, not the globally-newest JSONL across all roots. An
+  // explicit UUID/alias is left untouched — narrowing an alias can hide
+  // a legitimate cross-agent match.
+  const narrowLatestTo =
+    query === "latest" ? (fromCli ?? (detectedHost !== "unknown" ? detectedHost : null)) : null;
+  let hit;
+  let fallbackNote;
+  if (narrowLatestTo) {
+    hit = resolveNarrowed(narrowLatestTo, "latest");
+    const shortId = shortIdFromPath(hit.path);
+    fallbackNote = fromCli
+      ? `using --from ${narrowLatestTo} override, latest ${narrowLatestTo} session: ${shortId}`
+      : `latest ${narrowLatestTo} session: ${shortId}`;
+  } else {
+    hit = await resolveAny(query);
+    if (query === "latest" && detectedHost === "unknown") {
+      const shortId = shortIdFromPath(hit.path);
+      fallbackNote = `host not detected, using latest across all clis: ${shortId}`;
+    }
+  }
+  if (fallbackNote) process.stderr.write(fallbackNote + "\n");
   const meta = extractMeta(hit.cli, hit.path);
   const prompts = extractPrompts(hit.cli, hit.path);
   const turns = extractTurns(hit.cli, hit.path, limit);

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -457,6 +457,22 @@ function shortIdFromPath(path) {
   return m ? m[1] : "?";
 }
 
+// Centralizes the "latest" precedence (--from > detectedHost > union)
+// so push and bare <query> can't drift. Returns {hit, note}; note is
+// always populated because every branch emits a stderr diff-aid.
+async function resolveLatestWithHostScope({ fromCli, detectedHost }) {
+  const narrowTo = fromCli ?? (detectedHost !== "unknown" ? detectedHost : null);
+  if (narrowTo) {
+    const hit = resolveNarrowed(narrowTo, "latest");
+    const shortId = shortIdFromPath(hit.path);
+    const prefix = fromCli ? `using --from ${narrowTo} override, ` : "";
+    return { hit, note: `${prefix}latest ${narrowTo} session: ${shortId}` };
+  }
+  const hit = await resolveAny("latest");
+  const shortId = shortIdFromPath(hit.path);
+  return { hit, note: `host not detected, using latest across all clis: ${shortId}` };
+}
+
 async function main() {
   if (argv.positional.length === 0) {
     process.stdout.write(helpText(META) + "\n");
@@ -638,22 +654,10 @@ async function main() {
         ? resolveNarrowed(fromCli, explicitQuery)
         : await resolveAny(explicitQuery);
     } else {
-      // No query: pick a default session. Prefer --from, then the
-      // detected host, then the union resolver. Each fallback emits
-      // a one-line stderr note so the user can diff two runs and
-      // see why the pick changed.
-      const narrowTo = fromCli ?? (detectedHost !== "unknown" ? detectedHost : null);
-      if (narrowTo) {
-        sessionHit = resolveNarrowed(narrowTo, "latest");
-        const shortId = shortIdFromPath(sessionHit.path);
-        fallbackNote = fromCli
-          ? `using --from ${narrowTo} override, latest session: ${shortId}`
-          : `no current-session signal in ${narrowTo}, using latest ${narrowTo} session: ${shortId}`;
-      } else {
-        sessionHit = await resolveAny("latest");
-        const shortId = shortIdFromPath(sessionHit.path);
-        fallbackNote = `host not detected, using latest across all clis: ${shortId}`;
-      }
+      ({ hit: sessionHit, note: fallbackNote } = await resolveLatestWithHostScope({
+        fromCli,
+        detectedHost,
+      }));
     }
     if (fallbackNote) process.stderr.write(fallbackNote + "\n");
 
@@ -762,28 +766,14 @@ async function main() {
   }
 
   // ---- bare <query>: local cross-agent (implicit digest) -----------------
+  // `latest` is host-scoped (explicit UUIDs/aliases pass through — narrowing
+  // them could hide a legitimate cross-agent match).
   const query = first;
-  // Host-scoping rule (#85): when query == "latest" we respect --from
-  // and the detected host so the resolver picks the newest session on
-  // THIS agent, not the globally-newest JSONL across all roots. An
-  // explicit UUID/alias is left untouched — narrowing an alias can hide
-  // a legitimate cross-agent match.
-  const narrowLatestTo =
-    query === "latest" ? (fromCli ?? (detectedHost !== "unknown" ? detectedHost : null)) : null;
-  let hit;
-  let fallbackNote;
-  if (narrowLatestTo) {
-    hit = resolveNarrowed(narrowLatestTo, "latest");
-    const shortId = shortIdFromPath(hit.path);
-    fallbackNote = fromCli
-      ? `using --from ${narrowLatestTo} override, latest ${narrowLatestTo} session: ${shortId}`
-      : `latest ${narrowLatestTo} session: ${shortId}`;
+  let hit, fallbackNote;
+  if (query === "latest") {
+    ({ hit, note: fallbackNote } = await resolveLatestWithHostScope({ fromCli, detectedHost }));
   } else {
     hit = await resolveAny(query);
-    if (query === "latest" && detectedHost === "unknown") {
-      const shortId = shortIdFromPath(hit.path);
-      fallbackNote = `host not detected, using latest across all clis: ${shortId}`;
-    }
   }
   if (fallbackNote) process.stderr.write(fallbackNote + "\n");
   const meta = extractMeta(hit.cli, hit.path);

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -53,6 +53,15 @@ remote verb is explicit.
 full UUID, short UUID (first 8 hex), `latest`, Claude `customTitle`
 alias, Codex `thread_name` alias.
 
+**`latest` is host-scoped.** When the binary identifies the invoking
+CLI (via `CLAUDECODE=1`, `CODEX_*` / `COPILOT_*` env-vars, or `--from`),
+`latest` resolves within that CLI's root only — so inside Claude Code
+it picks the newest `~/.claude/projects` session even when a newer
+Codex JSONL exists on disk. Explicit UUIDs and aliases are never
+narrowed. Without a host signal `latest` falls back to the union
+resolver (globally newest across all roots) and stderr names the
+picked session. Pass `--from <cli>` to force a specific root.
+
 **Collision model.** When `<query>` matches multiple roots (or two
 remote handoffs on `pull`): TTY → interactive prompt; non-TTY → exit 2
 with a TSV candidate list on stderr.

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -54,7 +54,8 @@ full UUID, short UUID (first 8 hex), `latest`, Claude `customTitle`
 alias, Codex `thread_name` alias.
 
 **`latest` is host-scoped.** When the binary identifies the invoking
-CLI (via `CLAUDECODE=1`, `CODEX_*` / `COPILOT_*` env-vars, or `--from`),
+CLI (via `--from` or host-specific env-var probes such as `CLAUDECODE=1`,
+`CLAUDE_CODE_SSE_PORT`, `CODEX_*`, `COPILOT_*`, and `GITHUB_COPILOT_*`),
 `latest` resolves within that CLI's root only — so inside Claude Code
 it picks the newest `~/.claude/projects` session even when a newer
 Codex JSONL exists on disk. Explicit UUIDs and aliases are never

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -97,6 +97,55 @@ teardown() {
   [ "$status" -eq 2 ]
 }
 
+# -- `latest` host-scoping (#85) -----------------------------------------
+
+@test "<query> latest without host signal picks globally newest (across roots)" {
+  # setup() sleeps between fixtures so the codex file is newer. No host
+  # signal → cross-root winner = codex/bbbb2222.
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
+    node "$BIN" latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222"* ]]
+  [[ "$stderr" == *"host not detected"* ]]
+}
+
+@test "<query> latest with CLAUDECODE=1 narrows to claude root" {
+  # The outer-shell probe fires; `latest` must resolve within ~/.claude
+  # only, so aaaa1111 wins even though the codex fixture is newer on disk.
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \
+    node "$BIN" latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  [[ "$output" != *"bbbb2222"* ]]
+  [[ "$stderr" == *"latest claude session"* ]]
+  [[ "$stderr" == *"aaaa1111"* ]]
+}
+
+@test "<query> latest --from codex overrides host detection" {
+  # --from must outrank detectedHost, mirroring push's precedence.
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \
+    node "$BIN" latest --from codex
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222"* ]]
+  [[ "$output" != *"aaaa1111"* ]]
+  [[ "$stderr" == *"--from codex"* ]]
+}
+
+@test "<query> latest --from with unknown cli exits 64" {
+  run node "$BIN" latest --from bogus
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"--from must be one of"* ]]
+}
+
+@test "<query> non-latest: host detection does NOT narrow (UUID lookup stays global)" {
+  # A short-UUID is unambiguous — narrowing by host would hide a valid
+  # cross-agent match. CLAUDECODE=1 must not prevent bbbb2222 lookup.
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \
+    node "$BIN" bbbb2222
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222"* ]]
+}
+
 @test "<query>: collision across CLIs on non-TTY stdin exits 2 with candidate list" {
   # Introduce collision: claude customTitle "both" + codex thread_name "both"
   printf '{"type":"custom-title","customTitle":"both","sessionId":"aaaa1111-1111-1111-1111-111111111111"}\n' \

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -56,6 +56,15 @@ remote verb is explicit.
 full UUID, short UUID (first 8 hex), `latest`, Claude `customTitle`
 alias, Codex `thread_name` alias.
 
+**`latest` is host-scoped.** When the binary identifies the invoking
+CLI (via `CLAUDECODE=1`, `CODEX_*` / `COPILOT_*` env-vars, or `--from`),
+`latest` resolves within that CLI's root only — so inside Claude Code
+it picks the newest `~/.claude/projects` session even when a newer
+Codex JSONL exists on disk. Explicit UUIDs and aliases are never
+narrowed. Without a host signal `latest` falls back to the union
+resolver (globally newest across all roots) and stderr names the
+picked session. Pass `--from <cli>` to force a specific root.
+
 **Collision model.** When `<query>` matches multiple roots (or two
 remote handoffs on `pull`): TTY → interactive prompt; non-TTY → exit 2
 with a TSV candidate list on stderr.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -57,7 +57,8 @@ full UUID, short UUID (first 8 hex), `latest`, Claude `customTitle`
 alias, Codex `thread_name` alias.
 
 **`latest` is host-scoped.** When the binary identifies the invoking
-CLI (via `CLAUDECODE=1`, `CODEX_*` / `COPILOT_*` env-vars, or `--from`),
+CLI (via `--from` or host-specific env-var probes such as `CLAUDECODE=1`,
+`CLAUDE_CODE_SSE_PORT`, `CODEX_*`, `COPILOT_*`, and `GITHUB_COPILOT_*`),
 `latest` resolves within that CLI's root only — so inside Claude Code
 it picks the newest `~/.claude/projects` session even when a newer
 Codex JSONL exists on disk. Explicit UUIDs and aliases are never


### PR DESCRIPTION
## Summary

- `/handoff latest` (bare `<query>` form) now resolves within the invoking CLI's root when host detection fires (`CLAUDECODE=1`, `CODEX_*`, `COPILOT_*` env-vars) or when `--from <cli>` is explicit. Previously it always picked the globally-newest JSONL across all three roots, which returned the "wrong" agent's session after a context switch.
- `--from` outranks the detected host, mirroring the push-path precedence. Explicit UUIDs and aliases stay on the union resolver — narrowing them could hide a legitimate cross-agent match.
- Each branch emits a one-line stderr note naming the picked session, matching the existing `push` UX.
- `skills/handoff/SKILL.md` now documents host-scoped `latest` semantics so callers understand what the resolver returns in each env configuration.

Fixes #85.

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/` — 258/258 green (adds 5 `latest` cases to `dotclaude-handoff-five-form.bats`)
- [x] `npm test` from `plugins/dotclaude/` — 479/479 green
- [x] `npm run coverage` — branches 80.67% (≥ 80% threshold)
- [x] Manual: `env CLAUDECODE=1 node plugins/dotclaude/bin/dotclaude-handoff.mjs latest` narrows to `~/.claude/projects`; `--from codex` overrides the host

## Spec ID

dotclaude-core
