### PR TITLE
docs(handoff): drop --include-transcript from all docs (#91 Gap 6)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-23T14:26:01.962Z",
+  "generatedAt": "2026-04-23T17:22:22.145Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:b2e4ba3ab3b0524e5d1835d3a4cf1fb65663c1427228e4dc8d958446f858ba8f",
+      "checksum": "sha256:ddfbe33aae0b90a43dcd1469393e354b535f935e148e074590ae0a3647b7d000",
       "dependencies": [],
       "lastValidated": "2026-04-23"
     },

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -168,8 +168,6 @@ Headless runs skip the interactive bootstrap — set
   before upload.
 - **The handoff store is private by default** — the auto-bootstrap runs
   `gh repo create --private`. Don't flip it to public.
-- **`--include-transcript` is opt-in** — uploading raw turns increases secret
-  leakage blast radius. Off by default.
 - The skill never invokes another CLI itself — it produces the digest and hands
   you a paste-ready block. This is deliberate: it keeps the transfer auditable
   and prevents unintended cross-session execution.

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -10,15 +10,9 @@
       "name": "agents-search",
       "description": "Discover, search, and manage Claude Code agents. Use when you want to find available agents, list installed agents, or refresh the agent catalog. Triggers on: \"search agents\", \"list agents\", \"find agent\", \"what agents\", \"agent catalog\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -44,16 +38,9 @@
       "name": "audit-and-fix",
       "description": "Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to \"audit and fix\" or kicks off an overnight cleanup run.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -71,9 +58,7 @@
         "task": [],
         "maturity": "draft"
       },
-      "related": [
-        "aws-specialist"
-      ]
+      "related": ["aws-specialist"]
     },
     {
       "id": "aws-specialist",
@@ -82,16 +67,9 @@
       "name": "aws-specialist",
       "description": "Deep-dive AWS architecture review, debugging, and service design. Use for structured investigations of AWS-specific issues, cost or IAM audits, and multi-service design reviews. Triggers on: \"AWS audit\", \"AWS design review\", \"IAM review\", \"cost audit AWS\", \"review my VPC\", \"AWS troubleshooting\", \"Lambda deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "aws"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["aws"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -117,16 +95,9 @@
       "name": "azure-specialist",
       "description": "Deep-dive Azure architecture review, debugging, and service design. Use for structured investigations of Azure-specific issues, identity or cost audits, and multi-service design reviews. Triggers on: \"Azure audit\", \"Azure design review\", \"EntraID review\", \"Managed Identity debug\", \"review my Azure\", \"Azure troubleshooting\", \"AKS deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "azure"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["azure"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -152,15 +123,9 @@
       "name": "changelog",
       "description": "Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -212,16 +177,9 @@
       "name": "create-assessment",
       "description": "Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -234,16 +192,9 @@
       "name": "create-audit",
       "description": "Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -256,16 +207,9 @@
       "name": "create-inspection",
       "description": "Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -291,17 +235,9 @@
       "name": "crossplane-specialist",
       "description": "Deep-dive Crossplane platform review: XRD design, Composition correctness, provider config audit, managed resource health, and GitOps integration. Use for structured investigations of stuck Claims, composition pipeline bugs, and credential injection patterns. Triggers on: \"Crossplane audit\", \"XRD review\", \"Composition debug\", \"stuck Claim\", \"managed resource stuck\", \"provider config review\", \"Crossplane GitOps\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "crossplane",
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["crossplane", "kubernetes"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -327,16 +263,9 @@
       "name": "dependabot-sweep",
       "description": "Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "security"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex", "security"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -362,16 +291,9 @@
       "name": "detect-flaky",
       "description": "Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "testing",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["testing", "debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -423,16 +345,9 @@
       "name": "fix-with-evidence",
       "description": "Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -471,16 +386,9 @@
       "name": "gcp-specialist",
       "description": "Deep-dive Google Cloud architecture review, debugging, and service design. Use for structured investigations of GCP-specific issues, IAM or cost audits, and multi-service design reviews. Triggers on: \"GCP audit\", \"GCP design review\", \"Workload Identity debug\", \"IAM review GCP\", \"review my GKE\", \"GCP troubleshooting\", \"Cloud Run deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "gcp"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["gcp"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -493,15 +401,9 @@
       "name": "git",
       "description": "Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -514,16 +416,9 @@
       "name": "ground-first",
       "description": "Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -536,16 +431,9 @@
       "name": "handoff",
       "description": "Transfer conversation context between agentic CLIs (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a source session transcript by UUID and produces either an inline summary, a paste-ready handoff digest, a written markdown file, or a branch in a user-owned private git repo that another machine can fetch. Use when switching agents mid-task, recovering context, or moving between Windows/Linux/macOS setups. Triggers on: \"handoff\", \"transfer context\", \"continue in codex\", \"continue in claude\", \"continue in copilot\", \"switch to codex\", \"switch to claude\", \"what was that session about\", \"claude --resume\", \"copilot --resume\", \"codex resume\", \"find the session where\", \"search sessions\", \"which session did I\", \"push handoff\", \"fetch handoff\", \"handoff to other machine\", \"resume on my other laptop\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation", "debugging"],
         "maturity": "draft"
       },
       "version": "1.1.0",
