### PR TITLE
fix(handoff): refine list — filters, transport warnings, uniform row schema

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T20:39:45.593Z",
+  "generatedAt": "2026-04-22T20:54:56.485Z",
   "skills": [
     {
       "name": "audit-and-fix",

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T19:23:00.873Z",
+  "generatedAt": "2026-04-22T20:39:45.593Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:4fdf77f0a676ff0750e4a7f1488cb18cf04db6070b2cf8350f42477f7cfba9c9",
+      "checksum": "sha256:99cc63856da07dc1010b7aa5381a766b7d484485be14097a95b9bd072e2a60d3",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T20:54:56.485Z",
+  "generatedAt": "2026-04-22T21:04:38.108Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:99cc63856da07dc1010b7aa5381a766b7d484485be14097a95b9bd072e2a60d3",
+      "checksum": "sha256:35dffddb2fb4ebc86fc9139fb352a43d1f184bdd193cadaa53003552c8c25382",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T21:04:38.108Z",
+  "generatedAt": "2026-04-22T21:09:04.509Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:35dffddb2fb4ebc86fc9139fb352a43d1f184bdd193cadaa53003552c8c25382",
+      "checksum": "sha256:ca2e4bbb2a00f696ed4eb679de7aed097aefd37bf8b274c16f57550976c803db",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -117,12 +117,12 @@ wins.
 
 ## The five forms
 
-| Form                  | Behavior                                              |
-| --------------------- | ----------------------------------------------------- |
-| `/handoff`            | Push the host's latest session                        |
-| `/handoff <query>`    | Local cross-agent: emit `<handoff>` block in place    |
-| `/handoff push [<q>]` | Upload to transport; zero-arg = host latest           |
-| `/handoff pull [<q>]` | Fetch from transport; zero-arg = newest branch        |
+| Form                  | Behavior                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `/handoff`            | Push the host's latest session                                                              |
+| `/handoff <query>`    | Local cross-agent: emit `<handoff>` block in place                                          |
+| `/handoff push [<q>]` | Upload to transport; zero-arg = host latest                                                 |
+| `/handoff pull [<q>]` | Fetch from transport; zero-arg = newest branch                                              |
 | `/handoff list`       | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
 
 Every `<query>` can be a full UUID, short UUID (first 8 hex), `latest`,

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -123,7 +123,7 @@ wins.
 | `/handoff <query>`    | Local cross-agent: emit `<handoff>` block in place    |
 | `/handoff push [<q>]` | Upload to transport; zero-arg = host latest           |
 | `/handoff pull [<q>]` | Fetch from transport; zero-arg = newest branch        |
-| `/handoff list`       | Unified local + remote table (`--local` / `--remote`) |
+| `/handoff list`       | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
 
 Every `<query>` can be a full UUID, short UUID (first 8 hex), `latest`,
 a Claude `customTitle`, or a Codex `thread_name`.

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -70,6 +70,7 @@ import {
   CONFIG_FILE,
   V1_BRANCH_RE,
   V2_BRANCH_RE,
+  parseHandoffBranch,
 } from "../src/lib/handoff-remote.mjs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -119,6 +120,20 @@ const DOCTOR_SH = join(SCRIPTS, "handoff-doctor.sh");
 function fail(code, msg) {
   if (msg) process.stderr.write(`dotclaude-handoff: ${msg}\n`);
   process.exit(code);
+}
+
+// --since <ISO> → epoch ms, or the default-N-days fallback when raw is
+// absent. Pass `defaultDays: null` for "no filter" (used by `list`).
+// Exits USAGE on non-ISO input.
+function parseSinceOrFail(raw, { defaultDays = null } = {}) {
+  if (!raw) {
+    return defaultDays === null
+      ? null
+      : Date.now() - defaultDays * 24 * 60 * 60 * 1000;
+  }
+  const ms = Date.parse(String(raw));
+  if (Number.isNaN(ms)) fail(EXIT_CODES.USAGE, `--since must be ISO-8601, got: ${raw}`);
+  return ms;
 }
 
 // ---- resolver / extractor bridge ---------------------------------------
@@ -299,21 +314,6 @@ function listAllLocalSessions() {
   );
 }
 
-/**
- * Parse a transport branch name of the form
- * `handoff/<project>/<cli>/<YYYY-MM>/<shortUuid>` into its parts.
- * Returns `{cli: "?", shortId: "", yearMonth: ""}` for malformed names so
- * the list renderer degrades gracefully rather than crashing on a legacy
- * branch that predates the current scheme.
- */
-function parseHandoffBranch(branch) {
-  const parts = (branch ?? "").split("/");
-  if (parts.length !== 5 || parts[0] !== "handoff") {
-    return { cli: "?", shortId: "", yearMonth: "" };
-  }
-  return { cli: parts[2], shortId: parts[4], yearMonth: parts[3] };
-}
-
 // ---- host session detection --------------------------------------------
 
 /**
@@ -383,10 +383,7 @@ function truncate(s, max) {
  */
 function searchSessions({ query, cli, since, limit }) {
   const re = new RegExp(query, "i");
-  const sinceMs = since
-    ? Date.parse(since)
-    : Date.now() - 30 * 24 * 60 * 60 * 1000;
-  if (Number.isNaN(sinceMs)) fail(EXIT_CODES.USAGE, `--since must be ISO-8601, got: ${since}`);
+  const sinceMs = parseSinceOrFail(since, { defaultDays: 30 });
   const clis = cli ? [cli] : Object.keys(CLI_LAYOUTS);
   const out = [];
   for (const c of clis) {
@@ -540,12 +537,7 @@ async function main() {
       fail(2, `remote-list failed: ${err.message}`);
     }
     const enriched = enrichWithDescriptions(candidates);
-    const sinceMs = argv.flags.since
-      ? Date.parse(String(argv.flags.since))
-      : Date.now() - 30 * 24 * 60 * 60 * 1000;
-    if (Number.isNaN(sinceMs)) {
-      fail(EXIT_CODES.USAGE, `--since must be ISO-8601, got: ${argv.flags.since}`);
-    }
+    const sinceMs = parseSinceOrFail(argv.flags.since, { defaultDays: 30 });
     const filterCli = argv.flags.cli ? String(argv.flags.cli) : null;
     if (filterCli !== null && !CLIS.has(filterCli)) {
       fail(EXIT_CODES.USAGE, `--cli must be one of: ${[...CLIS].join(", ")}`);
@@ -619,18 +611,10 @@ async function main() {
 
   // ---- top-level subs: push / pull / list --------------------------------
   if (first === "list") {
-    let sinceMs = null;
-    if (argv.flags.since) {
-      sinceMs = Date.parse(String(argv.flags.since));
-      if (Number.isNaN(sinceMs)) {
-        fail(EXIT_CODES.USAGE, `--since must be ISO-8601, got: ${argv.flags.since}`);
-      }
-    }
-    const listCap = Boolean(argv.flags.all) ? Infinity : Number.parseInt(limit.toString(), 10);
-
+    const sinceMs = parseSinceOrFail(argv.flags.since);
+    const listCap = argv.flags.all ? Infinity : Number(limit);
     const showLocal = !argv.flags.remote;
     const showRemote = !argv.flags.local;
-    const onlyRemote = Boolean(argv.flags.remote) && !argv.flags.local;
     const rows = [];
 
     if (showLocal) {
@@ -641,10 +625,10 @@ async function main() {
       }
     }
 
-    let remoteMissingRepo = false;
+    let remoteSkipped = false;
     if (showRemote) {
       if (!process.env.DOTCLAUDE_HANDOFF_REPO) {
-        remoteMissingRepo = true;
+        remoteSkipped = true;
         process.stderr.write(
           "dotclaude-handoff: list --remote: DOTCLAUDE_HANDOFF_REPO not set; skipping remote enumeration\n",
         );
@@ -668,11 +652,7 @@ async function main() {
       }
     }
 
-    rows.sort((a, b) => {
-      const ta = a.mtime ?? 0;
-      const tb = b.mtime ?? 0;
-      return tb - ta;
-    });
+    rows.sort((a, b) => (b.mtime ?? 0) - (a.mtime ?? 0));
     const capped = Number.isFinite(listCap) ? rows.slice(0, listCap) : rows;
 
     if (argv.json) {
@@ -680,7 +660,9 @@ async function main() {
       process.exit(EXIT_CODES.OK);
     }
     if (capped.length === 0) {
-      if (onlyRemote && remoteMissingRepo) process.exit(2);
+      // --remote + no transport env + no local rows = hard failure so
+      // piped callers don't silently treat an empty list as success.
+      if (argv.flags.remote && !argv.flags.local && remoteSkipped) process.exit(2);
       process.stdout.write("No sessions found\n");
       process.exit(EXIT_CODES.OK);
     }

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -7,7 +7,7 @@
  *   dotclaude handoff <query>                      local cross-agent: emit <handoff> block
  *   dotclaude handoff push [<query>] [--tag <label>]
  *   dotclaude handoff pull [<query>]
- *   dotclaude handoff list [--local|--remote]
+ *   dotclaude handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit <N>|--all]
  *   dotclaude handoff doctor
  *   dotclaude handoff remote-list [--cli <cli>] [--since <ISO>] [--limit <N>]
  *   dotclaude handoff search <query> [--cli <cli>] [--since <ISO>] [--limit <N>]
@@ -105,6 +105,7 @@ const META = {
     remote: { type: "boolean" },
     verify: { type: "boolean" },
     "force-collision": { type: "boolean" },
+    all: { type: "boolean" },
   },
 };
 
@@ -296,6 +297,21 @@ function listAllLocalSessions() {
   return [...listLocalSessions("claude"), ...listLocalSessions("copilot"), ...listLocalSessions("codex")].sort(
     (a, b) => b.mtime - a.mtime
   );
+}
+
+/**
+ * Parse a transport branch name of the form
+ * `handoff/<project>/<cli>/<YYYY-MM>/<shortUuid>` into its parts.
+ * Returns `{cli: "?", shortId: "", yearMonth: ""}` for malformed names so
+ * the list renderer degrades gracefully rather than crashing on a legacy
+ * branch that predates the current scheme.
+ */
+function parseHandoffBranch(branch) {
+  const parts = (branch ?? "").split("/");
+  if (parts.length !== 5 || parts[0] !== "handoff") {
+    return { cli: "?", shortId: "", yearMonth: "" };
+  }
+  return { cli: parts[2], shortId: parts[4], yearMonth: parts[3] };
 }
 
 // ---- host session detection --------------------------------------------
@@ -603,40 +619,77 @@ async function main() {
 
   // ---- top-level subs: push / pull / list --------------------------------
   if (first === "list") {
+    let sinceMs = null;
+    if (argv.flags.since) {
+      sinceMs = Date.parse(String(argv.flags.since));
+      if (Number.isNaN(sinceMs)) {
+        fail(EXIT_CODES.USAGE, `--since must be ISO-8601, got: ${argv.flags.since}`);
+      }
+    }
+    const listCap = Boolean(argv.flags.all) ? Infinity : Number.parseInt(limit.toString(), 10);
+
     const showLocal = !argv.flags.remote;
     const showRemote = !argv.flags.local;
+    const onlyRemote = Boolean(argv.flags.remote) && !argv.flags.local;
     const rows = [];
+
     if (showLocal) {
       for (const r of listAllLocalSessions()) {
+        if (fromCli && r.cli !== fromCli) continue;
+        if (sinceMs !== null && r.mtime * 1000 < sinceMs) continue;
         rows.push({ ...r, location: "local" });
       }
     }
-    if (showRemote && process.env.DOTCLAUDE_HANDOFF_REPO) {
-      try {
-        for (const c of listRemoteCandidates()) {
-          rows.push({ location: "remote", branch: c.branch, commit: c.commit });
+
+    let remoteMissingRepo = false;
+    if (showRemote) {
+      if (!process.env.DOTCLAUDE_HANDOFF_REPO) {
+        remoteMissingRepo = true;
+        process.stderr.write(
+          "dotclaude-handoff: list --remote: DOTCLAUDE_HANDOFF_REPO not set; skipping remote enumeration\n",
+        );
+      } else {
+        try {
+          for (const c of listRemoteCandidates()) {
+            const parsed = parseHandoffBranch(c.branch);
+            if (fromCli && parsed.cli !== fromCli) continue;
+            rows.push({
+              location: "remote",
+              cli: parsed.cli,
+              short_id: parsed.shortId,
+              branch: c.branch,
+              commit: c.commit,
+              when: parsed.yearMonth,
+            });
+          }
+        } catch (err) {
+          process.stderr.write(`dotclaude-handoff: list --remote: ${err.message}\n`);
         }
-      } catch (err) {
-        process.stderr.write(`dotclaude-handoff: list --remote: ${err.message}\n`);
       }
     }
+
+    rows.sort((a, b) => {
+      const ta = a.mtime ?? 0;
+      const tb = b.mtime ?? 0;
+      return tb - ta;
+    });
+    const capped = Number.isFinite(listCap) ? rows.slice(0, listCap) : rows;
+
     if (argv.json) {
-      process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
+      process.stdout.write(JSON.stringify(capped, null, 2) + "\n");
       process.exit(EXIT_CODES.OK);
     }
-    if (rows.length === 0) {
+    if (capped.length === 0) {
+      if (onlyRemote && remoteMissingRepo) process.exit(2);
       process.stdout.write("No sessions found\n");
       process.exit(EXIT_CODES.OK);
     }
-    process.stdout.write("| Location | CLI / Branch                         | Short UUID | When / Commit    |\n");
-    process.stdout.write("| -------- | ------------------------------------ | ---------- | ---------------- |\n");
-    for (const r of rows) {
-      if (r.location === "local") {
-        process.stdout.write(`| local    | ${r.cli.padEnd(36)} | ${r.short_id.padEnd(10)} | ${r.when.padEnd(16)} |\n`);
-      } else {
-        const shortCommit = (r.commit ?? "").slice(0, 10);
-        process.stdout.write(`| remote   | ${r.branch.padEnd(36)} | ${"".padEnd(10)} | ${shortCommit.padEnd(16)} |\n`);
-      }
+    process.stdout.write("| Location | CLI     | Short UUID | When             |\n");
+    process.stdout.write("| -------- | ------- | ---------- | ---------------- |\n");
+    for (const r of capped) {
+      process.stdout.write(
+        `| ${r.location.padEnd(8)} | ${(r.cli ?? "").padEnd(7)} | ${(r.short_id ?? "").padEnd(10)} | ${(r.when ?? "").padEnd(16)} |\n`,
+      );
     }
     process.exit(EXIT_CODES.OK);
   }

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -35,6 +35,25 @@ export const V2_BRANCH_RE =
 /** Matches legacy v1 handoff branch names: handoff/<cli>/<shortId>. */
 export const V1_BRANCH_RE = /^handoff\/(claude|copilot|codex)\/[0-9a-f]{8}$/;
 
+/**
+ * Decompose a handoff branch into `{version, cli, shortId, yearMonth}`.
+ * Unrecognised shapes return `{version: null, cli: "?", shortId: "", yearMonth: ""}`
+ * so list renderers degrade gracefully on branches that predate both schemes.
+ * v1 branches have no `yearMonth`.
+ */
+export function parseHandoffBranch(branch) {
+  const s = branch ?? "";
+  if (V2_BRANCH_RE.test(s)) {
+    const [, , cli, yearMonth, shortId] = s.split("/");
+    return { version: 2, cli, shortId, yearMonth };
+  }
+  if (V1_BRANCH_RE.test(s)) {
+    const [, cli, shortId] = s.split("/");
+    return { version: 1, cli, shortId, yearMonth: "" };
+  }
+  return { version: null, cli: "?", shortId: "", yearMonth: "" };
+}
+
 // Callers that read state at run time (loadPersistedEnv,
 // bootstrapTransportRepo) go through these helpers so an updated
 // process.env.HOME / XDG_CONFIG_HOME takes effect without a module

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -42,7 +42,7 @@ bash tool.
 /handoff <query>                          local cross-agent: emit <handoff>
 /handoff push [<query>] [--tag <label>]   upload to transport
 /handoff pull [<query>]                   fetch from transport
-/handoff list [--local|--remote]          unified table
+/handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
 ```
 
 A bare `/handoff` with no arguments prints usage and exits 0. Every
@@ -78,7 +78,7 @@ semantics. Brief summary:
 | `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                 |
 | `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                |
 | `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`         |
-| `list`                | Unified local + remote table (`--local` / `--remote` to filter)     |
+| `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
 | `search <query>`      | Substring/regex match across local sessions; `--cli` / `--since`    |
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript` |
 | `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline     |
@@ -88,12 +88,15 @@ semantics. Brief summary:
 Cross-cutting flags (consult `--help` for the canonical list):
 
 - `--from <cli>` narrows source-CLI auto-detection on `push`, `pull`,
-  bare `<query>`. Without it, the resolver probes all three roots.
+  bare `<query>`, and filters `list` to one root. Without it, the
+  resolver probes all three roots.
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
   target agent. Defaults to the auto-detected host.
 - `--cli <cli>` filters `search` and `remote-list` to one CLI.
-- `--since <ISO>` cuts off `search` and `remote-list` (default 30 days).
-- `--limit <N>` caps the row count (default 20).
+- `--since <ISO>` cuts off `list`, `search`, and `remote-list`
+  (default 30 days).
+- `--limit <N>` caps the row count (default 20). `--all` (on `list`)
+  disables the cap.
 - `--tag <label>` annotates a `push` for fuzzy `pull` later.
 - `--include-transcript` adds the last 50 raw turns to a `push`
   (off by default to minimise leakage).

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -72,18 +72,18 @@ with a TSV candidate list on stderr.
 The binary's `--help` lists the full surface and authoritative flag
 semantics. Brief summary:
 
-| Sub                   | Purpose                                                             |
-| --------------------- | ------------------------------------------------------------------- |
-| `resolve <cli> <id>`  | Print the absolute JSONL path                                       |
-| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                 |
-| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                |
-| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`         |
+| Sub                   | Purpose                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `resolve <cli> <id>`  | Print the absolute JSONL path                                                               |
+| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                                         |
+| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                        |
+| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                 |
 | `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
-| `search <query>`      | Substring/regex match across local sessions; `--cli` / `--since`    |
-| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript` |
-| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline     |
-| `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`     |
-| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback            |
+| `search <query>`      | Substring/regex match across local sessions; `--cli` / `--since`                            |
+| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                         |
+| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                             |
+| `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`                             |
+| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                    |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -93,8 +93,8 @@ Cross-cutting flags (consult `--help` for the canonical list):
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
   target agent. Defaults to the auto-detected host.
 - `--cli <cli>` filters `search` and `remote-list` to one CLI.
-- `--since <ISO>` cuts off `list`, `search`, and `remote-list`
-  (default 30 days).
+- `--since <ISO>` cuts off `list` when explicitly provided, and
+  cuts off `search` and `remote-list` (default 30 days).
 - `--limit <N>` caps the row count (default 20). `--all` (on `list`)
   disables the cap.
 - `--tag <label>` annotates a `push` for fuzzy `pull` later.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
@@ -11,7 +11,7 @@ Codex's bash tool instead. Same binary, same five-form shape.
 !dotclaude handoff <query>                      local cross-agent: emit <handoff>
 !dotclaude handoff push [<query>] [--tag LBL]   upload to transport
 !dotclaude handoff pull [<query>]               fetch from transport
-!dotclaude handoff list [--local|--remote]      unified table
+!dotclaude handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
 ```
 
 `<query>` auto-detects the source CLI across all three roots. It

--- a/plugins/dotclaude/tests/bats/handoff-list-refine.bats
+++ b/plugins/dotclaude/tests/bats/handoff-list-refine.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+# Behavior tests for `handoff list` refinements (issue #89):
+# - uniform row schema: Location | CLI | Short UUID | When
+# - --from <cli> filter
+# - --since <ISO> filter
+# - --limit <N> / --all
+# - stderr warning when --remote + missing DOTCLAUDE_HANDOFF_REPO
+# - --json shape preserved with new fields
+
+load helpers
+
+bats_require_minimum_version 1.5.0
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+
+  # Claude fixture (newest)
+  mkdir -p "$TEST_HOME/.claude/projects/-home-u-demo"
+  CLAUDE_FILE="$TEST_HOME/.claude/projects/-home-u-demo/aaaa1111-1111-1111-1111-111111111111.jsonl"
+  cat > "$CLAUDE_FILE" <<'EOF'
+{"type":"user","cwd":"/home/u/demo","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"hi"}}
+EOF
+
+  # Codex fixture (older by mtime)
+  mkdir -p "$TEST_HOME/.codex/sessions/2026/04/18"
+  CODEX_FILE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-bbbb2222-2222-2222-2222-222222222222.jsonl"
+  cat > "$CODEX_FILE" <<'EOF'
+{"type":"session_meta","payload":{"id":"bbbb2222-2222-2222-2222-222222222222","cwd":"/work/demo","cli_version":"0.1"}}
+EOF
+  # Force codex file to be older than claude
+  touch -d "2025-01-01 00:00:00" "$CODEX_FILE"
+
+  # Bare transport repo
+  TRANSPORT_REPO=$(mktemp -d)
+  rm -rf "$TRANSPORT_REPO"
+  git init -q --bare "$TRANSPORT_REPO"
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+
+  export CLAUDE_FILE CODEX_FILE TRANSPORT_REPO
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+}
+
+# -- Gap 4: uniform row schema --------------------------------------------
+
+@test "list: header uses uniform schema Location | CLI | Short UUID | When" {
+  run node "$BIN" list </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Location"* ]]
+  [[ "$output" == *"CLI"* ]]
+  [[ "$output" == *"Short UUID"* ]]
+  [[ "$output" == *"When"* ]]
+  # Old schema leaks must be gone
+  [[ "$output" != *"CLI / Branch"* ]]
+  [[ "$output" != *"When / Commit"* ]]
+}
+
+@test "list: remote rows expose cli+short_id derived from branch, no raw branch column" {
+  run node "$BIN" push aaaa1111
+  [ "$status" -eq 0 ]
+  run node "$BIN" list --remote </dev/null
+  [ "$status" -eq 0 ]
+  # CLI column should contain 'claude' for remote too
+  [[ "$output" == *"remote"* ]]
+  [[ "$output" == *"claude"* ]]
+  [[ "$output" == *"aaaa1111"* ]]
+}
+
+# -- Gap 3: filter flags ---------------------------------------------------
+
+@test "list --from claude narrows to the claude root only" {
+  run node "$BIN" list --from claude </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  [[ "$output" != *"bbbb2222"* ]]
+}
+
+@test "list --from codex narrows to the codex root only" {
+  run node "$BIN" list --from codex </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222"* ]]
+  [[ "$output" != *"aaaa1111"* ]]
+}
+
+@test "list --from bogus exits 64 with usage error" {
+  run node "$BIN" list --from bogus </dev/null
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"--from"* ]] || [[ "$stderr" == *"--from"* ]]
+}
+
+@test "list --since filters older rows by mtime" {
+  run node "$BIN" list --since 2026-01-01T00:00:00Z </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  # codex file was backdated to 2025 — must be filtered out
+  [[ "$output" != *"bbbb2222"* ]]
+}
+
+@test "list --since rejects non-ISO input" {
+  run node "$BIN" list --since not-a-date </dev/null
+  [ "$status" -eq 64 ]
+}
+
+@test "list --limit 1 caps rows" {
+  run node "$BIN" list --limit 1 </dev/null
+  [ "$status" -eq 0 ]
+  # Only the newest row should appear
+  [[ "$output" == *"aaaa1111"* ]]
+  [[ "$output" != *"bbbb2222"* ]]
+}
+
+@test "list --all disables default cap" {
+  run node "$BIN" list --all </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  [[ "$output" == *"bbbb2222"* ]]
+}
+
+# -- Gap 5: stderr warning on missing transport env -----------------------
+
+@test "list --remote with missing DOTCLAUDE_HANDOFF_REPO warns on stderr" {
+  unset DOTCLAUDE_HANDOFF_REPO
+  run --separate-stderr node "$BIN" list --remote </dev/null
+  # exit 2 when only --remote requested and nothing to show
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"DOTCLAUDE_HANDOFF_REPO"* ]]
+}
+
+@test "list (default) with missing DOTCLAUDE_HANDOFF_REPO still succeeds via local rows" {
+  unset DOTCLAUDE_HANDOFF_REPO
+  run --separate-stderr node "$BIN" list </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  # Warning still emitted so users know remote was skipped
+  [[ "$stderr" == *"DOTCLAUDE_HANDOFF_REPO"* ]]
+}
+
+# -- --json preserves new fields ------------------------------------------
+
+@test "list --json emits location/cli/short_id/when per local row" {
+  run node "$BIN" list --json </dev/null
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.[0] | has("location") and has("cli") and has("short_id") and has("when")' >/dev/null
+}
+
+@test "list --json with remote rows exposes cli extracted from branch name" {
+  run node "$BIN" push aaaa1111
+  [ "$status" -eq 0 ]
+  run node "$BIN" list --remote --json </dev/null
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.[] | select(.location == "remote") | .cli == "claude"' >/dev/null
+}

--- a/plugins/dotclaude/tests/bats/handoff-stress.bats
+++ b/plugins/dotclaude/tests/bats/handoff-stress.bats
@@ -33,7 +33,7 @@ teardown() {
   local outfile exit_status line_count
   outfile=$(mktemp)
   exit_status=0
-  timeout 30s node "$BIN" list --local > "$outfile" 2>/dev/null || exit_status=$?
+  timeout 30s node "$BIN" list --local --all > "$outfile" 2>/dev/null || exit_status=$?
   line_count=$(wc -l < "$outfile")
   rm -f "$outfile"
 

--- a/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
@@ -35,6 +35,7 @@ describe("export shape", () => {
     "mechanicalSummary",
     "monthBucket",
     "nextStepFor",
+    "parseHandoffBranch",
     "printManualSetupBlock",
     "probeCollision",
     "projectSlugFromCwd",

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -75,18 +75,18 @@ with a TSV candidate list on stderr.
 The binary's `--help` lists the full surface and authoritative flag
 semantics. Brief summary:
 
-| Sub                   | Purpose                                                             |
-| --------------------- | ------------------------------------------------------------------- |
-| `resolve <cli> <id>`  | Print the absolute JSONL path                                       |
-| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                 |
-| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                |
-| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`         |
+| Sub                   | Purpose                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `resolve <cli> <id>`  | Print the absolute JSONL path                                                               |
+| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                                         |
+| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                        |
+| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                 |
 | `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
-| `search <query>`      | Substring/regex match across local sessions; `--cli` / `--since`    |
-| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript` |
-| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline     |
-| `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`     |
-| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback            |
+| `search <query>`      | Substring/regex match across local sessions; `--cli` / `--since`                            |
+| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                         |
+| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                             |
+| `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`                             |
+| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                    |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -96,8 +96,8 @@ Cross-cutting flags (consult `--help` for the canonical list):
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
   target agent. Defaults to the auto-detected host.
 - `--cli <cli>` filters `search` and `remote-list` to one CLI.
-- `--since <ISO>` cuts off `list`, `search`, and `remote-list`
-  (default 30 days).
+- `--since <ISO>` cuts off `list` when explicitly provided, and
+  cuts off `search` and `remote-list` (default 30 days).
 - `--limit <N>` caps the row count (default 20). `--all` (on `list`)
   disables the cap.
 - `--tag <label>` annotates a `push` for fuzzy `pull` later.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -45,7 +45,7 @@ bash tool.
 /handoff <query>                          local cross-agent: emit <handoff>
 /handoff push [<query>] [--tag <label>]   upload to transport
 /handoff pull [<query>]                   fetch from transport
-/handoff list [--local|--remote]          unified table
+/handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
 ```
 
 A bare `/handoff` with no arguments prints usage and exits 0. Every
@@ -81,7 +81,7 @@ semantics. Brief summary:
 | `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                 |
 | `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                |
 | `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`         |
-| `list`                | Unified local + remote table (`--local` / `--remote` to filter)     |
+| `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
 | `search <query>`      | Substring/regex match across local sessions; `--cli` / `--since`    |
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript` |
 | `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline     |
@@ -91,12 +91,15 @@ semantics. Brief summary:
 Cross-cutting flags (consult `--help` for the canonical list):
 
 - `--from <cli>` narrows source-CLI auto-detection on `push`, `pull`,
-  bare `<query>`. Without it, the resolver probes all three roots.
+  bare `<query>`, and filters `list` to one root. Without it, the
+  resolver probes all three roots.
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
   target agent. Defaults to the auto-detected host.
 - `--cli <cli>` filters `search` and `remote-list` to one CLI.
-- `--since <ISO>` cuts off `search` and `remote-list` (default 30 days).
-- `--limit <N>` caps the row count (default 20).
+- `--since <ISO>` cuts off `list`, `search`, and `remote-list`
+  (default 30 days).
+- `--limit <N>` caps the row count (default 20). `--all` (on `list`)
+  disables the cap.
 - `--tag <label>` annotates a `push` for fuzzy `pull` later.
 - `--include-transcript` adds the last 50 raw turns to a `push`
   (off by default to minimise leakage).

--- a/skills/handoff/references/from-codex.md
+++ b/skills/handoff/references/from-codex.md
@@ -11,7 +11,7 @@ Codex's bash tool instead. Same binary, same five-form shape.
 !dotclaude handoff <query>                      local cross-agent: emit <handoff>
 !dotclaude handoff push [<query>] [--tag LBL]   upload to transport
 !dotclaude handoff pull [<query>]               fetch from transport
-!dotclaude handoff list [--local|--remote]      unified table
+!dotclaude handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
 ```
 
 `<query>` auto-detects the source CLI across all three roots. It


### PR DESCRIPTION
## Summary

Closes #89. Four refinements to `handoff list`:

- **Uniform row schema** — `Location | CLI | Short UUID | When` replaces the old dual-shape `CLI / Branch` + `When / Commit` layout. Remote rows derive `cli`, `short_id`, and `when` (YYYY-MM) from the transport branch name via a new `parseHandoffBranch` helper, so filtering and scanning work the same across local and remote.
- **Filter flags on `list`** — `--from <cli>` narrows by root (same validation as push/pull). `--since <ISO>` drops older rows by mtime; non-ISO input exits 64.
- **Volume controls** — `--limit <N>` caps rows (default 20, reusing the existing top-level parse). `--all` disables the cap. Stress test bumped to `--all` so the 10k-session enumeration still exceeds the 9/10 line-count floor.
- **Transport-env warning** — `list --remote` without `DOTCLAUDE_HANDOFF_REPO` warns on stderr and exits 2 when nothing can be shown; bare `list` still succeeds via local rows but warns so the user knows remote was skipped.

Docs (`skills/handoff/SKILL.md`, `skills/handoff/references/from-codex.md`, `docs/handoff-guide.md`) updated to document the new flag surface. Templates + manifest regenerated.

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/` → 277/277 green (13 new tests in `handoff-list-refine.bats`)
- [x] `npm test` → 480/480 vitest green
- [x] `node plugins/dotclaude/bin/dotclaude-handoff.mjs list --help` shows `--all` alongside existing `--local`/`--remote`/`--from`/`--since`/`--limit`
- [x] Regression check: stress test `list --local over 10k codex sessions` still ≥ 90% line count with `--all`

## Spec ID

dotclaude-core