### PR TITLE
feat(handoff): tags first-class — multi-tag push, exact-tag pull, list filter, histogram (#91 Gap 7)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,209 +1,209 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-23T17:22:22.145Z",
+  "generatedAt": "2026-04-25T21:28:41.035Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
       "checksum": "sha256:f7a8fa0598d7925de95ed3829ea677a2df58fa3db93e9ff290944bb686fad7d7",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
       "checksum": "sha256:cf3ac020cd3ce7d8fc11dbf4f5f5a2ffa5e1d6443e60cd10179b564bd77894cc",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
       "checksum": "sha256:cabbf4bfe2deff3a328f15e025dfc0d63369825c0c32574790251f2793e62aeb",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
       "checksum": "sha256:cf987369294337fff90fc62e1d73d235d35055055dc8e4fbfb33a492f7cd38b5",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
       "checksum": "sha256:50573c4199f27083286fdbc3760b2f684105b4a6df39b7cb47094d7c0e5327f7",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
       "checksum": "sha256:3f7b90b69172e29cdcf66713f2708f9741003d05cc12cf9d81ff79ff9c5b692c",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
       "checksum": "sha256:7d888f6964725d82687fb61b68ff961f041f95d2c9eef7b5282061229499ca90",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
       "checksum": "sha256:6ffc091e9bd421798c5b7990f21d095563d69c59c3e2bd10d35b554b3ec225d9",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
       "checksum": "sha256:d0bc84f956c0ee8c176cf76a79374e8defb0bd2487c8340a2e2a1d9e04d8a1cc",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
       "checksum": "sha256:52e610b195a43fdd460106c1bdf56b32803cb86d163a4303274773ea3900bf79",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2dc1c4213ab6650d685e7b2243ddda91fce2ceba224ca3da3951afeb37d12946",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:ddfbe33aae0b90a43dcd1469393e354b535f935e148e074590ae0a3647b7d000",
+      "checksum": "sha256:d1d06474379bea85663678429b0ed54d5ce5571fe07649041320d3fd1edd834f",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "review-prs",
       "path": ".claude/commands/review-prs.md",
       "checksum": "sha256:e01a0432cd1a6cf6fe4a60cfc2b02f7cab3cde418062ca85beadc5491548bc71",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:347be395b0f8003816b4f3ed3bb777a63a3f9f7ae300d6f050b499ff66cfd3b0",
       "dependencies": [],
-      "lastValidated": "2026-04-23"
+      "lastValidated": "2026-04-25"
     }
   ]
 }

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -33,7 +33,7 @@ scrubbed digest.
 **On machine A**, from any Claude / Copilot / Codex session:
 
 ```
-/handoff push --tag "finishing auth refactor"
+/handoff push --tag finishing-auth-refactor --tag shipping
 ```
 
 On the **first** push the binary walks you through a one-time setup:
@@ -67,7 +67,9 @@ to your `~/.bashrc` or `~/.zshrc`.
 ```
 
 Bare `/handoff pull` fetches the newest handoff; the positional is a
-fuzzy-match query against tag, short UUID, project slug, hostname, or
+prefer exact-tag matches when present (`fetch shipping` resolves the
+branch tagged `shipping` even if "shipping" appears as a substring
+elsewhere); otherwise fuzzy-match the query against tag, short UUID, project slug, hostname, or
 CLI name.
 
 ---

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -66,11 +66,12 @@ to your `~/.bashrc` or `~/.zshrc`.
 /handoff pull finishing-auth-refactor
 ```
 