@@ -576,9 +464,7 @@
         "task": [],
         "maturity": "draft"
       },
-      "related": [
-        "kubernetes-specialist"
-      ]
+      "related": ["kubernetes-specialist"]
     },
     {
       "id": "kubernetes-specialist",
@@ -587,16 +473,9 @@
       "name": "kubernetes-specialist",
       "description": "Deep-dive Kubernetes troubleshooting, workload design, and cluster health review. Use when you need a structured investigation of a cluster issue, a design review of Kubernetes manifests, or a health audit of a namespace or workload. Triggers on: \"debug kubernetes\", \"why is my pod\", \"review my manifests\", \"cluster health\", \"kubernetes design review\", \"k8s audit\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["kubernetes"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -609,16 +488,9 @@
       "name": "markdown",
       "description": "Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "writing"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex", "writing"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -631,16 +503,9 @@
       "name": "merge-pr",
       "description": "Merge a pull request only after full local verification, with an optional data-regression gate for paths configured in docs/repo-facts.json.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -666,16 +531,9 @@
       "name": "pre-pr",
       "description": "Pre-PR quality gate: simplify changed code, security-review the diff, run the full test suite, and surface a go/no-go summary before opening a pull request.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -701,16 +559,9 @@
       "name": "pulumi-specialist",
       "description": "Deep-dive Pulumi stack review, component design, Automation API audit, and secrets management. Use for structured investigations of Pulumi stack drift, ComponentResource coupling, ESC configuration, and Automation API workflows. Triggers on: \"Pulumi audit\", \"stack review\", \"Automation API review\", \"ComponentResource design\", \"ESC audit\", \"Pulumi secrets\", \"Pulumi testing\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "pulumi"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["pulumi"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -723,15 +574,9 @@
       "name": "review-pr",
       "description": "Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -744,15 +589,9 @@
       "name": "review-prs",
       "description": "Batch-review multiple PRs in parallel: dispatch one sub-agent per PR in an isolated worktree, aggregate results into a summary table.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -791,16 +630,9 @@
       "name": "security-review",
       "description": "Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "security"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex", "security"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -813,15 +645,9 @@
       "name": "spec",
       "description": "Create structured engineering specs through interactive pairing. Use when the user wants to create a spec, design doc, technical specification, architecture document, RFC, or engineering plan. Triggers on \"let's spec this out\", \"create a spec\", \"design doc\", \"write a technical plan\", \"plan the architecture\". Works for greenfield and brownfield projects. Outputs to docs/specs/.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -834,16 +660,9 @@
       "name": "terraform-specialist",
       "description": "Deep-dive Terraform architecture review, module design, state management, and migration. Use for structured investigations of Terraform workspaces, provider configuration, module coupling, import workflows, and test coverage. Triggers on: \"Terraform audit\", \"module review\", \"state management\", \"Terraform import\", \"workspace design\", \"provider config review\", \"Terraform testing\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -869,17 +688,9 @@
       "name": "terragrunt-specialist",
       "description": "Deep-dive Terragrunt hierarchy review, DRY pattern audits, and run-all orchestration analysis. Use for structured investigations of multi-environment Terragrunt layouts, dependency graphs, remote state config, and hook correctness. Triggers on: \"Terragrunt audit\", \"run-all review\", \"dependency block\", \"DRY pattern review\", \"env hierarchy audit\", \"mock_outputs\", \"terragrunt hooks\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform",
-          "terragrunt"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform", "terragrunt"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -905,16 +716,9 @@
       "name": "validate-spec",
       "description": "Audit an already-implemented spec against the codebase. Walks each constraint (ARCH-N, PERF-N, KD-N, etc.) and acceptance criterion, grounds findings in file:line evidence, runs the spec.json acceptance_commands, and writes a single audit doc to docs/audits/. Use whenever the user asks to \"validate a spec\", \"audit a spec\", \"check if spec is implemented\", \"verify the spec is done\", \"is this spec really done\", or otherwise wants closure on spec-driven work. Read-only against the spec — produces an audit, never modifies the spec itself.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -927,16 +731,9 @@
       "name": "veracity-audit",
       "description": "Audit a data pipeline for Veracity and Value. Dispatches data-scientist, compliance-auditor, and data-engineer agents with project context injected at dispatch time. All source paths are supplied via flags — no defaults, no project assumptions. Subcommands: audit (full pipeline walk), score-check (scoring math only), gate-check (gate coverage only), source-trace <label> (single source end-to-end). Invoke when: \"audit pipeline\", \"veracity check\", \"scoring math correct?\", \"check gates\", \"trace source\", \"verify quality gates\", \"formula correct?\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "draft"
       },
       "version": "1.0.0",

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -33,13 +33,8 @@
       "terraform-specialist",
       "terragrunt-specialist"
     ],
