### PR TITLE
feat(handoff): collapse local surface under pull verb, rename remote pull→fetch (#87)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,209 +1,209 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-22T22:03:40.343Z",
+  "generatedAt": "2026-04-23T14:26:01.962Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
       "checksum": "sha256:f7a8fa0598d7925de95ed3829ea677a2df58fa3db93e9ff290944bb686fad7d7",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
       "checksum": "sha256:cf3ac020cd3ce7d8fc11dbf4f5f5a2ffa5e1d6443e60cd10179b564bd77894cc",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
       "checksum": "sha256:cabbf4bfe2deff3a328f15e025dfc0d63369825c0c32574790251f2793e62aeb",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
       "checksum": "sha256:cf987369294337fff90fc62e1d73d235d35055055dc8e4fbfb33a492f7cd38b5",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
       "checksum": "sha256:50573c4199f27083286fdbc3760b2f684105b4a6df39b7cb47094d7c0e5327f7",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
       "checksum": "sha256:3f7b90b69172e29cdcf66713f2708f9741003d05cc12cf9d81ff79ff9c5b692c",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
       "checksum": "sha256:7d888f6964725d82687fb61b68ff961f041f95d2c9eef7b5282061229499ca90",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
       "checksum": "sha256:6ffc091e9bd421798c5b7990f21d095563d69c59c3e2bd10d35b554b3ec225d9",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
       "checksum": "sha256:d0bc84f956c0ee8c176cf76a79374e8defb0bd2487c8340a2e2a1d9e04d8a1cc",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
       "checksum": "sha256:52e610b195a43fdd460106c1bdf56b32803cb86d163a4303274773ea3900bf79",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2dc1c4213ab6650d685e7b2243ddda91fce2ceba224ca3da3951afeb37d12946",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:0a541a50a4d8bb063eb74111700e8bc63a39b8553a581cf3e96e9d6b87b348f9",
+      "checksum": "sha256:b2e4ba3ab3b0524e5d1835d3a4cf1fb65663c1427228e4dc8d958446f858ba8f",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "review-prs",
       "path": ".claude/commands/review-prs.md",
       "checksum": "sha256:e01a0432cd1a6cf6fe4a60cfc2b02f7cab3cde418062ca85beadc5491548bc71",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:347be395b0f8003816b4f3ed3bb777a63a3f9f7ae300d6f050b499ff66cfd3b0",
       "dependencies": [],
-      "lastValidated": "2026-04-22"
+      "lastValidated": "2026-04-23"
     }
   ]
 }

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotclaude.dev/schemas/index.schema.json",
-  "generatedAt": "2026-04-20T19:26:06.654Z",
+  "generatedAt": "2026-04-23T14:45:59.879Z",
   "version": "0.11.0",
   "artifacts": [
     {
@@ -10,9 +10,15 @@
       "name": "agents-search",
       "description": "Discover, search, and manage Claude Code agents. Use when you want to find available agents, list installed agents, or refresh the agent catalog. Triggers on: \"search agents\", \"list agents\", \"find agent\", \"what agents\", \"agent catalog\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -38,9 +44,16 @@
       "name": "audit-and-fix",
       "description": "Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to \"audit and fix\" or kicks off an overnight cleanup run.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -58,7 +71,9 @@
         "task": [],
         "maturity": "draft"
       },
-      "related": ["aws-specialist"]
+      "related": [
+        "aws-specialist"
+      ]
     },
     {
       "id": "aws-specialist",
@@ -67,9 +82,16 @@
       "name": "aws-specialist",
       "description": "Deep-dive AWS architecture review, debugging, and service design. Use for structured investigations of AWS-specific issues, cost or IAM audits, and multi-service design reviews. Triggers on: \"AWS audit\", \"AWS design review\", \"IAM review\", \"cost audit AWS\", \"review my VPC\", \"AWS troubleshooting\", \"Lambda deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["aws"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "aws"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -95,9 +117,16 @@
       "name": "azure-specialist",
       "description": "Deep-dive Azure architecture review, debugging, and service design. Use for structured investigations of Azure-specific issues, identity or cost audits, and multi-service design reviews. Triggers on: \"Azure audit\", \"Azure design review\", \"EntraID review\", \"Managed Identity debug\", \"review my Azure\", \"Azure troubleshooting\", \"AKS deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["azure"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "azure"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -123,9 +152,15 @@
       "name": "changelog",
       "description": "Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -177,9 +212,16 @@
       "name": "create-assessment",
       "description": "Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -192,9 +234,16 @@
       "name": "create-audit",
       "description": "Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -207,9 +256,16 @@
       "name": "create-inspection",
       "description": "Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -235,9 +291,17 @@
       "name": "crossplane-specialist",
       "description": "Deep-dive Crossplane platform review: XRD design, Composition correctness, provider config audit, managed resource health, and GitOps integration. Use for structured investigations of stuck Claims, composition pipeline bugs, and credential injection patterns. Triggers on: \"Crossplane audit\", \"XRD review\", \"Composition debug\", \"stuck Claim\", \"managed resource stuck\", \"provider config review\", \"Crossplane GitOps\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["crossplane", "kubernetes"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "crossplane",
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -263,9 +327,16 @@
       "name": "dependabot-sweep",
       "description": "Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.\n",
       "facets": {
-        "domain": ["devex", "security"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex",
+          "security"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -291,9 +362,16 @@
       "name": "detect-flaky",
       "description": "Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["testing", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "testing",
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -345,9 +423,16 @@
       "name": "fix-with-evidence",
       "description": "Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -386,9 +471,16 @@
       "name": "gcp-specialist",
       "description": "Deep-dive Google Cloud architecture review, debugging, and service design. Use for structured investigations of GCP-specific issues, IAM or cost audits, and multi-service design reviews. Triggers on: \"GCP audit\", \"GCP design review\", \"Workload Identity debug\", \"IAM review GCP\", \"review my GKE\", \"GCP troubleshooting\", \"Cloud Run deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["gcp"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "gcp"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -401,9 +493,15 @@
       "name": "git",
       "description": "Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -416,9 +514,16 @@
       "name": "ground-first",
       "description": "Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -429,14 +534,21 @@
       "type": "skill",
       "path": "skills/handoff/SKILL.md",
       "name": "handoff",
-      "description": "Transfer conversation context between agentic CLIs (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a source session transcript by UUID and produces either an inline summary, a paste-ready handoff digest, a written markdown file, or a branch in a user-owned private git repo that another machine can pull. Use when switching agents mid-task, recovering context, or moving between Windows/Linux/macOS setups. Triggers on: \"handoff\", \"transfer context\", \"continue in codex\", \"continue in claude\", \"continue in copilot\", \"switch to codex\", \"switch to claude\", \"what was that session about\", \"claude --resume\", \"copilot --resume\", \"codex resume\", \"find the session where\", \"search sessions\", \"which session did I\", \"push handoff\", \"pull handoff\", \"handoff to other machine\", \"resume on my other laptop\".\n",
+      "description": "Transfer conversation context between agentic CLIs (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a source session transcript by UUID and produces either an inline summary, a paste-ready handoff digest, a written markdown file, or a branch in a user-owned private git repo that another machine can fetch. Use when switching agents mid-task, recovering context, or moving between Windows/Linux/macOS setups. Triggers on: \"handoff\", \"transfer context\", \"continue in codex\", \"continue in claude\", \"continue in copilot\", \"switch to codex\", \"switch to claude\", \"what was that session about\", \"claude --resume\", \"copilot --resume\", \"codex resume\", \"find the session where\", \"search sessions\", \"which session did I\", \"push handoff\", \"fetch handoff\", \"handoff to other machine\", \"resume on my other laptop\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation",
+          "debugging"
+        ],
         "maturity": "draft"
       },
-      "version": "1.0.0",
+      "version": "1.1.0",
       "owner": "@kaiohenricunha"
     },
     {
@@ -464,7 +576,9 @@
         "task": [],
         "maturity": "draft"
       },