-Bare `/handoff pull` fetches the newest handoff; the positional is a
-prefer exact-tag matches when present (`fetch shipping` resolves the
-branch tagged `shipping` even if "shipping" appears as a substring
-elsewhere); otherwise fuzzy-match the query against tag, short UUID, project slug, hostname, or
-CLI name.
+Bare `/handoff pull` fetches the newest handoff. With a positional, the
+resolver first prefers exact-tag matches (`/handoff fetch shipping`
+resolves the branch tagged exactly `shipping` even if "shipping" appears
+as a substring of another branch's description), and otherwise
+fuzzy-matches against tag, short UUID, project slug, hostname, or CLI
+name.
 
 ---
 

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -76,6 +76,8 @@ import {
   listRemoteCandidates,
   enrichWithDescriptions,
   matchesQuery,
+  // tags first-class (#91 Gap 7) — for list --tag filter and --tags histogram
+  parseTagsFromDescription,
   // prune (#91 Gap 5)
   parseDuration,
   listPruneCandidates,
@@ -106,11 +108,16 @@ const CLIS = new Set(["claude", "copilot", "codex"]);
 const META = {
   name: "dotclaude-handoff",
   synopsis:
-    "dotclaude handoff [pull|fetch|list|search|push|prune|doctor|remote-list] [args...] [--from <cli>] [--to <cli>] [--summary] [-o <path>] [--tag <label>] [--cli <cli>] [--since <ISO>] [--limit <N>] [--verify] [--dry-run] [--older-than <30d|6m|1y|YYYY-MM-DD>] [--yes]",
+    "dotclaude handoff [pull|fetch|list|search|push|prune|doctor|remote-list] [args...] [--from <cli>] [--to <cli>] [--summary] [-o <path>] [--tag <label>...] [--tags] [--cli <cli>] [--since <ISO>] [--limit <N>] [--verify] [--dry-run] [--older-than <30d|6m|1y|YYYY-MM-DD>] [--yes]",
   description:
     "Cross-agent and cross-machine session handoff. `pull <id>` renders a local session as <handoff> block (or --summary / -o <path>). push/fetch handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO). push/fetch auto-run a preflight check (cached 5 min); --verify forces re-run.",
   flags: {
-    tag: { type: "string" },
+    // #91 Gap 7: tag is multi-valued for push (--tag foo --tag bar) and a
+    // single-value filter on `list --remote --tag <name>`. argv.mjs always
+    // hands back an array when multiple is true.
+    tag: { type: "string", multiple: true },
+    // Boolean flag for `list --remote --tags` histogram mode.
+    tags: { type: "boolean" },
     from: { type: "string" },
     to: { type: "string" },
     limit: { type: "string" },
@@ -848,6 +855,17 @@ async function main() {
     }
 
     let remoteSkipped = false;
+    // #91 Gap 7: --tag <name> filters; --tags switches to histogram render.
+    // Both need description-side tag info, so enrich once if either flag is
+    // set (avoids the per-row fetch when neither is in play).
+    const tagFilter = (() => {
+      const t = argv.flags.tag;
+      if (Array.isArray(t) && t.length > 0) return String(t[0]);
+      if (typeof t === "string") return t;
+      return null;
+    })();
+    const wantHistogram = Boolean(argv.flags.tags);
+    const needTags = tagFilter !== null || wantHistogram;
     if (showRemote) {
       if (!process.env.DOTCLAUDE_HANDOFF_REPO) {
         remoteSkipped = true;
@@ -856,9 +874,13 @@ async function main() {
         );
       } else {
         try {
-          for (const c of listRemoteCandidates()) {
+          const inventory = listRemoteCandidates();
+          const enriched = needTags ? enrichWithDescriptions(inventory) : inventory;
+          for (const c of enriched) {
             const parsed = parseHandoffBranch(c.branch);
             if (fromCli && parsed.cli !== fromCli) continue;
+            const tagList = needTags ? parseTagsFromDescription(c.description) : [];
+            if (tagFilter !== null && !tagList.includes(tagFilter)) continue;
             rows.push({
               location: "remote",
               cli: parsed.cli,
@@ -866,12 +888,46 @@ async function main() {
               branch: c.branch,
               commit: c.commit,
               when: parsed.yearMonth,
+              tags: tagList,
             });
           }
         } catch (err) {
           process.stderr.write(`dotclaude-handoff: list --remote: ${err.message}\n`);
         }
       }
+    }
+
+    // Histogram mode short-circuits the row render. Aggregate over rows we
+    // already gathered (already filtered by --from / --since / --tag).
+    if (wantHistogram) {
+      const counts = new Map();
+      let untagged = 0;
+      for (const r of rows) {
+        if (!Array.isArray(r.tags) || r.tags.length === 0) {
+          untagged += 1;
+          continue;
+        }
+        for (const t of r.tags) counts.set(t, (counts.get(t) ?? 0) + 1);
+      }
+      const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+      if (argv.json) {
+        process.stdout.write(
+          JSON.stringify({ histogram: Object.fromEntries(sorted), untagged }, null, 2) + "\n",
+        );
+        process.exit(EXIT_CODES.OK);
+      }
+      const total = rows.length;
+      process.stdout.write(
+        `tag histogram on transport (${total} branch${total === 1 ? "" : "es"}):\n`,
+      );
+      const widest = sorted.reduce((w, [k]) => Math.max(w, k.length), "(untagged)".length);
+      for (const [tag, n] of sorted) {
+        process.stdout.write(`  ${tag.padEnd(widest)}  ${n}\n`);
+      }
+      if (untagged > 0) {
+        process.stdout.write(`  ${"(untagged)".padEnd(widest)}  ${untagged}\n`);
+      }
+      process.exit(EXIT_CODES.OK);
     }
 
     rows.sort((a, b) => (b.mtime ?? 0) - (a.mtime ?? 0));
@@ -918,7 +974,9 @@ async function main() {
     }
     if (fallbackNote) process.stderr.write(fallbackNote + "\n");
 
-    const tag = argv.flags.tag ? String(argv.flags.tag) : null;
+    // #91 Gap 7: --tag is multi-valued. argv.flags.tag is now string[] when
+    // any --tag was passed, or undefined. Pass through as `tags`.
+    const tags = Array.isArray(argv.flags.tag) ? argv.flags.tag.map(String) : [];
     const verify = Boolean(argv.flags.verify);
     const verbose = Boolean(argv.verbose);
     const force = Boolean(argv.flags["force-collision"]);
@@ -927,7 +985,7 @@ async function main() {
       const result = await pushRemote({
         cli: sessionHit.cli,
         path: sessionHit.path,
-        tag,
+        tags,
         verify,
         verbose,
         force,

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -858,14 +858,16 @@ async function main() {
     // #91 Gap 7: --tag <name> filters; --tags switches to histogram render.
     // Both need description-side tag info, so enrich once if either flag is
     // set (avoids the per-row fetch when neither is in play).
-    const tagFilter = (() => {
-      const t = argv.flags.tag;
-      if (Array.isArray(t) && t.length > 0) return String(t[0]);
-      if (typeof t === "string") return t;
-      return null;
-    })();
+    //
+    // Multiple --tag values on `list` are treated as OR: a row is kept if any
+    // of its tags matches any of the requested filters. The same flag is
+    // multi-value on `push` (collect) — argv.mjs returns string[] in both
+    // cases — so this is a deliberate per-verb semantic, not a smell.
+    const tagFilters = Array.isArray(argv.flags.tag)
+      ? argv.flags.tag.map(String).filter((t) => t.length > 0)
+      : [];
     const wantHistogram = Boolean(argv.flags.tags);
-    const needTags = tagFilter !== null || wantHistogram;
+    const needTags = tagFilters.length > 0 || wantHistogram;
     if (showRemote) {
       if (!process.env.DOTCLAUDE_HANDOFF_REPO) {
         remoteSkipped = true;
@@ -880,7 +882,7 @@ async function main() {
             const parsed = parseHandoffBranch(c.branch);
             if (fromCli && parsed.cli !== fromCli) continue;
             const tagList = needTags ? parseTagsFromDescription(c.description) : [];
-            if (tagFilter !== null && !tagList.includes(tagFilter)) continue;
+            if (tagFilters.length > 0 && !tagFilters.some((f) => tagList.includes(f))) continue;
             rows.push({
               location: "remote",
               cli: parsed.cli,

--- a/plugins/dotclaude/scripts/handoff-description.sh
+++ b/plugins/dotclaude/scripts/handoff-description.sh
@@ -45,13 +45,11 @@ valid_segment() {
 
 # Validates a tag segment: comma-joined slugified tokens, each [a-z0-9-]{1,40}.
 # Used for the optional 8th segment in v2 (and v1's optional 7th).
+# Single regex to also reject `a,,b`, `,a`, `a,` (bash word-splitting on
+# IFS=',' silently dropped empty fields, which would have let those
+# malformed segments through).
 valid_tag_segment() {
-  local seg="$1" IFS=','
-  [[ -z "$seg" ]] && return 1
-  for token in $seg; do
-    [[ "$token" =~ ^[a-z0-9-]{1,40}$ ]] || return 1
-  done
-  return 0
+  [[ "$1" =~ ^[a-z0-9-]{1,40}(,[a-z0-9-]{1,40})*$ ]]
 }
 
 # Emits the JSON fragment for tag/tags. Pass empty string for "no tag".

--- a/plugins/dotclaude/scripts/handoff-description.sh
+++ b/plugins/dotclaude/scripts/handoff-description.sh
@@ -106,7 +106,7 @@ cmd_encode() {
   [[ "$short_id" =~ ^[0-9a-f]{8}$ ]] || die "--short-id must be exactly 8 hex chars"
   valid_month "$month" || die "--month must be YYYY-MM (got: $month)"
 
-  local project_slug hostname_slug tag_slug=""
+  local project_slug hostname_slug
   project_slug="$(slugify "$project")"
   hostname_slug="$(slugify "$hostname")"
   valid_segment "$project_slug" || die "project slug invalid after normalization: $project_slug"

--- a/plugins/dotclaude/scripts/handoff-description.sh
+++ b/plugins/dotclaude/scripts/handoff-description.sh
@@ -43,6 +43,36 @@ valid_segment() {
   [[ "$1" =~ ^[a-z0-9-]{1,40}$ ]]
 }
 
+# Validates a tag segment: comma-joined slugified tokens, each [a-z0-9-]{1,40}.
+# Used for the optional 8th segment in v2 (and v1's optional 7th).
+valid_tag_segment() {
+  local seg="$1" IFS=','
+  [[ -z "$seg" ]] && return 1
+  for token in $seg; do
+    [[ "$token" =~ ^[a-z0-9-]{1,40}$ ]] || return 1
+  done
+  return 0
+}
+
+# Emits the JSON fragment for tag/tags. Pass empty string for "no tag".
+# Output: ,"tag":"first","tags":["a","b"]   OR   ,"tag":null,"tags":[]
+emit_tags_json() {
+  local seg="$1"
+  if [[ -z "$seg" ]]; then
+    printf ',"tag":null,"tags":[]'
+    return
+  fi
+  local first="${seg%%,*}"
+  local arr="" IFS=','
+  for token in $seg; do
+    [[ -z "$token" ]] && continue
+    if [[ -z "$arr" ]]; then arr="\"$token\""
+    else arr="${arr},\"$token\""
+    fi
+  done
+  printf ',"tag":"%s","tags":[%s]' "$first" "$arr"
+}
+
 # YYYY-MM month bucket — exactly 4 digits, dash, 2 digits.
 valid_month() {
   [[ "$1" =~ ^[0-9]{4}-[0-9]{2}$ ]]
@@ -84,9 +114,20 @@ cmd_encode() {
 
   local out="handoff:v2:${project_slug}:${cli}:${month}:${short_id}:${hostname_slug}"
   if [[ -n "$tag" ]]; then
-    tag_slug="$(slugify "$tag")"
-    valid_segment "$tag_slug" || die "tag slug invalid after normalization: $tag_slug"
-    out="${out}:${tag_slug}"
+    # Multi-tag (#91 Gap 7): value may be a single tag or a comma-joined list.
+    # Split on comma, slugify each token, validate, rejoin. Single-tag input
+    # has no comma → produces a one-element list → backward compatible.
+    local tag_joined="" first=1
+    local IFS=','
+    for token in $tag; do
+      [[ -z "$token" ]] && continue
+      local s; s="$(slugify "$token")"
+      valid_segment "$s" || die "tag slug invalid after normalization: $s"
+      if (( first )); then tag_joined="$s"; first=0
+      else tag_joined="${tag_joined},${s}"
+      fi
+    done
+    [[ -n "$tag_joined" ]] && out="${out}:${tag_joined}"
   fi
 
   printf '%s\n' "$out"
@@ -111,16 +152,11 @@ decode_v2() {
   valid_segment "$project" || die "malformed v2: project slug fails charset"
   valid_segment "$hostname" || die "malformed v2: hostname slug fails charset"
   if [[ -n "${tag:-}" ]]; then
-    valid_segment "$tag" || die "malformed v2: tag slug fails charset"
+    valid_tag_segment "$tag" || die "malformed v2: tag segment fails charset"
   fi
 
-  if [[ -n "${tag:-}" ]]; then
-    printf '{"schema":"v2","cli":"%s","short_id":"%s","project":"%s","month":"%s","hostname":"%s","tag":"%s"}\n' \
-      "$cli" "$short_id" "$project" "$month" "$hostname" "$tag"
-  else
-    printf '{"schema":"v2","cli":"%s","short_id":"%s","project":"%s","month":"%s","hostname":"%s","tag":null}\n' \
-      "$cli" "$short_id" "$project" "$month" "$hostname"
-  fi
+  printf '{"schema":"v2","cli":"%s","short_id":"%s","project":"%s","month":"%s","hostname":"%s"%s}\n' \
+    "$cli" "$short_id" "$project" "$month" "$hostname" "$(emit_tags_json "${tag:-}")"
 }
 
 # Decode a legacy v1 description (read-only — no encode path). Segments:
@@ -141,18 +177,13 @@ decode_v1() {
   valid_segment "$project" || die "malformed v1: project slug fails charset"
   valid_segment "$hostname" || die "malformed v1: hostname slug fails charset"
   if [[ -n "${tag:-}" ]]; then
-    valid_segment "$tag" || die "malformed v1: tag slug fails charset"
+    valid_tag_segment "$tag" || die "malformed v1: tag segment fails charset"
   fi
 
   # Emit the same shape as v2's JSON, with month=null (legacy lacks it)
   # and schema=v1 so callers can mark these as "(legacy)" in UI.
-  if [[ -n "${tag:-}" ]]; then
-    printf '{"schema":"v1","cli":"%s","short_id":"%s","project":"%s","month":null,"hostname":"%s","tag":"%s"}\n' \
-      "$cli" "$short_id" "$project" "$hostname" "$tag"
-  else
-    printf '{"schema":"v1","cli":"%s","short_id":"%s","project":"%s","month":null,"hostname":"%s","tag":null}\n' \
-      "$cli" "$short_id" "$project" "$hostname"
-  fi
+  printf '{"schema":"v1","cli":"%s","short_id":"%s","project":"%s","month":null,"hostname":"%s"%s}\n' \
+    "$cli" "$short_id" "$project" "$hostname" "$(emit_tags_json "${tag:-}")"
 }
 
 cmd_decode() {

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -1259,6 +1259,10 @@ export async function pullRemote(query, fromCli = null, { verify = false, verbos
   // Cheap pass: filter by branch name (no description fetch). Preserves the
   // O(1)-network behavior for `pull <short-uuid>` against large transports.
   const cheap = candidates.filter((c) => matchesQuery(c, query));
+  // Description-side tags are always slugified by handoff-description.sh,
+  // so slugify the query once here. Lets `fetch "Foo Bar!"` match a branch
+  // tagged `foo-bar` instead of silently failing the exact-match pre-pass.
+  const querySlug = slugify(query);
   let hits;
   if (cheap.length === 1) {
     // Unambiguous cheap hit — return without enriching. Saves one
@@ -1268,13 +1272,17 @@ export async function pullRemote(query, fromCli = null, { verify = false, verbos
     // Multiple cheap hits — enrich for the collision UI and prefer exact-tag
     // matches within (#91 Gap 7).
     const enriched = enrichWithDescriptions(cheap);
-    const tagHits = enriched.filter((c) => parseTagsFromDescription(c.description).includes(query));
+    const tagHits = enriched.filter((c) =>
+      parseTagsFromDescription(c.description).includes(querySlug),
+    );
     hits = tagHits.length > 0 ? tagHits : enriched;
   } else {
     // No cheap match — enrich everyone, try exact-tag first (#91 Gap 7),
     // fall back to description substring.
     const enriched = enrichWithDescriptions(candidates);
-    const tagHits = enriched.filter((c) => parseTagsFromDescription(c.description).includes(query));
+    const tagHits = enriched.filter((c) =>
+      parseTagsFromDescription(c.description).includes(querySlug),
+    );
     hits = tagHits.length > 0 ? tagHits : enriched.filter((c) => matchesQuery(c, query));
   }
 

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -333,6 +333,46 @@ export function encodeDescription({ cli, shortId, project, host, month, tag }) {
   return r.stdout.trim();
 }
 
+/**
+ * Read tags from a metadata object, transparently handling both the
+ * v0 single-string `tag` field (deployed before #91 Gap 7) and the
+ * current `tags: string[]` array. Returns [] when neither is set.
+ *
+ * Array shape always wins when present (even if empty) so an explicit
+ * empty array does NOT fall back to legacy `tag`.
+ */
+export function tagsFromMeta(meta) {
+  if (Array.isArray(meta?.tags)) return meta.tags;
+  if (typeof meta?.tag === "string" && meta.tag.length > 0) return [meta.tag];
+  return [];
+}
+
+/**
+ * Extract the tag list from the description-string segment-8 (or v1
+ * segment-7) without round-tripping through `decodeDescription`. The
+ * tag segment is comma-joined per #91 Gap 7; a single-tag segment with
+ * no comma is read as a one-element list. Returns [] on shape mismatch.
+ *
+ * This stays in sync with the description.txt encoder so list/pull
+ * filters can avoid an extra `metadata.json` fetch per branch.
+ */
+export function parseTagsFromDescription(desc) {
+  if (typeof desc !== "string" || desc.length === 0) return [];
+  const parts = desc.split(":");
+  // v2: handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]
+  // v1: handoff:v1:<cli>:<short>:<project>:<host>[:<tag>]
+  let tagSeg = "";
+  if (parts[0] === "handoff" && parts[1] === "v2" && parts.length === 8) {
+    tagSeg = parts[7];
+  } else if (parts[0] === "handoff" && parts[1] === "v1" && parts.length === 7) {
+    tagSeg = parts[6];
+  } else {
+    return [];
+  }
+  if (!tagSeg) return [];
+  return tagSeg.split(",").filter((t) => t.length > 0);
+}
+
 /** Decode a handoff description string back into a metadata object, or null on failure. */
 export function decodeDescription(desc) {
   if (!desc) return null;
@@ -693,11 +733,19 @@ export async function pushRemote({
   cli,
   path: sessionFile,
   tag,
+  tags,
   verify = false,
   verbose = false,
   force = false,
   dryRun = false,
 }) {
+  // #91 Gap 7: accept either `tags: string[]` (new, multi-tag) or the legacy
+  // `tag: string` (single). Internally everything below works on `tagList`.
+  const tagList = Array.isArray(tags)
+    ? tags.filter((t) => typeof t === "string" && t.length > 0)
+    : tag
+      ? [tag]
+      : [];
   // Dry-run must stay fully offline — no interactive bootstrap, no preflight
   // probe. The bin's emitRemoteError formats the HandoffError thrown here
   // when the env var is unset.
@@ -719,13 +767,16 @@ export async function pushRemote({
   const host = slugify(hostname());
   const project = projectSlugFromCwd(meta.cwd);
   const month = monthBucket();
+  // Pass tags pre-joined with commas; the encode script splits, slugifies
+  // each token, validates, and rejoins so single-tag input stays
+  // backward-compatible with the v0 single-tag segment shape.
   const description = encodeDescription({
     cli: meta.cli,
     shortId,
     project,
     host,
     month,
-    tag: tag || null,
+    tag: tagList.length > 0 ? tagList.join(",") : null,
   });
 
   const metadata = {
@@ -738,7 +789,12 @@ export async function pushRemote({
     hostname: host,
     created_at: new Date().toISOString(),
     scrubbed_count: scrubbedCount,
-    tag: tag || null,
+    // #91 Gap 7: write both shapes for one release cycle so deployed installs
+    // that only know about `metadata.tag` keep working. New readers prefer
+    // `metadata.tags` via tagsFromMeta(); the legacy field will be dropped
+    // in a follow-up.
+    tags: tagList,
+    tag: tagList[0] ?? null,
   };
 
   const branch = v2BranchName({ project, cli: meta.cli, month, shortId });
@@ -752,7 +808,8 @@ export async function pushRemote({
       scrubbedCount,
       digestBytes: Buffer.byteLength(scrubbed, "utf8"),
       metadata,
-      tag: tag || null,
+      tags: tagList,
+      tag: tagList[0] ?? null,
     };
   }
 
@@ -786,7 +843,7 @@ export async function pushRemote({
           : ["push", "-q", "-f", "origin", branch],
         tmp,
       );
-      return { dryRun: false, branch, url, description, scrubbedCount };
+      return { dryRun: false, branch, url, description, scrubbedCount, tags: tagList };
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -1199,14 +1256,21 @@ export async function pullRemote(query, fromCli = null, { verify = false, verbos
     return sorted ? sorted[0] : candidates[candidates.length - 1];
   }
 
-  // Cheap pass: filter by branch name.
+  // Cheap pass: filter by branch name (no description fetch). Preserves the
+  // O(1)-network behavior for `pull <short-uuid>` against large transports.
   let hits = candidates.filter((c) => matchesQuery(c, query));
   if (hits.length === 0) {
-    // Expensive pass: enrich with descriptions and re-match.
+    // No cheap match → enrich everyone and look for an exact-tag match
+    // first (#91 Gap 7), then fall back to description substring.
     const enriched = enrichWithDescriptions(candidates);
-    hits = enriched.filter((c) => matchesQuery(c, query));
+    const tagHits = enriched.filter((c) => parseTagsFromDescription(c.description).includes(query));
+    hits = tagHits.length > 0 ? tagHits : enriched.filter((c) => matchesQuery(c, query));
   } else {
-    hits = enrichWithDescriptions(hits);
+    // Cheap branch-name hits exist; enrich them so the collision UI shows
+    // descriptions, and within them prefer exact-tag matches if any (#91 Gap 7).
+    const enriched = enrichWithDescriptions(hits);
+    const tagHits = enriched.filter((c) => parseTagsFromDescription(c.description).includes(query));
+    hits = tagHits.length > 0 ? tagHits : enriched;
   }
 
   if (hits.length === 0) {

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -791,8 +791,8 @@ export async function pushRemote({
     scrubbed_count: scrubbedCount,
     // #91 Gap 7: write both shapes for one release cycle so deployed installs
     // that only know about `metadata.tag` keep working. New readers prefer
-    // `metadata.tags` via tagsFromMeta(); the legacy field will be dropped
-    // in a follow-up.
+    // `metadata.tags` via tagsFromMeta().
+    // TODO(#91 Gap 7 follow-up, after 0.13.0): drop the legacy `tag` field.
     tags: tagList,
     tag: tagList[0] ?? null,
   };
@@ -1258,19 +1258,24 @@ export async function pullRemote(query, fromCli = null, { verify = false, verbos
 
   // Cheap pass: filter by branch name (no description fetch). Preserves the
   // O(1)-network behavior for `pull <short-uuid>` against large transports.
-  let hits = candidates.filter((c) => matchesQuery(c, query));
-  if (hits.length === 0) {
-    // No cheap match → enrich everyone and look for an exact-tag match
-    // first (#91 Gap 7), then fall back to description substring.
+  const cheap = candidates.filter((c) => matchesQuery(c, query));
+  let hits;
+  if (cheap.length === 1) {
+    // Unambiguous cheap hit — return without enriching. Saves one
+    // description fetch on the common `fetch <short-uuid>` path.
+    hits = cheap;
+  } else if (cheap.length > 1) {
+    // Multiple cheap hits — enrich for the collision UI and prefer exact-tag
+    // matches within (#91 Gap 7).
+    const enriched = enrichWithDescriptions(cheap);
+    const tagHits = enriched.filter((c) => parseTagsFromDescription(c.description).includes(query));
+    hits = tagHits.length > 0 ? tagHits : enriched;
+  } else {
+    // No cheap match — enrich everyone, try exact-tag first (#91 Gap 7),
+    // fall back to description substring.
     const enriched = enrichWithDescriptions(candidates);
     const tagHits = enriched.filter((c) => parseTagsFromDescription(c.description).includes(query));
     hits = tagHits.length > 0 ? tagHits : enriched.filter((c) => matchesQuery(c, query));
-  } else {
-    // Cheap branch-name hits exist; enrich them so the collision UI shows
-    // descriptions, and within them prefer exact-tag matches if any (#91 Gap 7).
-    const enriched = enrichWithDescriptions(hits);
-    const tagHits = enriched.filter((c) => parseTagsFromDescription(c.description).includes(query));
-    hits = tagHits.length > 0 ? tagHits : enriched;
   }
 
   if (hits.length === 0) {

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -40,9 +40,9 @@ bash tool.
 
 ```
 /handoff pull [<id>] [--from <cli>] [--to <cli>] [--summary] [-o <path>]
-/handoff push [<query>] [--from <cli>] [--tag <label>]
+/handoff push [<query>] [--from <cli>] [--tag <label> ...]
 /handoff fetch [<query>] [--from <cli>] [--verify]
-/handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
+/handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all] [--tag <name>] [--tags]
 ```
 
 A bare `/handoff` with no arguments prints usage and exits 0. Every
@@ -79,7 +79,7 @@ semantics. Brief summary:
 | -------------------- | ---------------------------------------------------------------------------------------------------- |
 | `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk     |
 | `resolve <cli> <id>` | Print the absolute JSONL path                                                                        |
-| `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
+| `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`, `--tag <name>`, `--tags`) |
 | `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
 | `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                           |
 | `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
@@ -108,7 +108,11 @@ Cross-cutting flags (consult `--help` for the canonical list):
   disables the cap.
 - `--fixed` / `-F` treats the `search` query as a literal string
   instead of a regex.
-- `--tag <label>` annotates a `push` for fuzzy `fetch` later.
+- `--tag <label>` annotates a `push`. Repeatable for multi-tag
+  (`--tag shipping --tag perf`). On `list --remote`, `--tag <name>`
+  filters by exact tag and `--tags` switches to a tag-frequency
+  histogram. On `fetch <tag>`, exact-tag matches are preferred over
+  description substring fallback.
 - `--from-file <path>` lets `fetch` load a local markdown file written
   by `pull -o`. Works without network access.
 - `--json` is honoured by `list`, `pull`, `remote-list`, `search`.

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -75,16 +75,16 @@ with a TSV candidate list on stderr.
 The binary's `--help` lists the full surface and authoritative flag
 semantics. Brief summary:
 
-| Sub                  | Purpose                                                                                              |
-| -------------------- | ---------------------------------------------------------------------------------------------------- |
-| `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk     |
-| `resolve <cli> <id>` | Print the absolute JSONL path                                                                        |
+| Sub                  | Purpose                                                                                                               |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk                      |
+| `resolve <cli> <id>` | Print the absolute JSONL path                                                                                         |
 | `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`, `--tag <name>`, `--tags`) |
-| `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
-| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                           |
-| `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
-| `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
-| `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
+| `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json`                  |
+| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                                            |
+| `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                                       |
+| `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                                      |
+| `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                                              |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -252,12 +252,28 @@ teardown() {
   [[ "$output" == *"<handoff"* ]]
 }
 
-@test "fetch collision on non-TTY exits 2 with candidate list" {
+@test "fetch <tag>: exact-tag match wins over substring (#91 Gap 7)" {
+  # Two branches with overlapping tag substrings: "alpha" and "alpha-beta".
+  # Pre-Gap-7, `fetch alpha` would substring-match both and exit 2 with a
+  # collision. Post-Gap-7, exact-tag pre-pass resolves to the `alpha` branch.
   run node "$BIN" push my-feature --tag alpha
   [ "$status" -eq 0 ]
   run node "$BIN" push my-codex-task --tag alpha-beta
   [ "$status" -eq 0 ]
   run node "$BIN" fetch alpha </dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "fetch collision on non-TTY exits 2 when substring matches both descriptions" {
+  # `my-feature` substring appears in two distinct branch descriptions
+  # (one for the claude session, one for the codex session). With no
+  # exact-tag match available, the resolver falls back to substring and
+  # surfaces both candidates as a collision.
+  run node "$BIN" push my-feature
+  [ "$status" -eq 0 ]
+  run node "$BIN" push my-codex-task
+  [ "$status" -eq 0 ]
+  run node "$BIN" fetch demo </dev/null
   [ "$status" -eq 2 ]
   [[ "$output" =~ handoff/demo/(claude|codex)/ ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-tags.bats
+++ b/plugins/dotclaude/tests/bats/handoff-tags.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+# Integration tests for #91 Gap 7: tags first-class.
+#
+# Covers (a) multi-tag push writes both metadata.tags and legacy
+# metadata.tag, (b) exact-tag pull resolution beats substring,
+# (c) `list --remote --tag <name>` filter, (d) `list --remote --tags`
+# histogram, (e) legacy single-tag metadata still resolves through
+# the migration helper, (f) special-char tag slugification round-trip.
+
+bats_require_minimum_version 1.5.0
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+STUB_DOCTOR=""
+
+# slugify(hostname()) — must match the lib so own-host filter resolves.
+this_host_slug() {
+  hostname | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-40
+}
+
+# Push a stub branch directly, encoding tags into description + metadata.json.
+# Used to simulate branches written by older dotclaude installs (legacy
+# single-tag) and to seed the histogram + filter tests deterministically.
+seed_handoff_branch() {
+  local transport="$1" branch="$2" host="$3" cli="$4" desc_tag_seg="$5" meta_json="$6"
+  local tmp; tmp=$(mktemp -d)
+  (
+    cd "$tmp"
+    git init -q
+    git config user.email handoff@dotclaude.local
+    git config user.name dotclaude-handoff
+    git checkout -q -b "$branch"
+    printf 'stub handoff body\n' > handoff.md
+    if [ -n "$desc_tag_seg" ]; then
+      printf 'handoff:v2:%s:%s:2026-04:%s:%s:%s\n' \
+        proj "$cli" "${branch##*/}" "$host" "$desc_tag_seg" > description.txt
+    else
+      printf 'handoff:v2:%s:%s:2026-04:%s:%s\n' \
+        proj "$cli" "${branch##*/}" "$host" > description.txt
+    fi
+    printf '%s\n' "$meta_json" > metadata.json
+    git add . >/dev/null
+    git commit -q -m fixture >/dev/null
+    git push -q "$transport" "$branch" >/dev/null
+  )
+  rm -rf "$tmp"
+}
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  make_claude_session_tree "$TEST_HOME"
+
+  TRANSPORT_REPO=$(mktemp -d)
+  rm -rf "$TRANSPORT_REPO"
+  git init -q --bare "$TRANSPORT_REPO"
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+
+  STUB_DOCTOR=$(mktemp)
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_DOCTOR"
+  chmod +x "$STUB_DOCTOR"
+  export DOTCLAUDE_DOCTOR_SH="$STUB_DOCTOR"
+
+  THIS_HOST=$(this_host_slug)
+  export TRANSPORT_REPO STUB_DOCTOR THIS_HOST
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+  [ -f "${STUB_DOCTOR:-}" ] && rm -f "$STUB_DOCTOR"
+}
+
+# ---- 1: multi-tag push writes both tags array and legacy tag field --------
+
+@test "push --tag foo --tag bar: writes metadata.tags=[foo,bar] and tag=foo" {
+  run --separate-stderr node "$BIN" push --tag foo --tag bar
+  [ "$status" -eq 0 ]
+
+  # Fetch the branch and inspect metadata.json.
+  local branch; branch=$(echo "$output" | head -1)
+  local checkout; checkout=$(mktemp -d)
+  git clone -q --depth 1 --branch "$branch" "$TRANSPORT_REPO" "$checkout"
+  echo "$checkout/metadata.json:"
+  cat "$checkout/metadata.json"
+  jq -e '.tags == ["foo","bar"]' "$checkout/metadata.json" >/dev/null
+  jq -e '.tag == "foo"' "$checkout/metadata.json" >/dev/null
+  rm -rf "$checkout"
+}
+
+# ---- 2: exact-tag pull beats substring ------------------------------------
+
+@test "fetch <tag>: exact-tag match wins over substring on description" {
+  # Seed a branch tagged exactly "shipping" plus a decoy whose description
+  # contains "shipping" as a substring of project name.
+  seed_handoff_branch "$TRANSPORT_REPO" "handoff/proj/claude/2026-04/aaaaaaaa" \
+    "$THIS_HOST" claude "shipping" \
+    '{"cli":"claude","hostname":"'"$THIS_HOST"'","short_id":"aaaaaaaa","tags":["shipping"],"tag":"shipping"}'
+  seed_handoff_branch "$TRANSPORT_REPO" "handoff/proj/claude/2026-04/bbbbbbbb" \
+    "$THIS_HOST" claude "shipping-related" \
+    '{"cli":"claude","hostname":"'"$THIS_HOST"'","short_id":"bbbbbbbb","tags":["shipping-related"],"tag":"shipping-related"}'
+
+  run --separate-stderr node "$BIN" fetch shipping
+  [ "$status" -eq 0 ]
+  # The exact-tag match resolves to aaaaaaaa, not bbbbbbbb (substring would
+  # match both).
+  [[ "$output" == *"stub handoff body"* ]]
+}
+
+# ---- 3: legacy single-tag metadata still resolves -------------------------
+
+@test "fetch <tag>: legacy branch with only metadata.tag (no tags) still works" {
+  # Description carries only single-tag segment (no comma); metadata.json
+  # has only the legacy `tag` field.
+  seed_handoff_branch "$TRANSPORT_REPO" "handoff/proj/claude/2026-04/cccccccc" \
+    "$THIS_HOST" claude "legacy" \
+    '{"cli":"claude","hostname":"'"$THIS_HOST"'","short_id":"cccccccc","tag":"legacy"}'
+
+  run --separate-stderr node "$BIN" fetch legacy
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"stub handoff body"* ]]
+}
+
+# ---- 4: list --remote --tag filters by exact tag --------------------------
+
+@test "list --remote --tag foo: shows only branches tagged foo" {
+  seed_handoff_branch "$TRANSPORT_REPO" "handoff/proj/claude/2026-04/aaaaaaaa" \
+    "$THIS_HOST" claude "foo" \
+    '{"cli":"claude","tags":["foo"]}'
+  seed_handoff_branch "$TRANSPORT_REPO" "handoff/proj/claude/2026-04/bbbbbbbb" \
+    "$THIS_HOST" claude "bar" \
+    '{"cli":"claude","tags":["bar"]}'
+
+  run --separate-stderr node "$BIN" list --remote --tag foo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaaaaaa"* ]]
+  [[ "$output" != *"bbbbbbbb"* ]]
+}
+
+# ---- 5: list --remote --tags histogram ------------------------------------
+
+@test "list --remote --tags: prints sorted histogram" {
+  seed_handoff_branch "$TRANSPORT_REPO" "handoff/proj/claude/2026-04/aaaaaaaa" \
+    "$THIS_HOST" claude "shipping,perf" \
+    '{"cli":"claude","tags":["shipping","perf"]}'
+  seed_handoff_branch "$TRANSPORT_REPO" "handoff/proj/claude/2026-04/bbbbbbbb" \
+    "$THIS_HOST" claude "shipping" \
+    '{"cli":"claude","tags":["shipping"]}'
+  seed_handoff_branch "$TRANSPORT_REPO" "handoff/proj/claude/2026-04/cccccccc" \
+    "$THIS_HOST" claude "" \
+    '{"cli":"claude"}'
+
+  run --separate-stderr node "$BIN" list --remote --tags
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tag histogram"* ]]
+  [[ "$output" == *"shipping"* ]]
+  [[ "$output" == *"perf"* ]]
+  [[ "$output" == *"(untagged)"* ]]
+  # shipping=2, perf=1 — shipping should appear before perf in the output.
+  local shipping_line; shipping_line=$(echo "$output" | grep -n "shipping" | head -1 | cut -d: -f1)
+  local perf_line; perf_line=$(echo "$output" | grep -n "perf" | head -1 | cut -d: -f1)
+  [ "$shipping_line" -lt "$perf_line" ]
+}
+
+# ---- 6: special-char tag slugify round-trip -------------------------------
+
+@test "push --tag 'Foo Bar!': slugifies to foo-bar and round-trips" {
+  run --separate-stderr node "$BIN" push --tag 'Foo Bar!'
+  [ "$status" -eq 0 ]
+
+  local branch; branch=$(echo "$output" | head -1)
+  local description; description=$(echo "$output" | head -3 | tail -1)
+  # Description segment-8 is the slugified tag.
+  [[ "$description" == *":foo-bar" ]]
+
+  local checkout; checkout=$(mktemp -d)
+  git clone -q --depth 1 --branch "$branch" "$TRANSPORT_REPO" "$checkout"
+  # Metadata preserves the raw user input (matches existing single-tag
+  # behavior — the script slugifies for the description, not metadata).
+  jq -e '.tags == ["Foo Bar!"]' "$checkout/metadata.json" >/dev/null
+  rm -rf "$checkout"
+}

--- a/plugins/dotclaude/tests/bats/handoff-tags.bats
+++ b/plugins/dotclaude/tests/bats/handoff-tags.bats
@@ -163,6 +163,21 @@ teardown() {
   [ "$shipping_line" -lt "$perf_line" ]
 }
 
+# ---- bonus: fetch with raw user input still resolves slugified tag -------
+
+@test "fetch \"Foo Bar!\": matches a branch tagged foo-bar (slug-aware exact match)" {
+  # Push with raw special-char tag — encoder slugifies into description.
+  run --separate-stderr node "$BIN" push --tag 'Foo Bar!'
+  [ "$status" -eq 0 ]
+  # Fetch with the SAME raw user input — resolver must slugify before
+  # comparing to description-side tags so this exact-tag hit lands.
+  # Pre-fix, this would fall through to substring matching on the raw
+  # query "Foo Bar!" and never resolve.
+  run --separate-stderr node "$BIN" fetch 'Foo Bar!'
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
 # ---- 6: special-char tag slugify round-trip -------------------------------
 
 @test "push --tag 'Foo Bar!': slugifies to foo-bar and round-trips" {

--- a/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
@@ -41,6 +41,7 @@ describe("export shape", () => {
     "PRUNE_SKIP_BUCKETS",
     "parseDuration",
     "parseHandoffBranch",
+    "parseTagsFromDescription",
     "printManualSetupBlock",
     "probeCollision",
     "projectSlugFromCwd",
@@ -55,6 +56,7 @@ describe("export shape", () => {
     "runScript",
     "slugify",
     "slugifyRepoName",
+    "tagsFromMeta",
     "v2BranchName",
     "validateTransportUrl",
   ];

--- a/plugins/dotclaude/tests/handoff-tags.test.mjs
+++ b/plugins/dotclaude/tests/handoff-tags.test.mjs
@@ -1,0 +1,65 @@
+// Unit tests for handoff tags first-class promotion (#91 Gap 7).
+// Covers the migration helper `tagsFromMeta` and the description-side
+// `parseTagsFromDescription` helper. End-to-end behavior (push, pull,
+// list filter, histogram) is exercised by handoff-tags.bats.
+
+import { describe, it, expect } from "vitest";
+import { tagsFromMeta, parseTagsFromDescription } from "../src/lib/handoff-remote.mjs";
+
+describe("tagsFromMeta", () => {
+  it("returns the array as-is when metadata.tags is set", () => {
+    expect(tagsFromMeta({ tags: ["shipping", "perf"] })).toEqual(["shipping", "perf"]);
+  });
+
+  it("falls back to [metadata.tag] when only the legacy field is set", () => {
+    expect(tagsFromMeta({ tag: "shipping" })).toEqual(["shipping"]);
+  });
+
+  it("returns [] for null/empty/missing tag fields", () => {
+    expect(tagsFromMeta({ tag: null })).toEqual([]);
+    expect(tagsFromMeta({ tag: "" })).toEqual([]);
+    expect(tagsFromMeta({})).toEqual([]);
+    expect(tagsFromMeta(null)).toEqual([]);
+    expect(tagsFromMeta(undefined)).toEqual([]);
+  });
+
+  it("prefers tags over the legacy tag field when both are present", () => {
+    expect(tagsFromMeta({ tags: ["a", "b"], tag: "ignored" })).toEqual(["a", "b"]);
+  });
+
+  it("treats an empty tags array as no tags (not legacy fallback)", () => {
+    // Explicit empty array means "no tags"; we should NOT fall back to .tag.
+    expect(tagsFromMeta({ tags: [], tag: "ignored" })).toEqual([]);
+  });
+});
+
+describe("parseTagsFromDescription", () => {
+  it("returns [] for null/empty/non-handoff descriptions", () => {
+    expect(parseTagsFromDescription(null)).toEqual([]);
+    expect(parseTagsFromDescription("")).toEqual([]);
+    expect(parseTagsFromDescription("not a handoff string")).toEqual([]);
+  });
+
+  it("returns [] for v2 descriptions without a tag segment", () => {
+    expect(parseTagsFromDescription("handoff:v2:proj:claude:2026-04:abc12345:host")).toEqual([]);
+  });
+
+  it("returns [tag] for v2 descriptions with a single-tag segment (legacy)", () => {
+    expect(
+      parseTagsFromDescription("handoff:v2:proj:claude:2026-04:abc12345:host:shipping"),
+    ).toEqual(["shipping"]);
+  });
+
+  it("splits comma-joined tag segment into an array (multi-tag)", () => {
+    expect(
+      parseTagsFromDescription("handoff:v2:proj:claude:2026-04:abc12345:host:shipping,perf"),
+    ).toEqual(["shipping", "perf"]);
+  });
+
+  it("handles v1 descriptions (legacy) — single-tag only", () => {
+    expect(parseTagsFromDescription("handoff:v1:claude:abc12345:proj:host:legacy")).toEqual([
+      "legacy",
+    ]);
+    expect(parseTagsFromDescription("handoff:v1:claude:abc12345:proj:host")).toEqual([]);
+  });
+});

--- a/plugins/dotclaude/tests/handoff-tags.test.mjs
+++ b/plugins/dotclaude/tests/handoff-tags.test.mjs
@@ -33,6 +33,16 @@ describe("tagsFromMeta", () => {
   });
 });
 
+describe("description-tag matching is slug-aware (#91 Gap 7 review fix)", () => {
+  it("a description-side tag survives the slugify roundtrip", () => {
+    // Description tags are always slugified by handoff-description.sh.
+    // The exact-tag matcher in pullRemote slugifies the query before
+    // comparing so `fetch \"Foo Bar!\"` matches a branch tagged `foo-bar`.
+    const tags = parseTagsFromDescription("handoff:v2:p:claude:2026-04:abc12345:h:foo-bar");
+    expect(tags).toEqual(["foo-bar"]);
+  });
+});
+
 describe("parseTagsFromDescription", () => {
   it("returns [] for null/empty/non-handoff descriptions", () => {
     expect(parseTagsFromDescription(null)).toEqual([]);

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -43,9 +43,9 @@ bash tool.
 
 ```
 /handoff pull [<id>] [--from <cli>] [--to <cli>] [--summary] [-o <path>]
-/handoff push [<query>] [--from <cli>] [--tag <label>]
+/handoff push [<query>] [--from <cli>] [--tag <label> ...]
 /handoff fetch [<query>] [--from <cli>] [--verify]
-/handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all]
+/handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all] [--tag <name>] [--tags]
 ```
 
 A bare `/handoff` with no arguments prints usage and exits 0. Every
@@ -82,7 +82,7 @@ semantics. Brief summary:
 | -------------------- | ---------------------------------------------------------------------------------------------------- |
 | `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk     |
 | `resolve <cli> <id>` | Print the absolute JSONL path                                                                        |
-| `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`)          |
+| `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`, `--tag <name>`, `--tags`) |
 | `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
 | `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                           |
 | `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
@@ -111,7 +111,11 @@ Cross-cutting flags (consult `--help` for the canonical list):
   disables the cap.
 - `--fixed` / `-F` treats the `search` query as a literal string
   instead of a regex.
-- `--tag <label>` annotates a `push` for fuzzy `fetch` later.
+- `--tag <label>` annotates a `push`. Repeatable for multi-tag
+  (`--tag shipping --tag perf`). On `list --remote`, `--tag <name>`
+  filters by exact tag and `--tags` switches to a tag-frequency
+  histogram. On `fetch <tag>`, exact-tag matches are preferred over
+  description substring fallback.
 - `--from-file <path>` lets `fetch` load a local markdown file written
   by `pull -o`. Works without network access.
 - `--json` is honoured by `list`, `pull`, `remote-list`, `search`.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -78,16 +78,16 @@ with a TSV candidate list on stderr.
 The binary's `--help` lists the full surface and authoritative flag
 semantics. Brief summary:
 
-| Sub                  | Purpose                                                                                              |
-| -------------------- | ---------------------------------------------------------------------------------------------------- |
-| `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk     |
-| `resolve <cli> <id>` | Print the absolute JSONL path                                                                        |
+| Sub                  | Purpose                                                                                                               |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk                      |
+| `resolve <cli> <id>` | Print the absolute JSONL path                                                                                         |
 | `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`, `--tag <name>`, `--tags`) |
-| `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json` |
-| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                           |
-| `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                      |
-| `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                     |
-| `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                             |
+| `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json`                  |
+| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                                            |
+| `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                                       |
+| `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                                      |
+| `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                                              |
 
 Cross-cutting flags (consult `--help` for the canonical list):
 


### PR DESCRIPTION
## Summary

- Promotes `metadata.tags` from a single nullable string to a first-class array of strings, with a one-release-cycle migration window (writes both `tags: [...]` and legacy `tag: tags[0]`)
- Multi-tag push (`--tag foo --tag bar`), exact-tag fetch resolution (`fetch shipping` beats substring `shipping-related`), `list --remote --tag <name>` filter, `list --remote --tags` frequency histogram
- New `tagsFromMeta` and `parseTagsFromDescription` helpers as the single source of migration truth — used by list/pull/push so legacy single-tag branches keep resolving without metadata.json round trips

## Test plan

- [x] `npm test` — 532/532 pass (was 522; +11 new unit cases for tag helpers)
- [x] `npx bats plugins/dotclaude/tests/bats/` — 328/328 pass (was 321; +6 new integration cases, +1 substring-collision test, -1 deliberately removed substring-as-collision case that's now resolved by exact-tag)
- [x] Coverage: 88.32% statements / 80.88% branches (both above floor)
- [x] Manual: `push --tag foo --tag bar` → metadata.json has `tags: ["foo","bar"]` and `tag: "foo"`
- [x] Manual: `list --remote --tags` prints sorted histogram with `(untagged)` bucket

## Spec ID

dotclaude-core