-    "security": [
-      "dependabot-sweep",
-      "security-review"
-    ],
-    "writing": [
-      "markdown"
-    ]
+    "security": ["dependabot-sweep", "security-review"],
+    "writing": ["markdown"]
   },
   "platform": {
     "none": [
@@ -61,38 +56,15 @@
       "validate-spec",
       "veracity-audit"
     ],
-    "aws": [
-      "aws-specialist"
-    ],
-    "azure": [
-      "azure-specialist"
-    ],
-    "crossplane": [
-      "crossplane-specialist"
-    ],
-    "kubernetes": [
-      "crossplane-specialist",
-      "kubernetes-specialist"
-    ],
-    "github-actions": [
-      "dependabot-sweep",
-      "merge-pr",
-      "review-pr",
-      "review-prs"
-    ],
-    "gcp": [
-      "gcp-specialist"
-    ],
-    "pulumi": [
-      "pulumi-specialist"
-    ],
-    "terraform": [
-      "terraform-specialist",
-      "terragrunt-specialist"
-    ],
-    "terragrunt": [
-      "terragrunt-specialist"
-    ]
+    "aws": ["aws-specialist"],
+    "azure": ["azure-specialist"],
+    "crossplane": ["crossplane-specialist"],
+    "kubernetes": ["crossplane-specialist", "kubernetes-specialist"],
+    "github-actions": ["dependabot-sweep", "merge-pr", "review-pr", "review-prs"],
+    "gcp": ["gcp-specialist"],
+    "pulumi": ["pulumi-specialist"],
+    "terraform": ["terraform-specialist", "terragrunt-specialist"],
+    "terragrunt": ["terragrunt-specialist"]
   },
   "task": {
     "debugging": [

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -40,7 +40,7 @@ bash tool.
 
 ```
 /handoff pull [<id>] [--from <cli>] [--to <cli>] [--summary] [-o <path>]
-/handoff push [<query>] [--from <cli>] [--tag <label>] [--include-transcript]
+/handoff push [<query>] [--from <cli>] [--tag <label>]
 /handoff fetch [<query>] [--from <cli>] [--verify]
 /handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
 ```
@@ -81,7 +81,7 @@ semantics. Brief summary:
 | `resolve <cli> <id>` | Print the absolute JSONL path                                                                        |
 | `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
 | `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
-| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
+| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                           |
 | `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
 | `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
 | `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
@@ -109,8 +109,6 @@ Cross-cutting flags (consult `--help` for the canonical list):
 - `--fixed` / `-F` treats the `search` query as a literal string
   instead of a regex.
 - `--tag <label>` annotates a `push` for fuzzy `fetch` later.
-- `--include-transcript` adds the last 50 raw turns to a `push`
-  (off by default to minimise leakage).
 - `--from-file <path>` lets `fetch` load a local markdown file written
   by `pull -o`. Works without network access.
 - `--json` is honoured by `list`, `pull`, `remote-list`, `search`.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/redaction.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/redaction.md
@@ -1,7 +1,6 @@
 # Handoff redaction — patterns and semantics
 
-The `push` sub-command pipes the rendered digest (and, when
-`--include-transcript` is set, the raw transcript slice) through a
+The `push` sub-command pipes the rendered digest through a
 redaction pass before uploading. This file is the authoritative list
 of patterns. The reusable implementation lives at
 `plugins/dotclaude/scripts/handoff-scrub.sh`.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -43,7 +43,7 @@ bash tool.
 
 ```
 /handoff pull [<id>] [--from <cli>] [--to <cli>] [--summary] [-o <path>]
-/handoff push [<query>] [--from <cli>] [--tag <label>] [--include-transcript]
+/handoff push [<query>] [--from <cli>] [--tag <label>]
 /handoff fetch [<query>] [--from <cli>] [--verify]
 /handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
 ```
@@ -84,7 +84,7 @@ semantics. Brief summary:
 | `resolve <cli> <id>` | Print the absolute JSONL path                                                                        |
 | `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
 | `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
-| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag` / `--include-transcript`                                  |
+| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                           |
 | `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
 | `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
 | `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
@@ -112,8 +112,6 @@ Cross-cutting flags (consult `--help` for the canonical list):
 - `--fixed` / `-F` treats the `search` query as a literal string
   instead of a regex.
 - `--tag <label>` annotates a `push` for fuzzy `fetch` later.
-- `--include-transcript` adds the last 50 raw turns to a `push`
-  (off by default to minimise leakage).
 - `--from-file <path>` lets `fetch` load a local markdown file written
   by `pull -o`. Works without network access.
 - `--json` is honoured by `list`, `pull`, `remote-list`, `search`.

--- a/skills/handoff/references/redaction.md
+++ b/skills/handoff/references/redaction.md
@@ -1,7 +1,6 @@
 # Handoff redaction — patterns and semantics
 
-The `push` sub-command pipes the rendered digest (and, when
-`--include-transcript` is set, the raw transcript slice) through a
+The `push` sub-command pipes the rendered digest through a
 redaction pass before uploading. This file is the authoritative list
 of patterns. The reusable implementation lives at
 `plugins/dotclaude/scripts/handoff-scrub.sh`.


### PR DESCRIPTION
## Summary

- Drop `--include-transcript` from all documentation (SKILL.md ×2, references/redaction.md ×2, docs/handoff-guide.md)
- The flag was never implemented — absent from `META.flags`, rejected with exit 64 by the argv parser, no test coverage, and `pushRemote()` has no such parameter
- Pure doc cleanup; zero code changes

## Test plan

- [x] `grep -r "include-transcript" skills/ plugins/dotclaude/templates/ docs/` → empty
- [x] `npm test` → 480/480
- [x] `npx bats plugins/dotclaude/tests/bats/` → 304/304

## Spec ID

dotclaude-core