-      "related": ["kubernetes-specialist"]
+      "related": [
+        "kubernetes-specialist"
+      ]
     },
     {
       "id": "kubernetes-specialist",
@@ -473,9 +587,16 @@
       "name": "kubernetes-specialist",
       "description": "Deep-dive Kubernetes troubleshooting, workload design, and cluster health review. Use when you need a structured investigation of a cluster issue, a design review of Kubernetes manifests, or a health audit of a namespace or workload. Triggers on: \"debug kubernetes\", \"why is my pod\", \"review my manifests\", \"cluster health\", \"kubernetes design review\", \"k8s audit\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["kubernetes"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -488,9 +609,16 @@
       "name": "markdown",
       "description": "Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.\n",
       "facets": {
-        "domain": ["devex", "writing"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex",
+          "writing"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -503,9 +631,16 @@
       "name": "merge-pr",
       "description": "Merge a pull request only after full local verification, with an optional data-regression gate for paths configured in docs/repo-facts.json.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -531,9 +666,16 @@
       "name": "pre-pr",
       "description": "Pre-PR quality gate: simplify changed code, security-review the diff, run the full test suite, and surface a go/no-go summary before opening a pull request.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -559,9 +701,16 @@
       "name": "pulumi-specialist",
       "description": "Deep-dive Pulumi stack review, component design, Automation API audit, and secrets management. Use for structured investigations of Pulumi stack drift, ComponentResource coupling, ESC configuration, and Automation API workflows. Triggers on: \"Pulumi audit\", \"stack review\", \"Automation API review\", \"ComponentResource design\", \"ESC audit\", \"Pulumi secrets\", \"Pulumi testing\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["pulumi"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "pulumi"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -574,9 +723,15 @@
       "name": "review-pr",
       "description": "Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -589,9 +744,15 @@
       "name": "review-prs",
       "description": "Batch-review multiple PRs in parallel: dispatch one sub-agent per PR in an isolated worktree, aggregate results into a summary table.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -630,9 +791,16 @@
       "name": "security-review",
       "description": "Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.\n",
       "facets": {
-        "domain": ["devex", "security"],
-        "platform": ["none"],
-        "task": ["review"],
+        "domain": [
+          "devex",
+          "security"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -645,9 +813,15 @@
       "name": "spec",
       "description": "Create structured engineering specs through interactive pairing. Use when the user wants to create a spec, design doc, technical specification, architecture document, RFC, or engineering plan. Triggers on \"let's spec this out\", \"create a spec\", \"design doc\", \"write a technical plan\", \"plan the architecture\". Works for greenfield and brownfield projects. Outputs to docs/specs/.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -660,9 +834,16 @@
       "name": "terraform-specialist",
       "description": "Deep-dive Terraform architecture review, module design, state management, and migration. Use for structured investigations of Terraform workspaces, provider configuration, module coupling, import workflows, and test coverage. Triggers on: \"Terraform audit\", \"module review\", \"state management\", \"Terraform import\", \"workspace design\", \"provider config review\", \"Terraform testing\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terraform"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -688,9 +869,17 @@
       "name": "terragrunt-specialist",
       "description": "Deep-dive Terragrunt hierarchy review, DRY pattern audits, and run-all orchestration analysis. Use for structured investigations of multi-environment Terragrunt layouts, dependency graphs, remote state config, and hook correctness. Triggers on: \"Terragrunt audit\", \"run-all review\", \"dependency block\", \"DRY pattern review\", \"env hierarchy audit\", \"mock_outputs\", \"terragrunt hooks\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terraform", "terragrunt"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform",
+          "terragrunt"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -716,9 +905,16 @@
       "name": "validate-spec",
       "description": "Audit an already-implemented spec against the codebase. Walks each constraint (ARCH-N, PERF-N, KD-N, etc.) and acceptance criterion, grounds findings in file:line evidence, runs the spec.json acceptance_commands, and writes a single audit doc to docs/audits/. Use whenever the user asks to \"validate a spec\", \"audit a spec\", \"check if spec is implemented\", \"verify the spec is done\", \"is this spec really done\", or otherwise wants closure on spec-driven work. Read-only against the spec — produces an audit, never modifies the spec itself.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -731,9 +927,16 @@
       "name": "veracity-audit",
       "description": "Audit a data pipeline for Veracity and Value. Dispatches data-scientist, compliance-auditor, and data-engineer agents with project context injected at dispatch time. All source paths are supplied via flags — no defaults, no project assumptions. Subcommands: audit (full pipeline walk), score-check (scoring math only), gate-check (gate coverage only), source-trace <label> (single source end-to-end). Invoke when: \"audit pipeline\", \"veracity check\", \"scoring math correct?\", \"check gates\", \"trace source\", \"verify quality gates\", \"formula correct?\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -33,8 +33,13 @@
       "terraform-specialist",
       "terragrunt-specialist"
     ],
-    "security": ["dependabot-sweep", "security-review"],
-    "writing": ["markdown"]
+    "security": [
+      "dependabot-sweep",
+      "security-review"
+    ],
+    "writing": [
+      "markdown"
+    ]
   },
   "platform": {
     "none": [
@@ -56,15 +61,38 @@
       "validate-spec",
       "veracity-audit"
     ],
-    "aws": ["aws-specialist"],
-    "azure": ["azure-specialist"],
-    "crossplane": ["crossplane-specialist"],
-    "kubernetes": ["crossplane-specialist", "kubernetes-specialist"],
-    "github-actions": ["dependabot-sweep", "merge-pr", "review-pr", "review-prs"],
-    "gcp": ["gcp-specialist"],
-    "pulumi": ["pulumi-specialist"],
-    "terraform": ["terraform-specialist", "terragrunt-specialist"],
-    "terragrunt": ["terragrunt-specialist"]
+    "aws": [
+      "aws-specialist"
+    ],
+    "azure": [
+      "azure-specialist"
+    ],
+    "crossplane": [
+      "crossplane-specialist"
+    ],
+    "kubernetes": [
+      "crossplane-specialist",
+      "kubernetes-specialist"
+    ],
+    "github-actions": [
+      "dependabot-sweep",
+      "merge-pr",
+      "review-pr",
+      "review-prs"
+    ],
+    "gcp": [
+      "gcp-specialist"
+    ],
+    "pulumi": [
+      "pulumi-specialist"
+    ],
+    "terraform": [
+      "terraform-specialist",
+      "terragrunt-specialist"
+    ],
+    "terragrunt": [
+      "terragrunt-specialist"
+    ]
   },
   "task": {
     "debugging": [

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -1,29 +1,32 @@
 #!/usr/bin/env node
 /**
- * dotclaude-handoff — five-form cross-agent / cross-machine handoff.
+ * dotclaude-handoff — four-verb cross-agent / cross-machine handoff (#87).
  *
  * Usage:
  *   dotclaude handoff                              print usage and exit 0 (#86)
- *   dotclaude handoff <query>                      local cross-agent: emit <handoff> block
+ *   dotclaude handoff pull [<id>] [--summary] [-o <path|auto|->] [--from <cli>] [--to <cli>]
+ *                                                  render a local session: <handoff> block (default),
+ *                                                  --summary for describe-style markdown, -o to write to disk.
+ *   dotclaude handoff fetch [<query>] [--from <cli>] [--verify]
+ *                                                  fetch a remote handoff branch from DOTCLAUDE_HANDOFF_REPO.
  *   dotclaude handoff push [<query>] [--tag <label>]
- *   dotclaude handoff pull [<query>]
+ *                                                  commit a local session as a handoff branch to the transport repo.
  *   dotclaude handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit <N>|--all]
+ *   dotclaude handoff search <query> [--from <cli>] [--since <ISO>] [--limit <N>] [--fixed] [--json]
+ *   dotclaude handoff remote-list [--from <cli>] [--since <ISO>] [--limit <N>]
  *   dotclaude handoff doctor
- *   dotclaude handoff remote-list [--cli <cli>] [--since <ISO>] [--limit <N>]
- *   dotclaude handoff search <query> [--cli <cli>] [--since <ISO>] [--limit <N>]
  *
- * Remote transport is always git: push/pull commit a `handoff/<cli>/<short>`
- * branch into the user-owned private repo named by `DOTCLAUDE_HANDOFF_REPO`.
+ * Deprecated aliases (stderr notice, removed in 0.14.0; set DOTCLAUDE_QUIET=1 to suppress):
+ *   describe <cli> <id>  → `pull <id> --summary`
+ *   digest   <cli> <id>  → `pull <id>`
+ *   file     <cli> <id>  → `pull <id> -o auto`
+ *   <query>              → `pull <query>`
  *
- * Power-user sub-commands (still work):
- *   resolve   <cli> <id>         print resolved session file path
- *   describe  <cli> <id>         inline summary (markdown or --json)
- *   digest    <cli> <id>         full <handoff> block for paste
- *   file      <cli> <id>         write markdown handoff doc to disk
+ * `resolve <cli> <id>` stays unchanged — scripting primitive, not user-facing.
  *
- * `<query>` resolves across all three CLIs (claude, copilot, codex):
+ * `<id>` / `<query>` resolves across all three CLIs (claude, copilot, codex):
  * full UUID, short UUID (first 8 hex), `latest`, or a named alias
- * (Claude customTitle, Codex thread_name).
+ * (Claude customTitle, Codex thread_name). `latest` is host-scoped (#85).
  *
  * Exits: 0 ok, 2 not-found / runtime error, 64 usage error.
  */
@@ -91,9 +94,9 @@ const CLIS = new Set(["claude", "copilot", "codex"]);
 const META = {
   name: "dotclaude-handoff",
   synopsis:
-    "dotclaude handoff [<query>|push|pull|list|doctor|remote-list|search] [args...] [--from <cli>] [--to <cli>] [--tag <label>] [--cli <cli>] [--since <ISO>] [--limit <N>] [--verify]",
+    "dotclaude handoff [pull|fetch|list|search|push|doctor|remote-list] [args...] [--from <cli>] [--to <cli>] [--summary] [-o <path>] [--tag <label>] [--cli <cli>] [--since <ISO>] [--limit <N>] [--verify]",
   description:
-    "Cross-agent and cross-machine session handoff. Bare <query> emits a <handoff> block for local cross-agent. push/pull/list handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO). push/pull auto-run a preflight check (cached 5 min); --verify forces re-run.",
+    "Cross-agent and cross-machine session handoff. `pull <id>` renders a local session as <handoff> block (or --summary / -o <path>). push/fetch handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO). push/fetch auto-run a preflight check (cached 5 min); --verify forces re-run.",
   flags: {
     tag: { type: "string" },
     from: { type: "string" },
@@ -102,12 +105,14 @@ const META = {
     since: { type: "string" },
     cli: { type: "string" },
     "out-dir": { type: "string" },
+    output: { type: "string", short: "o" },
     local: { type: "boolean" },
     remote: { type: "boolean" },
     verify: { type: "boolean" },
     "force-collision": { type: "boolean" },
     all: { type: "boolean" },
     fixed: { type: "boolean", short: "F" },
+    summary: { type: "boolean" },
   },
 };
 
@@ -199,6 +204,38 @@ function resolveNarrowed(cli, id) {
   return { cli, path: r.stdout.trim() };
 }
 
+/**
+ * Local resolver variant for the `pull` verb. Mirrors resolveAny /
+ * resolveNarrowed but intercepts the no-match path so the binary can
+ * append a single stderr hint (`for remote handoffs use fetch <id>`)
+ * when a remote transport is configured — without auto-forwarding.
+ * Collisions in the union path still route through resolveAny's TTY
+ * prompt / non-TTY candidate dump.
+ *
+ * @param {string} id
+ * @param {string|null} narrowTo   one of CLIS, or null for union lookup.
+ * @returns {Promise<{cli: string, path: string}>}
+ */
+async function resolveLocalForPull(id, narrowTo) {
+  const args = narrowTo ? [narrowTo, id] : ["any", id];
+  const r = runScript(RESOLVE_SH, args);
+  if (r.status === 0) {
+    const path = r.stdout.trim();
+    const cli = narrowTo ?? cliFromPath(path);
+    return { cli, path };
+  }
+  const stderr = r.stderr;
+  if (!narrowTo && stderr.includes("multiple sessions match")) {
+    return await resolveAny(id);
+  }
+  const msg = stderr.trim() || (narrowTo ? `no ${narrowTo} session matches: ${id}` : `no session matches: ${id}`);
+  process.stderr.write(`dotclaude-handoff: ${msg}\n`);
+  if (process.env.DOTCLAUDE_HANDOFF_REPO) {
+    process.stderr.write("for remote handoffs use `fetch <id>`\n");
+  }
+  process.exit(r.status === 64 ? EXIT_CODES.USAGE : 2);
+}
+
 async function promptCollisionChoice(query, candidates) {
   process.stderr.write(`dotclaude-handoff: multiple sessions match "${query}":\n`);
   candidates.forEach((c, i) => {
@@ -224,7 +261,79 @@ function cliFromPath(path) {
   return "claude";
 }
 
-// ---- describe renderer (bin-only) --------------------------------------
+// ---- describe / digest renderers (bin-only) ---------------------------
+
+/**
+ * Structured equivalent of `renderHandoffBlock`. The block caps prompts/turns
+ * for readability; the JSON returns full arrays so downstream tooling can
+ * apply its own trimming. Fields mirror the issue #87 contract:
+ *   {origin, user_prompts, assistant_turns, next_step_suggestion, to}
+ */
+function buildDigestJson(meta, prompts, turns, toCli) {
+  return {
+    origin: meta,
+    user_prompts: prompts,
+    assistant_turns: turns,
+    next_step_suggestion: nextStepFor(toCli),
+    to: toCli,
+  };
+}
+
+/**
+ * Route a rendered body to stdout, an auto-placed markdown file, or a
+ * caller-specified path. Shared between `pull` (digest) and
+ * `pull --summary` so both forms honor `-o <path|auto|->` identically.
+ *
+ * - `out === undefined` or `out === "-"` → stdout, caller provides trailing `\n`.
+ * - `out === "auto"` → write a disk envelope to
+ *   `<git-root>/docs/handoffs/<YYYY-MM-DD>-<cli>-<short>.md` (falls back to
+ *   `$HOME/.claude/handoffs/` off-repo). Kind switches the top heading.
+ * - any other string → absolute/relative path; body written verbatim.
+ */
+function writeOutput(body, out, meta, kind, { prompts, sourcePath, toCli }) {
+  if (out === undefined || out === "-") {
+    process.stdout.write(body.endsWith("\n") ? body : body + "\n");
+    return;
+  }
+  if (out === "auto") {
+    const gitRes = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+    const target =
+      gitRes.status === 0 && gitRes.stdout.trim()
+        ? join(gitRes.stdout.trim(), "docs", "handoffs")
+        : join(process.env.HOME ?? "", ".claude", "handoffs");
+    mkdirSync(target, { recursive: true });
+    const today = new Date().toISOString().slice(0, 10);
+    const shortId = meta.short_id ?? "unknown";
+    const outPath = join(target, `${today}-${meta.cli}-${shortId}.md`);
+    const heading = kind === "summary" ? "Handoff summary" : "Handoff";
+    const arrow = toCli ? ` → ${toCli}` : "";
+    const envelope = [
+      `# ${heading}: ${meta.cli}${arrow}`,
+      "",
+      `_Generated: ${new Date().toISOString()}_`,
+      `_Origin session: \`${meta.session_id ?? "?"}\` (cwd: \`${meta.cwd ?? "?"}\`)_`,
+      "",
+      body,
+      "",
+      "---",
+      "",
+      "## Full user prompt log",
+      "",
+      ...(prompts ?? []).map((p, i) => `${i + 1}. ${p}`),
+      "",
+      "## Notes",
+      "",
+      `- Source transcript: \`${sourcePath ?? "?"}\``,
+      `- Prompts: ${(prompts ?? []).length} (verbatim); assistant turns summarized above.`,
+    ].join("\n");
+    writeFileSync(outPath, envelope + "\n");
+    process.stdout.write(`${outPath}\n`);
+    return;
+  }
+  const outPath = resolvePath(out.toString());
+  writeFileSync(outPath, body.endsWith("\n") ? body : body + "\n");
+  process.stdout.write(`${outPath}\n`);
+}
 
 function renderDescribeMarkdown(meta, prompts) {
   const lines = [];
@@ -510,9 +619,10 @@ async function main() {
 
   // ---- breaking-change shim ---------------------------------------------
   // A lone CLI name is never a valid query under the new surface, so
-  // catch `push/pull claude|copilot|codex` (with or without a trailing
-  // positional) and point the user at --from.
-  if ((first === "push" || first === "pull") && CLIS.has(second)) {
+  // catch `push/pull/fetch claude|copilot|codex` (with or without a
+  // trailing positional) and point the user at --from. Covers both the
+  // remote (push/fetch) and the new local (pull) verb families.
+  if ((first === "push" || first === "pull" || first === "fetch") && CLIS.has(second)) {
     fail(
       EXIT_CODES.USAGE,
       `${first} no longer takes a <cli> positional; use --from ${second} or drop it entirely`
@@ -616,7 +726,7 @@ async function main() {
         `| ${h.cli.padEnd(7)} | ${h.short_id.padEnd(10)} | ${(h.cwd ?? "").padEnd(37)} | ${when.padEnd(19)} | ${h.match_snippet.padEnd(40)} |\n`
       );
     }
-    process.stdout.write("\nDrill in with `dotclaude handoff describe <cli> <short-uuid>`.\n");
+    process.stdout.write("\nDrill in with `dotclaude handoff pull <short-uuid> --summary`.\n");
     process.exit(EXIT_CODES.OK);
   }
 
@@ -730,6 +840,41 @@ async function main() {
   }
 
   if (first === "pull") {
+    // Local render verb. Collapses the previous describe/digest/file/bare
+    // surface under one verb with --summary and -o <path|auto|->. Always
+    // runs the local resolver — never forwards to remote. When local misses
+    // and DOTCLAUDE_HANDOFF_REPO is set, resolveLocalForPull appends a
+    // single stderr hint pointing at `fetch` (#87).
+    const id = second ?? "latest";
+    const summaryMode = Boolean(argv.flags.summary);
+    const out = argv.flags.output != null ? String(argv.flags.output) : undefined;
+    let hit;
+    if (id === "latest") {
+      // Host-scope the `latest` shortcut per #85: --from > detected host > union.
+      const { hit: latestHit, note } = await resolveLatestWithHostScope({ fromCli, detectedHost });
+      if (note) process.stderr.write(note + "\n");
+      hit = latestHit;
+    } else {
+      hit = await resolveLocalForPull(id, fromCli);
+    }
+    const meta = extractMeta(hit.cli, hit.path);
+    const prompts = extractPrompts(hit.cli, hit.path);
+    if (summaryMode) {
+      const body = argv.json
+        ? JSON.stringify({ origin: meta, user_prompts: prompts }, null, 2)
+        : renderDescribeMarkdown(meta, prompts);
+      writeOutput(body, out, meta, "summary", { prompts, sourcePath: hit.path, toCli });
+      process.exit(EXIT_CODES.OK);
+    }
+    const turns = extractTurns(hit.cli, hit.path, limit);
+    const body = argv.json
+      ? JSON.stringify(buildDigestJson(meta, prompts, turns, toCli), null, 2)
+      : renderHandoffBlock(meta, prompts, turns, toCli);
+    writeOutput(body, out, meta, "digest", { prompts, sourcePath: hit.path, toCli });
+    process.exit(EXIT_CODES.OK);
+  }
+
+  if (first === "fetch") {
     const verify = Boolean(argv.flags.verify);
     const verbose = Boolean(argv.verbose);
     try {
@@ -738,7 +883,7 @@ async function main() {
       process.stdout.write(content.endsWith("\n") ? content : content + "\n");
       process.exit(EXIT_CODES.OK);
     } catch (err) {
-      fail(2, `pull failed: ${err.message}`);
+      fail(2, `fetch failed: ${err.message}`);
     }
   }
 
@@ -750,6 +895,20 @@ async function main() {
     if (!cli) fail(EXIT_CODES.USAGE, `${sub} requires <cli>`);
     if (!CLIS.has(cli)) fail(EXIT_CODES.USAGE, `cli must be one of: ${[...CLIS].join(", ")}`);
     if (!id) fail(EXIT_CODES.USAGE, `${sub} requires an identifier after <cli>`);
+    // describe/digest/file are deprecation aliases for `pull <id>` variants
+    // (#87). Emit a stderr pointer unless the caller opts out via
+    // DOTCLAUDE_QUIET=1 (CI pipelines that can't update yet). `resolve`
+    // stays as a scripting primitive and is not deprecated.
+    if (sub !== "resolve" && process.env.DOTCLAUDE_QUIET !== "1") {
+      const replacement = {
+        describe: `pull ${id} --summary${argv.json ? " --json" : ""}`,
+        digest: `pull ${id}`,
+        file: `pull ${id} -o auto`,
+      }[sub];
+      process.stderr.write(
+        `dotclaude-handoff: \`${sub} ${cli} ${id}\` is deprecated — use \`${replacement}\` instead (removed in 0.14.0)\n`
+      );
+    }
     const { path } = resolveNarrowed(cli, id);
     if (sub === "resolve") {
       process.stdout.write(`${path}\n`);
@@ -811,10 +970,15 @@ async function main() {
     }
   }
 
-  // ---- bare <query>: local cross-agent (implicit digest) -----------------
-  // `latest` is host-scoped (explicit UUIDs/aliases pass through — narrowing
-  // them could hide a legitimate cross-agent match).
+  // ---- bare <query>: deprecated alias for `pull <query>` (#87) ----------
+  // Collapsed under `pull` for a four-verb surface. Behavior unchanged
+  // (digest emitted to stdout); DOTCLAUDE_QUIET=1 suppresses the notice.
   const query = first;
+  if (process.env.DOTCLAUDE_QUIET !== "1") {
+    process.stderr.write(
+      `dotclaude-handoff: bare \`<query>\` is deprecated — use \`pull ${query}\` instead (removed in 0.14.0)\n`
+    );
+  }
   let hit, fallbackNote;
   if (query === "latest") {
     ({ hit, note: fallbackNote } = await resolveLatestWithHostScope({ fromCli, detectedHost }));

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -287,10 +287,10 @@ function buildDigestJson(meta, prompts, turns, toCli) {
  * - `out === undefined` or `out === "-"` → stdout, caller provides trailing `\n`.
  * - `out === "auto"` → write a disk envelope to
  *   `<git-root>/docs/handoffs/<YYYY-MM-DD>-<cli>-<short>.md` (falls back to
- *   `$HOME/.claude/handoffs/` off-repo). Kind switches the top heading.
+ *   `$HOME/.claude/handoffs/` off-repo). `kind` switches the heading.
  * - any other string → absolute/relative path; body written verbatim.
  */
-function writeOutput(body, out, meta, kind, { prompts, sourcePath, toCli }) {
+function writeOutput(body, out, meta, { kind, prompts, sourcePath, toCli }) {
   if (out === undefined || out === "-") {
     process.stdout.write(body.endsWith("\n") ? body : body + "\n");
     return;
@@ -611,6 +611,13 @@ function resolveFilterCli() {
   return v;
 }
 
+function warnDeprecated(old, replacement) {
+  if (process.env.DOTCLAUDE_QUIET === "1") return;
+  process.stderr.write(
+    `dotclaude-handoff: ${old} is deprecated — use \`${replacement}\` instead (removed in 0.14.0)\n`
+  );
+}
+
 async function main() {
   if (argv.positional.length === 0) {
     process.stdout.write(helpText(META) + "\n");
@@ -863,14 +870,14 @@ async function main() {
       const body = argv.json
         ? JSON.stringify({ origin: meta, user_prompts: prompts }, null, 2)
         : renderDescribeMarkdown(meta, prompts);
-      writeOutput(body, out, meta, "summary", { prompts, sourcePath: hit.path, toCli });
+      writeOutput(body, out, meta, { kind: "summary", prompts, sourcePath: hit.path, toCli });
       process.exit(EXIT_CODES.OK);
     }
     const turns = extractTurns(hit.cli, hit.path, limit);
     const body = argv.json
       ? JSON.stringify(buildDigestJson(meta, prompts, turns, toCli), null, 2)
       : renderHandoffBlock(meta, prompts, turns, toCli);
-    writeOutput(body, out, meta, "digest", { prompts, sourcePath: hit.path, toCli });
+    writeOutput(body, out, meta, { kind: "digest", prompts, sourcePath: hit.path, toCli });
     process.exit(EXIT_CODES.OK);
   }
 
@@ -899,15 +906,13 @@ async function main() {
     // (#87). Emit a stderr pointer unless the caller opts out via
     // DOTCLAUDE_QUIET=1 (CI pipelines that can't update yet). `resolve`
     // stays as a scripting primitive and is not deprecated.
-    if (sub !== "resolve" && process.env.DOTCLAUDE_QUIET !== "1") {
+    if (sub !== "resolve") {
       const replacement = {
         describe: `pull ${id} --summary${argv.json ? " --json" : ""}`,
         digest: `pull ${id}`,
         file: `pull ${id} -o auto`,
       }[sub];
-      process.stderr.write(
-        `dotclaude-handoff: \`${sub} ${cli} ${id}\` is deprecated — use \`${replacement}\` instead (removed in 0.14.0)\n`
-      );
+      warnDeprecated(`\`${sub} ${cli} ${id}\``, replacement);
     }
     const { path } = resolveNarrowed(cli, id);
     if (sub === "resolve") {
@@ -974,11 +979,7 @@ async function main() {
   // Collapsed under `pull` for a four-verb surface. Behavior unchanged
   // (digest emitted to stdout); DOTCLAUDE_QUIET=1 suppresses the notice.
   const query = first;
-  if (process.env.DOTCLAUDE_QUIET !== "1") {
-    process.stderr.write(
-      `dotclaude-handoff: bare \`<query>\` is deprecated — use \`pull ${query}\` instead (removed in 0.14.0)\n`
-    );
-  }
+  warnDeprecated("bare `<query>`", `pull ${query}`);
   let hit, fallbackNote;
   if (query === "latest") {
     ({ hit, note: fallbackNote } = await resolveLatestWithHostScope({ fromCli, detectedHost }));

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -2,7 +2,7 @@
 id: handoff
 name: handoff
 type: skill
-version: 1.0.0
+version: 1.1.0
 domain: [devex]
 platform: [none]
 task: [documentation, debugging]
@@ -12,16 +12,16 @@ description: >
   Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a
   source session transcript by UUID and produces either an inline summary,
   a paste-ready handoff digest, a written markdown file, or a branch in a
-  user-owned private git repo that another machine can pull. Use when
+  user-owned private git repo that another machine can fetch. Use when
   switching agents mid-task, recovering context, or moving between
   Windows/Linux/macOS setups. Triggers on: "handoff", "transfer context",
   "continue in codex", "continue in claude", "continue in copilot",
   "switch to codex", "switch to claude", "what was that session about",
   "claude --resume", "copilot --resume", "codex resume",
   "find the session where", "search sessions", "which session did I",
-  "push handoff", "pull handoff", "handoff to other machine",
+  "push handoff", "fetch handoff", "handoff to other machine",
   "resume on my other laptop".
-argument-hint: "[<query>|push|pull|list|doctor|remote-list|search] [args...]"
+argument-hint: "[pull|push|fetch|list|search|resolve|doctor] [args...]"
 tools: Glob, Read, Grep, Bash, Write
 effort: medium
 model: sonnet
@@ -39,16 +39,19 @@ bash tool.
 ## The four forms
 
 ```
-/handoff <query>                          local cross-agent: emit <handoff>
-/handoff push [<query>] [--tag <label>]   upload to transport
-/handoff pull [<query>]                   fetch from transport
+/handoff pull [<id>] [--from <cli>] [--to <cli>] [--summary] [-o <path>]
+/handoff push [<query>] [--from <cli>] [--tag <label>] [--include-transcript]
+/handoff fetch [<query>] [--from <cli>] [--verify]
 /handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
 ```
 
 A bare `/handoff` with no arguments prints usage and exits 0. Every
-remote verb is explicit.
+remote verb (`push`, `fetch`) is explicit.
 
-`<query>` auto-detects across `~/.claude/projects`,
+If `--from` is set, resolution narrows to that CLI; otherwise the host is
+auto-detected; otherwise all three roots are scanned.
+
+`<id>` / `<query>` auto-detects across `~/.claude/projects`,
 `~/.copilot/session-state`, and `~/.codex/sessions`. Accepted forms:
 full UUID, short UUID (first 8 hex), `latest`, Claude `customTitle`
 alias, Codex `thread_name` alias.
@@ -64,7 +67,7 @@ resolver (globally newest across all roots) and stderr names the
 picked session. Pass `--from <cli>` to force a specific root.
 
 **Collision model.** When `<query>` matches multiple roots (or two
-remote handoffs on `pull`): TTY → interactive prompt; non-TTY → exit 2
+remote handoffs on `fetch`): TTY → interactive prompt; non-TTY → exit 2
 with a TSV candidate list on stderr.
 
 ## Sub-commands
@@ -74,43 +77,70 @@ semantics. Brief summary:
 
 | Sub                   | Purpose                                                                                              |
 | --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `pull [<id>]`         | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk    |
 | `resolve <cli> <id>`  | Print the absolute JSONL path                                                                        |
-| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                                                  |
-| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                                 |
-| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                          |
 | `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
 | `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
-| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
+| `fetch [<handle>]`    | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
 | `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
 | `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 
-- `--from <cli>` narrows source-CLI auto-detection on `push`, `pull`,
-  bare `<query>`, and filters `list`, `search`, and `remote-list` to
-  one root. Without it, the resolver probes all three roots. `--cli`
-  is accepted as a legacy alias on `search` and `remote-list`.
+- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`,
+  `pull`, and filters `list`, `search`, and `remote-list` to one root.
+  Without it, the resolver probes all three roots. `--cli` is accepted
+  as a legacy alias on `search` and `remote-list`.
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
-  target agent. Defaults to the auto-detected host.
+  target agent. Defaults to the auto-detected host. `--from` narrows
+  the source root; `--to` still resolves to the invoking host unless
+  explicitly overridden.
+- `--summary` (on `pull`) emits a prose summary + verbatim user prompts
+  instead of the full `<handoff>` block.
+- `-o <path>` (on `pull`) controls the output destination:
+  `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`
+  (falling back to `~/.claude/handoffs/` when off-repo) and prints the
+  file path on stdout; any other string is used as the literal output path.
 - `--since <ISO>` cuts off `list` when explicitly provided, and
   cuts off `search` and `remote-list` (default 30 days).
 - `--limit <N>` caps the row count (default 20). `--all` (on `list`)
   disables the cap.
 - `--fixed` / `-F` treats the `search` query as a literal string
   instead of a regex.
-- `--tag <label>` annotates a `push` for fuzzy `pull` later.
+- `--tag <label>` annotates a `push` for fuzzy `fetch` later.
 - `--include-transcript` adds the last 50 raw turns to a `push`
   (off by default to minimise leakage).
-- `--from-file <path>` lets `pull` load a local markdown file written
-  by `file`. Works without network access.
-- `--json` is honoured by `list`, `describe`, `remote-list`, `search`.
+- `--from-file <path>` lets `fetch` load a local markdown file written
+  by `pull -o`. Works without network access.
+- `--json` is honoured by `list`, `pull`, `remote-list`, `search`.
+
+## Cross-agent behavior
+
+(a) **`pull` stdout is the transport into the model's context.** All three
+host runtimes (Claude Code, Copilot CLI, Codex via its bash tool) capture
+stdout the same way. `pull` to stdout; the runtime delivers it.
+
+(b) **`--to` on `pull` defaults to the detected host, not `--from`.** When
+`--from` is set without `--to`, `--to` still resolves to the invoking host.
+`--from` narrows the source root; `--to` tunes the next-step wording for
+where the output will be read.
+
+(c) **Self-referential pull is allowed and renders normally.** When
+host-scoped `latest` resolves to the session the command was run from,
+the digest renders the current session into its own context. Occasionally
+useful for capturing the current session via `-o auto`.
+
+(d) **`pull <unmatched>` does not auto-forward to `fetch`.** If the local
+resolver returns no match and `$DOTCLAUDE_HANDOFF_REPO` is set, a single
+stderr hint suggests `fetch <id>`. If the variable is unset, only the
+standard no-match error appears. No silent source override.
 
 ## Prerequisites
 
 Local sub-commands need only `jq` and the session files on disk.
 
-The remote transport (`push`/`pull`/`remote-list`/`doctor`) is a
+The remote transport (`push`/`fetch`/`remote-list`/`doctor`) is a
 user-owned private git repo (any provider — GitHub, GitLab, Gitea,
 self-hosted). Required:
 
@@ -136,13 +166,13 @@ handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
 
 e.g. `handoff/dotclaude/claude/2026-04/aaaa1111`. The store needs no
 setup beyond "be a reachable git repo"; `main` is never touched by
-`push` / `pull` / `remote-list`. GitHub UI + `git ls-remote` render
+`push` / `fetch` / `remote-list`. GitHub UI + `git ls-remote` render
 the branches directly.
 
 ## Auto-trigger contract
 
-When the user message matches any of these patterns, run the bare
-`<query>` form (local cross-agent digest) by default:
+When the user message matches any of these patterns, run `pull` (local
+cross-agent digest) by default:
 
 - Resume-command fragments: `claude --resume <uuid>`,
   `claude --resume "<name>"`, `copilot --resume=<uuid>`,
@@ -150,10 +180,10 @@ When the user message matches any of these patterns, run the bare
 - Natural language: "what was that session about", "continue in X",
   "switch to X", "handoff".
 
-Extract the `<query>` from the user message (UUID, short UUID, or
-named alias). The skill probes all three roots — no `<cli>` argument
-needed. If the query is missing or ambiguous, ask one clarifying
-question before proceeding.
+Extract the `<id>` from the user message (UUID, short UUID, or named
+alias). The skill probes all three roots — no `--from` argument needed.
+If the query is missing or ambiguous, ask one clarifying question before
+proceeding.
 
 ## Out of scope
 
@@ -171,3 +201,20 @@ question before proceeding.
 - **Fuzzy or semantic search.** `search` is substring/regex only.
 - **Persistent indexing.** Grep-at-query-time is fast enough for
   local session volumes; revisit only if p95 exceeds ~2s.
+
+## Deprecated aliases
+
+The following forms are deprecated as of 0.12.0 and removed in 0.14.0.
+They still function but emit a stderr warning on every invocation.
+
+| Old form                       | New form                          |
+| ------------------------------ | --------------------------------- |
+| `describe <cli> <id>`          | `pull <id> --summary`             |
+| `describe <cli> <id> --json`   | `pull <id> --summary --json`      |
+| `digest <cli> <id>`            | `pull <id>`                       |
+| `file <cli> <id>`              | `pull <id> -o auto`               |
+| `pull <query>` (remote fetch)  | `fetch <query>`                   |
+
+Set `DOTCLAUDE_QUIET=1` to suppress deprecation stderr in CI pipelines
+that cannot update callers immediately. Real errors (exit 2 / exit 64)
+are never suppressed.

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -75,16 +75,16 @@ with a TSV candidate list on stderr.
 The binary's `--help` lists the full surface and authoritative flag
 semantics. Brief summary:
 
-| Sub                   | Purpose                                                                                              |
-| --------------------- | ---------------------------------------------------------------------------------------------------- |
-| `pull [<id>]`         | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk    |
-| `resolve <cli> <id>`  | Print the absolute JSONL path                                                                        |
-| `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
-| `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
-| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
-| `fetch [<handle>]`    | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
-| `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
-| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
+| Sub                  | Purpose                                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------------------- |
+| `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk     |
+| `resolve <cli> <id>` | Print the absolute JSONL path                                                                        |
+| `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
+| `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
+| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
+| `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
+| `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
+| `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 
@@ -207,13 +207,13 @@ proceeding.
 The following forms are deprecated as of 0.12.0 and removed in 0.14.0.
 They still function but emit a stderr warning on every invocation.
 
-| Old form                       | New form                          |
-| ------------------------------ | --------------------------------- |
-| `describe <cli> <id>`          | `pull <id> --summary`             |
-| `describe <cli> <id> --json`   | `pull <id> --summary --json`      |
-| `digest <cli> <id>`            | `pull <id>`                       |
-| `file <cli> <id>`              | `pull <id> -o auto`               |
-| `pull <query>` (remote fetch)  | `fetch <query>`                   |
+| Old form                      | New form                     |
+| ----------------------------- | ---------------------------- |
+| `describe <cli> <id>`         | `pull <id> --summary`        |
+| `describe <cli> <id> --json`  | `pull <id> --summary --json` |
+| `digest <cli> <id>`           | `pull <id>`                  |
+| `file <cli> <id>`             | `pull <id> -o auto`          |
+| `pull <query>` (remote fetch) | `fetch <query>`              |
 
 Set `DOTCLAUDE_QUIET=1` to suppress deprecation stderr in CI pipelines
 that cannot update callers immediately. Real errors (exit 2 / exit 64)

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -1,13 +1,12 @@
 #!/usr/bin/env bats
-# Behavior tests for the five-form public surface of dotclaude-handoff.mjs:
+# Behavior tests for the public surface of dotclaude-handoff.mjs (#87):
 #
-#   dotclaude handoff                          # push host's current session
-#   dotclaude handoff <query>                  # local cross-agent: <handoff> block
-#   dotclaude handoff push [<query>] [--tag]   # explicit push
-#   dotclaude handoff pull  [<query>]          # pull by fuzzy match; bare = latest
-#   dotclaude handoff list                     # unified local + remote table
+#   dotclaude handoff pull  [<id>] [--summary] [-o <path>] [--from <cli>] [--to <cli>]
+#   dotclaude handoff fetch [<query>] [--from <cli>] [--verify]
+#   dotclaude handoff push  [<query>] [--tag]
+#   dotclaude handoff list
 #
-# Transport for push/pull tests: a local bare repo named by
+# Transport for push/fetch tests: a local bare repo named by
 # DOTCLAUDE_HANDOFF_REPO. The git transport is the only remote
 # transport since v0.9.0; no GitHub auth required.
 
@@ -31,7 +30,16 @@ setup() {
 {"type":"custom-title","customTitle":"my-feature","sessionId":"aaaa1111-1111-1111-1111-111111111111"}
 EOF
 
-  # Codex fixture: a rollout renamed to "refactor" (for collision with claude below)
+  # Copilot fixture — seeded before the sleep so codex remains newest.
+  mkdir -p "$TEST_HOME/.copilot/session-state/cccc3333-3333-3333-3333-333333333333"
+  COPILOT_FILE="$TEST_HOME/.copilot/session-state/cccc3333-3333-3333-3333-333333333333/events.jsonl"
+  cat > "$COPILOT_FILE" <<'EOF'
+{"type":"session.start","data":{"sessionId":"cccc3333-3333-3333-3333-333333333333","cwd":"/work/copilot","model":"gpt-4o"}}
+{"type":"user.message","data":{"content":"Implement the new feature"}}
+{"type":"assistant.message","data":{"content":"Working on it now."}}
+EOF
+
+  # Codex fixture (seeded last, after sleep → newest on disk).
   sleep 0.01
   mkdir -p "$TEST_HOME/.codex/sessions/2026/04/18"
   CODEX_FILE="$TEST_HOME/.codex/sessions/2026/04/18/rollout-2026-04-18T10-00-00-bbbb2222-2222-2222-2222-222222222222.jsonl"
@@ -42,78 +50,76 @@ EOF
 {"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"running"}]}}
 EOF
 
-  # Set up a bare git repo as the remote transport endpoint and
-  # pre-initialise it with the v2 schema pin so push/pull work without
-  # each test having to run `init` first. v0.10.0 pushRemote() refuses
-  # Set up a bare git repo for the transport. The binary writes directly
-  # to `handoff/...` branches with no init / schema-pin ceremony.
+  # Set up a bare git repo as the remote transport endpoint.
   TRANSPORT_REPO=$(mktemp -d)
   rm -rf "$TRANSPORT_REPO"
   git init -q --bare "$TRANSPORT_REPO"
   export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
 
-  export CLAUDE_FILE CODEX_FILE TRANSPORT_REPO
+  export CLAUDE_FILE COPILOT_FILE CODEX_FILE TRANSPORT_REPO
 }
 
 teardown() {
   rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
 }
 
-# -- zero-arg and <query> (local, no network) ----------------------------
+# -- help / zero-arg surface -----------------------------------------------
 
-@test "--help prints the five-form surface" {
-  # Bare invocation no longer prints usage — it executes `push`. Help
-  # lives behind --help, which is the conventional opt-in.
+@test "--help prints pull fetch and list" {
   run node "$BIN" --help
   [ "$status" -eq 0 ]
   [[ "$output" == *"push"* ]]
   [[ "$output" == *"pull"* ]]
+  [[ "$output" == *"fetch"* ]]
   [[ "$output" == *"list"* ]]
 }
 
-@test "<query>: short UUID produces <handoff> block locally" {
-  run node "$BIN" aaaa1111
+# -- pull: local resolution -----------------------------------------------
+
+@test "pull: short UUID produces <handoff> block locally" {
+  run node "$BIN" pull aaaa1111
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
   [[ "$output" == *"</handoff>"* ]]
 }
 
-@test "<query>: customTitle alias produces <handoff> block" {
-  run node "$BIN" my-feature
+@test "pull: customTitle alias produces <handoff> block" {
+  run node "$BIN" pull my-feature
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
   [[ "$output" == *"aaaa1111"* ]]
 }
 
-@test "<query>: codex thread_name alias produces <handoff> block" {
-  run node "$BIN" my-codex-task
+@test "pull: codex thread_name alias produces <handoff> block" {
+  run node "$BIN" pull my-codex-task
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
   [[ "$output" == *"bbbb2222"* ]]
 }
 
-@test "<query>: unknown identifier exits 2" {
-  run node "$BIN" nonexistent-xyz
+@test "pull: unknown identifier exits 2" {
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
+    node "$BIN" pull nonexistent-xyz
   [ "$status" -eq 2 ]
 }
 
-# -- `latest` host-scoping (#85) -----------------------------------------
+# -- pull `latest` host-scoping (#85) ------------------------------------
 
-@test "<query> latest without host signal picks globally newest (across roots)" {
+@test "pull latest without host signal picks globally newest (across roots)" {
   # setup() sleeps between fixtures so the codex file is newer. No host
   # signal → cross-root winner = codex/bbbb2222.
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
-    node "$BIN" latest
+    node "$BIN" pull latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"bbbb2222"* ]]
   [[ "$stderr" == *"host not detected"* ]]
 }
 
-@test "<query> latest with CLAUDECODE=1 narrows to claude root" {
+@test "pull latest with CLAUDECODE=1 narrows to claude root" {
   # The outer-shell probe fires; `latest` must resolve within ~/.claude
   # only, so aaaa1111 wins even though the codex fixture is newer on disk.
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \
-    node "$BIN" latest
+    node "$BIN" pull latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"aaaa1111"* ]]
   [[ "$output" != *"bbbb2222"* ]]
@@ -121,41 +127,57 @@ teardown() {
   [[ "$stderr" == *"aaaa1111"* ]]
 }
 
-@test "<query> latest --from codex overrides host detection" {
+@test "pull latest --from codex overrides host detection" {
   # --from must outrank detectedHost, mirroring push's precedence.
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \
-    node "$BIN" latest --from codex
+    node "$BIN" pull latest --from codex
   [ "$status" -eq 0 ]
   [[ "$output" == *"bbbb2222"* ]]
   [[ "$output" != *"aaaa1111"* ]]
   [[ "$stderr" == *"--from codex"* ]]
 }
 
-@test "<query> latest --from with unknown cli exits 64" {
-  run node "$BIN" latest --from bogus
+@test "pull latest --from with unknown cli exits 64" {
+  run node "$BIN" pull latest --from bogus
   [ "$status" -eq 64 ]
   [[ "$output" == *"--from must be one of"* ]]
 }
 
-@test "<query> non-latest: host detection does NOT narrow (UUID lookup stays global)" {
+@test "pull non-latest: host detection does NOT narrow (UUID lookup stays global)" {
   # A short-UUID is unambiguous — narrowing by host would hide a valid
   # cross-agent match. CLAUDECODE=1 must not prevent bbbb2222 lookup.
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \
-    node "$BIN" bbbb2222
+    node "$BIN" pull bbbb2222
   [ "$status" -eq 0 ]
   [[ "$output" == *"bbbb2222"* ]]
 }
 
-@test "<query>: collision across CLIs on non-TTY stdin exits 2 with candidate list" {
+@test "pull: collision across CLIs on non-TTY stdin exits 2 with candidate list" {
   # Introduce collision: claude customTitle "both" + codex thread_name "both"
   printf '{"type":"custom-title","customTitle":"both","sessionId":"aaaa1111-1111-1111-1111-111111111111"}\n' \
     >> "$CLAUDE_FILE"
   printf '{"type":"event_msg","payload":{"thread_name":"both","type":"thread_renamed"}}\n' \
     >> "$CODEX_FILE"
-  run node "$BIN" both </dev/null
+  run node "$BIN" pull both </dev/null
   [ "$status" -eq 2 ]
   [[ "$output" == *"claude"* ]]
   [[ "$output" == *"codex"* ]]
+}
+
+# -- pull: no-match hint for remote handoffs (#87) ------------------------
+
+@test "pull <unmatched> with DOTCLAUDE_HANDOFF_REPO set appends fetch hint" {
+  run --separate-stderr node "$BIN" pull nonexistent-tag
+  [ "$status" -eq 2 ]
+  # DOTCLAUDE_HANDOFF_REPO is set in setup(); hint must surface.
+  [[ "$stderr" == *"fetch"* ]]
+}
+
+@test "pull <unmatched> without DOTCLAUDE_HANDOFF_REPO emits no fetch hint" {
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
+    node "$BIN" pull nonexistent-tag
+  [ "$status" -eq 2 ]
+  [[ "$stderr" != *"fetch <id>"* ]]
 }
 
 # -- list (unified + filters) --------------------------------------------
@@ -181,10 +203,6 @@ teardown() {
 @test "push <query> uploads to remote (v2 branch shape)" {
   run node "$BIN" push my-feature
   [ "$status" -eq 0 ]
-  # Confirm the transport repo has a v2 branch. The month segment
-  # reflects the current UTC month; we match with a glob rather than
-  # hard-coding the date so the test stays stable across calendar
-  # rollovers. Fixture cwd `/home/u/demo` → project slug "demo".
   run bash -c "git --git-dir='$TRANSPORT_REPO' branch -a"
   [ "$status" -eq 0 ]
   [[ "$output" =~ handoff/demo/claude/[0-9]{4}-[0-9]{2}/aaaa1111 ]]
@@ -193,8 +211,6 @@ teardown() {
 @test "push --tag label embeds tag in the transport description" {
   run node "$BIN" push my-feature --tag finishing-auth
   [ "$status" -eq 0 ]
-  # Find the branch name via ls-remote, then grep its commit message
-  # for the tag segment.
   run bash -c "git --git-dir='$TRANSPORT_REPO' for-each-ref --format='%(refname:short)' 'refs/heads/handoff/demo/claude/*/aaaa1111'"
   [ "$status" -eq 0 ]
   branch="$output"
@@ -210,39 +226,38 @@ teardown() {
   [[ "$output" == *"handoff/"* ]]
 }
 
-# -- pull (fuzzy match across description fields) ------------------------
+# -- fetch (remote git transport, formerly `pull`) -----------------------
 
-@test "pull <tag-substring> fetches by tag match" {
-  # First push with a tag, then try to pull by that tag.
+@test "fetch <tag-substring> fetches by tag match" {
   run node "$BIN" push my-feature --tag finishing-auth
   [ "$status" -eq 0 ]
-  run node "$BIN" pull finishing-auth
+  run node "$BIN" fetch finishing-auth
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
 }
 
-@test "pull <short-uuid> fetches by short UUID match" {
+@test "fetch <short-uuid> fetches by short UUID match" {
   run node "$BIN" push my-feature
   [ "$status" -eq 0 ]
-  run node "$BIN" pull aaaa1111
+  run node "$BIN" fetch aaaa1111
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
 }
 
-@test "pull (zero-arg) fetches the latest" {
+@test "fetch (zero-arg) fetches the latest" {
   run node "$BIN" push my-feature --tag keepme
   [ "$status" -eq 0 ]
-  run node "$BIN" pull
+  run node "$BIN" fetch
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
 }
 
-@test "pull collision on non-TTY exits 2 with candidate list" {
+@test "fetch collision on non-TTY exits 2 with candidate list" {
   run node "$BIN" push my-feature --tag alpha
   [ "$status" -eq 0 ]
   run node "$BIN" push my-codex-task --tag alpha-beta
   [ "$status" -eq 0 ]
-  run node "$BIN" pull alpha </dev/null
+  run node "$BIN" fetch alpha </dev/null
   [ "$status" -eq 2 ]
   [[ "$output" =~ handoff/demo/(claude|codex)/ ]]
 }
@@ -257,8 +272,6 @@ teardown() {
 }
 
 @test "push <cli> <query> exits 64 with the breaking-change message" {
-  # The shim catches the removed form and points the user at --from
-  # or dropping the positional entirely.
   run node "$BIN" push claude aaaa1111
   [ "$status" -eq 64 ]
   [[ "$output" == *"no longer takes a <cli> positional"* ]]
@@ -266,19 +279,22 @@ teardown() {
 }
 
 @test "pull <cli> <query> exits 64 with the breaking-change message" {
-  # Mirror of the push shim — the parallel surface keeps parallel errors.
   run node "$BIN" pull claude aaaa1111
   [ "$status" -eq 64 ]
   [[ "$output" == *"no longer takes a <cli> positional"* ]]
   [[ "$output" == *"--from claude"* ]]
 }
 
+@test "fetch <cli> <query> exits 64 with the breaking-change message" {
+  run node "$BIN" fetch codex bbbb2222
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"no longer takes a <cli> positional"* ]]
+  [[ "$output" == *"--from codex"* ]]
+}
+
 # -- --from flag ----------------------------------------------------------
 
 @test "push --from codex (no query) narrows the fallback to the codex root" {
-  # With env cleared (no host detected), --from steers the fallback away
-  # from `resolveAny("latest")` (union) to the codex-only "latest".
-  # setup() seeds codex with bbbb2222 as the newest of its root.
   run env -i HOME="$TEST_HOME" PATH="$PATH" DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO" \
     node "$BIN" push --from codex
   [ "$status" -eq 0 ]
@@ -292,14 +308,8 @@ teardown() {
   [[ "$output" == *"--from must be one of"* ]]
 }
 
-@test "pull --from codex narrows the transport candidate pool" {
-  # Push one handoff per CLI, then pull with --from codex and confirm
-  # the returned block names the codex session (bbbb2222), not the
-  # claude one (aaaa1111). Proves --from is wired through pullRemote.
-  run node "$BIN" push my-feature
-  [ "$status" -eq 0 ]
-  run node "$BIN" push my-codex-task
-  [ "$status" -eq 0 ]
+@test "pull --from codex narrows to local codex session" {
+  # `pull --from codex` resolves locally; bbbb2222 is the only codex session.
   run node "$BIN" pull --from codex
   [ "$status" -eq 0 ]
   [[ "$output" == *"bbbb2222"* ]]
@@ -312,11 +322,21 @@ teardown() {
   [[ "$output" == *"--from must be one of"* ]]
 }
 
+@test "fetch --from codex narrows the remote candidate pool" {
+  # Push one handoff per CLI, then fetch with --from codex and confirm
+  # the returned block names the codex session (bbbb2222), not the
+  # claude one (aaaa1111). Proves --from is wired through pullRemote.
+  run node "$BIN" push my-feature
+  [ "$status" -eq 0 ]
+  run node "$BIN" push my-codex-task
+  [ "$status" -eq 0 ]
+  run node "$BIN" fetch --from codex
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222"* ]]
+  [[ "$output" != *"aaaa1111"* ]]
+}
+
 @test "push --from codex beats CLAUDECODE=1 (override precedence)" {
-  # --from is an explicit user intent and must outrank the env-var
-  # probe. Without this assertion, a regression swapping the precedence
-  # of `fromCli ?? detectedHost` would silently mis-route a user who
-  # explicitly asked for codex from inside a Claude Code session.
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
     DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO" CLAUDECODE=1 \
     node "$BIN" push --from codex
@@ -329,9 +349,6 @@ teardown() {
 # -- honest stderr fallback notes ----------------------------------------
 
 @test "push (no args, no host signal) emits stderr note about unknown host" {
-  # env -i clears CLAUDECODE / CODEX_* / COPILOT_* leaking from the
-  # parent shell, so detectHost() returns "unknown" and the bare-push
-  # path uses the union resolver with the matching stderr note.
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
     DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO" \
     node "$BIN" push
@@ -341,9 +358,6 @@ teardown() {
 }
 
 @test "push (no args, CLAUDECODE=1) emits stderr note about claude" {
-  # The claude probe fires, so the fallback narrows to the claude root.
-  # The seeded claude session (aaaa1111) is the only one under that
-  # root, so its short-UUID must surface in the stderr note.
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
     DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO" CLAUDECODE=1 \
     node "$BIN" push
@@ -352,13 +366,56 @@ teardown() {
   [[ "$stderr" == *"aaaa1111"* ]]
 }
 
+# -- cross-agent regression tests (#87) ----------------------------------
+# These lock in the invariants described in SKILL.md for all three hosts.
+
+@test "pull copilot session under CLAUDECODE=1 resolves globally and targets claude" {
+  # resolveAny finds cccc3333 in the copilot root.
+  # CLAUDECODE=1 → detected host = claude → --to defaults to claude.
+  # The Claude-tuned next-step hint must appear in the block.
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \
+    node "$BIN" pull cccc3333
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"copilot"* ]]
+  [[ "$output" == *"Continue from"* ]]
+}
+
+@test "pull zero-arg under CODEX_HOME narrows to codex root" {
+  # CODEX_HOME triggers the CODEX_* env-var probe, returning "codex" from
+  # detectHost(). Host-scoped `latest` then narrows to the codex root.
+  # bbbb2222 is the newest codex session (seeded last in setup).
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CODEX_HOME="/any/path" \
+    node "$BIN" pull
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bbbb2222"* ]]
+  [[ "$output" != *"aaaa1111"* ]]
+  [[ "$stderr" == *"latest codex session"* ]]
+  [[ "$stderr" == *"bbbb2222"* ]]
+}
+
+@test "pull --to copilot overrides detected host for the next-step hint" {
+  # --to is orthogonal to --from and detection; passing --to copilot must
+  # use the Copilot-tuned wording regardless of detected host.
+  run node "$BIN" pull aaaa1111 --to copilot
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+  [[ "$output" == *"pick up where"* ]]
+}
+
+@test "pull --from copilot under CLAUDECODE=1: source narrows, --to stays claude" {
+  # --from narrows the local resolver to the copilot root.
+  # CLAUDECODE=1 makes the detected host claude.
+  # --to must still default to claude (detected host), NOT to the --from value.
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \
+    node "$BIN" pull cccc3333 --from copilot
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"copilot"* ]]
+  [[ "$output" == *"Continue from"* ]]
+}
+
 # -- --via flag removal (v0.9.0 breaking change) -------------------------
 
 @test "--via with any value exits 64 (gist transport removed)" {
-  # The flag was deleted along with the gist transports. The argv
-  # parser is the first line of defence — it rejects --via as an
-  # unknown option, so legacy scripts surface the migration via the
-  # usage error rather than silently accepting a no-op flag.
   run node "$BIN" push --via github
   [ "$status" -eq 64 ]
   [[ "$output" == *"--via"* ]]

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff.bats
@@ -1,12 +1,13 @@
 #!/usr/bin/env bats
-# Power-user sub-command tests for plugins/dotclaude/bin/dotclaude-handoff.mjs.
+# Tests for dotclaude-handoff.mjs: the canonical `pull` verb (--summary, -o,
+# --json) + deprecated power-user aliases (describe/digest/file). `pull`
+# collapses the old four-form local surface under one verb (#87).
 #
-# The PRIMARY public surface (bare <query>, push, pull, list) is covered
-# by dotclaude-handoff-five-form.bats. This file covers the legacy
-# power-user subs still reachable for scripting: resolve / describe /
-# digest / file. Each takes an explicit <cli> <id>.
+# Remote transport tests (push/fetch/list) live in dotclaude-handoff-five-form.bats.
 
 load helpers
+
+bats_require_minimum_version 1.5.0
 
 BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
 
@@ -40,11 +41,12 @@ teardown() {
   [[ "$output" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]
 }
 
-@test "--help exits 0 and mentions the five forms" {
+@test "--help exits 0 and mentions pull fetch and list" {
   run node "$BIN" --help
   [ "$status" -eq 0 ]
   [[ "$output" == *"push"* ]]
   [[ "$output" == *"pull"* ]]
+  [[ "$output" == *"fetch"* ]]
   [[ "$output" == *"list"* ]]
 }
 
@@ -76,8 +78,10 @@ teardown() {
   [ "$status" -eq 2 ]
 }
 
-@test "describe emits markdown with cwd and prompts" {
-  run node "$BIN" describe claude aaaa1111
+# -- canonical `pull` verb --------------------------------------------------
+
+@test "pull --summary emits markdown with cwd and prompts" {
+  run node "$BIN" pull aaaa1111 --summary
   [ "$status" -eq 0 ]
   [[ "$output" == *"claude"* ]]
   [[ "$output" == *"/home/u/proj"* ]]
@@ -85,26 +89,124 @@ teardown() {
   [[ "$output" == *"Run the full test suite"* ]]
 }
 
-@test "describe --json emits structured JSON" {
-  run node "$BIN" describe claude aaaa1111 --json
+@test "pull --summary --json emits structured JSON" {
+  run node "$BIN" pull aaaa1111 --summary --json
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.origin.cli == "claude"' >/dev/null
   echo "$output" | jq -e '.origin.session_id == "aaaa1111-1111-1111-1111-111111111111"' >/dev/null
   echo "$output" | jq -e '.user_prompts | length >= 2' >/dev/null
 }
 
-@test "digest emits a <handoff> block with next-step tuned for --to codex" {
-  run node "$BIN" digest claude aaaa1111 --to codex
+@test "pull emits a <handoff> block with next-step tuned for --to codex" {
+  run node "$BIN" pull aaaa1111 --to codex
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
   [[ "$output" == *"</handoff>"* ]]
   [[ "$output" == *"Next step"* ]]
 }
 
-@test "digest --to claude produces imperative next step" {
-  run node "$BIN" digest claude aaaa1111 --to claude
+@test "pull --to claude produces imperative next step" {
+  run node "$BIN" pull aaaa1111 --to claude
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
+}
+
+@test "pull --json emits structured digest JSON" {
+  run node "$BIN" pull aaaa1111 --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.origin.cli == "claude"' >/dev/null
+  echo "$output" | jq -e '.user_prompts | length >= 2' >/dev/null
+  echo "$output" | jq -e '.assistant_turns | type == "array"' >/dev/null
+  echo "$output" | jq -e '.next_step_suggestion | type == "string"' >/dev/null
+  echo "$output" | jq -e '.to == "claude"' >/dev/null
+}
+
+@test "pull -o - forces stdout" {
+  run node "$BIN" pull aaaa1111 -o -
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff"* ]]
+}
+
+@test "pull -o <tmpfile> writes to exact path" {
+  local outfile
+  outfile=$(mktemp)
+  run node "$BIN" pull aaaa1111 -o "$outfile"
+  [ "$status" -eq 0 ]
+  [ -f "$outfile" ]
+  grep -q '<handoff' "$outfile"
+  rm -f "$outfile"
+}
+
+@test "pull -o auto writes a handoff doc to disk (non-git fallback)" {
+  # Run from a non-git temp dir so the binary falls back to
+  # $HOME/.claude/handoffs/ instead of <repo>/docs/handoffs/.
+  run bash -c "cd \"$TEST_HOME\" && HOME=\"$TEST_HOME\" node \"$BIN\" pull aaaa1111 -o auto"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  [ -f "$output" ]
+  grep -q '<handoff' "$output"
+}
+
+@test "pull --summary -o auto writes a summary note to disk" {
+  run bash -c "cd \"$TEST_HOME\" && HOME=\"$TEST_HOME\" node \"$BIN\" pull aaaa1111 --summary -o auto"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  [ -f "$output" ]
+  grep -q 'Fix the retry loop' "$output"
+}
+
+@test "pull <cli> <uuid> exits 64 with the breaking-change message" {
+  run node "$BIN" pull claude aaaa1111
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"no longer takes a <cli> positional"* ]]
+  [[ "$output" == *"--from claude"* ]]
+}
+
+@test "pull <unmatched> with DOTCLAUDE_HANDOFF_REPO set appends fetch hint" {
+  run --separate-stderr env HOME="$TEST_HOME" DOTCLAUDE_HANDOFF_REPO="/tmp/fake-repo" \
+    node "$BIN" pull nonexistent-xyz
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"fetch"* ]]
+}
+
+@test "pull <unmatched> without DOTCLAUDE_HANDOFF_REPO emits no fetch hint" {
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
+    node "$BIN" pull nonexistent-xyz
+  [ "$status" -eq 2 ]
+  [[ "$stderr" != *"fetch <id>"* ]]
+}
+
+# -- deprecated aliases (describe / digest / file) -------------------------
+
+@test "describe emits deprecation warning on stderr" {
+  run --separate-stderr node "$BIN" describe claude aaaa1111
+  [ "$status" -eq 0 ]
+  [[ "$stderr" == *"deprecated"* ]]
+  [[ "$stderr" == *"pull aaaa1111 --summary"* ]]
+  [[ "$output" == *"Fix the retry loop"* ]]
+}
+
+@test "digest emits deprecation warning on stderr" {
+  run --separate-stderr node "$BIN" digest claude aaaa1111
+  [ "$status" -eq 0 ]
+  [[ "$stderr" == *"deprecated"* ]]
+  [[ "$stderr" == *"pull aaaa1111"* ]]
+  [[ "$output" == *"<handoff"* ]]
+}
+
+@test "file emits deprecation warning on stderr" {
+  run --separate-stderr bash -c "cd \"$TEST_HOME\" && HOME=\"$TEST_HOME\" node \"$BIN\" file claude aaaa1111"
+  [ "$status" -eq 0 ]
+  [[ "$stderr" == *"deprecated"* ]]
+  [[ "$stderr" == *"pull aaaa1111 -o auto"* ]]
+}
+
+@test "DOTCLAUDE_QUIET=1 suppresses deprecation on describe" {
+  run --separate-stderr env HOME="$TEST_HOME" DOTCLAUDE_QUIET=1 \
+    node "$BIN" describe claude aaaa1111
+  [ "$status" -eq 0 ]
+  [[ "$stderr" != *"deprecated"* ]]
+  [[ "$output" == *"Fix the retry loop"* ]]
 }
 
 @test "unknown cli in power-user sub exits 64" {

--- a/plugins/dotclaude/tests/bats/handoff-integration.bats
+++ b/plugins/dotclaude/tests/bats/handoff-integration.bats
@@ -3,10 +3,12 @@
 #
 # Complements dotclaude-handoff-five-form.bats, which covers the user-facing
 # five-form surface. These tests chain multiple handoff scripts together
-# (resolve → extract → digest / push → pull → file / list → describe) to
+# (resolve → extract → digest / push → fetch → file / list → pull) to
 # verify the boundaries between them hold.
 
 load helpers
+
+bats_require_minimum_version 1.5.0
 
 RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
 EXTRACT="$REPO_ROOT/plugins/dotclaude/scripts/handoff-extract.sh"
@@ -125,9 +127,9 @@ teardown() {
   run bash -c "git --git-dir='$TRANSPORT_REPO' log --format=%s $branch"
   [ "$status" -eq 0 ]
   [[ "$output" == *"shipping-the-thing"* ]]
-  # Pull-by-tag resolves and returns a valid block (content-equivalence
+  # Fetch-by-tag resolves and returns a valid block (content-equivalence
   # already asserted above; here we just prove routing works).
-  run node "$BIN" pull shipping-the-thing
+  run node "$BIN" fetch shipping-the-thing
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
 }
@@ -159,7 +161,7 @@ teardown() {
   # assertion fails before the end of this test (no separate mktemp needed).
   local outdir="$TEST_HOME/file-out"
   mkdir -p "$outdir"
-  run node "$BIN" file claude aaaa1111 --out-dir "$outdir"
+  run --separate-stderr node "$BIN" file claude aaaa1111 --out-dir "$outdir"
   [ "$status" -eq 0 ]
   # The command prints the absolute path of the file written.
   local outpath="$output"
@@ -187,11 +189,11 @@ teardown() {
 
 # -- describe --json is a self-contained document -----------------------
 
-@test "describe --json → pipe to jq → origin.session_id equals seeded UUID" {
-  # Integration check: describe --json must be parseable by jq *and*
+@test "pull --summary --json → pipe to jq → origin.session_id equals seeded UUID" {
+  # Integration check: pull --summary --json must be parseable by jq *and*
   # expose a usable path to the session id. This is what tooling-on-top
   # (skills, agents) actually does.
-  run bash -c "node '$BIN' describe claude aaaa1111 --json | jq -r '.origin.session_id'"
+  run bash -c "node '$BIN' pull aaaa1111 --summary --json | jq -r '.origin.session_id'"
   [ "$status" -eq 0 ]
   [[ "$output" == "$CLAUDE_UUID" ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-observability.bats
+++ b/plugins/dotclaude/tests/bats/handoff-observability.bats
@@ -5,6 +5,8 @@
 
 load helpers
 
+bats_require_minimum_version 1.5.0
+
 RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
 EXTRACT="$REPO_ROOT/plugins/dotclaude/scripts/handoff-extract.sh"
 DESCRIPTION="$REPO_ROOT/plugins/dotclaude/scripts/handoff-description.sh"
@@ -80,9 +82,9 @@ teardown() {
 
 # -- JSON output contract ------------------------------------------------
 
-@test "describe --json emits valid JSON parsable by jq" {
+@test "pull --summary --json emits valid JSON parsable by jq" {
   make_claude_session_tree "$TEST_HOME" "aaaa1111-1111-1111-1111-111111111111"
-  run node "$HANDOFF_BIN" describe claude latest --json
+  run --separate-stderr node "$HANDOFF_BIN" pull latest --summary --json
   [ "$status" -eq 0 ]
   # jq must be able to parse the entire output as a single JSON document.
   # If it is malformed, jq exits non-zero and the chained assertion fails.

--- a/plugins/dotclaude/tests/bats/handoff-pull-latest.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-latest.bats
@@ -46,7 +46,7 @@ teardown() {
   rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
 }
 
-@test "pull (bare): returns newest-committed branch, not lex-last" {
+@test "fetch (bare): returns newest-committed branch, not lex-last" {
   # Push oldest → middle → newest, >1s apart so the committer dates are
   # strictly increasing and reflect push order.
   run node "$BIN" push fffffff0
@@ -58,9 +58,9 @@ teardown() {
   run node "$BIN" push 00000001
   [ "$status" -eq 0 ]
 
-  run node "$BIN" pull
+  run node "$BIN" fetch
   [ "$status" -eq 0 ]
-  # Pulled branch must be the newest (marker-newest). If the bug is
+  # Fetched branch must be the newest (marker-newest). If the bug is
   # still present, the lex-last branch (fffffff0 / marker-oldest) is
   # returned instead.
   [[ "$output" == *"marker-newest"* ]]
@@ -68,7 +68,7 @@ teardown() {
   [[ "$output" != *"marker-middle"* ]]
 }
 
-@test "pull --from claude (no query): still returns newest by commit date" {
+@test "fetch --from claude (no query): still returns newest by commit date" {
   # Same ordering as above; verify the fromCli-scoped path also sorts
   # correctly — the filter runs before the sort, so all three remain in
   # the candidate set.
@@ -81,19 +81,19 @@ teardown() {
   run node "$BIN" push 00000001
   [ "$status" -eq 0 ]
 
-  run node "$BIN" pull --from claude
+  run node "$BIN" fetch --from claude
   [ "$status" -eq 0 ]
   [[ "$output" == *"marker-newest"* ]]
   [[ "$output" != *"marker-oldest"* ]]
 }
 
-@test "pull (bare) with a single branch: no sort attempted, fast path" {
+@test "fetch (bare) with a single branch: no sort attempted, fast path" {
   # Single-candidate short-circuit. If this regresses to unconditional
   # fetch-for-sort, the test is still green but would be slower — we
   # pin correctness, not cost.
   run node "$BIN" push fffffff0
   [ "$status" -eq 0 ]
-  run node "$BIN" pull
+  run node "$BIN" fetch
   [ "$status" -eq 0 ]
   [[ "$output" == *"marker-oldest"* ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-stress.bats
+++ b/plugins/dotclaude/tests/bats/handoff-stress.bats
@@ -42,13 +42,13 @@ teardown() {
   [ "$line_count" -ge $(( file_count * 9 / 10 )) ]
 }
 
-@test "pull <short-uuid> against 10k transport branches completes under 30s" {
+@test "fetch <short-uuid> against 10k transport branches completes under 30s" {
   TRANSPORT_REPO=$(make_transport_repo "$(mktemp -d)")
   export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
   make_many_transport_branches "$TRANSPORT_REPO" 10000
 
   # index 5000 → 00001388 (seeded by make_many_transport_branches as %08x).
-  run timeout 30s node "$BIN" pull 00001388
+  run timeout 30s node "$BIN" fetch 00001388
   [ "$status" -eq 0 ]
   [[ "$output" == *"<handoff"* ]]
 }

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -78,16 +78,16 @@ with a TSV candidate list on stderr.
 The binary's `--help` lists the full surface and authoritative flag
 semantics. Brief summary:
 
-| Sub                   | Purpose                                                                                              |
-| --------------------- | ---------------------------------------------------------------------------------------------------- |
-| `pull [<id>]`         | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk    |
-| `resolve <cli> <id>`  | Print the absolute JSONL path                                                                        |
-| `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
-| `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
-| `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
-| `fetch [<handle>]`    | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
-| `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
-| `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
+| Sub                  | Purpose                                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------------------- |
+| `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk     |
+| `resolve <cli> <id>` | Print the absolute JSONL path                                                                        |
+| `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
+| `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
+| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
+| `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
+| `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
+| `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 
@@ -210,13 +210,13 @@ proceeding.
 The following forms are deprecated as of 0.12.0 and removed in 0.14.0.
 They still function but emit a stderr warning on every invocation.
 
-| Old form                       | New form                          |
-| ------------------------------ | --------------------------------- |
-| `describe <cli> <id>`          | `pull <id> --summary`             |
-| `describe <cli> <id> --json`   | `pull <id> --summary --json`      |
-| `digest <cli> <id>`            | `pull <id>`                       |
-| `file <cli> <id>`              | `pull <id> -o auto`               |
-| `pull <query>` (remote fetch)  | `fetch <query>`                   |
+| Old form                      | New form                     |
+| ----------------------------- | ---------------------------- |
+| `describe <cli> <id>`         | `pull <id> --summary`        |
+| `describe <cli> <id> --json`  | `pull <id> --summary --json` |
+| `digest <cli> <id>`           | `pull <id>`                  |
+| `file <cli> <id>`             | `pull <id> -o auto`          |
+| `pull <query>` (remote fetch) | `fetch <query>`              |
 
 Set `DOTCLAUDE_QUIET=1` to suppress deprecation stderr in CI pipelines
 that cannot update callers immediately. Real errors (exit 2 / exit 64)

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -2,29 +2,29 @@
 id: handoff
 name: handoff
 type: skill
-version: 1.0.0
+version: 1.1.0
 domain: [devex]
 platform: [none]
 task: [documentation, debugging]
 maturity: draft
 owner: "@kaiohenricunha"
 created: 2026-04-17
-updated: 2026-04-19
+updated: 2026-04-23
 description: >
   Transfer conversation context between agentic CLIs (Claude Code, GitHub
   Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a
   source session transcript by UUID and produces either an inline summary,
   a paste-ready handoff digest, a written markdown file, or a branch in a
-  user-owned private git repo that another machine can pull. Use when
+  user-owned private git repo that another machine can fetch. Use when
   switching agents mid-task, recovering context, or moving between
   Windows/Linux/macOS setups. Triggers on: "handoff", "transfer context",
   "continue in codex", "continue in claude", "continue in copilot",
   "switch to codex", "switch to claude", "what was that session about",
   "claude --resume", "copilot --resume", "codex resume",
   "find the session where", "search sessions", "which session did I",
-  "push handoff", "pull handoff", "handoff to other machine",
+  "push handoff", "fetch handoff", "handoff to other machine",
   "resume on my other laptop".
-argument-hint: "[<query>|push|pull|list|doctor|remote-list|search] [args...]"
+argument-hint: "[pull|push|fetch|list|search|resolve|doctor] [args...]"
 tools: Glob, Read, Grep, Bash, Write
 effort: medium
 model: sonnet
@@ -42,16 +42,19 @@ bash tool.
 ## The four forms
 
 ```
-/handoff <query>                          local cross-agent: emit <handoff>
-/handoff push [<query>] [--tag <label>]   upload to transport
-/handoff pull [<query>]                   fetch from transport
+/handoff pull [<id>] [--from <cli>] [--to <cli>] [--summary] [-o <path>]
+/handoff push [<query>] [--from <cli>] [--tag <label>] [--include-transcript]
+/handoff fetch [<query>] [--from <cli>] [--verify]
 /handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
 ```
 
 A bare `/handoff` with no arguments prints usage and exits 0. Every
-remote verb is explicit.
+remote verb (`push`, `fetch`) is explicit.
 
-`<query>` auto-detects across `~/.claude/projects`,
+If `--from` is set, resolution narrows to that CLI; otherwise the host is
+auto-detected; otherwise all three roots are scanned.
+
+`<id>` / `<query>` auto-detects across `~/.claude/projects`,
 `~/.copilot/session-state`, and `~/.codex/sessions`. Accepted forms:
 full UUID, short UUID (first 8 hex), `latest`, Claude `customTitle`
 alias, Codex `thread_name` alias.
@@ -67,7 +70,7 @@ resolver (globally newest across all roots) and stderr names the
 picked session. Pass `--from <cli>` to force a specific root.
 
 **Collision model.** When `<query>` matches multiple roots (or two
-remote handoffs on `pull`): TTY → interactive prompt; non-TTY → exit 2
+remote handoffs on `fetch`): TTY → interactive prompt; non-TTY → exit 2
 with a TSV candidate list on stderr.
 
 ## Sub-commands
@@ -77,43 +80,70 @@ semantics. Brief summary:
 
 | Sub                   | Purpose                                                                                              |
 | --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `pull [<id>]`         | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk    |
 | `resolve <cli> <id>`  | Print the absolute JSONL path                                                                        |
-| `describe <cli> <id>` | Inline 2–4 sentence summary + verbatim user prompts                                                  |
-| `digest <cli> <id>`   | Print a paste-ready `<handoff>` block (no transport)                                                 |
-| `file <cli> <id>`     | Write the digest to `docs/handoffs/<date>-<cli>-<short>.md`                                          |
 | `list`                | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
 | `search <query>`      | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
 | `push [<query>]`      | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
-| `pull [<handle>]`     | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
+| `fetch [<handle>]`    | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
 | `remote-list`         | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
 | `doctor`              | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 
-- `--from <cli>` narrows source-CLI auto-detection on `push`, `pull`,
-  bare `<query>`, and filters `list`, `search`, and `remote-list` to
-  one root. Without it, the resolver probes all three roots. `--cli`
-  is accepted as a legacy alias on `search` and `remote-list`.
+- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`,
+  `pull`, and filters `list`, `search`, and `remote-list` to one root.
+  Without it, the resolver probes all three roots. `--cli` is accepted
+  as a legacy alias on `search` and `remote-list`.
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
-  target agent. Defaults to the auto-detected host.
+  target agent. Defaults to the auto-detected host. `--from` narrows
+  the source root; `--to` still resolves to the invoking host unless
+  explicitly overridden.
+- `--summary` (on `pull`) emits a prose summary + verbatim user prompts
+  instead of the full `<handoff>` block.
+- `-o <path>` (on `pull`) controls the output destination:
+  `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`
+  (falling back to `~/.claude/handoffs/` when off-repo) and prints the
+  file path on stdout; any other string is used as the literal output path.
 - `--since <ISO>` cuts off `list` when explicitly provided, and
   cuts off `search` and `remote-list` (default 30 days).
 - `--limit <N>` caps the row count (default 20). `--all` (on `list`)
   disables the cap.
 - `--fixed` / `-F` treats the `search` query as a literal string
   instead of a regex.
-- `--tag <label>` annotates a `push` for fuzzy `pull` later.
+- `--tag <label>` annotates a `push` for fuzzy `fetch` later.
 - `--include-transcript` adds the last 50 raw turns to a `push`
   (off by default to minimise leakage).
-- `--from-file <path>` lets `pull` load a local markdown file written
-  by `file`. Works without network access.
-- `--json` is honoured by `list`, `describe`, `remote-list`, `search`.
+- `--from-file <path>` lets `fetch` load a local markdown file written
+  by `pull -o`. Works without network access.
+- `--json` is honoured by `list`, `pull`, `remote-list`, `search`.
+
+## Cross-agent behavior
+
+(a) **`pull` stdout is the transport into the model's context.** All three
+host runtimes (Claude Code, Copilot CLI, Codex via its bash tool) capture
+stdout the same way. `pull` to stdout; the runtime delivers it.
+
+(b) **`--to` on `pull` defaults to the detected host, not `--from`.** When
+`--from` is set without `--to`, `--to` still resolves to the invoking host.
+`--from` narrows the source root; `--to` tunes the next-step wording for
+where the output will be read.
+
+(c) **Self-referential pull is allowed and renders normally.** When
+host-scoped `latest` resolves to the session the command was run from,
+the digest renders the current session into its own context. Occasionally
+useful for capturing the current session via `-o auto`.
+
+(d) **`pull <unmatched>` does not auto-forward to `fetch`.** If the local
+resolver returns no match and `$DOTCLAUDE_HANDOFF_REPO` is set, a single
+stderr hint suggests `fetch <id>`. If the variable is unset, only the
+standard no-match error appears. No silent source override.
 
 ## Prerequisites
 
 Local sub-commands need only `jq` and the session files on disk.
 
-The remote transport (`push`/`pull`/`remote-list`/`doctor`) is a
+The remote transport (`push`/`fetch`/`remote-list`/`doctor`) is a
 user-owned private git repo (any provider — GitHub, GitLab, Gitea,
 self-hosted). Required:
 
@@ -139,13 +169,13 @@ handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
 
 e.g. `handoff/dotclaude/claude/2026-04/aaaa1111`. The store needs no
 setup beyond "be a reachable git repo"; `main` is never touched by
-`push` / `pull` / `remote-list`. GitHub UI + `git ls-remote` render
+`push` / `fetch` / `remote-list`. GitHub UI + `git ls-remote` render
 the branches directly.
 
 ## Auto-trigger contract
 
-When the user message matches any of these patterns, run the bare
-`<query>` form (local cross-agent digest) by default:
+When the user message matches any of these patterns, run `pull` (local
+cross-agent digest) by default:
 
 - Resume-command fragments: `claude --resume <uuid>`,
   `claude --resume "<name>"`, `copilot --resume=<uuid>`,
@@ -153,10 +183,10 @@ When the user message matches any of these patterns, run the bare
 - Natural language: "what was that session about", "continue in X",
   "switch to X", "handoff".
 
-Extract the `<query>` from the user message (UUID, short UUID, or
-named alias). The skill probes all three roots — no `<cli>` argument
-needed. If the query is missing or ambiguous, ask one clarifying
-question before proceeding.
+Extract the `<id>` from the user message (UUID, short UUID, or named
+alias). The skill probes all three roots — no `--from` argument needed.
+If the query is missing or ambiguous, ask one clarifying question before
+proceeding.
 
 ## Out of scope
 
@@ -174,3 +204,20 @@ question before proceeding.
 - **Fuzzy or semantic search.** `search` is substring/regex only.
 - **Persistent indexing.** Grep-at-query-time is fast enough for
   local session volumes; revisit only if p95 exceeds ~2s.
+
+## Deprecated aliases
+
+The following forms are deprecated as of 0.12.0 and removed in 0.14.0.
+They still function but emit a stderr warning on every invocation.
+
+| Old form                       | New form                          |
+| ------------------------------ | --------------------------------- |
+| `describe <cli> <id>`          | `pull <id> --summary`             |
+| `describe <cli> <id> --json`   | `pull <id> --summary --json`      |
+| `digest <cli> <id>`            | `pull <id>`                       |
+| `file <cli> <id>`              | `pull <id> -o auto`               |
+| `pull <query>` (remote fetch)  | `fetch <query>`                   |
+
+Set `DOTCLAUDE_QUIET=1` to suppress deprecation stderr in CI pipelines
+that cannot update callers immediately. Real errors (exit 2 / exit 64)
+are never suppressed.


### PR DESCRIPTION
## Summary

- Introduces `pull <id>` as the single local-render verb (`--summary`, `--summary --json`, `--json`, `-o <path|auto|->`) collapsing `describe`/`digest`/`file`/bare-`<query>` under one surface (#87)
- Renames the remote-fetch verb from `pull` to `fetch` so `push`/`fetch` is the matched remote pair and `pull` unambiguously means "local render"
- Keeps `describe`, `digest`, `file` as stderr-deprecated aliases for one minor; `DOTCLAUDE_QUIET=1` suppresses noise in CI; aliases removed in 0.14.0

## Breaking changes

- `pull <query>` for remote fetch → use `fetch <query>` (old form warns on stderr until 0.14.0)
- `describe` / `digest` / `file` with a `<cli>` positional → use `pull <id> [--summary] [-o auto]` (old forms warn on stderr until 0.14.0)
- `pull/push/fetch <cli> <id>` (3-positional) → exit 64 with `--from` redirect hint

## New flags on `pull`

| Flag | Effect |
|---|---|
| `--summary` | Prose summary + prompts (was `describe`) |
| `--summary --json` | JSON `{origin, user_prompts}` |
| `--json` | Digest JSON `{origin, user_prompts, assistant_turns, next_step_suggestion, to}` |
| `-o -` | Force stdout |
| `-o auto` | Write to `<repo>/docs/handoffs/<date>-<cli>-<short>.md` (or `~/.claude/handoffs/` off-repo), print path |
| `-o <path>` | Write to explicit path |

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/dotclaude-handoff.bats` — 24/24
- [x] `npx bats plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats` — 39/39
- [x] `npx bats plugins/dotclaude/tests/bats/handoff-integration.bats` — 9/9
- [x] `npx bats plugins/dotclaude/tests/bats/handoff-pull-latest.bats` — 3/3
- [x] `npx bats plugins/dotclaude/tests/bats/handoff-observability.bats` — 9/9
- [x] `npx bats plugins/dotclaude/tests/bats/handoff-stress.bats` — 4/4
- [x] `npx bats plugins/dotclaude/tests/bats/` — 304/304 (full suite)
- [x] `npm test` — 480/480
- [x] `npm run coverage` — branches 80.3% (≥ 80%)

## Downstream docs to update separately

The following files reference old verbs and should be updated in a follow-up sweep:
- `README.md` (grep: `digest`, `describe`, `handoff file`, `handoff pull`)
- `docs/**` (any file referencing the old verbs or the bare-`<query>` form)

## Spec ID

dotclaude-core
