### PR TITLE
feat(handoff): search --fixed, two-pass clean filter, documented JSON shape (#88)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T21:59:55.858Z",
+  "generatedAt": "2026-04-22T22:03:40.343Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:1820d40dc524e870a27d79420fc493538900f60b6821b33e1334c455ada79c3a",
+      "checksum": "sha256:0a541a50a4d8bb063eb74111700e8bc63a39b8553a581cf3e96e9d6b87b348f9",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T21:54:07.516Z",
+  "generatedAt": "2026-04-22T21:59:55.858Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:601efea940c906de9fa787bcef05b033c4f2549047993cf4ab5ba46b54333ec3",
+      "checksum": "sha256:1820d40dc524e870a27d79420fc493538900f60b6821b33e1334c455ada79c3a",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T21:09:04.509Z",
+  "generatedAt": "2026-04-22T21:28:28.592Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:ca2e4bbb2a00f696ed4eb679de7aed097aefd37bf8b274c16f57550976c803db",
+      "checksum": "sha256:601efea940c906de9fa787bcef05b033c4f2549047993cf4ab5ba46b54333ec3",
       "dependencies": [],
       "lastValidated": "2026-04-22"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T21:28:28.592Z",
+  "generatedAt": "2026-04-22T21:54:07.516Z",
   "skills": [
     {
       "name": "audit-and-fix",

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -107,6 +107,7 @@ const META = {
     verify: { type: "boolean" },
     "force-collision": { type: "boolean" },
     all: { type: "boolean" },
+    fixed: { type: "boolean", short: "F" },
   },
 };
 
@@ -371,18 +372,19 @@ function truncate(s, max) {
 }
 
 /**
- * Port of SKILL.md's `search` algorithm (L258-324 in v0.8.0). Walks
- * each CLI's session roots, mtime-prefilters against `--since`,
- * matches the raw JSONL via a case-insensitive regex, then refines
- * the hit against the extracted user prompts so matches in
- * tool-use / metadata noise are dropped.
+ * Port of SKILL.md's `search` algorithm (L258-324 in v0.8.0). Two-pass
+ * design: fast raw-regex pass over JSONL to narrow candidates, then a
+ * clean pass over extractPrompts + extractTurns output (tool-use and
+ * env-context noise already stripped by handoff-extract.sh) to confirm
+ * the hit. `fixed` escapes regex metachars for literal-string queries.
  *
- * Returns a newest-first array of {cli, short_id, cwd, mtime,
- * snippet} objects capped at `limit`. The binary caller handles
- * table rendering vs `--json` serialization.
+ * Returns a newest-first array of {cli, short_id, session_id, path,
+ * cwd, mtime, match_snippet} objects capped at `limit`. The binary
+ * caller handles table rendering vs `--json` serialization.
  */
-function searchSessions({ query, cli, since, limit }) {
-  const re = new RegExp(query, "i");
+function searchSessions({ query, cli, since, limit, fixed }) {
+  const pattern = fixed ? query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : query;
+  const re = new RegExp(pattern, "i");
   const sinceMs = parseSinceOrFail(since, { defaultDays: 30 });
   const clis = cli ? [cli] : Object.keys(CLI_LAYOUTS);
   const out = [];
@@ -406,17 +408,22 @@ function searchSessions({ query, cli, since, limit }) {
         continue;
       }
       if (!re.test(raw)) continue;
-      const prompts = extractPrompts(c, file);
-      const hit = prompts.find((p) => re.test(p));
-      if (!hit) continue;
+      const promptHit = extractPrompts(c, file).find((p) => re.test(p));
+      const turnHit = promptHit ? null : extractTurns(c, file).find((t) => re.test(t));
+      if (!promptHit && !turnHit) continue;
+      const snippet = promptHit
+        ? truncate(`user: ${promptHit}`, 80)
+        : truncate(`assistant: ${turnHit}`, 80);
       const meta = extractMeta(c, file);
       const m = file.match(UUID_HEAD_RE);
       out.push({
         cli: c,
         short_id: m ? m[1] : "?",
+        session_id: meta.session_id ?? null,
+        path: file,
         cwd: meta.cwd ?? null,
         mtime: stat.mtimeMs,
-        snippet: truncate(`user: ${hit}`, 80),
+        match_snippet: snippet,
       });
     }
   }
@@ -538,9 +545,10 @@ async function main() {
     }
     const enriched = enrichWithDescriptions(candidates);
     const sinceMs = parseSinceOrFail(argv.flags.since, { defaultDays: 30 });
-    const filterCli = argv.flags.cli ? String(argv.flags.cli) : null;
+    const filterCli =
+      fromCli ?? (argv.flags.cli ? String(argv.flags.cli) : null);
     if (filterCli !== null && !CLIS.has(filterCli)) {
-      fail(EXIT_CODES.USAGE, `--cli must be one of: ${[...CLIS].join(", ")}`);
+      fail(EXIT_CODES.USAGE, `--from must be one of: ${[...CLIS].join(", ")}`);
     }
     const rows = [];
     for (const c of enriched) {
@@ -579,15 +587,17 @@ async function main() {
   if (first === "search") {
     const query = second;
     if (!query) fail(EXIT_CODES.USAGE, "search requires a <query> argument");
-    const filterCli = argv.flags.cli ? String(argv.flags.cli) : null;
+    const filterCli =
+      fromCli ?? (argv.flags.cli ? String(argv.flags.cli) : null);
     if (filterCli !== null && !CLIS.has(filterCli)) {
-      fail(EXIT_CODES.USAGE, `--cli must be one of: ${[...CLIS].join(", ")}`);
+      fail(EXIT_CODES.USAGE, `--from must be one of: ${[...CLIS].join(", ")}`);
     }
     const hits = searchSessions({
       query,
       cli: filterCli,
       since: argv.flags.since ? String(argv.flags.since) : null,
       limit: limit.toString(),
+      fixed: Boolean(argv.flags.fixed),
     });
     if (argv.json) {
       process.stdout.write(JSON.stringify(hits, null, 2) + "\n");
@@ -602,7 +612,7 @@ async function main() {
     for (const h of hits) {
       const when = new Date(h.mtime).toISOString().replace("T", " ").slice(0, 19);
       process.stdout.write(
-        `| ${h.cli.padEnd(7)} | ${h.short_id.padEnd(10)} | ${(h.cwd ?? "").padEnd(37)} | ${when.padEnd(19)} | ${h.snippet.padEnd(40)} |\n`
+        `| ${h.cli.padEnd(7)} | ${h.short_id.padEnd(10)} | ${(h.cwd ?? "").padEnd(37)} | ${when.padEnd(19)} | ${h.match_snippet.padEnd(40)} |\n`
       );
     }
     process.stdout.write("\nDrill in with `dotclaude handoff describe <cli> <short-uuid>`.\n");

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -30,7 +30,7 @@
 
 import { parse, helpText } from "../src/lib/argv.mjs";
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
-import { version } from "../src/index.mjs";
+import { version, escapeRegex } from "../src/index.mjs";
 import {
   // subprocess primitives
   runScript,
@@ -372,19 +372,17 @@ function truncate(s, max) {
 }
 
 /**
- * Port of SKILL.md's `search` algorithm (L258-324 in v0.8.0). Two-pass
- * design: fast raw-regex pass over JSONL to narrow candidates, then a
- * clean pass over extractPrompts + extractTurns output (tool-use and
- * env-context noise already stripped by handoff-extract.sh) to confirm
- * the hit. `fixed` escapes regex metachars for literal-string queries.
+ * Two-pass search: fast raw-regex pass over JSONL to narrow candidates,
+ * then a clean pass over extractPrompts + extractTurns output (tool-use
+ * and env-context noise already stripped by handoff-extract.sh) to
+ * confirm the hit. `fixed` escapes regex metachars for literal queries.
  *
  * Returns a newest-first array of {cli, short_id, session_id, path,
  * cwd, mtime, match_snippet} objects capped at `limit`. The binary
  * caller handles table rendering vs `--json` serialization.
  */
 function searchSessions({ query, cli, since, limit, fixed }) {
-  const pattern = fixed ? query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : query;
-  const re = new RegExp(pattern, "i");
+  const re = new RegExp(fixed ? escapeRegex(query) : query, "i");
   const sinceMs = parseSinceOrFail(since, { defaultDays: 30 });
   const clis = cli ? [cli] : Object.keys(CLI_LAYOUTS);
   const out = [];
@@ -409,7 +407,7 @@ function searchSessions({ query, cli, since, limit, fixed }) {
       }
       if (!re.test(raw)) continue;
       const promptHit = extractPrompts(c, file).find((p) => re.test(p));
-      const turnHit = promptHit ? null : extractTurns(c, file).find((t) => re.test(t));
+      const turnHit = promptHit ? null : extractTurns(c, file, 0).find((t) => re.test(t));
       if (!promptHit && !turnHit) continue;
       const snippet = promptHit
         ? truncate(`user: ${promptHit}`, 80)
@@ -493,6 +491,17 @@ async function resolveLatestWithHostScope({ fromCli, detectedHost }) {
   return { hit, note: `host not detected, using latest across all clis: ${shortId}` };
 }
 
+// Resolve the CLI filter for sub-commands that accept `--from` with a
+// `--cli` legacy alias (search, remote-list). Fails USAGE on an unknown
+// value. Returns null when neither flag was passed.
+function resolveFilterCli() {
+  const v = fromCli ?? (argv.flags.cli ? String(argv.flags.cli) : null);
+  if (v !== null && !CLIS.has(v)) {
+    fail(EXIT_CODES.USAGE, `--from must be one of: ${[...CLIS].join(", ")}`);
+  }
+  return v;
+}
+
 async function main() {
   if (argv.positional.length === 0) {
     process.stdout.write(helpText(META) + "\n");
@@ -545,11 +554,7 @@ async function main() {
     }
     const enriched = enrichWithDescriptions(candidates);
     const sinceMs = parseSinceOrFail(argv.flags.since, { defaultDays: 30 });
-    const filterCli =
-      fromCli ?? (argv.flags.cli ? String(argv.flags.cli) : null);
-    if (filterCli !== null && !CLIS.has(filterCli)) {
-      fail(EXIT_CODES.USAGE, `--from must be one of: ${[...CLIS].join(", ")}`);
-    }
+    const filterCli = resolveFilterCli();
     const rows = [];
     for (const c of enriched) {
       const decoded = decodeDescription(c.description);
@@ -587,11 +592,7 @@ async function main() {
   if (first === "search") {
     const query = second;
     if (!query) fail(EXIT_CODES.USAGE, "search requires a <query> argument");
-    const filterCli =
-      fromCli ?? (argv.flags.cli ? String(argv.flags.cli) : null);
-    if (filterCli !== null && !CLIS.has(filterCli)) {
-      fail(EXIT_CODES.USAGE, `--from must be one of: ${[...CLIS].join(", ")}`);
-    }
+    const filterCli = resolveFilterCli();
     const hits = searchSessions({
       query,
       cli: filterCli,

--- a/plugins/dotclaude/scripts/handoff-extract.sh
+++ b/plugins/dotclaude/scripts/handoff-extract.sh
@@ -157,12 +157,14 @@ prompts_claude() {
 turns_claude() {
   local file="$1"
   local limit="${2:-20}"
+  local tail_arg="$limit"
+  [[ "$limit" == "0" ]] && tail_arg="+1"
   jq -c '
     select(.type == "assistant")
     | .message.content
     | (map(select(.type == "text") | .text) | join("\n"))
     | select(length > 0)
-  ' "$file" 2>/dev/null | tail -n "$limit"
+  ' "$file" 2>/dev/null | tail -n "$tail_arg"
 }
 
 # -- copilot --------------------------------------------------------------
@@ -228,11 +230,13 @@ prompts_copilot() {
 turns_copilot() {
   local file="$1"
   local limit="${2:-20}"
+  local tail_arg="$limit"
+  [[ "$limit" == "0" ]] && tail_arg="+1"
   jq -c '
     select(.type == "assistant.message")
     | (.data.content // .data.text // "")
     | select(length > 0)
-  ' "$file" 2>/dev/null | tail -n "$limit"
+  ' "$file" 2>/dev/null | tail -n "$tail_arg"
 }
 
 # -- codex ----------------------------------------------------------------
@@ -275,13 +279,15 @@ prompts_codex() {
 turns_codex() {
   local file="$1"
   local limit="${2:-20}"
+  local tail_arg="$limit"
+  [[ "$limit" == "0" ]] && tail_arg="+1"
   jq -c '
     select(.type == "response_item"
            and .payload.type == "message"
            and .payload.role == "assistant")
     | .payload.content[0].text // ""
     | select(length > 0)
-  ' "$file" 2>/dev/null | tail -n "$limit"
+  ' "$file" 2>/dev/null | tail -n "$tail_arg"
 }
 
 # -- dispatch -------------------------------------------------------------

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -158,9 +158,9 @@ export function extractLines(sub, cli, file, extra = []) {
 
 /** Extract user prompt lines from a session file. */
 export const extractPrompts = (cli, file) => extractLines("prompts", cli, file);
-/** Extract assistant turn lines from a session file (optionally capped). */
+/** Extract assistant turn lines from a session file (optionally capped; 0 = unbounded). */
 export const extractTurns = (cli, file, limit) =>
-  extractLines("turns", cli, file, limit ? [String(limit)] : []);
+  extractLines("turns", cli, file, limit == null ? [] : [String(limit)]);
 
 // ---- rendering ---------------------------------------------------------
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -72,18 +72,18 @@ with a TSV candidate list on stderr.
 The binary's `--help` lists the full surface and authoritative flag
 semantics. Brief summary:
 
-| Sub                   | Purpose                                                                                     |
-| --------------------- | ------------------------------------------------------------------------------------------- |
-| `resolve <cli> <id>`  | Print the absolute JSONL path                                                               |
-| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                                         |
-| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                        |
-| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                 |
-| `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
+| Sub                   | Purpose                                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `resolve <cli> <id>`  | Print the absolute JSONL path                                                                        |
+| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                                                  |
+| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                                 |
+| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                          |
+| `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
 | `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
-| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                         |
-| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                             |
-| `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                            |
-| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                    |
+| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
+| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
+| `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
+| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -79,10 +79,10 @@ semantics. Brief summary:
 | `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                        |
 | `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                 |
 | `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
-| `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--fixed` / `--json`    |
+| `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                         |
 | `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                             |
-| `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`                             |
+| `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                            |
 | `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                    |
 
 Cross-cutting flags (consult `--help` for the canonical list):

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -79,7 +79,7 @@ semantics. Brief summary:
 | `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                        |
 | `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                 |
 | `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
-| `search <query>`      | Substring/regex match across local sessions; `--cli` / `--since`                            |
+| `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--fixed` / `--json`    |
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                         |
 | `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                             |
 | `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`                             |
@@ -88,15 +88,17 @@ semantics. Brief summary:
 Cross-cutting flags (consult `--help` for the canonical list):
 
 - `--from <cli>` narrows source-CLI auto-detection on `push`, `pull`,
-  bare `<query>`, and filters `list` to one root. Without it, the
-  resolver probes all three roots.
+  bare `<query>`, and filters `list`, `search`, and `remote-list` to
+  one root. Without it, the resolver probes all three roots. `--cli`
+  is accepted as a legacy alias on `search` and `remote-list`.
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
   target agent. Defaults to the auto-detected host.
-- `--cli <cli>` filters `search` and `remote-list` to one CLI.
 - `--since <ISO>` cuts off `list` when explicitly provided, and
   cuts off `search` and `remote-list` (default 30 days).
 - `--limit <N>` caps the row count (default 20). `--all` (on `list`)
   disables the cap.
+- `--fixed` / `-F` treats the `search` query as a literal string
+  instead of a regex.
 - `--tag <label>` annotates a `push` for fuzzy `pull` later.
 - `--include-transcript` adds the last 50 raw turns to a `push`
   (off by default to minimise leakage).

--- a/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
+++ b/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
@@ -178,7 +178,6 @@ teardown() {
 }
 
 @test "search --fixed makes regex metacharacters literal (no regex parse error, only literal match)" {
-  # Seed a claude session whose prompt contains literal parens.
   local fixed_home
   fixed_home=$(mktemp -d)
   mkdir -p "$fixed_home/.claude/projects/-home-u-demo"
@@ -226,7 +225,6 @@ EOF
 }
 
 @test "search matches terms that only appear in assistant turns" {
-  # Word appears only in an assistant text block, never in user prompts.
   local asst_home
   asst_home=$(mktemp -d)
   mkdir -p "$asst_home/.claude/projects/-home-u-demo"
@@ -239,6 +237,28 @@ EOF
   [[ "$output" == *"ffff6666"* ]]
   [[ "$output" == *"assistant:"* ]]
   rm -rf "$asst_home"
+}
+
+@test "search finds a match in an early assistant turn past extractTurns' default 20-turn window" {
+  # Regression: earlier impl asked extractTurns for the default (last 20
+  # turns) while calling .find() to locate the first match. A session with
+  # >20 assistant turns and the target term only in turn #1 silently
+  # returned no results. Seed such a session and confirm the hit comes
+  # through with the unbounded-turns fix.
+  local deep_home
+  deep_home=$(mktemp -d)
+  mkdir -p "$deep_home/.claude/projects/-home-u-demo"
+  local jsonl="$deep_home/.claude/projects/-home-u-demo/deadbeef-beef-beef-beef-deadbeefbeef.jsonl"
+  printf '%s\n' '{"type":"user","cwd":"/home/u/demo","sessionId":"deadbeef-beef-beef-beef-deadbeefbeef","version":"2.1","message":{"content":"driving prompt"}}' > "$jsonl"
+  printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"Glimfarble is the unique word we are looking for"}]}}' >> "$jsonl"
+  for i in $(seq 1 40); do
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"filler turn %s"}]}}\n' "$i" >> "$jsonl"
+  done
+  run env HOME="$deep_home" node "$BIN" search Glimfarble
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deadbeef"* ]]
+  [[ "$output" == *"assistant:"* ]]
+  rm -rf "$deep_home"
 }
 
 # ---- self-bootstrap ----------------------------------------------------

--- a/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
+++ b/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
@@ -106,7 +106,16 @@ teardown() {
 @test "remote-list --cli with an invalid value exits 64" {
   run node "$BIN" remote-list --cli bogus
   [ "$status" -eq 64 ]
-  [[ "$output" == *"--cli must be one of"* ]]
+  [[ "$output" == *"--from must be one of"* ]]
+}
+
+@test "remote-list --from claude filters to claude-only (canonical flag)" {
+  run node "$BIN" push my-feature
+  run node "$BIN" push my-codex-task
+  run node "$BIN" remote-list --from claude
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ handoff/demo/claude/[0-9]{4}-[0-9]{2}/aaaa1111 ]]
+  [[ "$output" != *"bbbb2222"* ]]
 }
 
 # ---- search ------------------------------------------------------------
@@ -137,10 +146,17 @@ teardown() {
   [[ "$output" == *"search requires a <query>"* ]]
 }
 
-@test "search --cli bogus exits 64" {
-  run node "$BIN" search migration --cli bogus
+@test "search --from bogus exits 64" {
+  run node "$BIN" search migration --from bogus
   [ "$status" -eq 64 ]
-  [[ "$output" == *"--cli must be one of"* ]]
+  [[ "$output" == *"--from must be one of"* ]]
+}
+
+@test "search --from codex narrows to codex (canonical flag)" {
+  run node "$BIN" search migration --from codex
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222"* ]]
+  [[ "$output" != *"aaaa1111"* ]]
 }
 
 @test "search --since with an invalid date exits 64" {
@@ -149,12 +165,80 @@ teardown() {
   [[ "$output" == *"--since must be ISO-8601"* ]]
 }
 
-@test "search --json emits JSON parsable by callers" {
+@test "search --json emits the documented shape (cli/short_id/session_id/path/cwd/mtime/match_snippet)" {
   run node "$BIN" --json search migration
   [ "$status" -eq 0 ]
   [[ "$output" == *'"cli":'* ]]
   [[ "$output" == *'"short_id":'* ]]
-  [[ "$output" == *'"snippet":'* ]]
+  [[ "$output" == *'"session_id":'* ]]
+  [[ "$output" == *'"path":'* ]]
+  [[ "$output" == *'"cwd":'* ]]
+  [[ "$output" == *'"mtime":'* ]]
+  [[ "$output" == *'"match_snippet":'* ]]
+}
+
+@test "search --fixed makes regex metacharacters literal (no regex parse error, only literal match)" {
+  # Seed a claude session whose prompt contains literal parens.
+  local fixed_home
+  fixed_home=$(mktemp -d)
+  mkdir -p "$fixed_home/.claude/projects/-home-u-demo"
+  cat > "$fixed_home/.claude/projects/-home-u-demo/cccc3333-3333-3333-3333-333333333333.jsonl" <<'EOF'
+{"type":"user","cwd":"/home/u/demo","sessionId":"cccc3333-3333-3333-3333-333333333333","version":"2.1","message":{"content":"Call foo.bar() from the handler"}}
+EOF
+
+  # Regex-mode `foo.bar` matches `foobar` too, but here it happens to match
+  # the literal. The real signal is that the literal-paren query `foo.bar()`
+  # would fail as a regex (unescaped `(`) — `--fixed` must let it through.
+  run env HOME="$fixed_home" node "$BIN" search "foo.bar()" --fixed
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cccc3333"* ]]
+  rm -rf "$fixed_home"
+}
+
+@test "search -F short flag matches --fixed" {
+  local fixed_home
+  fixed_home=$(mktemp -d)
+  mkdir -p "$fixed_home/.claude/projects/-home-u-demo"
+  cat > "$fixed_home/.claude/projects/-home-u-demo/dddd4444-4444-4444-4444-444444444444.jsonl" <<'EOF'
+{"type":"user","cwd":"/home/u/demo","sessionId":"dddd4444-4444-4444-4444-444444444444","version":"2.1","message":{"content":"Grep for a+b literally"}}
+EOF
+  run env HOME="$fixed_home" node "$BIN" search "a+b" -F
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dddd4444"* ]]
+  rm -rf "$fixed_home"
+}
+
+@test "search drops candidates whose only raw match is inside a tool_use payload" {
+  # A claude session where 'widgetizer' appears only as a tool_use block,
+  # never in any user prompt or assistant text. The raw-regex pass catches
+  # it, but the clean pass (extractPrompts + extractTurns) must drop it.
+  local tu_home
+  tu_home=$(mktemp -d)
+  mkdir -p "$tu_home/.claude/projects/-home-u-demo"
+  cat > "$tu_home/.claude/projects/-home-u-demo/eeee5555-5555-5555-5555-555555555555.jsonl" <<'EOF'
+{"type":"user","cwd":"/home/u/demo","sessionId":"eeee5555-5555-5555-5555-555555555555","version":"2.1","message":{"content":"Do something unrelated"}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"widgetizer --run"}}]}}
+EOF
+  run env HOME="$tu_home" node "$BIN" search widgetizer
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No sessions matching"* ]]
+  rm -rf "$tu_home"
+}
+
+@test "search matches terms that only appear in assistant turns" {
+  # Word appears only in an assistant text block, never in user prompts.
+  local asst_home
+  asst_home=$(mktemp -d)
+  mkdir -p "$asst_home/.claude/projects/-home-u-demo"
+  cat > "$asst_home/.claude/projects/-home-u-demo/ffff6666-6666-6666-6666-666666666666.jsonl" <<'EOF'
+{"type":"user","cwd":"/home/u/demo","sessionId":"ffff6666-6666-6666-6666-666666666666","version":"2.1","message":{"content":"plain user prompt"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Zephyrine is the codename for this rollout"}]}}
+EOF
+  run env HOME="$asst_home" node "$BIN" search Zephyrine
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ffff6666"* ]]
+  [[ "$output" == *"assistant:"* ]]
+  rm -rf "$asst_home"
 }
 
 # ---- self-bootstrap ----------------------------------------------------

--- a/plugins/dotclaude/tests/bats/handoff-boundary.bats
+++ b/plugins/dotclaude/tests/bats/handoff-boundary.bats
@@ -141,11 +141,11 @@ teardown() {
 
 # -- extract turns: limit normalization ---------------------------------
 
-@test "extract turns with limit=0 yields no lines (SIGPIPE tolerated)" {
-  # Seed a session with 5 assistant turns. Behavior: `tail -n 0` closes
-  # its stdin immediately, sending SIGPIPE to jq. The pipeline exits 141
-  # (128 + 13) with empty stdout. Locked in — if a future change routes
-  # this through a head/awk filter with exit-0 semantics, update here.
+@test "extract turns with limit=0 is unbounded (returns every turn)" {
+  # `0` is the documented unbounded sentinel — search uses it to scan every
+  # assistant turn, not just the last 20. `handoff-extract.sh` translates
+  # it to `tail -n +1`. Previous behavior (SIGPIPE from `tail -n 0`) was
+  # a contract bug: search dropped matches in long sessions.
   local uuid="ffff6666-6666-6666-6666-666666666666"
   local file="$TEST_HOME/.claude/projects/-demo/$uuid.jsonl"
   mkdir -p "$(dirname "$file")"
@@ -156,10 +156,9 @@ teardown() {
     done
   } > "$file"
   run "$EXTRACT" turns claude "$file" 0
-  # Exit 141 is acceptable here (SIGPIPE from tail -n 0). The important
-  # invariant is that no turn content leaks through.
-  [[ "$status" -eq 0 || "$status" -eq 141 ]]
-  [ -z "$output" ]
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"turn 1"* ]]
+  [[ "$output" == *"turn 5"* ]]
 }
 
 @test "extract turns with absurdly large limit returns all turns" {

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -82,10 +82,10 @@ semantics. Brief summary:
 | `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                        |
 | `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                 |
 | `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
-| `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--fixed` / `--json`    |
+| `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                         |
 | `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                             |
-| `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`                             |
+| `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                            |
 | `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                    |
 
 Cross-cutting flags (consult `--help` for the canonical list):

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -82,7 +82,7 @@ semantics. Brief summary:
 | `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                        |
 | `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                 |
 | `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
-| `search <query>`      | Substring/regex match across local sessions; `--cli` / `--since`                            |
+| `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--fixed` / `--json`    |
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                         |
 | `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                             |
 | `remote-list`         | List handoffs on the transport; `--cli` / `--since` / `--limit`                             |
@@ -91,15 +91,17 @@ semantics. Brief summary:
 Cross-cutting flags (consult `--help` for the canonical list):
 
 - `--from <cli>` narrows source-CLI auto-detection on `push`, `pull`,
-  bare `<query>`, and filters `list` to one root. Without it, the
-  resolver probes all three roots.
+  bare `<query>`, and filters `list`, `search`, and `remote-list` to
+  one root. Without it, the resolver probes all three roots. `--cli`
+  is accepted as a legacy alias on `search` and `remote-list`.
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
   target agent. Defaults to the auto-detected host.
-- `--cli <cli>` filters `search` and `remote-list` to one CLI.
 - `--since <ISO>` cuts off `list` when explicitly provided, and
   cuts off `search` and `remote-list` (default 30 days).
 - `--limit <N>` caps the row count (default 20). `--all` (on `list`)
   disables the cap.
+- `--fixed` / `-F` treats the `search` query as a literal string
+  instead of a regex.
 - `--tag <label>` annotates a `push` for fuzzy `pull` later.
 - `--include-transcript` adds the last 50 raw turns to a `push`
   (off by default to minimise leakage).

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -75,18 +75,18 @@ with a TSV candidate list on stderr.
 The binary's `--help` lists the full surface and authoritative flag
 semantics. Brief summary:
 
-| Sub                   | Purpose                                                                                     |
-| --------------------- | ------------------------------------------------------------------------------------------- |
-| `resolve <cli> <id>`  | Print the absolute JSONL path                                                               |
-| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                                         |
-| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                        |
-| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                 |
-| `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
+| Sub                   | Purpose                                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `resolve <cli> <id>`  | Print the absolute JSONL path                                                                        |
+| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                                                  |
+| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                                 |
+| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                          |
+| `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
 | `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
-| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                         |
-| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                             |
-| `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                            |
-| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                    |
+| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
+| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
+| `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
+| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 


### PR DESCRIPTION
## Summary

Closes #88. Four small refinements to `handoff search` to match the issue's acceptance list:

- **`--fixed` / `-F`** — treats the query as a literal string by escaping regex metacharacters before compiling. No `rg` shell-out (Node-side RegExp is enough and has no binary dependency).
- **Two-pass clean filter now covers assistant turns.** Previous impl only checked `extractPrompts`; tool_use-only raw matches were dropped, but assistant text hits were lost too. New impl checks `extractPrompts` first, then falls back to `extractTurns`. Snippet prefix reflects which side matched (`user:` vs `assistant:`).
- **JSON shape matches the documented contract** — `{cli, short_id, session_id, path, cwd, mtime, match_snippet}`. Adds `session_id` + `path`; renames `snippet` → `match_snippet`.
- **`--from` is canonical on `search` and `remote-list`** (`push`/`pull` already use it). `--cli` kept as a silent legacy alias for one minor-version window. Error messages unified to `--from must be one of`.

### Scoping note

The issue lists one more acceptance bullet — "Drill-in hint references the new `pull <id> --summary` verb (coordinates with #87)" — that **is not in this PR**. #87 hasn't landed, so switching the hint now would emit a stale verb. The hint stays as `describe <cli> <short-uuid>` until #87 updates it in the same commit that introduces `pull --summary`.

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/handoff-binary-subs.bats` → 23/23 green (3 net-new tests: `--from` canonical, `-F` short flag, assistant-turn match; plus tool_use-drop + JSON-shape rewrites)
- [x] `npx bats plugins/dotclaude/tests/bats/` → 283/283 green (full regression)
- [x] `npm test` → 480/480 vitest green
- [x] `npm run coverage` → branches 80.3% (above 80% floor)
- [x] `node plugins/dotclaude/bin/dotclaude-handoff.mjs --help` shows `--fixed, -F` in the options list
- [x] `node plugins/dotclaude/bin/dotclaude-handoff.mjs search 'foo.bar()' -F` against a seeded claude session returns the match without a regex parse error

## Spec ID

dotclaude-core
