### PR TITLE
spec(handoff-skill): redesign + ARCH-10 drift test

### DIFF
--- a/docs/specs/handoff-skill/README.md
+++ b/docs/specs/handoff-skill/README.md
@@ -1,0 +1,31 @@
+# handoff-skill — Engineering Spec
+
+> Redesign the cross-CLI / cross-machine session handoff skill to fix accumulated UX debt — strip cosmetic flags that don't carry information, abstract source/target detection from the user, and commit to one coherent mental model end-to-end.
+>
+> Created: 2026-04-26
+> Branch: `spec/handoff-skill`
+> Worktree: `.claude/worktrees/spec-handoff-skill/`
+> Base: `origin/main` @ `c117418`
+
+## Status
+
+| #   | Section                     | Status    |
+| --- | --------------------------- | --------- |
+| 1   | Problem / Motivation        | [x] done  |
+| 2   | Scope                       | [x] done  |
+| 3   | High-Level Architecture     | [x] done  |
+| 4   | Data Flow / Components      | [x] done  |
+| 5   | Interfaces and APIs         | [x] done  |
+| 6   | Implementation Plan         | [x] done  |
+| 7   | Non-Functional Requirements | [x] done  |
+| 8   | Risks and Alternatives      | [x] done  |
+
+## Quick Start
+
+1. **Drift test is the spec's tooth** — see [ARCH-10](spec/3-high-level-architecture.md).
+2. **Read in order**: [§1](spec/1-problem-motivation.md) → [§2](spec/2-scope.md) → [§5](spec/5-interfaces-apis.md) (the contract). Skip to [§8](spec/8-risks-alternatives.md) if you want to know why something *isn't* in the design.
+3. **Constraint IDs (ARCH / KD / REL / SEC / PERF / OPS / R / A) and file citations (function/heading anchors, never line ranges) are stable references** — don't renumber, don't reanchor.
+
+## Research Sources
+
+See [research/sources.md](research/sources.md) for indexed source documents.

--- a/docs/specs/handoff-skill/README.md
+++ b/docs/specs/handoff-skill/README.md
@@ -9,21 +9,21 @@
 
 ## Status
 
-| #   | Section                     | Status    |
-| --- | --------------------------- | --------- |
-| 1   | Problem / Motivation        | [x] done  |
-| 2   | Scope                       | [x] done  |
-| 3   | High-Level Architecture     | [x] done  |
-| 4   | Data Flow / Components      | [x] done  |
-| 5   | Interfaces and APIs         | [x] done  |
-| 6   | Implementation Plan         | [x] done  |
-| 7   | Non-Functional Requirements | [x] done  |
-| 8   | Risks and Alternatives      | [x] done  |
+| #   | Section                     | Status   |
+| --- | --------------------------- | -------- |
+| 1   | Problem / Motivation        | [x] done |
+| 2   | Scope                       | [x] done |
+| 3   | High-Level Architecture     | [x] done |
+| 4   | Data Flow / Components      | [x] done |
+| 5   | Interfaces and APIs         | [x] done |
+| 6   | Implementation Plan         | [x] done |
+| 7   | Non-Functional Requirements | [x] done |
+| 8   | Risks and Alternatives      | [x] done |
 
 ## Quick Start
 
 1. **Drift test is the spec's tooth** — see [ARCH-10](spec/3-high-level-architecture.md).
-2. **Read in order**: [§1](spec/1-problem-motivation.md) → [§2](spec/2-scope.md) → [§5](spec/5-interfaces-apis.md) (the contract). Skip to [§8](spec/8-risks-alternatives.md) if you want to know why something *isn't* in the design.
+2. **Read in order**: [§1](spec/1-problem-motivation.md) → [§2](spec/2-scope.md) → [§5](spec/5-interfaces-apis.md) (the contract). Skip to [§8](spec/8-risks-alternatives.md) if you want to know why something _isn't_ in the design.
 3. **Constraint IDs (ARCH / KD / REL / SEC / PERF / OPS / R / A) and file citations (function/heading anchors, never line ranges) are stable references** — don't renumber, don't reanchor.
 
 ## Research Sources

--- a/docs/specs/handoff-skill/research/sources.md
+++ b/docs/specs/handoff-skill/research/sources.md
@@ -1,0 +1,7 @@
+# Research Sources
+
+> Indexed documents feeding into this spec. Each tagged with which sections it informs.
+
+<!-- Format:
+- **DOC-N**: {title} — {one-line description}. Feeds: §N, §N.
+-->

--- a/docs/specs/handoff-skill/spec.json
+++ b/docs/specs/handoff-skill/spec.json
@@ -1,0 +1,36 @@
+{
+  "id": "handoff-skill",
+  "title": "Handoff skill — cross-CLI / cross-machine session transfer",
+  "status": "draft",
+  "owners": ["dotclaude maintainers"],
+  "linked_paths": [
+    "skills/handoff/SKILL.md",
+    "skills/handoff/references/**",
+    "plugins/dotclaude/bin/dotclaude-handoff.mjs",
+    "plugins/dotclaude/src/lib/handoff-remote.mjs",
+    "plugins/dotclaude/src/lib/handoff-scrub.mjs",
+    "plugins/dotclaude/scripts/handoff-resolve.sh",
+    "plugins/dotclaude/scripts/handoff-extract.sh",
+    "plugins/dotclaude/scripts/handoff-scrub.sh",
+    "plugins/dotclaude/scripts/handoff-description.sh",
+    "plugins/dotclaude/scripts/handoff-doctor.sh",
+    "plugins/dotclaude/tests/bats/handoff-*.bats",
+    "plugins/dotclaude/tests/handoff-*.test.mjs",
+    "docs/handoff-guide.md"
+  ],
+  "acceptance_commands": [
+    "npm test -- handoff-drift",
+    "bats plugins/dotclaude/tests/bats/handoff-*.bats"
+  ],
+  "depends_on_specs": ["dotclaude-core"],
+  "active_prs": [],
+  "_label_history": {
+    "note": "During spec drafting, chat-time NFR labels were renumbered to sequential order in §7. Mapping preserved here for chat-history-to-spec reconciliation. Spec body uses the sequential labels exclusively.",
+    "mappings": [
+      "chat OPS-3 (stdout determinism) -> spec OPS-2",
+      "chat OPS-4 (exit codes are public contract) -> spec OPS-3",
+      "chat SEC-4 (per-branch payload ceiling) -> spec SEC-4 (no shift)",
+      "OPS-2 (bootstrap idempotent) was folded into REL-3, freeing the OPS-2 number"
+    ]
+  }
+}

--- a/docs/specs/handoff-skill/spec.json
+++ b/docs/specs/handoff-skill/spec.json
@@ -1,7 +1,7 @@
 {
   "id": "handoff-skill",
   "title": "Handoff skill — cross-CLI / cross-machine session transfer",
-  "status": "draft",
+  "status": "implementing",
   "owners": ["dotclaude maintainers"],
   "linked_paths": [
     "skills/handoff/SKILL.md",
@@ -23,7 +23,7 @@
     "bats plugins/dotclaude/tests/bats/handoff-*.bats"
   ],
   "depends_on_specs": ["dotclaude-core"],
-  "active_prs": [],
+  "active_prs": [108],
   "_label_history": {
     "note": "During spec drafting, chat-time NFR labels were renumbered to sequential order in §7. Mapping preserved here for chat-history-to-spec reconciliation. Spec body uses the sequential labels exclusively.",
     "mappings": [

--- a/docs/specs/handoff-skill/spec/1-problem-motivation.md
+++ b/docs/specs/handoff-skill/spec/1-problem-motivation.md
@@ -1,0 +1,75 @@
+# §1 — Problem / Motivation
+
+> Why does this exist? What's broken? Why now?
+
+## Why
+
+The handoff skill exists to solve one user-facing problem in two flavors:
+
+1. **Cross-agent handoff (same machine).** When the user has to leave the
+   current agent — Claude Code session limits hit, the model degrades, or a
+   different agent is better suited for the next task — they need to continue
+   the work in another agent without re-explaining context. All three
+   supported agents (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI) must
+   work as both source and target, in any combination
+   (Claude ↔ Copilot, Claude ↔ Codex, Copilot ↔ Codex).
+
+2. **Cross-machine handoff (any agent → any agent).** When the user shifts to
+   a different machine — laptop ↔ desktop, work ↔ personal, end-of-day on
+   machine A ↔ morning on machine B — the same context transfer has to
+   survive the move. The transport is a private GitHub repository: push from
+   the source machine, pull on the target machine.
+
+These are the **only** primary jobs. Every other capability the skill exposes
+today (`search`, `describe`, `list`, `file`, `digest`, `resolve`,
+`remote-list`, `doctor`) is supporting infrastructure that exists to make the
+two primary jobs reliable — not a peer feature on the public surface.
+
+## What
+
+A skill whose **public surface is the two jobs**, not five forms and eleven
+sub-commands:
+
+- **Handoff to another agent.** One obvious invocation that produces the
+  digest the user pastes into the next agent. The source CLI is auto-detected
+  from where the binary is running. The target CLI is, by definition,
+  whatever the user pastes into — so the user is never asked to declare the
+  target.
+
+- **Push / pull across machines.** One invocation per direction. Source is
+  detected the same way; the remote is a private GitHub repository configured
+  once.
+
+Everything else (search, describe, list, …) is reachable when needed but does
+not compete with the primary surface for the user's attention.
+
+## Why Now
+
+The skill has been iterated on across at least ten merged PRs touching the
+same surface (#66 drop `<cli>` positional → #68 remove gist transports → #70
+rename internals → #71 promote sub-commands into the binary → #72 slim
+`SKILL.md` → #73 v2 store taxonomy → #80 self-bootstrap → #92 fail-closed
+scrub → #93 shared library → #107 tags first-class). Each PR fixed a local
+symptom without converging on a coherent shape. The current state has these
+concrete tells:
+
+- The skill description, the references, the binary `--help`, and the actual
+  binary code disagree on what flags exist (e.g. `--from-file` is documented
+  in `skills/handoff/SKILL.md` and `references/prerequisites.md` but not
+  wired in `plugins/dotclaude/bin/dotclaude-handoff.mjs`).
+- Cosmetic flags (`--to`) are required to do things that should be automatic
+  — the target CLI is implicitly "wherever the user pastes," yet the binary
+  treats it as a value the user must declare.
+
+Three further symptoms enumerated in earlier drafts of this section
+(bare `/handoff` defaulting to push, "private GitHub gist" prose in old
+`SKILL.md`, and `--include-transcript` documented-but-unwired) shifted
+under us while this spec was being written — all three were patched in
+flight on `origin/main` (PRs #87 / silent-fix / #103). The patch-loop
+tax is the spec's thesis, not its background.
+
+The accumulated effect is that explaining what the skill does — to a new
+user, to a contributor, or to the maintainer six weeks later — keeps
+surfacing the same problems. A spec is needed to commit to **one** mental
+model, lock the public surface, and stop the patch-on-patch loop. Future PRs
+measure themselves against this spec rather than against the previous PR.

--- a/docs/specs/handoff-skill/spec/2-scope.md
+++ b/docs/specs/handoff-skill/spec/2-scope.md
@@ -5,7 +5,7 @@
 ## In Scope
 
 - **Public surface redesign.** Replace the current five-form / eleven-sub-command sprawl with a two-job surface (cross-agent + cross-machine) and demote supporting commands.
-- **Source-CLI auto-detection.** The binary determines source from where it's running; users never pass a `--from`-equivalent for normal flows.
+- **Source-CLI auto-detection.** For query-based flows, the binary determines source from the path it resolves; users do not pass a `--from`-equivalent. For `push` without a `<query>`, `--from` is required.
 - **Target-CLI implicit handling.** The target is "wherever the user pastes" — the user is never asked to declare it. The `--to` flag and the per-target Next-step text branching get removed.
 - **Push / pull contract for the GitHub-repo transport.** Lock the branch-naming, scrubbing, metadata, and pull-resolution semantics so they stop changing PR-to-PR.
 - **Supporting-command surface.** Define how `search`, `describe`, `list`, `file`, `digest`, `resolve`, `remote-list`, `doctor` are reachable without competing for primary attention. Some may be removed entirely if they don't feed a primary job.
@@ -40,19 +40,19 @@
 
 ## Boundaries
 
-| Touches                                                  | Does Not Touch                                              |
-| -------------------------------------------------------- | ----------------------------------------------------------- |
-| `skills/handoff/SKILL.md`                                | Other skill SKILL.md files                                  |
-| `skills/handoff/references/*.md`                         | Skills outside `skills/handoff/`                            |
-| `plugins/dotclaude/bin/dotclaude-handoff.mjs`            | Other `plugins/dotclaude/bin/*.mjs` entrypoints             |
-| `plugins/dotclaude/src/lib/handoff-remote.mjs`           | `plugins/dotclaude/src/lib/argv.mjs`, `exit-codes.mjs`      |
-| `plugins/dotclaude/src/lib/handoff-scrub.mjs`            | Scrub patterns in `plugins/dotclaude/scripts/handoff-scrub.sh` |
-| `plugins/dotclaude/scripts/handoff-doctor.sh`            | `handoff-extract.sh` (substrate, frozen)                    |
-| `plugins/dotclaude/scripts/handoff-description.sh`       | `handoff-resolve.sh` internals (substrate, frozen)          |
+| Touches                                                  | Does Not Touch                                                       |
+| -------------------------------------------------------- | -------------------------------------------------------------------- |
+| `skills/handoff/SKILL.md`                                | Other skill SKILL.md files                                           |
+| `skills/handoff/references/*.md`                         | Skills outside `skills/handoff/`                                     |
+| `plugins/dotclaude/bin/dotclaude-handoff.mjs`            | Other `plugins/dotclaude/bin/*.mjs` entrypoints                      |
+| `plugins/dotclaude/src/lib/handoff-remote.mjs`           | `plugins/dotclaude/src/lib/argv.mjs`, `exit-codes.mjs`               |
+| `plugins/dotclaude/src/lib/handoff-scrub.mjs`            | Scrub patterns in `plugins/dotclaude/scripts/handoff-scrub.sh`       |
+| `plugins/dotclaude/scripts/handoff-doctor.sh`            | `handoff-extract.sh` (substrate, frozen)                             |
+| `plugins/dotclaude/scripts/handoff-description.sh`       | `handoff-resolve.sh` internals (substrate, frozen)                   |
 | `plugins/dotclaude/tests/bats/handoff-*.bats`            | `plugins/dotclaude/tests/bats/dotclaude-*.bats` for non-handoff bins |
-| `plugins/dotclaude/tests/handoff-*.test.mjs`             | Other vitest suites in `plugins/dotclaude/tests/`           |
-| `docs/handoff-guide.md`                                  | Other `docs/*.md` files                                     |
-| `docs/specs/handoff-skill/spec.json` (added at finalize) | Other `docs/specs/*/spec.json` files                        |
+| `plugins/dotclaude/tests/handoff-*.test.mjs`             | Other vitest suites in `plugins/dotclaude/tests/`                    |
+| `docs/handoff-guide.md`                                  | Other `docs/*.md` files                                              |
+| `docs/specs/handoff-skill/spec.json` (added at finalize) | Other `docs/specs/*/spec.json` files                                 |
 
 ## Urgency
 

--- a/docs/specs/handoff-skill/spec/2-scope.md
+++ b/docs/specs/handoff-skill/spec/2-scope.md
@@ -1,0 +1,62 @@
+# §2 — Scope
+
+> What's in, what's out, and where are the boundaries?
+
+## In Scope
+
+- **Public surface redesign.** Replace the current five-form / eleven-sub-command sprawl with a two-job surface (cross-agent + cross-machine) and demote supporting commands.
+- **Source-CLI auto-detection.** The binary determines source from where it's running; users never pass a `--from`-equivalent for normal flows.
+- **Target-CLI implicit handling.** The target is "wherever the user pastes" — the user is never asked to declare it. The `--to` flag and the per-target Next-step text branching get removed.
+- **Push / pull contract for the GitHub-repo transport.** Lock the branch-naming, scrubbing, metadata, and pull-resolution semantics so they stop changing PR-to-PR.
+- **Supporting-command surface.** Define how `search`, `describe`, `list`, `file`, `digest`, `resolve`, `remote-list`, `doctor` are reachable without competing for primary attention. Some may be removed entirely if they don't feed a primary job.
+- **Documentation reconciliation.** Bring `skills/handoff/SKILL.md`,
+  `skills/handoff/references/*.md`, the binary `--help` text, and
+  `docs/handoff-guide.md` into agreement with the implementation. Drift fixes
+  ship in this spec's PRs, not separately.
+- **Test surface alignment.** Update `plugins/dotclaude/tests/bats/*.bats` and
+  vitest suites to cover the new public surface; remove tests for removed
+  flags/forms.
+
+## Out of Scope
+
+- **New agents.** Claude Code, GitHub Copilot CLI, OpenAI Codex CLI only. Cursor, Aider, Continue, etc. are not added.
+- **New transports.** Git repo (named by `$DOTCLAUDE_HANDOFF_REPO`) is the
+  only remote transport. The previously-removed gist transports
+  (`--via github`, `--via gist-token`) do not return.
+- **End-to-end encryption.** Content stays plaintext in a private repo; the
+  existing best-effort scrubber stays. New scrub patterns out of scope.
+- **Auto-injecting the digest into the target agent.** The skill prints; the
+  user pastes. Stays manual by design (see `skills/handoff/SKILL.md`'s
+  `## Out of scope` section).
+- **Session-file reader internals.** The per-CLI `jq` filters in
+  `plugins/dotclaude/scripts/handoff-extract.sh` and the resolver logic in
+  `plugins/dotclaude/scripts/handoff-resolve.sh` keep their current
+  semantics. Their **public CLI interface** may move, but the substrate that
+  understands each CLI's transcript format is not redesigned.
+- **The `dotclaude` plugin packaging / distribution model.** How the binary
+  ships (`@dotclaude/dotclaude` npm package, `bootstrap.sh` symlink path)
+  is unchanged. The skill's binary entrypoint is the only thing that
+  evolves.
+
+## Boundaries
+
+| Touches                                                  | Does Not Touch                                              |
+| -------------------------------------------------------- | ----------------------------------------------------------- |
+| `skills/handoff/SKILL.md`                                | Other skill SKILL.md files                                  |
+| `skills/handoff/references/*.md`                         | Skills outside `skills/handoff/`                            |
+| `plugins/dotclaude/bin/dotclaude-handoff.mjs`            | Other `plugins/dotclaude/bin/*.mjs` entrypoints             |
+| `plugins/dotclaude/src/lib/handoff-remote.mjs`           | `plugins/dotclaude/src/lib/argv.mjs`, `exit-codes.mjs`      |
+| `plugins/dotclaude/src/lib/handoff-scrub.mjs`            | Scrub patterns in `plugins/dotclaude/scripts/handoff-scrub.sh` |
+| `plugins/dotclaude/scripts/handoff-doctor.sh`            | `handoff-extract.sh` (substrate, frozen)                    |
+| `plugins/dotclaude/scripts/handoff-description.sh`       | `handoff-resolve.sh` internals (substrate, frozen)          |
+| `plugins/dotclaude/tests/bats/handoff-*.bats`            | `plugins/dotclaude/tests/bats/dotclaude-*.bats` for non-handoff bins |
+| `plugins/dotclaude/tests/handoff-*.test.mjs`             | Other vitest suites in `plugins/dotclaude/tests/`           |
+| `docs/handoff-guide.md`                                  | Other `docs/*.md` files                                     |
+| `docs/specs/handoff-skill/spec.json` (added at finalize) | Other `docs/specs/*/spec.json` files                        |
+
+## Urgency
+
+No hard external deadline. Internal urgency is the patch-loop tax: every PR
+that touches the handoff surface without a spec to anchor against compounds
+the drift. The longer this stays unspec'd, the more rework future PRs cost.
+Treat as "next-up after the current in-flight PRs (#91 Gap variants) land."

--- a/docs/specs/handoff-skill/spec/3-high-level-architecture.md
+++ b/docs/specs/handoff-skill/spec/3-high-level-architecture.md
@@ -71,11 +71,11 @@ binary entrypoint:
 
 The user-facing surface settles on three verbs, partitioned by transport:
 
-| Verb     | Transport            | Direction               | Resolves via                                     |
-| -------- | -------------------- | ----------------------- | ------------------------------------------------ |
-| `pull`   | local filesystem     | cross-agent same-machine | session id / alias / `latest` / `--from <cli>`   |
-| `push`   | remote git repo      | upload current session  | env-detected current session, optional `--tag`   |
-| `fetch`  | remote git repo      | download from remote    | tag / short id / commit prefix / `--from <cli>`  |
+| Verb    | Transport        | Direction                | Resolves via                                    |
+| ------- | ---------------- | ------------------------ | ----------------------------------------------- |
+| `pull`  | local filesystem | cross-agent same-machine | session id / alias / `latest` / `--from <cli>`  |
+| `push`  | remote git repo  | upload current session   | env-detected current session, optional `--tag`  |
+| `fetch` | remote git repo  | download from remote     | tag / short id / commit prefix / `--from <cli>` |
 
 Tagged **ARCH-1**: the public surface is exactly these three primary commands
 plus a bounded supporting set (`list`, `search`, `describe`, `doctor`). Bare
@@ -120,29 +120,29 @@ that SKILL.md, `--help`, and `docs/handoff-guide.md` all reference
 
 ## Components
 
-| Component                                            | Role                                                                  | Fate in this spec                                |
-| ---------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------ |
-| `skills/handoff/SKILL.md`                            | Natural-language trigger surface for Claude/Copilot                   | Shrinks to ~45 lines; points at binary `--help`  |
-| `plugins/dotclaude/bin/dotclaude-handoff.mjs`        | Public CLI: argv parse, dispatch, render `--help`                     | Reshaped to three primaries + four supporting    |
-| `plugins/dotclaude/src/lib/handoff-remote.mjs`       | Shared lib: render, encode/decode, transport, bootstrap               | Restructured around the three-verb partition     |
-| `plugins/dotclaude/src/lib/handoff-scrub.mjs`        | Fail-closed scrub wrapper                                             | Unchanged                                        |
-| `plugins/dotclaude/scripts/handoff-resolve.sh`       | Per-CLI session resolution (UUID/alias/latest)                        | Frozen substrate (§2)                            |
-| `plugins/dotclaude/scripts/handoff-extract.sh`       | Per-CLI jq filters for meta/prompts/turns                             | Frozen substrate (§2)                            |
-| `plugins/dotclaude/scripts/handoff-scrub.sh`         | Eight-pattern perl scrubber                                           | Patterns frozen (§2)                             |
-| `plugins/dotclaude/scripts/handoff-description.sh`   | Encode/decode `handoff:v2:…` description                              | Schema reviewed in §5                            |
-| `plugins/dotclaude/scripts/handoff-doctor.sh`        | Preflight checks for the git transport                                | Reduced to current single transport              |
-| `docs/handoff-guide.md`                              | Long-form user guide                                                  | Reconciled with binary surface, drift-tested     |
-| `skills/handoff/references/*.md`                     | Per-CLI reference docs + redaction + transport                        | Pruned of removed transports / flags             |
+| Component                                          | Role                                                    | Fate in this spec                               |
+| -------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------- |
+| `skills/handoff/SKILL.md`                          | Natural-language trigger surface for Claude/Copilot     | Shrinks to ~45 lines; points at binary `--help` |
+| `plugins/dotclaude/bin/dotclaude-handoff.mjs`      | Public CLI: argv parse, dispatch, render `--help`       | Reshaped to three primaries + four supporting   |
+| `plugins/dotclaude/src/lib/handoff-remote.mjs`     | Shared lib: render, encode/decode, transport, bootstrap | Restructured around the three-verb partition    |
+| `plugins/dotclaude/src/lib/handoff-scrub.mjs`      | Fail-closed scrub wrapper                               | Unchanged                                       |
+| `plugins/dotclaude/scripts/handoff-resolve.sh`     | Per-CLI session resolution (UUID/alias/latest)          | Frozen substrate (§2)                           |
+| `plugins/dotclaude/scripts/handoff-extract.sh`     | Per-CLI jq filters for meta/prompts/turns               | Frozen substrate (§2)                           |
+| `plugins/dotclaude/scripts/handoff-scrub.sh`       | Eight-pattern perl scrubber                             | Patterns frozen (§2)                            |
+| `plugins/dotclaude/scripts/handoff-description.sh` | Encode/decode `handoff:v2:…` description                | Schema reviewed in §5                           |
+| `plugins/dotclaude/scripts/handoff-doctor.sh`      | Preflight checks for the git transport                  | Reduced to current single transport             |
+| `docs/handoff-guide.md`                            | Long-form user guide                                    | Reconciled with binary surface, drift-tested    |
+| `skills/handoff/references/*.md`                   | Per-CLI reference docs + redaction + transport          | Pruned of removed transports / flags            |
 
 ## Data Stores
 
-| Store                              | Role                                                      | Access Pattern                                                              |
-| ---------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `~/.claude/projects/`              | Claude Code session JSONLs                                | Read on `pull`, `push` (current), `search`, `list --local`                  |
-| `~/.copilot/session-state/`        | Copilot CLI session JSONL + `workspace.yaml`              | Read on `pull`, `push` (current), `search`, `list --local`                  |
-| `~/.codex/sessions/`               | Codex CLI rollout JSONLs (deep date-bucketed tree)        | Read on `pull`, `push` (current), `search`, `list --local`                  |
-| `$DOTCLAUDE_HANDOFF_REPO`          | Private GitHub repo, single transport                     | Write on `push`; read on `fetch`, `list --remote`                           |
-| `$XDG_CONFIG_HOME/dotclaude/handoff.env` | Persisted env (`DOTCLAUDE_HANDOFF_REPO=…`)          | Sourced at binary start; written by self-bootstrap                          |
+| Store                                    | Role                                               | Access Pattern                                             |
+| ---------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------- |
+| `~/.claude/projects/`                    | Claude Code session JSONLs                         | Read on `pull`, `push` (current), `search`, `list --local` |
+| `~/.copilot/session-state/`              | Copilot CLI session JSONL + `workspace.yaml`       | Read on `pull`, `push` (current), `search`, `list --local` |
+| `~/.codex/sessions/`                     | Codex CLI rollout JSONLs (deep date-bucketed tree) | Read on `pull`, `push` (current), `search`, `list --local` |
+| `$DOTCLAUDE_HANDOFF_REPO`                | Private GitHub repo, single transport              | Write on `push`; read on `fetch`, `list --remote`          |
+| `$XDG_CONFIG_HOME/dotclaude/handoff.env` | Persisted env (`DOTCLAUDE_HANDOFF_REPO=…`)         | Sourced at binary start; written by self-bootstrap         |
 
 Tagged **ARCH-4**: there is exactly **one** remote per user, named by
 `$DOTCLAUDE_HANDOFF_REPO`. Multi-remote / multi-store is out of scope (§2).
@@ -162,13 +162,13 @@ Tagged **ARCH-5** (branch naming):
 refs/heads/handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
 ```
 
-| Segment       | Purpose                                                                   | Source                                              |
-| ------------- | ------------------------------------------------------------------------- | --------------------------------------------------- |
-| `handoff/`    | Namespace; `main` is reserved for store metadata, never touched by push   | Hardcoded                                           |
-| `<project>`   | Slug of the source repo / cwd top-level. Bucket scoping for ls-remote     | `git rev-parse --show-toplevel` then slugified      |
-| `<cli>`       | One of `claude`, `copilot`, `codex`. Cheap CLI filter without fetch       | Resolver detects from session path                  |
-| `<YYYY-MM>`   | Month bucket, UTC. Caps any one prefix at ~thousands of branches          | `created_at` ISO timestamp                          |
-| `<short-uuid>`| First 8 hex of the source session UUID. Stable identifier                 | Session metadata extraction                         |
+| Segment        | Purpose                                                                 | Source                                         |
+| -------------- | ----------------------------------------------------------------------- | ---------------------------------------------- |
+| `handoff/`     | Namespace; `main` is reserved for store metadata, never touched by push | Hardcoded                                      |
+| `<project>`    | Slug of the source repo / cwd top-level. Bucket scoping for ls-remote   | `git rev-parse --show-toplevel` then slugified |
+| `<cli>`        | One of `claude`, `copilot`, `codex`. Cheap CLI filter without fetch     | Resolver detects from session path             |
+| `<YYYY-MM>`    | Month bucket, UTC. Caps any one prefix at ~thousands of branches        | `created_at` ISO timestamp                     |
+| `<short-uuid>` | First 8 hex of the source session UUID. Stable identifier               | Session metadata extraction                    |
 
 Tagged **ARCH-6** (description / commit-message schema):
 
@@ -177,6 +177,7 @@ handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]
 ```
 
 The same string lands in three places:
+
 - The git commit message (so `git log --format=%s` is the index).
 - A `description.txt` file in the branch (so `gh api /repos/.../git/refs`
   responses can include it without a separate fetch).
@@ -208,6 +209,7 @@ substring on description / branch / commit. Tag namespace is flat under
 `refs/tags/` to keep `git ls-remote refs/tags/*` cheap.
 
 Tagged **ARCH-9** (scalability targets):
+
 - A single `git ls-remote` returns enough metadata (refs + commit messages
   via subsequent description fetch) to render `list --remote` for
   ≤ 1000 branches in < 2 s on a warm connection.
@@ -218,13 +220,13 @@ Tagged **ARCH-9** (scalability targets):
 
 ## External APIs / Dependencies
 
-| Tool   | Purpose                                            | Required for                                                | Fallback                                            |
-| ------ | -------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------------- |
-| `git`  | All remote transport operations                    | `push`, `fetch`, `list --remote`                            | None — required                                     |
-| `gh`   | Auto-bootstrap of the private repo on first push   | First `push` only (interactive)                             | Manual `export DOTCLAUDE_HANDOFF_REPO=…`            |
-| `jq`   | Per-CLI JSONL extraction                           | `pull`, `push`, `search`, `describe`                        | None — required                                     |
-| `perl` | Scrub-pattern engine                               | `push` (fail-closed)                                        | None — required (push aborts if missing)            |
-| `bash` | Substrate runtime                                  | All shell scripts                                           | None — required                                     |
+| Tool   | Purpose                                          | Required for                         | Fallback                                 |
+| ------ | ------------------------------------------------ | ------------------------------------ | ---------------------------------------- |
+| `git`  | All remote transport operations                  | `push`, `fetch`, `list --remote`     | None — required                          |
+| `gh`   | Auto-bootstrap of the private repo on first push | First `push` only (interactive)      | Manual `export DOTCLAUDE_HANDOFF_REPO=…` |
+| `jq`   | Per-CLI JSONL extraction                         | `pull`, `push`, `search`, `describe` | None — required                          |
+| `perl` | Scrub-pattern engine                             | `push` (fail-closed)                 | None — required (push aborts if missing) |
+| `bash` | Substrate runtime                                | All shell scripts                    | None — required                          |
 
 No HTTP libraries, no cloud SDKs, no auth daemons. Everything goes through
 either `git` (which the user has authenticated for `$DOTCLAUDE_HANDOFF_REPO`)
@@ -251,12 +253,14 @@ synchronously per invocation and exits.
 
 ## Drift-Detection Constraint
 
-Tagged **ARCH-10**: a single test asserts that `skills/handoff/SKILL.md`,
-`dotclaude handoff --help` output, and `docs/handoff-guide.md` agree on the
-list of primary commands, supporting commands, and flags. The test fails
-when any one drifts; SKILL.md and the docs guide are pruned content (links
-into `--help` for canonical detail), so the agreement check is on the
-list-of-symbols, not on prose. Implementation lives in §6.
+Tagged **ARCH-10**: the drift gate is phased. In Phase 1, a single test
+asserts that `skills/handoff/SKILL.md` and `dotclaude handoff --help`
+output agree on the list of primary commands, supporting commands, and
+flags. In Phase 2, `docs/handoff-guide.md` is promoted into the same
+agreement check as the third source. The enforced comparison is on the
+list-of-symbols, not on prose, because SKILL.md and the docs guide are
+pruned content that link into `--help` for canonical detail. §6 defines
+when the Phase 2 three-source gate becomes required.
 
 ## Cross-references
 

--- a/docs/specs/handoff-skill/spec/3-high-level-architecture.md
+++ b/docs/specs/handoff-skill/spec/3-high-level-architecture.md
@@ -1,0 +1,272 @@
+# §3 — High-Level Architecture
+
+> System view: components, data stores, external dependencies, deployment.
+
+## System Overview
+
+The handoff skill is a single binary (`dotclaude handoff`) plus a thin
+natural-language trigger surface (`skills/handoff/SKILL.md`) and a frozen
+shell substrate that knows each agent CLI's transcript format. All three
+agents (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI) reach the same
+binary entrypoint:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Claude Code                Copilot CLI               Codex CLI      │
+│  ────────────               ───────────               ─────────      │
+│  loads SKILL.md             loads SKILL.md            no skill load  │
+│  /handoff … or              /handoff … or             !dotclaude     │
+│  natural language           natural language          handoff …      │
+│         │                          │                       │        │
+│         └────────────┬─────────────┴───────────┬───────────┘        │
+│                      ▼                         ▼                     │
+│             Bash tool spawn:        direct shell invocation         │
+│                      │                         │                     │
+│                      └────────────┬────────────┘                    │
+│                                   ▼                                  │
+│                       ┌───────────────────────────┐                 │
+│                       │   dotclaude handoff       │  ← public       │
+│                       │   bin (Node.js)           │    contract     │
+│                       └───────────────────────────┘                 │
+│                              │                                       │
+│                              ├── handoff-remote.mjs (shared lib)    │
+│                              │   render, transport, encode/decode   │
+│                              │                                       │
+│                              ├── handoff-scrub.mjs (fail-closed)    │
+│                              │                                       │
+│                              └── shell substrate (frozen):          │
+│                                  resolve.sh, extract.sh,            │
+│                                  scrub.sh, description.sh,          │
+│                                  doctor.sh                          │
+└──────────────────────────────────────────────────────────────────────┘
+                                   │
+                  ┌────────────────┼────────────────┐
+                  ▼                ▼                ▼
+         ┌──────────────┐ ┌──────────────┐ ┌──────────────────┐
+         │ ~/.claude/   │ │ ~/.copilot/  │ │ ~/.codex/        │
+         │ projects/    │ │ session-     │ │ sessions/        │
+         │ <…>/<uuid>   │ │ state/<uuid> │ │ <yyyy>/<mm>/<dd> │
+         │ .jsonl       │ │ /events.json │ │ /rollout-…jsonl  │
+         └──────────────┘ └──────────────┘ └──────────────────┘
+                   ↑ local read for `pull <id>`
+
+         ┌─────────────────────────────────────────┐
+         │  Private GitHub repo                    │
+         │  $DOTCLAUDE_HANDOFF_REPO                │
+         │                                         │
+         │  refs/heads/handoff/                    │
+         │    <project>/<cli>/<YYYY-MM>/<short>    │
+         │                                         │
+         │  Each branch:                           │
+         │    handoff.md   (the digest block)      │
+         │    metadata.json                        │
+         │    description.txt                      │
+         │                                         │
+         │  Tags: refs/tags/<label>  (multi-tag)   │
+         └─────────────────────────────────────────┘
+                   ↑ remote read/write for `push`/`fetch`
+```
+
+## Public Contract: Three Primary Commands
+
+The user-facing surface settles on three verbs, partitioned by transport:
+
+| Verb     | Transport            | Direction               | Resolves via                                     |
+| -------- | -------------------- | ----------------------- | ------------------------------------------------ |
+| `pull`   | local filesystem     | cross-agent same-machine | session id / alias / `latest` / `--from <cli>`   |
+| `push`   | remote git repo      | upload current session  | env-detected current session, optional `--tag`   |
+| `fetch`  | remote git repo      | download from remote    | tag / short id / commit prefix / `--from <cli>`  |
+
+Tagged **ARCH-1**: the public surface is exactly these three primary commands
+plus a bounded supporting set (`list`, `search`, `describe`, `doctor`). Bare
+invocation prints `--help`; no foot-gun aliases.
+
+## Source / Target Resolution
+
+Tagged **ARCH-2**: target CLI is **always implicit** — it is, by definition,
+wherever the binary's stdout gets pasted. The binary never asks.
+
+Tagged **ARCH-3**: source CLI is resolved in this priority order:
+
+1. `--from <cli>` if explicitly passed (fastest path; **mandatory** for
+   `push` without a query — see below).
+2. Identifier search across all three local roots; if exactly one matches,
+   that's the source.
+3. If multiple match (e.g. a Claude session and a Codex session share a
+   short-UUID prefix or alias):
+   - TTY → interactively prompt the user to pick.
+   - Non-TTY → exit 2 with a TSV candidate list on stderr.
+
+There is no env-var detection step. The previous `detectHost()` probes
+(`CLAUDECODE`, `CODEX_*`, `GITHUB_COPILOT_*` / `COPILOT_*`) admit
+`UNCONFIRMED` status in their own code (legacy `detectHost()` in
+`plugins/dotclaude/bin/dotclaude-handoff.mjs`), and an unreliable signal that
+silently picks the wrong source is exactly the failure mode §1 is
+designed to stop. Instead:
+
+- The SKILL.md auto-trigger contract instructs Claude / Copilot to pass
+  `--from <its-own-cli>` when invoking `push` without a query — the host
+  LLM trivially knows which agent it is.
+- Codex and scripted callers pass `--from` explicitly, or pass a
+  `<query>` that resolves via step 2.
+- The binary refuses `push` with no query AND no `--from` — exit 64 with
+  a usage hint.
+
+This makes the source contract single-pathed and auditable: every `push`
+either has a query (which pins the source) or has `--from` (which pins
+the source). Nothing is silently inferred. ARCH-10's drift-test enforces
+that SKILL.md, `--help`, and `docs/handoff-guide.md` all reference
+`--from` for push the same way.
+
+## Components
+
+| Component                                            | Role                                                                  | Fate in this spec                                |
+| ---------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------ |
+| `skills/handoff/SKILL.md`                            | Natural-language trigger surface for Claude/Copilot                   | Shrinks to ~45 lines; points at binary `--help`  |
+| `plugins/dotclaude/bin/dotclaude-handoff.mjs`        | Public CLI: argv parse, dispatch, render `--help`                     | Reshaped to three primaries + four supporting    |
+| `plugins/dotclaude/src/lib/handoff-remote.mjs`       | Shared lib: render, encode/decode, transport, bootstrap               | Restructured around the three-verb partition     |
+| `plugins/dotclaude/src/lib/handoff-scrub.mjs`        | Fail-closed scrub wrapper                                             | Unchanged                                        |
+| `plugins/dotclaude/scripts/handoff-resolve.sh`       | Per-CLI session resolution (UUID/alias/latest)                        | Frozen substrate (§2)                            |
+| `plugins/dotclaude/scripts/handoff-extract.sh`       | Per-CLI jq filters for meta/prompts/turns                             | Frozen substrate (§2)                            |
+| `plugins/dotclaude/scripts/handoff-scrub.sh`         | Eight-pattern perl scrubber                                           | Patterns frozen (§2)                             |
+| `plugins/dotclaude/scripts/handoff-description.sh`   | Encode/decode `handoff:v2:…` description                              | Schema reviewed in §5                            |
+| `plugins/dotclaude/scripts/handoff-doctor.sh`        | Preflight checks for the git transport                                | Reduced to current single transport              |
+| `docs/handoff-guide.md`                              | Long-form user guide                                                  | Reconciled with binary surface, drift-tested     |
+| `skills/handoff/references/*.md`                     | Per-CLI reference docs + redaction + transport                        | Pruned of removed transports / flags             |
+
+## Data Stores
+
+| Store                              | Role                                                      | Access Pattern                                                              |
+| ---------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `~/.claude/projects/`              | Claude Code session JSONLs                                | Read on `pull`, `push` (current), `search`, `list --local`                  |
+| `~/.copilot/session-state/`        | Copilot CLI session JSONL + `workspace.yaml`              | Read on `pull`, `push` (current), `search`, `list --local`                  |
+| `~/.codex/sessions/`               | Codex CLI rollout JSONLs (deep date-bucketed tree)        | Read on `pull`, `push` (current), `search`, `list --local`                  |
+| `$DOTCLAUDE_HANDOFF_REPO`          | Private GitHub repo, single transport                     | Write on `push`; read on `fetch`, `list --remote`                           |
+| `$XDG_CONFIG_HOME/dotclaude/handoff.env` | Persisted env (`DOTCLAUDE_HANDOFF_REPO=…`)          | Sourced at binary start; written by self-bootstrap                          |
+
+Tagged **ARCH-4**: there is exactly **one** remote per user, named by
+`$DOTCLAUDE_HANDOFF_REPO`. Multi-remote / multi-store is out of scope (§2).
+The repo URL is persisted to a config file so `gh repo create` ceremony
+happens at most once per machine.
+
+## Remote Taxonomy (CRITICAL)
+
+The remote git repo's branch + commit-message schema is the load-bearing
+piece of the cross-machine surface. It has to make `fetch <id>` cheap,
+`list --remote` scan well as the store grows, and stay stable across
+schema versions.
+
+Tagged **ARCH-5** (branch naming):
+
+```
+refs/heads/handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
+```
+
+| Segment       | Purpose                                                                   | Source                                              |
+| ------------- | ------------------------------------------------------------------------- | --------------------------------------------------- |
+| `handoff/`    | Namespace; `main` is reserved for store metadata, never touched by push   | Hardcoded                                           |
+| `<project>`   | Slug of the source repo / cwd top-level. Bucket scoping for ls-remote     | `git rev-parse --show-toplevel` then slugified      |
+| `<cli>`       | One of `claude`, `copilot`, `codex`. Cheap CLI filter without fetch       | Resolver detects from session path                  |
+| `<YYYY-MM>`   | Month bucket, UTC. Caps any one prefix at ~thousands of branches          | `created_at` ISO timestamp                          |
+| `<short-uuid>`| First 8 hex of the source session UUID. Stable identifier                 | Session metadata extraction                         |
+
+Tagged **ARCH-6** (description / commit-message schema):
+
+```
+handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]
+```
+
+The same string lands in three places:
+- The git commit message (so `git log --format=%s` is the index).
+- A `description.txt` file in the branch (so `gh api /repos/.../git/refs`
+  responses can include it without a separate fetch).
+- The Github branch's UI label (free).
+
+`fetch` decodes this string to filter without per-branch clone. The encoder
+and decoder both live in `handoff-description.sh`; both are pinned-version
+(`v1` legacy decode is preserved; only `v2` encodes).
+
+Tagged **ARCH-7** (per-branch payload):
+
+Each `handoff/...` branch's tree is exactly:
+
+```
+handoff.md       # the rendered <handoff>...</handoff> block
+metadata.json    # {cli, session_id, short_id, cwd, project, month, hostname,
+                 #  created_at, scrubbed_count, tag}
+description.txt  # the handoff:v2:… string, redundant for offline tooling
+```
+
+No `transcript.jsonl`, no opt-in transcript upload — the previously
+documented `--include-transcript` was never wired and is removed from the
+spec.
+
+Tagged **ARCH-8** (tag layer): tags are first-class for human addressing
+(per PR #107). `push --tag <label>` may attach multiple tags to a single
+branch; `fetch <label>` does an exact tag match before falling back to
+substring on description / branch / commit. Tag namespace is flat under
+`refs/tags/` to keep `git ls-remote refs/tags/*` cheap.
+
+Tagged **ARCH-9** (scalability targets):
+- A single `git ls-remote` returns enough metadata (refs + commit messages
+  via subsequent description fetch) to render `list --remote` for
+  ≤ 1000 branches in < 2 s on a warm connection.
+- Per-branch `fetch` is one shallow clone (`--depth 1 --branch <branch>`),
+  bounded by the size of `handoff.md` + `metadata.json` (≤ 50 KB typical).
+- The month-bucket prefix means even pathologically active projects don't
+  spam `list --remote` output.
+
+## External APIs / Dependencies
+
+| Tool   | Purpose                                            | Required for                                                | Fallback                                            |
+| ------ | -------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------------- |
+| `git`  | All remote transport operations                    | `push`, `fetch`, `list --remote`                            | None — required                                     |
+| `gh`   | Auto-bootstrap of the private repo on first push   | First `push` only (interactive)                             | Manual `export DOTCLAUDE_HANDOFF_REPO=…`            |
+| `jq`   | Per-CLI JSONL extraction                           | `pull`, `push`, `search`, `describe`                        | None — required                                     |
+| `perl` | Scrub-pattern engine                               | `push` (fail-closed)                                        | None — required (push aborts if missing)            |
+| `bash` | Substrate runtime                                  | All shell scripts                                           | None — required                                     |
+
+No HTTP libraries, no cloud SDKs, no auth daemons. Everything goes through
+either `git` (which the user has authenticated for `$DOTCLAUDE_HANDOFF_REPO`)
+or `gh` (used once at bootstrap).
+
+## Deployment
+
+The binary ships via the existing `@dotclaude/dotclaude` npm package
+(unchanged per §2):
+
+- Installed binary: `~/.local/bin/dotclaude` (symlink) →
+  `<node-prefix>/lib/node_modules/@dotclaude/dotclaude/plugins/dotclaude/bin/dotclaude.mjs`,
+  which dispatches `handoff` to `dotclaude-handoff.mjs`.
+- Skill markdown: `~/.claude/skills/handoff/SKILL.md` (symlink to the
+  package's `skills/handoff/SKILL.md`); auto-loaded by Claude Code and
+  Copilot CLI; not loaded by Codex.
+- Shell scripts: live next to the binary in the package; resolved via
+  `__dirname` from the bin entrypoint.
+- Config: `$XDG_CONFIG_HOME/dotclaude/handoff.env` (default
+  `~/.config/dotclaude/handoff.env`), mode 0600, written by self-bootstrap.
+
+There is no daemon, no service, no background process. The binary runs
+synchronously per invocation and exits.
+
+## Drift-Detection Constraint
+
+Tagged **ARCH-10**: a single test asserts that `skills/handoff/SKILL.md`,
+`dotclaude handoff --help` output, and `docs/handoff-guide.md` agree on the
+list of primary commands, supporting commands, and flags. The test fails
+when any one drifts; SKILL.md and the docs guide are pruned content (links
+into `--help` for canonical detail), so the agreement check is on the
+list-of-symbols, not on prose. Implementation lives in §6.
+
+## Cross-references
+
+- §4 elaborates the data flow for each of the three primary commands and
+  documents resolver / extractor pipelines.
+- §5 freezes the exact CLI surface (flag list, exit codes, output formats),
+  the description schema, and the metadata.json schema.
+- §6 sequences the migration: keep current verbs working until cutover,
+  introduce `pull`/`fetch` aliases, retire old surface, land drift-test.
+- §7 captures non-functional targets (push p95, fetch p95, scrub fail-closed
+  semantics, scalability ceilings tied to ARCH-9).
+- §8 covers risks: env-var probe reliability, description-schema bumps,
+  user-paste-the-block UX as a deliberate non-feature.

--- a/docs/specs/handoff-skill/spec/4-data-flow-components.md
+++ b/docs/specs/handoff-skill/spec/4-data-flow-components.md
@@ -1,0 +1,401 @@
+# §4 — Data Flow / Components
+
+> Walk-throughs of the three primary commands plus the remote-taxonomy
+> lifecycle. Supporting commands are one-line summaries pointing into §5
+> for the I/O contract — they exist to feed the primaries, not to compete
+> for surface real estate.
+
+## Current State (brief)
+
+Today's binary mixes the public surface (eleven sub-commands across two
+verbs and a bare-positional form) with implementation flow. Most of the
+substrate (per-CLI resolvers, jq filters, scrub patterns, description
+schema) is solid and frozen per §2. The reshape is at the dispatch +
+naming + flag layer; the data flow downstream of "we know which session
+file to read" is largely preserved.
+
+## Component Boundaries (brief)
+
+Recap from §3: the binary owns argv parsing, dispatch into the three
+primary verbs, and rendering / scrubbing through the shared library.
+The shell substrate owns per-CLI session resolution and JSONL extraction.
+The shared library owns the transport (git operations) and the
+description-encoding round-trip. No data-flow responsibilities cross
+those lines.
+
+## Shared State
+
+| State                                            | Lifetime           | Read by                              | Written by              |
+| ------------------------------------------------ | ------------------ | ------------------------------------ | ----------------------- |
+| `$DOTCLAUDE_HANDOFF_REPO` (env)                  | shell process      | every `push` / `fetch` / `list -r`   | self-bootstrap          |
+| `$XDG_CONFIG_HOME/dotclaude/handoff.env`         | persistent, mode 0600 | binary startup (sourced)          | self-bootstrap (one-time) |
+| `~/.claude/projects/`, `~/.copilot/session-state/`, `~/.codex/sessions/` | persistent | `pull`, `push --query`, `search`, `list -l` | the host CLIs themselves |
+| `$DOTCLAUDE_HANDOFF_REPO`'s `handoff/...` branches | persistent       | `fetch`, `list -r`                   | `push`                  |
+
+No in-process caches, no daemons, no inter-invocation state on the local
+filesystem beyond the persisted env file.
+
+---
+
+## Target Architecture
+
+### 4.1 `pull <query>` — cross-agent same-machine
+
+The user is in agent T (target), wants to pull session `<query>` from
+agent S (source) on the same machine. T is implicit; S is resolved.
+
+```
+INPUT:  dotclaude handoff pull <query> [--from <cli>]
+
+ 1. Argv parse. <query> is the only positional. --from is optional.
+    No --to. Exit 64 if any unknown flag.
+
+ 2. Source resolution (ARCH-3):
+    a. If --from given:
+         handoff-resolve.sh <cli> <query>   → one path or exit 2.
+    b. Else:
+         handoff-resolve.sh any <query>     → 0/1/many.
+         - 0    → exit 2 ("no session matches: <query>").
+         - 1    → continue.
+         - many → TTY prompt | non-TTY exit 2 + TSV candidates.
+
+ 3. The resolver returns an absolute JSONL path. The path's root
+    determines the source CLI (KD-5: path-based source detection — the
+    path can't lie about which root it came from).
+
+ 4. Extract:
+       handoff-extract.sh meta    <cli> <path>   → {session_id, short_id,
+                                                    cwd, model, started_at}
+       handoff-extract.sh prompts <cli> <path>   → user prompts
+       handoff-extract.sh turns   <cli> <path> 20 → assistant tail
+
+ 5. Render <handoff origin="<src-cli>"
+                    session="<short-id>"
+                    cwd="<cwd>">…</handoff>
+    The block carries one Next-step line, generic across targets. No
+    per-target branching (--to was removed; the target is whoever
+    pastes the block).
+
+ 6. Stdout: the block, exit 0.
+
+OUTPUT: <handoff>...</handoff> on stdout.
+```
+
+No transport, no scrubbing, no remote calls. `pull` is local-only by
+definition.
+
+### 4.2 `push [<query>] [--tag <label>...] [--from <cli>]` — upload to remote
+
+```
+INPUT: dotclaude handoff push [<query>] [--tag a [--tag b ...]] [--from <cli>]
+
+ 1. Argv parse.
+    - <query> optional positional.
+    - --tag may repeat (multi-tag, PR #107).
+    - --from optional UNLESS no <query> is given (ARCH-3 mandatory rule).
+    - Exit 64 with usage hint if both <query> and --from are absent.
+
+ 2. Source resolution (ARCH-3):
+    - <query> given:  same path as `pull` step 2 (search across roots,
+                      --from narrows).
+    - No <query>:     handoff-resolve.sh <from-cli> latest.
+
+ 3. Transport ready-check:
+       requireTransportRepo()
+         - If $DOTCLAUDE_HANDOFF_REPO set → validate URL, return.
+         - Else if TTY + gh authenticated → bootstrap interactively
+           (gh repo create --private, persist URL, set env).
+         - Else → exit 2 with manual-setup block.
+
+ 4. Extract meta + prompts + turns (same as 4.1 step 4).
+
+ 5. Render <handoff>…</handoff> block.
+
+ 6. Scrub (FAIL-CLOSED):
+       handoff-scrub.sh < block > scrubbed
+         - Eight perl regex passes (frozen substrate).
+         - Reports `scrubbed:N` on stderr.
+         - Any non-zero exit, missing perl, or absent count line →
+           push aborts with exit 2 and nothing reaches the remote.
+       metadata.scrubbed_count = N.
+
+ 7. Compute taxonomy fields:
+       project = projectSlugFromCwd(meta.cwd)
+                 (git rev-parse --show-toplevel of cwd, slugified, or "adhoc")
+       month   = monthBucket(now-utc)             → "YYYY-MM"
+       host    = slugify(hostname())
+       cli     = source CLI (from step 2)
+       short   = meta.short_id (8 hex)
+
+ 8. Encode description:
+       handoff-description.sh encode --cli <cli> --short-id <short>
+                                     --project <project> --hostname <host>
+                                     --month <month> [--tag <label>]
+       → handoff:v2:<project>:<cli>:<YYYY-MM>:<short>:<host>[:<tag>]
+
+ 9. Branch: handoff/<project>/<cli>/<month>/<short>.
+
+10. KD-1 (force-push policy): the branch may already exist (re-push of
+    the same source UUID within the same month). Force-push and
+    overwrite. The branch represents "the latest handoff for this
+    UUID + month"; metadata.json.created_at reflects this push.
+    Pre-push commit GC'd by GitHub eventually. History across pushes
+    is not preserved by branch lineage; users who want a paper trail
+    use distinct tags per push.
+
+11. KD-2 (tag mutability): if --tag is passed:
+    - Multi-tag (--tag a --tag b) → all attached to the same commit.
+    - Re-push with --tag <existing> → tag MOVES to the new commit
+      (mutable, addressable label, not an immutable release).
+    - Tags live flat under refs/tags/<label>; no namespacing.
+
+12. Operation:
+       mkdtemp; git init -q
+       git remote add origin $DOTCLAUDE_HANDOFF_REPO
+       git checkout -q -b handoff/<project>/<cli>/<month>/<short>
+       write handoff.md (scrubbed block)
+       write metadata.json
+       write description.txt (the handoff:v2:… string)
+       git add . && git commit -q -m "<description>"
+       git push -q -f origin <branch>
+       for each --tag: git tag -f <label> && git push -q -f origin tag <label>
+
+13. Stdout:
+       <branch>
+       <repo-url>
+       <description>
+       [scrubbed N secrets]
+    Exit 0.
+
+OUTPUT: branch + url + description + scrub count, one per line.
+```
+
+### 4.3 `fetch <query> [--from <cli>]` — download from remote
+
+```
+INPUT: dotclaude handoff fetch <query> [--from <cli>]
+
+ 1. Argv parse. <query> mandatory; matches against tag, branch suffix,
+    commit prefix, or description substring. --from optional, narrows
+    cli segment.
+
+ 2. Read-only transport check:
+       requireTransportRepoStrict()
+         - $DOTCLAUDE_HANDOFF_REPO must be set; no bootstrap. Exit 2 if
+           unset (fetch on a fresh machine: user runs `push` first or
+           sets the env var).
+
+ 3. List remote refs:
+       git ls-remote $DOTCLAUDE_HANDOFF_REPO refs/heads/handoff/* refs/tags/*
+
+ 4. Match priority (KD-4: same prompt-or-exit-2 model as `pull`):
+    a. Exact tag: refs/tags/<query>.
+    b. Branch full match: refs/heads/handoff/<query>.
+    c. Branch trailing-short match: any refs/heads/handoff/.../*/<query>.
+    d. Commit prefix match: any commit hash whose first chars match.
+    e. Description substring match: requires per-branch `description.txt`
+       fetch; capped at 20 candidate fetches before bailing with
+       "too many candidates, narrow the query".
+    f. --from filter: drop candidates whose <cli> path-segment doesn't
+       match.
+
+ 5. Disambiguation:
+    - 0 hits  → exit 2 ("no remote handoffs match: <query>").
+    - 1 hit   → continue with that branch.
+    - 2+ hits → TTY prompt | non-TTY exit 2 + TSV candidates.
+
+ 6. Shallow clone:
+       mkdtemp
+       git clone -q --depth 1 --branch <branch> $DOTCLAUDE_HANDOFF_REPO .
+       read tmp/handoff.md verbatim.
+
+ 7. Stdout: handoff.md content (already a complete <handoff>…</handoff>
+    block, scrubbed at push time). Exit 0.
+
+OUTPUT: <handoff>...</handoff> on stdout.
+```
+
+### 4.4 Remote taxonomy lifecycle
+
+How the store evolves over time, end-to-end:
+
+```
+INITIAL STATE: empty private repo.
+    First `push` → requireTransportRepo prompts gh repo create.
+    Repo created with default `main` branch.
+    Bootstrap optionally writes a README.md to `main` describing the
+    store (small, idempotent, gives the GitHub UI a non-empty default).
+    `main` is never written to again by push/fetch/list.
+
+FIRST PUSH (project=dotclaude, cli=claude, month=2026-04, short=aaaa1111):
+    refs/heads/handoff/dotclaude/claude/2026-04/aaaa1111
+    └── handoff.md, metadata.json, description.txt
+    Optional refs/tags/<label> if --tag was passed.
+
+RE-PUSH OF SAME SESSION, SAME MONTH:
+    Same branch path (deterministic from project+cli+month+short).
+    Force-push overwrites the commit (KD-1).
+    metadata.created_at reflects the latest push.
+
+RE-PUSH OF SAME SESSION, NEXT MONTH:
+    NEW branch under .../2026-05/aaaa1111. Month bucket roll-over
+    creates a new branch; the old one stays under 2026-04 (until the
+    user GCs it). This bounds any single ls-remote prefix.
+
+MULTIPLE SESSIONS, SAME PROJECT/CLI/MONTH:
+    refs/heads/handoff/dotclaude/claude/2026-04/aaaa1111
+    refs/heads/handoff/dotclaude/claude/2026-04/bbbb2222
+    refs/heads/handoff/dotclaude/claude/2026-04/cccc3333
+    Each ls-remote returns all three; user filters via search/list/fetch.
+
+TAG LIFECYCLE:
+    Multi-tag at push: --tag auth-fix --tag eod attaches both to the
+    same commit on the branch.
+    Re-push with --tag auth-fix → auth-fix retargets to the new commit.
+    Tags are flat under refs/tags/. No `handoff/<tag>` namespace
+    prefix; the user knows their tags belong to handoff because they
+    typed --tag.
+
+STORE GROWTH OVER TIME:
+    1 user × 5 projects × daily handoffs × 12 months ≈ 1800 branches
+    spread across 60 month-buckets. ARCH-9 budget (≤ 1000 branches in
+    < 2s for full ls-remote) covers a year of moderate use; project +
+    month bucketing keeps any sub-tree fast indefinitely.
+
+RETENTION:
+    KD-3: out of scope. The store grows forever by default. The user
+    manages retention with regular git operations (git push --delete,
+    gh api DELETE refs/..., or a one-off shell loop). No `prune`
+    sub-command ships with this spec — adding one is a future delta,
+    not a now-feature.
+```
+
+### 4.5 Supporting commands (one-liners)
+
+These exist to feed the primary jobs. Output contracts and exact flag
+shapes are pinned in §5; here, just what they do:
+
+- **`list [--local|--remote]`** — local sessions across the three roots
+  and/or remote handoff branches, unified into one table; exists so the
+  user can see what's available before running `pull` or `fetch`.
+- **`search <text> [--cli <c>] [--since <ISO>] [--limit <N>]`** —
+  substring/regex match across local session content; exists so
+  "I forgot the UUID but remember the topic" turns into a `pull` target.
+- **`describe <query> [--from <cli>]`** — preview a session without
+  rendering the full block; exists so the user can confirm "yes, this
+  is the session I want" before pasting.
+- **`doctor`** — verify the remote transport is reachable; exists to
+  diagnose `push` / `fetch` failures without exposing the user to raw
+  git error output.
+
+Any command not in §4.1 / 4.2 / 4.3 / 4.4 / 4.5 is gone (the v0.10
+surface had `digest`, `file`, `resolve`, `remote-list` — see §6 for
+the migration table that retires them).
+
+---
+
+## Key Decisions
+
+Tagged decisions that bind the rest of the spec; later sections must not
+contradict these without amending here.
+
+### KD-1 — Re-push of same UUID + month: update branch (force), but with a collision probe.
+
+The branch `handoff/<project>/<cli>/<YYYY-MM>/<short>` represents "the
+latest handoff snapshot for this session UUID in this month-bucket."
+Re-pushes by the same UUID update (force-push) the branch.
+`metadata.json.created_at` reflects the most recent push, not the
+original session's start time. History across re-pushes is **not**
+preserved by branch lineage; users who need a paper trail rely on
+git's reflog or push with distinct `--tag` labels.
+
+The 8-hex `short_id` is a prefix and can theoretically collide between
+two distinct session UUIDs. Before pushing, the binary fetches the
+existing branch's `metadata.json.session_id` and compares it to the
+local session_id:
+
+- Branch absent → **create** mode, non-force push (so a racing session
+  produces a non-fast-forward error rather than a silent clobber).
+- Branch present, same `session_id` → **update** mode, force-push.
+- Branch present, different `session_id` → **exit 2** with the
+  collision details. `--force-collision` overrides for the rare case
+  the user actually wants to overwrite.
+
+**Reasoning**: branch-per-push would explode `ls-remote` for hot
+sessions and undermine ARCH-9's scalability budget. The single-branch
+model means `fetch <short>` always resolves to "current state" without
+disambiguation. The collision probe is the safety net against the
+1-in-2^32 short-prefix collision between distinct UUIDs — the binary
+refuses to silently overwrite a stranger's branch.
+
+### KD-2 — Tags are mutable addressable labels, encoded in the description and `metadata.tags`.
+
+`push --tag <label>` (repeatable, or comma-joined) attaches the tag
+list to the branch's description string and to `metadata.tags`.
+Tags do **not** materialize as `refs/tags/` git tag refs; they live
+inside the branch's metadata. Re-pushing with a new tag list rewrites
+the metadata and description on the same branch — tags retarget when
+re-pushed because they are properties of the latest push, not standalone
+refs.
+
+`fetch <label>` matches the description's tag segment (and falls back
+to the on-branch `metadata.tags` after a candidate fetch). Multi-tag
+syntax: `--tag a --tag b` (repeated flag) or `--tag a,b` (comma-joined).
+
+**Reasoning**: tags are how the user addresses semantic snapshots
+("end-of-day", "auth-fix"). Immutability would force the user to invent
+a new label each push, which destroys their addressing scheme. Storing
+tags inside the branch keeps the remote's ref namespace tidy
+(`refs/heads/handoff/...` only) and lets `git ls-remote` + description
+parsing surface tags without a separate tag-ref enumeration.
+
+### KD-3 — Store retention is the user's job, not the skill's.
+
+The remote grows forever by default. No automatic GC, no `prune`
+sub-command, no TTL on branches. Users with full stores run
+`git push --delete origin <branch>` or batch-delete via `gh api`.
+Surfacing a `prune` is a future delta if user demand justifies it.
+
+**Reasoning**: prune is a destructive operation with no obvious
+default policy (delete-by-age? by project? keep-tagged?). Shipping
+defaults wrong is worse than not shipping defaults. The user has
+explicitly de-scoped this.
+
+### KD-4 — `fetch` ambiguity resolves with the same model as `pull`.
+
+When `fetch <query>` matches multiple refs (tags, branches, descriptions,
+or commits), the disambiguation is:
+- TTY → numbered prompt.
+- Non-TTY → exit 2 with TSV candidate list on stderr.
+
+No silent first-match, no "newest wins" heuristic, no special-casing.
+
+**Reasoning**: symmetry with `pull`'s resolution means one mental model
+for "I gave the binary an ambiguous identifier." Heuristic
+tie-breakers introduce silent failure modes.
+
+### KD-5 — Source CLI is determined by path, not by env.
+
+Once the resolver returns an absolute JSONL path, the path's root
+prefix (`~/.claude/projects/`, `~/.copilot/session-state/`,
+`~/.codex/sessions/`) is the authoritative source-CLI signal. The
+binary never asks the environment "which agent are we in" except
+through `--from`, and only on the `push --no-query` path.
+
+**Reasoning**: paths can't lie. Env-vars admit `UNCONFIRMED` status
+in their own probe code. Eliminating env-detection eliminates the
+"silently picks wrong source" failure mode §1 was written to stop.
+
+### KD-6 — SKILL.md auto-trigger contract pre-fills `--from`.
+
+The skill markdown explicitly instructs Claude / Copilot host LLMs to
+include `--from <its-own-cli-name>` when invoking `dotclaude handoff
+push` without a query. The host LLM trivially knows its own identity;
+this turns the binary's mandatory `--from` into invisible-to-the-user
+plumbing for the slash-command surface, while keeping the binary's
+contract single-pathed.
+
+**Reasoning**: closes the gap between "binary is honest about needing
+the source pinned" and "user shouldn't have to type ceremony." The
+host LLM is the right place to fill the flag because it's the only
+component that always knows the answer with certainty.

--- a/docs/specs/handoff-skill/spec/4-data-flow-components.md
+++ b/docs/specs/handoff-skill/spec/4-data-flow-components.md
@@ -25,12 +25,12 @@ those lines.
 
 ## Shared State
 
-| State                                            | Lifetime           | Read by                              | Written by              |
-| ------------------------------------------------ | ------------------ | ------------------------------------ | ----------------------- |
-| `$DOTCLAUDE_HANDOFF_REPO` (env)                  | shell process      | every `push` / `fetch` / `list -r`   | self-bootstrap          |
-| `$XDG_CONFIG_HOME/dotclaude/handoff.env`         | persistent, mode 0600 | binary startup (sourced)          | self-bootstrap (one-time) |
-| `~/.claude/projects/`, `~/.copilot/session-state/`, `~/.codex/sessions/` | persistent | `pull`, `push --query`, `search`, `list -l` | the host CLIs themselves |
-| `$DOTCLAUDE_HANDOFF_REPO`'s `handoff/...` branches | persistent       | `fetch`, `list -r`                   | `push`                  |
+| State                                                                    | Lifetime              | Read by                                     | Written by                |
+| ------------------------------------------------------------------------ | --------------------- | ------------------------------------------- | ------------------------- |
+| `$DOTCLAUDE_HANDOFF_REPO` (env)                                          | shell process         | every `push` / `fetch` / `list -r`          | self-bootstrap            |
+| `$XDG_CONFIG_HOME/dotclaude/handoff.env`                                 | persistent, mode 0600 | binary startup (sourced)                    | self-bootstrap (one-time) |
+| `~/.claude/projects/`, `~/.copilot/session-state/`, `~/.codex/sessions/` | persistent            | `pull`, `push --query`, `search`, `list -l` | the host CLIs themselves  |
+| `$DOTCLAUDE_HANDOFF_REPO`'s `handoff/...` branches                       | persistent            | `fetch`, `list -r`                          | `push`                    |
 
 No in-process caches, no daemons, no inter-invocation state on the local
 filesystem beyond the persisted env file.
@@ -328,26 +328,29 @@ disambiguation. The collision probe is the safety net against the
 1-in-2^32 short-prefix collision between distinct UUIDs — the binary
 refuses to silently overwrite a stranger's branch.
 
-### KD-2 — Tags are mutable addressable labels, encoded in the description and `metadata.tags`.
+### KD-2 — Tags are mutable addressable labels, materialized as `refs/tags/<label>` and mirrored in the description and `metadata.tags`.
 
-`push --tag <label>` (repeatable, or comma-joined) attaches the tag
-list to the branch's description string and to `metadata.tags`.
-Tags do **not** materialize as `refs/tags/` git tag refs; they live
-inside the branch's metadata. Re-pushing with a new tag list rewrites
-the metadata and description on the same branch — tags retarget when
-re-pushed because they are properties of the latest push, not standalone
-refs.
+`push --tag <label>` (repeatable, or comma-joined) creates or updates
+a remote tag ref at `refs/tags/<label>` pointing at the pushed handoff
+commit. The same tag list is also written into the branch's description
+string and `metadata.tags` as mirrored metadata for post-fetch
+inspection and UX. Re-pushing with a new tag list rewrites the metadata
+and description on the same branch, and any reused labels retarget by
+updating their corresponding `refs/tags/<label>` refs.
 
-`fetch <label>` matches the description's tag segment (and falls back
-to the on-branch `metadata.tags` after a candidate fetch). Multi-tag
-syntax: `--tag a --tag b` (repeated flag) or `--tag a,b` (comma-joined).
+`fetch <label>` resolves via `refs/tags/<label>` first (via
+`git ls-remote refs/tags/<label>`), then fetches the tagged commit and
+reads the branch metadata/description as confirmation and context.
+Multi-tag syntax: `--tag a --tag b` (repeated flag) or `--tag a,b`
+(comma-joined).
 
 **Reasoning**: tags are how the user addresses semantic snapshots
 ("end-of-day", "auth-fix"). Immutability would force the user to invent
-a new label each push, which destroys their addressing scheme. Storing
-tags inside the branch keeps the remote's ref namespace tidy
-(`refs/heads/handoff/...` only) and lets `git ls-remote` + description
-parsing surface tags without a separate tag-ref enumeration.
+a new label each push, which destroys their addressing scheme. Encoding
+tags as real `refs/tags/<label>` refs keeps fetch/list behavior aligned
+with standard Git primitives and with `git ls-remote refs/tags/*`, while
+the mirrored description/`metadata.tags` preserves the richer handoff
+metadata on the branch itself.
 
 ### KD-3 — Store retention is the user's job, not the skill's.
 
@@ -365,6 +368,7 @@ explicitly de-scoped this.
 
 When `fetch <query>` matches multiple refs (tags, branches, descriptions,
 or commits), the disambiguation is:
+
 - TTY → numbered prompt.
 - Non-TTY → exit 2 with TSV candidate list on stderr.
 

--- a/docs/specs/handoff-skill/spec/5-interfaces-apis.md
+++ b/docs/specs/handoff-skill/spec/5-interfaces-apis.md
@@ -7,19 +7,19 @@
 
 ## 5.0 What this section locks vs. what it leaves open
 
-| Locked here                                                       | Editable without spec amendment                |
-| ----------------------------------------------------------------- | ---------------------------------------------- |
-| Command names (`pull` / `push` / `fetch` / supporting four)       | The wording of `--help` prose                  |
-| Flag names, types, defaults, mandatory-when                       | Tone / phrasing of stderr templates beyond the listed prefix |
-| Exit codes per command + stderr **prefix** template               | Internal stage names within the prefix         |
-| `metadata.json` field names + types + character classes           | Field documentation phrasing                   |
-| `handoff:v2:…` description grammar                                | n/a (frozen)                                   |
-| `<handoff>` block grammar (attribute list + section order)        | Wording inside the Summary / Next-step lines (within length cap) |
-| `<query>` valid forms                                             | n/a (frozen)                                   |
-| TSV candidate-list column order                                   | n/a (frozen)                                   |
-| SKILL.md auto-trigger phrase → binary form mapping                | The wording of natural-language phrases (additions allowed) |
-| Bootstrap interactive prompt **structure** + manual-setup block   | Decorative whitespace / leading icons (`✓`)    |
-| `doctor` output structure (success / `ok (unconfigured)` / failure) | Diagnostic-line wording                      |
+| Locked here                                                         | Editable without spec amendment                                  |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Command names (`pull` / `push` / `fetch` / supporting four)         | The wording of `--help` prose                                    |
+| Flag names, types, defaults, mandatory-when                         | Tone / phrasing of stderr templates beyond the listed prefix     |
+| Exit codes per command + stderr **prefix** template                 | Internal stage names within the prefix                           |
+| `metadata.json` field names + types + character classes             | Field documentation phrasing                                     |
+| `handoff:v2:…` description grammar                                  | n/a (frozen)                                                     |
+| `<handoff>` block grammar (attribute list + section order)          | Wording inside the Summary / Next-step lines (within length cap) |
+| `<query>` valid forms                                               | n/a (frozen)                                                     |
+| TSV candidate-list column order                                     | n/a (frozen)                                                     |
+| SKILL.md auto-trigger phrase → binary form mapping                  | The wording of natural-language phrases (additions allowed)      |
+| Bootstrap interactive prompt **structure** + manual-setup block     | Decorative whitespace / leading icons (`✓`)                      |
+| `doctor` output structure (success / `ok (unconfigured)` / failure) | Diagnostic-line wording                                          |
 
 ## 5.1 Frozen schemas
 
@@ -48,19 +48,19 @@ Written into every `handoff/...` branch's tree by `push`. Read by `fetch`,
 }
 ```
 
-| Field             | Type    | Required | Character class / shape                         | Notes                                                  |
-| ----------------- | ------- | -------- | ----------------------------------------------- | ------------------------------------------------------ |
-| `cli`             | string  | yes      | enum `claude` \| `copilot` \| `codex`           | source CLI                                             |
-| `session_id`      | string  | yes (since 0.10) | UUID `[0-9a-f]{8}-[0-9a-f]{4}-…` | null only for legacy branches; collision probe gates push |
-| `short_id`        | string  | yes      | `[0-9a-f]{8}`                                   | first 8 hex of `session_id`                            |
-| `cwd`             | string  | yes      | absolute path or null                           | null when source session has no cwd record             |
-| `project`         | string  | yes      | `[a-z0-9-]{1,40}`                               | slugified from cwd top-level; "adhoc" if unresolvable  |
-| `month`           | string  | yes      | `[0-9]{4}-[0-9]{2}`                             | UTC month bucket at push time                          |
-| `hostname`        | string  | yes      | `[a-z0-9-]{1,40}`                               | slugified from `hostname()` short form                 |
-| `created_at`      | string  | yes      | ISO-8601 UTC, `YYYY-MM-DDTHH:MM:SS.sssZ`        | reflects this push, not session start                  |
-| `scrubbed_count`  | integer | yes      | `≥ 0`                                           | redactions applied during this push                    |
-| `tags`            | array   | yes      | `[<slug>, ...]` each `[a-z0-9-]{1,40}`           | possibly empty array `[]`                              |
-| `tag`             | string  | yes (deprecated) | first element of `tags` or null         | dropped after 0.13.0 (see Migration §6.5)              |
+| Field            | Type    | Required         | Character class / shape                  | Notes                                                     |
+| ---------------- | ------- | ---------------- | ---------------------------------------- | --------------------------------------------------------- |
+| `cli`            | string  | yes              | enum `claude` \| `copilot` \| `codex`    | source CLI                                                |
+| `session_id`     | string  | yes (since 0.10) | UUID `[0-9a-f]{8}-[0-9a-f]{4}-…`         | null only for legacy branches; collision probe gates push |
+| `short_id`       | string  | yes              | `[0-9a-f]{8}`                            | first 8 hex of `session_id`                               |
+| `cwd`            | string  | yes              | absolute path or null                    | null when source session has no cwd record                |
+| `project`        | string  | yes              | `[a-z0-9-]{1,40}`                        | slugified from cwd top-level; "adhoc" if unresolvable     |
+| `month`          | string  | yes              | `[0-9]{4}-[0-9]{2}`                      | UTC month bucket at push time                             |
+| `hostname`       | string  | yes              | `[a-z0-9-]{1,40}`                        | slugified from `hostname()` short form                    |
+| `created_at`     | string  | yes              | ISO-8601 UTC, `YYYY-MM-DDTHH:MM:SS.sssZ` | reflects this push, not session start                     |
+| `scrubbed_count` | integer | yes              | `≥ 0`                                    | redactions applied during this push                       |
+| `tags`           | array   | yes              | `[<slug>, ...]` each `[a-z0-9-]{1,40}`   | possibly empty array `[]`                                 |
+| `tag`            | string  | yes (deprecated) | first element of `tags` or null          | dropped after 0.13.0 (see Migration §6.5)                 |
 
 **Forward-compatibility rule.** New fields may be added in additive
 patch releases without spec amendment provided they are optional and
@@ -89,18 +89,18 @@ slug           = 1*40(LOWER-ALNUM | "-")
 
 **Lexical rules (frozen):**
 
-| Rule    | Description                                                                              |
-| ------- | ---------------------------------------------------------------------------------------- |
-| L-1     | All segments are lowercased ASCII; uppercase rejected by the encoder (slugify).           |
-| L-2     | `:` is the segment delimiter and is **illegal** inside any segment.                       |
-| L-3     | `,` is the within-tag-list delimiter and is **illegal** inside any other segment.         |
-| L-4     | Any segment exceeding 40 chars is truncated by `slugify()`; encoder never emits > 40.     |
-| L-5     | Empty segments are invalid (no `::` runs).                                                |
-| L-6     | Trailing `:` (no tags) is invalid; if `tag-list` is empty, the trailing `:` is omitted.   |
-| L-7     | The leading literal `handoff:v2:` is the schema-version pin; bumping to `v3` requires an  |
-|         | additive decoder and a spec amendment.                                                    |
-| L-8     | Hostnames containing characters outside `[a-z0-9-]` (spaces, dots, capitals — common on   |
-|         | Mac default hostnames like "Kaio's MacBook.local") are slugified upstream by the encoder. |
+| Rule | Description                                                                               |
+| ---- | ----------------------------------------------------------------------------------------- |
+| L-1  | All segments are lowercased ASCII; uppercase rejected by the encoder (slugify).           |
+| L-2  | `:` is the segment delimiter and is **illegal** inside any segment.                       |
+| L-3  | `,` is the within-tag-list delimiter and is **illegal** inside any other segment.         |
+| L-4  | Any segment exceeding 40 chars is truncated by `slugify()`; encoder never emits > 40.     |
+| L-5  | Empty segments are invalid (no `::` runs).                                                |
+| L-6  | Trailing `:` (no tags) is invalid; if `tag-list` is empty, the trailing `:` is omitted.   |
+| L-7  | The leading literal `handoff:v2:` is the schema-version pin; bumping to `v3` requires an  |
+|      | additive decoder and a spec amendment.                                                    |
+| L-8  | Hostnames containing characters outside `[a-z0-9-]` (spaces, dots, capitals — common on   |
+|      | Mac default hostnames like "Kaio's MacBook.local") are slugified upstream by the encoder. |
 
 **Decode error mode.** Any input failing the grammar exits 2 from
 `handoff-description.sh decode` with stderr:
@@ -149,11 +149,11 @@ when the user pastes it.** Grammar drift breaks consumer parsing.
 
 **Attribute rules (frozen):**
 
-| Attribute  | Required | Value                                       | Notes                                              |
-| ---------- | -------- | ------------------------------------------- | -------------------------------------------------- |
-| `origin`   | yes      | `claude` \| `copilot` \| `codex`            | source CLI                                         |
-| `session`  | yes      | 8 lowercase hex chars (the source short_id) | empty string when no session_id was extractable    |
-| `cwd`      | yes (attribute present) | absolute path or empty string  | empty string when source had no cwd                |
+| Attribute | Required                | Value                                       | Notes                                           |
+| --------- | ----------------------- | ------------------------------------------- | ----------------------------------------------- |
+| `origin`  | yes                     | `claude` \| `copilot` \| `codex`            | source CLI                                      |
+| `session` | yes                     | 8 lowercase hex chars (the source short_id) | empty string when no session_id was extractable |
+| `cwd`     | yes (attribute present) | absolute path or empty string               | empty string when source had no cwd             |
 
 No other attributes are emitted. Adding new attributes requires a spec
 amendment + ARCH-10 drift-test update. The previous `target=…` attribute
@@ -161,12 +161,12 @@ is removed (target is implicit per ARCH-2).
 
 **Section rules (frozen):**
 
-| #  | Section heading                          | Body shape                                                  |
-| -- | ---------------------------------------- | ----------------------------------------------------------- |
-| 1  | `**Summary.**`                            | one sentence, ≤ 400 chars                                    |
-| 2  | `**User prompts (last 10, in order).**`   | 1-indexed numbered list, last 10 prompts, ≤ 300 chars each  |
-| 3  | `**Last assistant turns (tail).**`        | block-quote `> …`, last 3 turns, ≤ 400 chars each            |
-| 4  | `**Next step.**`                          | single fixed line (per ARCH-2 generic next-step text)        |
+| #   | Section heading                         | Body shape                                                 |
+| --- | --------------------------------------- | ---------------------------------------------------------- |
+| 1   | `**Summary.**`                          | one sentence, ≤ 400 chars                                  |
+| 2   | `**User prompts (last 10, in order).**` | 1-indexed numbered list, last 10 prompts, ≤ 300 chars each |
+| 3   | `**Last assistant turns (tail).**`      | block-quote `> …`, last 3 turns, ≤ 400 chars each          |
+| 4   | `**Next step.**`                        | single fixed line (per ARCH-2 generic next-step text)      |
 
 **Empty-content fallbacks (frozen):**
 
@@ -186,35 +186,35 @@ per-target variants exist.
 
 ### 5.2.1 `pull <query> [flags]`
 
-| Flag          | Type     | Default | Mandatory when                 | Notes                                                        |
-| ------------- | -------- | ------- | ------------------------------ | ------------------------------------------------------------ |
-| `<query>`     | positional | n/a   | always                         | UUID / 8-hex short / `latest` / Claude customTitle / Codex thread_name |
-| `--from <cli>` | string  | (none)  | optional                       | narrow to one root; values: `claude` \| `copilot` \| `codex`  |
-| `--limit <N>` | integer  | 20      | optional                       | turns extraction tail length                                  |
+| Flag           | Type       | Default | Mandatory when | Notes                                                                  |
+| -------------- | ---------- | ------- | -------------- | ---------------------------------------------------------------------- |
+| `<query>`      | positional | n/a     | always         | UUID / 8-hex short / `latest` / Claude customTitle / Codex thread_name |
+| `--from <cli>` | string     | (none)  | optional       | narrow to one root; values: `claude` \| `copilot` \| `codex`           |
+| `--limit <N>`  | integer    | 20      | optional       | turns extraction tail length                                           |
 
 No `--to`. No `--json`. No `--out-dir`. No environment-variable detection.
 
 ### 5.2.2 `push [<query>] [flags]`
 
-| Flag                  | Type             | Default  | Mandatory when                          | Notes                                                                          |
-| --------------------- | ---------------- | -------- | --------------------------------------- | ------------------------------------------------------------------------------ |
-| `[<query>]`           | positional       | (none)   | mandatory unless `--from` given          | session resolution input                                                       |
-| `--from <cli>`        | string           | (none)   | mandatory if `<query>` absent            | per ARCH-3                                                                     |
-| `--tag <label>`       | string, repeatable | (none) | optional                                | multi-tag via repeat (`--tag a --tag b`) **or** comma-joined (`--tag a,b`)     |
-| `--force-collision`   | bool             | false    | optional                                | override different-session-id-on-same-short-id error                           |
-| `--dry-run`           | bool             | false    | optional                                | render+scrub+probe, skip remote write                                          |
-| `--verify`            | bool             | false    | optional                                | extra preflight checks before push                                             |
-| `--verbose`           | bool             | false    | optional                                | extra debug output on stderr                                                   |
+| Flag                | Type               | Default | Mandatory when                  | Notes                                                                      |
+| ------------------- | ------------------ | ------- | ------------------------------- | -------------------------------------------------------------------------- |
+| `[<query>]`         | positional         | (none)  | mandatory unless `--from` given | session resolution input                                                   |
+| `--from <cli>`      | string             | (none)  | mandatory if `<query>` absent   | per ARCH-3                                                                 |
+| `--tag <label>`     | string, repeatable | (none)  | optional                        | multi-tag via repeat (`--tag a --tag b`) **or** comma-joined (`--tag a,b`) |
+| `--force-collision` | bool               | false   | optional                        | override different-session-id-on-same-short-id error                       |
+| `--dry-run`         | bool               | false   | optional                        | render+scrub+probe, skip remote write                                      |
+| `--verify`          | bool               | false   | optional                        | extra preflight checks before push                                         |
+| `--verbose`         | bool               | false   | optional                        | extra debug output on stderr                                               |
 
 No `--to`. No env-var detection.
 
 ### 5.2.3 `fetch <query> [flags]`
 
-| Flag           | Type     | Default | Mandatory when | Notes                                                                                    |
-| -------------- | -------- | ------- | -------------- | ---------------------------------------------------------------------------------------- |
-| `<query>`      | positional | n/a   | always         | tag / 8-hex short / branch-suffix / commit prefix / description substring                |
-| `--from <cli>` | string   | (none)  | optional       | filter candidates whose `<cli>` segment matches; values: `claude` \| `copilot` \| `codex` |
-| `--limit <N>`  | integer  | 20      | optional       | candidate cap before bailing with "too many candidates, narrow the query"                |
+| Flag           | Type       | Default | Mandatory when | Notes                                                                                     |
+| -------------- | ---------- | ------- | -------------- | ----------------------------------------------------------------------------------------- |
+| `<query>`      | positional | n/a     | always         | tag / 8-hex short / branch-suffix / commit prefix / description substring                 |
+| `--from <cli>` | string     | (none)  | optional       | filter candidates whose `<cli>` segment matches; values: `claude` \| `copilot` \| `codex` |
+| `--limit <N>`  | integer    | 20      | optional       | candidate cap before bailing with "too many candidates, narrow the query"                 |
 
 No `--to`. No `--json` (output is the `<handoff>` block, already a structured contract per 5.1.3).
 
@@ -224,23 +224,23 @@ No `--to`. No `--json` (output is the `<handoff>` block, already a structured co
 
 Unified table of local sessions and remote handoffs. Source of truth for "what's available before I `pull` or `fetch`."
 
-| Flag         | Type    | Default | Notes                                                  |
-| ------------ | ------- | ------- | ------------------------------------------------------ |
-| `--local`    | bool    | false   | local-only (mutually exclusive with `--remote`)         |
-| `--remote`   | bool    | false   | remote-only (mutually exclusive with `--local`)         |
-| `--limit <N>`| integer | 50      | row cap; applies independently to local and remote     |
-| `--json`     | bool    | false   | emit JSON array `[{location, cli, short_id, when, ...}, ...]` |
+| Flag          | Type    | Default | Notes                                                         |
+| ------------- | ------- | ------- | ------------------------------------------------------------- |
+| `--local`     | bool    | false   | local-only (mutually exclusive with `--remote`)               |
+| `--remote`    | bool    | false   | remote-only (mutually exclusive with `--local`)               |
+| `--limit <N>` | integer | 50      | row cap; applies independently to local and remote            |
+| `--json`      | bool    | false   | emit JSON array `[{location, cli, short_id, when, ...}, ...]` |
 
 #### `search <text> [flags]`
 
 Substring/regex match across **local** session content (no remote search; remote uses `fetch` substring match instead). Resolves "I forgot the UUID but remember the topic."
 
-| Flag         | Type    | Default | Notes                                       |
-| ------------ | ------- | ------- | ------------------------------------------- |
-| `<text>`     | positional | n/a  | regex, case-insensitive by default          |
-| `--cli <cli>`| string  | (none)  | narrow to one root                          |
-| `--limit <N>`| integer | 50      | row cap                                     |
-| `--json`     | bool    | false   | emit JSON array of `{cli, short_id, cwd, mtime, snippet}` |
+| Flag          | Type       | Default | Notes                                                     |
+| ------------- | ---------- | ------- | --------------------------------------------------------- |
+| `<text>`      | positional | n/a     | regex, case-insensitive by default                        |
+| `--cli <cli>` | string     | (none)  | narrow to one root                                        |
+| `--limit <N>` | integer    | 50      | row cap                                                   |
+| `--json`      | bool       | false   | emit JSON array of `{cli, short_id, cwd, mtime, snippet}` |
 
 (`--since <ISO>` deferred — month-bucket prefix in branch naming is the cheap filter; revisit only if usage shows monthly granularity is too coarse.)
 
@@ -248,11 +248,11 @@ Substring/regex match across **local** session content (no remote search; remote
 
 Preview a session's metadata + last 10 user prompts without rendering the full `<handoff>` block.
 
-| Flag         | Type    | Default | Notes                                       |
-| ------------ | ------- | ------- | ------------------------------------------- |
-| `<query>`    | positional | n/a  | same forms as `pull`'s `<query>`            |
-| `--from <cli>`| string | (none)  | narrow to one root                          |
-| `--json`     | bool    | false   | emit `{origin: <meta>, user_prompts: [...]}` |
+| Flag           | Type       | Default | Notes                                        |
+| -------------- | ---------- | ------- | -------------------------------------------- |
+| `<query>`      | positional | n/a     | same forms as `pull`'s `<query>`             |
+| `--from <cli>` | string     | (none)  | narrow to one root                           |
+| `--json`       | bool       | false   | emit `{origin: <meta>, user_prompts: [...]}` |
 
 #### `doctor`
 
@@ -266,53 +266,53 @@ command and locks the **prefix** of the stderr template.
 
 ### 5.3.1 Universal codes
 
-| Code | Meaning                                                                  | Stderr prefix                                                                  |
-| ---- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| 0    | success                                                                  | (none)                                                                         |
-| 1    | preflight check failed (recoverable)                                     | `Preflight failed: <reason>` followed by `What's wrong:` / `How to fix:` block (existing `handoff-doctor.sh` format) |
-| 2    | runtime error (resolution miss, transport failure, scrub failure, etc.) | `dotclaude-handoff: <reason>`                                                  |
-| 64   | usage error (unknown flag, missing positional, conflicting flags)        | `dotclaude-handoff: <reason>` followed by `Usage: …` block                     |
+| Code | Meaning                                                                 | Stderr prefix                                                                                                        |
+| ---- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 0    | success                                                                 | (none)                                                                                                               |
+| 1    | preflight check failed (recoverable)                                    | `Preflight failed: <reason>` followed by `What's wrong:` / `How to fix:` block (existing `handoff-doctor.sh` format) |
+| 2    | runtime error (resolution miss, transport failure, scrub failure, etc.) | `dotclaude-handoff: <reason>`                                                                                        |
+| 64   | usage error (unknown flag, missing positional, conflicting flags)       | `dotclaude-handoff: <reason>` followed by `Usage: …` block                                                           |
 
 ### 5.3.2 `pull`-specific exits
 
-| Code | Condition                                  | Stderr template                                                                     |
-| ---- | ------------------------------------------ | ----------------------------------------------------------------------------------- |
-| 2    | no session matches                          | `dotclaude-handoff: no session matches: <query>`                                    |
-| 2    | multiple sessions match (non-TTY)           | header `dotclaude-handoff: multiple sessions match "<query>":` + TSV lines (5.3.5) |
-| 64   | unknown flag                                | `dotclaude-handoff: unknown flag: <flag>` + usage                                   |
-| 64   | missing `<query>`                           | `dotclaude-handoff: pull requires a <query>` + usage                                |
+| Code | Condition                         | Stderr template                                                                    |
+| ---- | --------------------------------- | ---------------------------------------------------------------------------------- |
+| 2    | no session matches                | `dotclaude-handoff: no session matches: <query>`                                   |
+| 2    | multiple sessions match (non-TTY) | header `dotclaude-handoff: multiple sessions match "<query>":` + TSV lines (5.3.5) |
+| 64   | unknown flag                      | `dotclaude-handoff: unknown flag: <flag>` + usage                                  |
+| 64   | missing `<query>`                 | `dotclaude-handoff: pull requires a <query>` + usage                               |
 
 ### 5.3.3 `push`-specific exits
 
-| Code | Condition                                                  | Stderr template                                                                                                |
-| ---- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| 2    | transport not configured (env unset, non-TTY)               | `dotclaude-handoff: transport not configured` + manual-setup block (5.5.2)                                     |
-| 2    | scrub fail-closed                                           | `dotclaude-handoff: scrub not applied: <reason>`                                                               |
-| 2    | short-id collision, different session_id                    | `dotclaude-handoff: short-id collision on <branch>: local-session=<X> remote-session=<Y>; rerun with --force-collision to override` |
+| Code | Condition                                                                  | Stderr template                                                                                                                                    |
+| ---- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2    | transport not configured (env unset, non-TTY)                              | `dotclaude-handoff: transport not configured` + manual-setup block (5.5.2)                                                                         |
+| 2    | scrub fail-closed                                                          | `dotclaude-handoff: scrub not applied: <reason>`                                                                                                   |
+| 2    | short-id collision, different session_id                                   | `dotclaude-handoff: short-id collision on <branch>: local-session=<X> remote-session=<Y>; rerun with --force-collision to override`                |
 | 2    | metadata.json missing on existing branch (legacy + no `--force-collision`) | `dotclaude-handoff: short-id collision on <branch>: existing branch has no provable owner (<git error>); rerun with --force-collision to override` |
-| 64   | no `<query>` and no `--from`                                | `dotclaude-handoff: push: --from required when no <query> is given` + usage                                    |
-| 64   | unknown flag                                                | `dotclaude-handoff: unknown flag: <flag>` + usage                                                              |
+| 64   | no `<query>` and no `--from`                                               | `dotclaude-handoff: push: --from required when no <query> is given` + usage                                                                        |
+| 64   | unknown flag                                                               | `dotclaude-handoff: unknown flag: <flag>` + usage                                                                                                  |
 
 ### 5.3.4 `fetch`-specific exits
 
-| Code | Condition                                  | Stderr template                                                                  |
-| ---- | ------------------------------------------ | -------------------------------------------------------------------------------- |
-| 2    | transport not configured                    | `dotclaude-handoff: transport not configured` + "run push first" hint            |
-| 2    | no remote handoffs match                    | `dotclaude-handoff: no remote handoffs match: <query>`                           |
-| 2    | multiple handoffs match (non-TTY)           | header `dotclaude-handoff: multiple handoffs match "<query>":` + TSV lines (5.3.5) |
-| 2    | too many description-substring candidates    | `dotclaude-handoff: too many candidates, narrow the query`                       |
-| 64   | unknown flag                                | `dotclaude-handoff: unknown flag: <flag>` + usage                                |
-| 64   | missing `<query>`                           | `dotclaude-handoff: fetch requires a <query>` + usage                            |
+| Code | Condition                                 | Stderr template                                                                    |
+| ---- | ----------------------------------------- | ---------------------------------------------------------------------------------- |
+| 2    | transport not configured                  | `dotclaude-handoff: transport not configured` + "run push first" hint              |
+| 2    | no remote handoffs match                  | `dotclaude-handoff: no remote handoffs match: <query>`                             |
+| 2    | multiple handoffs match (non-TTY)         | header `dotclaude-handoff: multiple handoffs match "<query>":` + TSV lines (5.3.5) |
+| 2    | too many description-substring candidates | `dotclaude-handoff: too many candidates, narrow the query`                         |
+| 64   | unknown flag                              | `dotclaude-handoff: unknown flag: <flag>` + usage                                  |
+| 64   | missing `<query>`                         | `dotclaude-handoff: fetch requires a <query>` + usage                              |
 
 ### 5.3.5 TSV candidate-list format (frozen column order)
 
 Both `pull` and `fetch` emit candidate lines on multi-match (non-TTY).
 Column order is fixed; tools parsing this format can rely on field positions.
 
-| Command  | Columns (tab-separated, in order)                       |
-| -------- | -------------------------------------------------------- |
-| `pull`   | `<cli>`, `<session_id>`, `<absolute-path>`, `<query>`     |
-| `fetch`  | `<branch>`, `<commit>`, `<description>`, `<query>`        |
+| Command | Columns (tab-separated, in order)                     |
+| ------- | ----------------------------------------------------- |
+| `pull`  | `<cli>`, `<session_id>`, `<absolute-path>`, `<query>` |
+| `fetch` | `<branch>`, `<commit>`, `<description>`, `<query>`    |
 
 One candidate per line. No header row in the TSV (the human-readable
 header line above the TSV is plain prose, ignored by parsers). Fields
@@ -323,16 +323,16 @@ controlled).
 
 Frozen across `pull`, `push`, `fetch`, `describe`:
 
-| Form                          | Lexical                                                | Notes                                         |
-| ----------------------------- | ------------------------------------------------------ | --------------------------------------------- |
-| Full UUID                      | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | exact match on session id                  |
-| Short UUID                     | `[0-9a-f]{8}`                                          | first 8 hex of session id                     |
-| Literal `latest`              | exactly the string `latest`                             | newest by mtime in target root(s)             |
-| Claude `customTitle` alias     | non-hex string ≤ 256 chars                              | scanned via `customTitle` JSONL records       |
-| Codex `thread_name` alias      | non-hex string ≤ 256 chars                              | scanned via `event_msg.thread_name` records   |
-| Tag (fetch only)              | `[a-z0-9-]{1,40}`                                      | matches description tag segment               |
-| Branch suffix (fetch only)    | partial branch path                                     | trailing-`/<short>` match against ls-remote   |
-| Commit prefix (fetch only)    | `[0-9a-f]{4,40}`                                       | matches commit hash prefix in ls-remote       |
+| Form                       | Lexical                                                        | Notes                                       |
+| -------------------------- | -------------------------------------------------------------- | ------------------------------------------- |
+| Full UUID                  | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | exact match on session id                   |
+| Short UUID                 | `[0-9a-f]{8}`                                                  | first 8 hex of session id                   |
+| Literal `latest`           | exactly the string `latest`                                    | newest by mtime in target root(s)           |
+| Claude `customTitle` alias | non-hex string ≤ 256 chars                                     | scanned via `customTitle` JSONL records     |
+| Codex `thread_name` alias  | non-hex string ≤ 256 chars                                     | scanned via `event_msg.thread_name` records |
+| Tag (fetch only)           | `[a-z0-9-]{1,40}`                                              | matches description tag segment             |
+| Branch suffix (fetch only) | partial branch path                                            | trailing-`/<short>` match against ls-remote |
+| Commit prefix (fetch only) | `[0-9a-f]{4,40}`                                               | matches commit hash prefix in ls-remote     |
 
 Copilot has **no** alias support; UUID / short / `latest` only (per
 `handoff-resolve.sh:151`). Claude does; Codex does.
@@ -349,19 +349,21 @@ phrase → invocation mapping below. ARCH-10's drift-test asserts:
 
 ### 5.5.1 Phrase-pattern → binary-form mapping (frozen)
 
-| Trigger phrase pattern                                              | Binary invocation                                                       |
-| ------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `handoff` + identifier (UUID / short / `latest` / alias)             | `dotclaude handoff pull <id>`                                            |
-| `continue in <cli>` / `switch to <cli>` / `pull from <cli>` + id     | `dotclaude handoff pull <id> --from <cli>`                               |
-| `claude --resume <id>` / `codex resume <id>` / `copilot --resume=<id>` | `dotclaude handoff pull <id>`                                          |
-| `what was that session about` + identifier                          | `dotclaude handoff describe <id>`                                        |
-| `push handoff` / `send to other machine` / `save this`               | `dotclaude handoff push --from <host-cli> [--tag <label>]`               |
-| `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch <query-or-prompt-user>`                       |
+| Trigger phrase pattern                                                 | Binary invocation                                          |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `handoff` + identifier (UUID / short / `latest` / alias)               | `dotclaude handoff pull <id>`                              |
+| `continue in <cli>` / `switch to <cli>` / `pull from <cli>` + id       | `dotclaude handoff pull <id> --from <cli>`                 |
+| `claude --resume <id>` / `codex resume <id>` / `copilot --resume=<id>` | `dotclaude handoff pull <id>`                              |
+| `what was that session about` + identifier                             | `dotclaude handoff describe <id>`                          |
+| `push handoff` / `send to other machine` / `save this`                 | `dotclaude handoff push --from <host-cli> [--tag <label>]` |
+| `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch <query-or-prompt-user>`           |
 
 ### 5.5.2 The `--from` filling rule (frozen text)
 
-The skill markdown MUST contain this paragraph verbatim (the drift-test
-greps for it):
+The skill markdown MUST contain this paragraph (the drift-test uses a
+four-clause structural match — presence of `--from`, `push`, a "no
+query" marker, and a "required" marker — per spec §5.0 which keeps
+wording editable while enforcing semantics):
 
 > When invoking `dotclaude handoff push` without a `<query>` positional,
 > include `--from <your-cli>` where `<your-cli>` is the agent the host
@@ -420,11 +422,11 @@ DOTCLAUDE_HANDOFF_REPO to any ssh://, git@, https://, file://, or absolute path.
 
 ### 5.6.3 `doctor` output format
 
-| Outcome                                                       | Stdout                                                            | Exit |
-| ------------------------------------------------------------- | ----------------------------------------------------------------- | ---- |
-| All checks pass, env configured, repo reachable                | `ok` + diagnostic lines (config / gh / repo URL)                  | 0    |
-| Env unset, gh authenticated (bootstrap will succeed on push)   | `ok (unconfigured)` + diagnostic lines + bootstrap-ready hint     | 0    |
-| Any check fails                                                | (none — failure block on stderr)                                  | 1    |
+| Outcome                                                      | Stdout                                                        | Exit |
+| ------------------------------------------------------------ | ------------------------------------------------------------- | ---- |
+| All checks pass, env configured, repo reachable              | `ok` + diagnostic lines (config / gh / repo URL)              | 0    |
+| Env unset, gh authenticated (bootstrap will succeed on push) | `ok (unconfigured)` + diagnostic lines + bootstrap-ready hint | 0    |
+| Any check fails                                              | (none — failure block on stderr)                              | 1    |
 
 Diagnostic-line shape (frozen):
 
@@ -451,15 +453,15 @@ Rerun /handoff doctor to verify.
 
 ## 5.7 Output-format summary per primary command
 
-| Command  | Stdout (success)                                                                                       |
-| -------- | ------------------------------------------------------------------------------------------------------ |
-| `pull`   | `<handoff>...</handoff>` block per 5.1.3 + trailing newline                                             |
-| `push`   | four lines: `<branch>` / `<repo-url>` / `<description>` / `[scrubbed N secrets]`                        |
-| `fetch`  | `<handoff>...</handoff>` block per 5.1.3 (read verbatim from `handoff.md` in the resolved branch)       |
-| `list`   | markdown table (default) or JSON array (`--json`); empty: `No sessions found` + exit 0                  |
-| `search` | markdown table + drill-in hint (default) or JSON array (`--json`); empty: `No sessions matching '<q>'` + exit 0 |
-| `describe` | markdown summary (default) or `{origin: <meta>, user_prompts: [...]}` (`--json`)                      |
-| `doctor` | per 5.6.3                                                                                              |
+| Command    | Stdout (success)                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------- |
+| `pull`     | `<handoff>...</handoff>` block per 5.1.3 + trailing newline                                                     |
+| `push`     | four lines: `<branch>` / `<repo-url>` / `<description>` / `[scrubbed N secrets]`                                |
+| `fetch`    | `<handoff>...</handoff>` block per 5.1.3 (read verbatim from `handoff.md` in the resolved branch)               |
+| `list`     | markdown table (default) or JSON array (`--json`); empty: `No sessions found` + exit 0                          |
+| `search`   | markdown table + drill-in hint (default) or JSON array (`--json`); empty: `No sessions matching '<q>'` + exit 0 |
+| `describe` | markdown summary (default) or `{origin: <meta>, user_prompts: [...]}` (`--json`)                                |
+| `doctor`   | per 5.6.3                                                                                                       |
 
 ## 5.8 Cross-references
 

--- a/docs/specs/handoff-skill/spec/5-interfaces-apis.md
+++ b/docs/specs/handoff-skill/spec/5-interfaces-apis.md
@@ -1,0 +1,470 @@
+# §5 — Interfaces and APIs
+
+> Tight, table-driven contract. Frozen schemas + flag matrices + exit-code
+> matrices + output formats + the SKILL.md auto-trigger contract +
+> bootstrap/doctor user-facing strings. ARCH-10's drift-test asserts
+> against the symbol list in this section, not against `--help` prose.
+
+## 5.0 What this section locks vs. what it leaves open
+
+| Locked here                                                       | Editable without spec amendment                |
+| ----------------------------------------------------------------- | ---------------------------------------------- |
+| Command names (`pull` / `push` / `fetch` / supporting four)       | The wording of `--help` prose                  |
+| Flag names, types, defaults, mandatory-when                       | Tone / phrasing of stderr templates beyond the listed prefix |
+| Exit codes per command + stderr **prefix** template               | Internal stage names within the prefix         |
+| `metadata.json` field names + types + character classes           | Field documentation phrasing                   |
+| `handoff:v2:…` description grammar                                | n/a (frozen)                                   |
+| `<handoff>` block grammar (attribute list + section order)        | Wording inside the Summary / Next-step lines (within length cap) |
+| `<query>` valid forms                                             | n/a (frozen)                                   |
+| TSV candidate-list column order                                   | n/a (frozen)                                   |
+| SKILL.md auto-trigger phrase → binary form mapping                | The wording of natural-language phrases (additions allowed) |
+| Bootstrap interactive prompt **structure** + manual-setup block   | Decorative whitespace / leading icons (`✓`)    |
+| `doctor` output structure (success / `ok (unconfigured)` / failure) | Diagnostic-line wording                      |
+
+## 5.1 Frozen schemas
+
+These are persistent on-disk state in users' remote stores (or wire
+formats consumed by external agents). Any change here is a migration
+problem, not a documentation problem.
+
+### 5.1.1 `metadata.json`
+
+Written into every `handoff/...` branch's tree by `push`. Read by `fetch`,
+`list --remote`, `describe --remote-id`, and the collision probe.
+
+```jsonc
+{
+  "cli":            "claude" | "copilot" | "codex",
+  "session_id":     <uuid string> | null,
+  "short_id":       <8 lowercase hex chars>,
+  "cwd":            <absolute path string> | null,
+  "project":        <slug>,
+  "month":          "YYYY-MM",
+  "hostname":       <slug>,
+  "created_at":     <ISO-8601 UTC, "Z" suffix>,
+  "scrubbed_count": <integer ≥ 0>,
+  "tags":           [<slug>, ...],
+  "tag":            <first slug> | null   // DEPRECATED — see migration note
+}
+```
+
+| Field             | Type    | Required | Character class / shape                         | Notes                                                  |
+| ----------------- | ------- | -------- | ----------------------------------------------- | ------------------------------------------------------ |
+| `cli`             | string  | yes      | enum `claude` \| `copilot` \| `codex`           | source CLI                                             |
+| `session_id`      | string  | yes (since 0.10) | UUID `[0-9a-f]{8}-[0-9a-f]{4}-…` | null only for legacy branches; collision probe gates push |
+| `short_id`        | string  | yes      | `[0-9a-f]{8}`                                   | first 8 hex of `session_id`                            |
+| `cwd`             | string  | yes      | absolute path or null                           | null when source session has no cwd record             |
+| `project`         | string  | yes      | `[a-z0-9-]{1,40}`                               | slugified from cwd top-level; "adhoc" if unresolvable  |
+| `month`           | string  | yes      | `[0-9]{4}-[0-9]{2}`                             | UTC month bucket at push time                          |
+| `hostname`        | string  | yes      | `[a-z0-9-]{1,40}`                               | slugified from `hostname()` short form                 |
+| `created_at`      | string  | yes      | ISO-8601 UTC, `YYYY-MM-DDTHH:MM:SS.sssZ`        | reflects this push, not session start                  |
+| `scrubbed_count`  | integer | yes      | `≥ 0`                                           | redactions applied during this push                    |
+| `tags`            | array   | yes      | `[<slug>, ...]` each `[a-z0-9-]{1,40}`           | possibly empty array `[]`                              |
+| `tag`             | string  | yes (deprecated) | first element of `tags` or null         | dropped after 0.13.0 (see Migration §6.5)              |
+
+**Forward-compatibility rule.** New fields may be added in additive
+patch releases without spec amendment provided they are optional and
+old readers ignore unknowns gracefully. Removing or changing a field's
+type **does** require a spec amendment.
+
+### 5.1.2 `handoff:v2:…` description grammar
+
+Used in three places: the branch's commit message, the branch's
+`description.txt`, and (read-only) any v1 legacy decoder in the wild.
+
+**Grammar (BNF-ish):**
+
+```
+description    = "handoff:v2:" project ":" cli ":" month ":" short ":" host
+                 [ ":" tag-list ]
+project        = slug                          ; [a-z0-9-]{1,40}
+cli            = "claude" | "copilot" | "codex"
+month          = 4*DIGIT "-" 2*DIGIT            ; YYYY-MM
+short          = 8*HEXDIG                       ; lowercase
+host           = slug                          ; [a-z0-9-]{1,40}
+tag-list       = slug *("," slug)               ; comma-joined, no trailing comma
+slug           = 1*40(LOWER-ALNUM | "-")
+                 ; ASCII lowercase a-z, 0-9, hyphen; max 40 chars
+```
+
+**Lexical rules (frozen):**
+
+| Rule    | Description                                                                              |
+| ------- | ---------------------------------------------------------------------------------------- |
+| L-1     | All segments are lowercased ASCII; uppercase rejected by the encoder (slugify).           |
+| L-2     | `:` is the segment delimiter and is **illegal** inside any segment.                       |
+| L-3     | `,` is the within-tag-list delimiter and is **illegal** inside any other segment.         |
+| L-4     | Any segment exceeding 40 chars is truncated by `slugify()`; encoder never emits > 40.     |
+| L-5     | Empty segments are invalid (no `::` runs).                                                |
+| L-6     | Trailing `:` (no tags) is invalid; if `tag-list` is empty, the trailing `:` is omitted.   |
+| L-7     | The leading literal `handoff:v2:` is the schema-version pin; bumping to `v3` requires an  |
+|         | additive decoder and a spec amendment.                                                    |
+| L-8     | Hostnames containing characters outside `[a-z0-9-]` (spaces, dots, capitals — common on   |
+|         | Mac default hostnames like "Kaio's MacBook.local") are slugified upstream by the encoder. |
+
+**Decode error mode.** Any input failing the grammar exits 2 from
+`handoff-description.sh decode` with stderr:
+
+```
+handoff-description: malformed v2: <reason>
+```
+
+where `<reason>` is one of: `too many colon segments`, `missing required
+segment`, `cli not one of claude|copilot|codex (<got>)`, `month not YYYY-MM
+(<got>)`, `short-id not 8 hex chars`, `<segment> slug fails charset`,
+`tag segment fails charset`. The decoder also accepts v1 legacy input
+(`handoff:v1:<cli>:<short>:<project>:<host>[:<tag>]`) for read-only paths
+(`fetch`, `remote-list`); encoders only emit v2.
+
+### 5.1.3 `<handoff>` block grammar
+
+The rendered output of `pull`, the persisted body of `handoff.md` in
+each branch, and the stdout of `fetch`. **External agents parse this
+when the user pastes it.** Grammar drift breaks consumer parsing.
+
+```
+<handoff origin="<cli>" session="<short>" cwd="<cwd-or-empty>">
+
+**Summary.** <one-sentence summary, ≤ 400 chars>
+
+**User prompts (last 10, in order).**
+
+1. <prompt 1, ≤ 300 chars, `…` if truncated>
+2. <prompt 2, ≤ 300 chars>
+…
+10. <prompt 10, ≤ 300 chars>
+
+**Last assistant turns (tail).**
+
+> <turn 1, ≤ 400 chars per line, multi-line `\n> ` prefixed>
+
+> <turn 2, ≤ 400 chars per line>
+
+> <turn 3, ≤ 400 chars per line>
+
+**Next step.** <single generic line, fixed text per ARCH-2>
+
+</handoff>
+```
+
+**Attribute rules (frozen):**
+
+| Attribute  | Required | Value                                       | Notes                                              |
+| ---------- | -------- | ------------------------------------------- | -------------------------------------------------- |
+| `origin`   | yes      | `claude` \| `copilot` \| `codex`            | source CLI                                         |
+| `session`  | yes      | 8 lowercase hex chars (the source short_id) | empty string when no session_id was extractable    |
+| `cwd`      | yes (attribute present) | absolute path or empty string  | empty string when source had no cwd                |
+
+No other attributes are emitted. Adding new attributes requires a spec
+amendment + ARCH-10 drift-test update. The previous `target=…` attribute
+is removed (target is implicit per ARCH-2).
+
+**Section rules (frozen):**
+
+| #  | Section heading                          | Body shape                                                  |
+| -- | ---------------------------------------- | ----------------------------------------------------------- |
+| 1  | `**Summary.**`                            | one sentence, ≤ 400 chars                                    |
+| 2  | `**User prompts (last 10, in order).**`   | 1-indexed numbered list, last 10 prompts, ≤ 300 chars each  |
+| 3  | `**Last assistant turns (tail).**`        | block-quote `> …`, last 3 turns, ≤ 400 chars each            |
+| 4  | `**Next step.**`                          | single fixed line (per ARCH-2 generic next-step text)        |
+
+**Empty-content fallbacks (frozen):**
+
+- No prompts: `1. (no user prompts captured)`.
+- No turns: `_(no assistant output captured)_` in place of the quote block.
+
+**Generic Next-step line (frozen text):**
+
+```
+Continue from the last assistant turn using the same file scope and goals summarized above.
+```
+
+This is the single line emitted regardless of source or target CLI. No
+per-target variants exist.
+
+## 5.2 Per-command flag matrix
+
+### 5.2.1 `pull <query> [flags]`
+
+| Flag          | Type     | Default | Mandatory when                 | Notes                                                        |
+| ------------- | -------- | ------- | ------------------------------ | ------------------------------------------------------------ |
+| `<query>`     | positional | n/a   | always                         | UUID / 8-hex short / `latest` / Claude customTitle / Codex thread_name |
+| `--from <cli>` | string  | (none)  | optional                       | narrow to one root; values: `claude` \| `copilot` \| `codex`  |
+| `--limit <N>` | integer  | 20      | optional                       | turns extraction tail length                                  |
+
+No `--to`. No `--json`. No `--out-dir`. No environment-variable detection.
+
+### 5.2.2 `push [<query>] [flags]`
+
+| Flag                  | Type             | Default  | Mandatory when                          | Notes                                                                          |
+| --------------------- | ---------------- | -------- | --------------------------------------- | ------------------------------------------------------------------------------ |
+| `[<query>]`           | positional       | (none)   | mandatory unless `--from` given          | session resolution input                                                       |
+| `--from <cli>`        | string           | (none)   | mandatory if `<query>` absent            | per ARCH-3                                                                     |
+| `--tag <label>`       | string, repeatable | (none) | optional                                | multi-tag via repeat (`--tag a --tag b`) **or** comma-joined (`--tag a,b`)     |
+| `--force-collision`   | bool             | false    | optional                                | override different-session-id-on-same-short-id error                           |
+| `--dry-run`           | bool             | false    | optional                                | render+scrub+probe, skip remote write                                          |
+| `--verify`            | bool             | false    | optional                                | extra preflight checks before push                                             |
+| `--verbose`           | bool             | false    | optional                                | extra debug output on stderr                                                   |
+
+No `--to`. No env-var detection.
+
+### 5.2.3 `fetch <query> [flags]`
+
+| Flag           | Type     | Default | Mandatory when | Notes                                                                                    |
+| -------------- | -------- | ------- | -------------- | ---------------------------------------------------------------------------------------- |
+| `<query>`      | positional | n/a   | always         | tag / 8-hex short / branch-suffix / commit prefix / description substring                |
+| `--from <cli>` | string   | (none)  | optional       | filter candidates whose `<cli>` segment matches; values: `claude` \| `copilot` \| `codex` |
+| `--limit <N>`  | integer  | 20      | optional       | candidate cap before bailing with "too many candidates, narrow the query"                |
+
+No `--to`. No `--json` (output is the `<handoff>` block, already a structured contract per 5.1.3).
+
+### 5.2.4 Supporting commands
+
+#### `list [flags]`
+
+Unified table of local sessions and remote handoffs. Source of truth for "what's available before I `pull` or `fetch`."
+
+| Flag         | Type    | Default | Notes                                                  |
+| ------------ | ------- | ------- | ------------------------------------------------------ |
+| `--local`    | bool    | false   | local-only (mutually exclusive with `--remote`)         |
+| `--remote`   | bool    | false   | remote-only (mutually exclusive with `--local`)         |
+| `--limit <N>`| integer | 50      | row cap; applies independently to local and remote     |
+| `--json`     | bool    | false   | emit JSON array `[{location, cli, short_id, when, ...}, ...]` |
+
+#### `search <text> [flags]`
+
+Substring/regex match across **local** session content (no remote search; remote uses `fetch` substring match instead). Resolves "I forgot the UUID but remember the topic."
+
+| Flag         | Type    | Default | Notes                                       |
+| ------------ | ------- | ------- | ------------------------------------------- |
+| `<text>`     | positional | n/a  | regex, case-insensitive by default          |
+| `--cli <cli>`| string  | (none)  | narrow to one root                          |
+| `--limit <N>`| integer | 50      | row cap                                     |
+| `--json`     | bool    | false   | emit JSON array of `{cli, short_id, cwd, mtime, snippet}` |
+
+(`--since <ISO>` deferred — month-bucket prefix in branch naming is the cheap filter; revisit only if usage shows monthly granularity is too coarse.)
+
+#### `describe <query> [flags]`
+
+Preview a session's metadata + last 10 user prompts without rendering the full `<handoff>` block.
+
+| Flag         | Type    | Default | Notes                                       |
+| ------------ | ------- | ------- | ------------------------------------------- |
+| `<query>`    | positional | n/a  | same forms as `pull`'s `<query>`            |
+| `--from <cli>`| string | (none)  | narrow to one root                          |
+| `--json`     | bool    | false   | emit `{origin: <meta>, user_prompts: [...]}` |
+
+#### `doctor`
+
+Verify the remote transport is reachable; no flags.
+
+## 5.3 Exit-code matrix
+
+ADR 0013 (referenced from `docs/repo-facts.json`) pins the exit-code domain
+to `{0, 1, 2, 64}`. This section maps each code to the conditions per
+command and locks the **prefix** of the stderr template.
+
+### 5.3.1 Universal codes
+
+| Code | Meaning                                                                  | Stderr prefix                                                                  |
+| ---- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| 0    | success                                                                  | (none)                                                                         |
+| 1    | preflight check failed (recoverable)                                     | `Preflight failed: <reason>` followed by `What's wrong:` / `How to fix:` block (existing `handoff-doctor.sh` format) |
+| 2    | runtime error (resolution miss, transport failure, scrub failure, etc.) | `dotclaude-handoff: <reason>`                                                  |
+| 64   | usage error (unknown flag, missing positional, conflicting flags)        | `dotclaude-handoff: <reason>` followed by `Usage: …` block                     |
+
+### 5.3.2 `pull`-specific exits
+
+| Code | Condition                                  | Stderr template                                                                     |
+| ---- | ------------------------------------------ | ----------------------------------------------------------------------------------- |
+| 2    | no session matches                          | `dotclaude-handoff: no session matches: <query>`                                    |
+| 2    | multiple sessions match (non-TTY)           | header `dotclaude-handoff: multiple sessions match "<query>":` + TSV lines (5.3.5) |
+| 64   | unknown flag                                | `dotclaude-handoff: unknown flag: <flag>` + usage                                   |
+| 64   | missing `<query>`                           | `dotclaude-handoff: pull requires a <query>` + usage                                |
+
+### 5.3.3 `push`-specific exits
+
+| Code | Condition                                                  | Stderr template                                                                                                |
+| ---- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 2    | transport not configured (env unset, non-TTY)               | `dotclaude-handoff: transport not configured` + manual-setup block (5.5.2)                                     |
+| 2    | scrub fail-closed                                           | `dotclaude-handoff: scrub not applied: <reason>`                                                               |
+| 2    | short-id collision, different session_id                    | `dotclaude-handoff: short-id collision on <branch>: local-session=<X> remote-session=<Y>; rerun with --force-collision to override` |
+| 2    | metadata.json missing on existing branch (legacy + no `--force-collision`) | `dotclaude-handoff: short-id collision on <branch>: existing branch has no provable owner (<git error>); rerun with --force-collision to override` |
+| 64   | no `<query>` and no `--from`                                | `dotclaude-handoff: push: --from required when no <query> is given` + usage                                    |
+| 64   | unknown flag                                                | `dotclaude-handoff: unknown flag: <flag>` + usage                                                              |
+
+### 5.3.4 `fetch`-specific exits
+
+| Code | Condition                                  | Stderr template                                                                  |
+| ---- | ------------------------------------------ | -------------------------------------------------------------------------------- |
+| 2    | transport not configured                    | `dotclaude-handoff: transport not configured` + "run push first" hint            |
+| 2    | no remote handoffs match                    | `dotclaude-handoff: no remote handoffs match: <query>`                           |
+| 2    | multiple handoffs match (non-TTY)           | header `dotclaude-handoff: multiple handoffs match "<query>":` + TSV lines (5.3.5) |
+| 2    | too many description-substring candidates    | `dotclaude-handoff: too many candidates, narrow the query`                       |
+| 64   | unknown flag                                | `dotclaude-handoff: unknown flag: <flag>` + usage                                |
+| 64   | missing `<query>`                           | `dotclaude-handoff: fetch requires a <query>` + usage                            |
+
+### 5.3.5 TSV candidate-list format (frozen column order)
+
+Both `pull` and `fetch` emit candidate lines on multi-match (non-TTY).
+Column order is fixed; tools parsing this format can rely on field positions.
+
+| Command  | Columns (tab-separated, in order)                       |
+| -------- | -------------------------------------------------------- |
+| `pull`   | `<cli>`, `<session_id>`, `<absolute-path>`, `<query>`     |
+| `fetch`  | `<branch>`, `<commit>`, `<description>`, `<query>`        |
+
+One candidate per line. No header row in the TSV (the human-readable
+header line above the TSV is plain prose, ignored by parsers). Fields
+are guaranteed not to contain literal tabs (resolver / git outputs are
+controlled).
+
+## 5.4 `<query>` valid forms (cross-cutting)
+
+Frozen across `pull`, `push`, `fetch`, `describe`:
+
+| Form                          | Lexical                                                | Notes                                         |
+| ----------------------------- | ------------------------------------------------------ | --------------------------------------------- |
+| Full UUID                      | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | exact match on session id                  |
+| Short UUID                     | `[0-9a-f]{8}`                                          | first 8 hex of session id                     |
+| Literal `latest`              | exactly the string `latest`                             | newest by mtime in target root(s)             |
+| Claude `customTitle` alias     | non-hex string ≤ 256 chars                              | scanned via `customTitle` JSONL records       |
+| Codex `thread_name` alias      | non-hex string ≤ 256 chars                              | scanned via `event_msg.thread_name` records   |
+| Tag (fetch only)              | `[a-z0-9-]{1,40}`                                      | matches description tag segment               |
+| Branch suffix (fetch only)    | partial branch path                                     | trailing-`/<short>` match against ls-remote   |
+| Commit prefix (fetch only)    | `[0-9a-f]{4,40}`                                       | matches commit hash prefix in ls-remote       |
+
+Copilot has **no** alias support; UUID / short / `latest` only (per
+`handoff-resolve.sh:151`). Claude does; Codex does.
+
+## 5.5 SKILL.md auto-trigger contract (testable)
+
+The skill markdown's `## Auto-trigger contract` section MUST list the
+phrase → invocation mapping below. ARCH-10's drift-test asserts:
+
+1. Every phrase pattern in SKILL.md maps to a known binary form in §5.2.
+2. Every primary form in §5.2 is reachable by at least one phrase pattern.
+3. The `--from` filling rule is documented identically in SKILL.md, the
+   binary's `--help`, and `docs/handoff-guide.md`.
+
+### 5.5.1 Phrase-pattern → binary-form mapping (frozen)
+
+| Trigger phrase pattern                                              | Binary invocation                                                       |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `handoff` + identifier (UUID / short / `latest` / alias)             | `dotclaude handoff pull <id>`                                            |
+| `continue in <cli>` / `switch to <cli>` / `pull from <cli>` + id     | `dotclaude handoff pull <id> --from <cli>`                               |
+| `claude --resume <id>` / `codex resume <id>` / `copilot --resume=<id>` | `dotclaude handoff pull <id>`                                          |
+| `what was that session about` + identifier                          | `dotclaude handoff describe <id>`                                        |
+| `push handoff` / `send to other machine` / `save this`               | `dotclaude handoff push --from <host-cli> [--tag <label>]`               |
+| `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch <query-or-prompt-user>`                       |
+
+### 5.5.2 The `--from` filling rule (frozen text)
+
+The skill markdown MUST contain this paragraph verbatim (the drift-test
+greps for it):
+
+> When invoking `dotclaude handoff push` without a `<query>` positional,
+> include `--from <your-cli>` where `<your-cli>` is the agent the host
+> LLM is running in (`claude` for Claude Code, `copilot` for GitHub
+> Copilot CLI, `codex` for Codex). The binary requires this flag in
+> that mode and will exit 64 without it.
+
+### 5.5.3 Out-of-trigger flags
+
+`--limit`, `--json`, `--force-collision`, `--dry-run`, `--verify`,
+`--verbose` are **not** part of the skill auto-trigger contract.
+Direct/scripted callers may pass them; the host LLM does not.
+
+## 5.6 Bootstrap & doctor user-facing strings
+
+### 5.6.1 Bootstrap interactive prompts (structure frozen, decoration editable)
+
+Locked structure (✓ icons, exact whitespace are decoration; reorderable but each line semantic must appear):
+
+```
+DOTCLAUDE_HANDOFF_REPO is not set — dotclaude can set this up for you.
+
+  Detected: gh CLI authenticated as @<login>.
+  Plan: create private repo  <login>/<name>
+        persist URL to       <config-file>
+
+  Repo name? [dotclaude-handoff-store] █
+  Create <login>/<name> and proceed? [y/N] █
+  ✓ created <login>/<name>             ; or "✓ repo <login>/<name> already exists — reusing"
+  ✓ wrote <config-file>
+    (add `source <config-file>` to ~/.bashrc or ~/.zshrc to persist across shells)
+```
+
+The prompts MUST gate on (a) detected `gh` login, (b) repo-name confirmation,
+(c) create-or-reuse confirmation. No silent creates.
+
+### 5.6.2 Manual-setup block (printed when bootstrap can't proceed)
+
+```
+Can't auto-bootstrap the handoff store: <reason>
+
+Set it up manually:
+  1. gh repo create <you>/dotclaude-handoff-store --private
+  2. export DOTCLAUDE_HANDOFF_REPO=git@github.com:<you>/dotclaude-handoff-store.git
+  3. dotclaude handoff push   # retries
+
+Alternative providers (GitLab, Gitea, self-hosted) work too — set
+DOTCLAUDE_HANDOFF_REPO to any ssh://, git@, https://, file://, or absolute path.
+```
+
+`<reason>` is one of: `not running in an interactive terminal`,
+``\`gh\` CLI is not on PATH — install it from https://cli.github.com/``,
+``\`gh\` is not authenticated — run \`gh auth login\` (scopes: repo)``,
+`could not read GitHub username via \`gh api user\``,
+`configured repo is unreachable (<url>) and we can't prompt in non-interactive mode`.
+
+### 5.6.3 `doctor` output format
+
+| Outcome                                                       | Stdout                                                            | Exit |
+| ------------------------------------------------------------- | ----------------------------------------------------------------- | ---- |
+| All checks pass, env configured, repo reachable                | `ok` + diagnostic lines (config / gh / repo URL)                  | 0    |
+| Env unset, gh authenticated (bootstrap will succeed on push)   | `ok (unconfigured)` + diagnostic lines + bootstrap-ready hint     | 0    |
+| Any check fails                                                | (none — failure block on stderr)                                  | 1    |
+
+Diagnostic-line shape (frozen):
+
+```
+config: <path-or-"(not written yet — first push will create it)">
+gh: <"authenticated" | "installed, not authenticated" | "not installed">
+DOTCLAUDE_HANDOFF_REPO: <url-or-"(unset — will bootstrap on first push)">
+```
+
+Failure block shape (frozen, on stderr):
+
+```
+Preflight failed: <reason>
+
+  What's wrong: <diagnosis>
+  How to fix:
+    1. <command>
+    2. <command>
+
+  Workaround: <alternative>
+
+Rerun /handoff doctor to verify.
+```
+
+## 5.7 Output-format summary per primary command
+
+| Command  | Stdout (success)                                                                                       |
+| -------- | ------------------------------------------------------------------------------------------------------ |
+| `pull`   | `<handoff>...</handoff>` block per 5.1.3 + trailing newline                                             |
+| `push`   | four lines: `<branch>` / `<repo-url>` / `<description>` / `[scrubbed N secrets]`                        |
+| `fetch`  | `<handoff>...</handoff>` block per 5.1.3 (read verbatim from `handoff.md` in the resolved branch)       |
+| `list`   | markdown table (default) or JSON array (`--json`); empty: `No sessions found` + exit 0                  |
+| `search` | markdown table + drill-in hint (default) or JSON array (`--json`); empty: `No sessions matching '<q>'` + exit 0 |
+| `describe` | markdown summary (default) or `{origin: <meta>, user_prompts: [...]}` (`--json`)                      |
+| `doctor` | per 5.6.3                                                                                              |
+
+## 5.8 Cross-references
+
+- §3 ARCH-10 enforces drift-detection across SKILL.md, `--help`, and `docs/handoff-guide.md`. The symbol-list under test is exactly what 5.2 + 5.3 + 5.5 freeze.
+- §4 KD-1 / KD-2 are the policy decisions; §5 is the wire-format and surface contract that implements them.
+- §6 sequences the migration including the `metadata.tag` deprecation cycle (one release, then drop) and the SKILL.md trigger-mapping rewrite.
+- §7 attaches non-functional targets (push / fetch / list latencies, store-growth ceilings) to specific commands above.
+- §8 captures risks: schema-bump migration, encoder/decoder version drift, the deprecated `metadata.tag` window.

--- a/docs/specs/handoff-skill/spec/6-implementation-plan.md
+++ b/docs/specs/handoff-skill/spec/6-implementation-plan.md
@@ -1,0 +1,221 @@
+# §6 — Implementation Plan
+
+> **Release-bang with phased PRs.** Multiple PRs land on `main` over a
+> tight window with no npm release between Phase 1 and cutover; the
+> npm version bumps exactly once (major) when the new surface is
+> complete. No deprecation warnings ever ship — the major version bump
+> is the deprecation signal, which is what semver is for. Internally
+> staged, externally atomic.
+>
+> **The on-disk remote format does not change.** Per §3 ARCH-6 the v1
+> description decoder is already preserved and only v2 encodes.
+> Existing pushed branches in users' `$DOTCLAUDE_HANDOFF_REPO` keep
+> working through the verb rename — there is no data migration, just
+> a CLI surface migration. This makes the big-bang less scary.
+
+## 6.1 Phased Rollout
+
+### Phase 1 — Foundation (no user-visible change)
+
+| Field | Detail                                                                                                                                                                                                                          |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Goal  | Land ARCH-10's drift test asserting the **current (old)** symbol list before any surface changes ship.                                                                                                                          |
+| Why   | A drift test that baselines against current state proves the test mechanism works before it has to defend a moving target. If it starts failing in Phase 2, that's the cutover signal, not a bug in the test.                  |
+| Exit  | Drift test on `main`, CI green, asserting old surface (`pull` = remote fetch, bare-positional = local emit, `--to` accepted, `push` falls back to env detection when no `<query>` and no `--from`).                              |
+| Risk  | Low — purely additive, no behavior change.                                                                                                                                                                                       |
+
+### Phase 2 — Surface cutover
+
+| Field | Detail                                                                                                                                                                                                                                                                              |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Goal  | Binary reshape + SKILL.md shrink + docs reconciliation land in lockstep PRs that flip the drift-test expectations PR by PR. Each PR makes the drift test **fail** on the old assertion and **pass** on the new one. No npm release in between.                                       |
+| How   | The drift test has its expected-symbol-list updated in the same PR that changes the binary surface. CI on each PR validates that PR's slice of the cutover is internally consistent (binary + SKILL.md + docs all updated together for that slice). Phase 2 ends when the full new surface is on `main`, all assertions are green, and the cumulative diff equals "old surface → new surface." |
+| Exit  | New surface on `main`: `pull` (local cross-agent), `fetch` (remote download), `push` (with mandatory `--from` rule), `--to` removed, supporting commands per §5.2.4. SKILL.md shrunk per §3 component table + §5.5 mapping. `docs/handoff-guide.md` reconciled.                       |
+| Risk  | Medium — the breaking change. Mitigated by lockstep PRs (small reviewable diffs), no release until Phase 2 complete (no user breakage during partial state), and the drift test forcing every component to update together.                                                          |
+
+### Phase 3 — Cleanup
+
+| Field | Detail                                                                                                                                                                                                                |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Goal  | Dead-code removal (any compatibility shims that helped Phase 2 stay reviewable), drop legacy `metadata.tag` field per §5.1.1, drift-test refinements based on what slipped through Phase 2.                            |
+| Exit  | No legacy fields written; no compatibility shims; drift test asserts only the new shape from §5.                                                                                                                       |
+| Risk  | Low — internal cleanup, no public-surface change.                                                                                                                                                                       |
+
+### Release
+
+After Phase 3, **one major version bump** ships to npm via the existing
+`release-please` automation. CHANGELOG entry includes the migration table
+from §6.5. No patch / minor releases between the start of Phase 1 and the
+major-version release.
+
+## 6.2 Workstream Breakdown
+
+Five parallel workstreams. Dependencies (edges) determine merge ordering
+within and between phases.
+
+| ID  | Workstream                              | Files (primary)                                                                                                                  |
+| --- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| W-1 | Binary surface refactor                 | `plugins/dotclaude/bin/dotclaude-handoff.mjs`, `plugins/dotclaude/src/lib/handoff-remote.mjs`                                     |
+| W-2 | SKILL.md + references rewrite           | `skills/handoff/SKILL.md`, `skills/handoff/references/*.md`                                                                       |
+| W-3 | Tests update                            | `plugins/dotclaude/tests/bats/handoff-*.bats`, `plugins/dotclaude/tests/handoff-*.test.mjs`                                       |
+| W-4 | Drift-detection test infrastructure     | `plugins/dotclaude/tests/handoff-drift.test.mjs` (new), CI wiring in `.github/workflows/`                                         |
+| W-5 | Long-form docs reconciliation           | `docs/handoff-guide.md`                                                                                                           |
+
+### Dependency edges
+
+```
+                    Phase 1
+   ┌─────────────────────────────────────┐
+   │ W-4 (drift test, baselines OLD)     │
+   └────────────────┬────────────────────┘
+                    │ exits Phase 1 → green CI
+                    ▼
+                    Phase 2
+   ┌──────────────────────────────────────┐
+   │ W-1 (binary reshape)  ◀───┐          │
+   │   ↳ drives PR-by-PR       │          │
+   │     drift-test flips      │          │
+   │                           │          │
+   │ W-3 (tests update)  ──────┘          │
+   │   must move WITH W-1                  │
+   │   (same PR or immediate next)         │
+   │                                       │
+   │ W-2 (SKILL.md shrink) ── parallel ──  │
+   │   to W-1, must merge before drift     │
+   │   test asserts new SKILL.md mapping   │
+   │                                       │
+   │ W-5 (docs guide) ── waits on W-1+W-2  │
+   │   (downstream of binary surface and   │
+   │    SKILL.md, reconciles to both)      │
+   └──────────────────────────────────────┘
+                    │
+                    ▼
+                    Phase 3
+   ┌──────────────────────────────────────┐
+   │ W-1 (cleanup, drop metadata.tag)     │
+   │ W-3 (drop tests for removed surface) │
+   │ W-4 (refine drift assertions)        │
+   └──────────────────────────────────────┘
+                    │
+                    ▼
+                  Release
+```
+
+## 6.3 Prompt Sequence
+
+Skeletal, deliberately. Per-PR prompts are **derived work** from the
+spec, not part of the spec itself. Pre-written prompts rot — by the
+time PR #N is being worked on, the codebase has moved past PR #(N-1)'s
+assumptions and the pre-written prompt is stale. The discipline §1's
+"stop the patch loop" needs is supplied by:
+
+1. The spec existing and being referenced (§1-5).
+2. ARCH-10's drift test failing when surface drifts.
+3. PRs scoped to single workstreams (this section).
+
+Per-PR prompts get written at implementation kickoff, not now.
+
+### Phase 1
+
+| Workstream | One-line PR summary                                                                                                |
+| ---------- | ------------------------------------------------------------------------------------------------------------------ |
+| W-4        | Add `handoff-drift.test.mjs` asserting the current (old) symbol list across SKILL.md, `--help`, `docs/handoff-guide.md`. CI wires it on every PR. Test passes on green main. |
+
+### Phase 2
+
+| Order | Workstream | One-line PR summary                                                                                                                                  |
+| ----- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | W-1 + W-3  | Add new `pull` verb (local cross-agent emit, was bare-positional). Drift test flipped for `pull`. Old bare-positional path kept temporarily.         |
+| 2     | W-1 + W-3  | Add new `fetch` verb (remote download, replaces old `pull`). Drift test flipped for `fetch`. Old `pull` kept temporarily.                            |
+| 3     | W-1 + W-3  | Make `--from` mandatory on `push` without `<query>`; remove env-detection fallback. Drift test flipped. Exit 64 with usage hint.                     |
+| 4     | W-1 + W-3  | Remove `--to` flag entirely + render single generic Next-step line per §5.1.3. Drift test flipped.                                                    |
+| 5     | W-1 + W-3  | Remove old verbs: bare-positional path, old `pull`. Remove unused `digest`, `file`, `resolve`, `remote-list` subs. Drift test flipped.                |
+| 6     | W-2        | Shrink SKILL.md per §3 component table; install §5.5 phrase mapping verbatim. Drift test asserts new SKILL.md mapping.                                |
+| 7     | W-2        | Prune `skills/handoff/references/*.md` of removed-flag references. Update `from-codex.md` for new verb names.                                         |
+| 8     | W-5        | Reconcile `docs/handoff-guide.md` against new surface. Drift test now passes against the full new symbol list.                                        |
+
+PRs 1-5 ship the binary cutover; PRs 6-7 ship the SKILL.md cutover; PR 8 closes docs. Within Phase 2 these can interleave but each PR must leave drift-test green for whatever subset has cut over.
+
+### Phase 3
+
+| Workstream | One-line PR summary                                                                       |
+| ---------- | ----------------------------------------------------------------------------------------- |
+| W-1        | Drop `metadata.tag` legacy field from push writes; readers continue to accept old reads.    |
+| W-3        | Drop tests for removed surface (`--to`, env-detection, old verbs).                          |
+| W-4        | Refine drift-test assertions based on Phase 2 lessons (likely: stricter regex on prefixes). |
+
+### Where the actual prompts live (when they're written)
+
+Reference: `docs/plans/handoff-skill-prompts.md` — **to be written at implementation kickoff**, not now while the spec is settling. That artifact will pull <read-first> file lists, TDD test names, and exact paths from the §3-§5 ground truth as it exists at the moment each PR starts.
+
+## 6.4 Testing Strategy
+
+| Workstream | UNIT                                                                                | INTEGRATION                                                                                  | POST-DEPLOY (manual)                                                            |
+| ---------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| W-1        | argv parser per command (5.2 flag matrices), exit codes per command (5.3 templates) | end-to-end `pull` / `push` / `fetch` against `file://` bare repo (existing bats pattern)      | one round-trip against the real `$DOTCLAUDE_HANDOFF_REPO` from a fresh shell    |
+| W-2        | n/a (markdown)                                                                       | drift-test asserts §5.5 mapping survives the rewrite                                          | trigger a real `/handoff` via Claude Code from a session, confirm Bash invocation matches mapping |
+| W-3        | bats coverage per command kept ≥ 90%                                                 | every primary command + every supporting command + every error path in §5.3                   | run full bats suite from `npm test` on macOS + Linux                            |
+| W-4        | unit test for the symbol-list extractor itself                                        | drift-test runs in CI on every PR; intentional drift (test fixture) must fail it              | n/a                                                                              |
+| W-5        | n/a (markdown)                                                                       | drift-test asserts `docs/handoff-guide.md` symbol list                                         | render docs locally, eyeball                                                    |
+
+ARCH-10's drift test runs as a **gate** on every PR through CI. Local
+dev runs `npm test` to surface drift before push.
+
+## 6.5 Migration Sequence
+
+> **The migration that doesn't happen:** the on-disk remote format
+> doesn't change. v1 description decode is preserved; only v2 encodes.
+> Existing branches in users' `$DOTCLAUDE_HANDOFF_REPO` keep working
+> through the verb rename. There is **no data migration step in this
+> spec.**
+
+The migration table for the major-version CHANGELOG:
+
+| Old surface (v0.x)                              | New surface (v1.x)                                   | User action required                                                                                  |
+| ----------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `dotclaude handoff <query>` (bare positional)   | `dotclaude handoff pull <query>`                     | Add the `pull` verb                                                                                    |
+| `dotclaude handoff pull <query>` (remote fetch) | `dotclaude handoff fetch <query>`                    | Rename invocation: `pull` → `fetch` for remote retrieval                                              |
+| `dotclaude handoff push --to <cli>`             | `dotclaude handoff push` (no `--to`)                 | Remove `--to`. The flag did nothing functional; it tuned a one-line Next-step text that's now generic |
+| `dotclaude handoff push` (env-detection fallback) | `dotclaude handoff push --from <cli>` (mandatory) | When pushing without a `<query>`, pass `--from <your-cli>`. The skill's auto-trigger contract fills this for slash-command users; direct shell users must add it. **Calling `push` without either will exit 64 with a usage hint.** |
+| `dotclaude handoff digest <cli> <id>`           | `dotclaude handoff describe <id> --json`             | Use `describe --json` for scripting (preview without rendering)                                       |
+| `dotclaude handoff file <cli> <id>`             | `dotclaude handoff pull <id> > <path>`               | Pipe the rendered block to a file; the dedicated `file` sub is removed                                |
+| `dotclaude handoff resolve <cli> <id>`          | (removed)                                            | Internal sub no longer exposed; was scripting-only and unused                                         |
+| `dotclaude handoff remote-list`                 | `dotclaude handoff list --remote`                    | Use `list --remote` (and `list --local` for local sessions)                                           |
+| `metadata.json.tag` (legacy field)              | `metadata.json.tags` (array)                         | None — readers ignore unknowns, the legacy single-tag field is dropped from writes in Phase 3         |
+
+Three user-visible breakages explicit in the table because they have
+different user-affordance shapes:
+
+1. **Verb rename** (rows 1, 2). Mechanical find-replace in any scripts.
+2. **`--to` removal** (row 3). The flag was cosmetic; remove from any saved invocations.
+3. **`--from` mandatory on `push`** (row 4). New friction for shell-direct users; transparent for slash-command users.
+
+## 6.6 Rollback Plan
+
+| Scenario                                                 | Action                                                                                                                                                              | Notes                                                                                            |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Critical bug discovered post-release                       | Publish a **patch release** that restores the prior surface (revert the cutover commits, bump major's first patch). Users `npm install -g @dotclaude/dotclaude@<prior-major>` to pin until fixed. | The drift test on the revert PR catches partial reverts; CI must pass before publishing.          |
+| Bug discovered between Phase 2 and release                 | Revert the offending Phase 2 PR(s) on `main`. Drift test stays green because the assertions revert with the surface change.                                          | This is the cheap rollback window — no users affected because no release has shipped.             |
+| Bug discovered during Phase 3 (post-cutover, pre-release)  | Same as above — revert offending PR. Phase 3 is internal cleanup; no user-visible state to migrate.                                                                  | Same drift-test invariant.                                                                       |
+| Phase 1 drift test itself is buggy                         | Revert W-4 PR. Phase 1 has no other artifacts.                                                                                                                       | Trivial.                                                                                          |
+| User pins to old major and never upgrades                  | Acceptable. v0.x stays on npm under its tags; users upgrade when they're ready.                                                                                      | This is what semver major is for.                                                                |
+
+### Things explicitly NOT in the rollback plan
+
+| Anti-action                                                | Why not                                                                                                                                              |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `npm unpublish`                                             | 72-hour publish window only; generally a bad-idea operation that breaks lockfiles for anyone who installed during the window. Don't do it.        |
+| Hot-patching old releases with backports                    | Out of scope. v0.x is the "old major"; bug fixes there require explicit user demand and are a separate decision.                                  |
+| Dual-publishing v0.x and v1.x                               | Out of scope. The deprecation signal is the major version bump, not parallel maintenance.                                                         |
+
+### Pre-release confidence is the actual rollback insurance
+
+ARCH-10's drift test running on every PR through Phase 1 + Phase 2 + Phase 3 means the major version that ships has been incrementally validated for surface consistency from baseline → cutover. The drift test is what makes the big-bang less scary; it's the rollback insurance, not a literal rollback procedure.
+
+## 6.7 Cross-references
+
+- §3 ARCH-10 — drift-test invariant, the gating mechanism throughout this plan.
+- §5.5 — SKILL.md auto-trigger phrase mapping that drift-test asserts against.
+- §5.1 — frozen schemas; §6 does not change them, the surface migration is CLI-only.
+- §7 — non-functional acceptance gates for Phase 2 PRs (latency, scrub fail-closed semantics).
+- §8 — risks specific to this migration (verb-rename muscle-memory cost, `--from` mandatory friction, accidental Phase 1 baseline drift).

--- a/docs/specs/handoff-skill/spec/6-implementation-plan.md
+++ b/docs/specs/handoff-skill/spec/6-implementation-plan.md
@@ -17,29 +17,29 @@
 
 ### Phase 1 — Foundation (no user-visible change)
 
-| Field | Detail                                                                                                                                                                                                                          |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Goal  | Land ARCH-10's drift test asserting the **current (old)** symbol list before any surface changes ship.                                                                                                                          |
-| Why   | A drift test that baselines against current state proves the test mechanism works before it has to defend a moving target. If it starts failing in Phase 2, that's the cutover signal, not a bug in the test.                  |
-| Exit  | Drift test on `main`, CI green, asserting old surface (`pull` = remote fetch, bare-positional = local emit, `--to` accepted, `push` falls back to env detection when no `<query>` and no `--from`).                              |
-| Risk  | Low — purely additive, no behavior change.                                                                                                                                                                                       |
+| Field | Detail                                                                                                                                                                                                        |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Goal  | Land ARCH-10's drift test asserting the **current (old)** symbol list before any surface changes ship.                                                                                                        |
+| Why   | A drift test that baselines against current state proves the test mechanism works before it has to defend a moving target. If it starts failing in Phase 2, that's the cutover signal, not a bug in the test. |
+| Exit  | Drift test on `main`, CI green, asserting old surface (`pull` = remote fetch, bare-positional = local emit, `--to` accepted, `push` falls back to env detection when no `<query>` and no `--from`).           |
+| Risk  | Low — purely additive, no behavior change.                                                                                                                                                                    |
 
 ### Phase 2 — Surface cutover
 
-| Field | Detail                                                                                                                                                                                                                                                                              |
-| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Goal  | Binary reshape + SKILL.md shrink + docs reconciliation land in lockstep PRs that flip the drift-test expectations PR by PR. Each PR makes the drift test **fail** on the old assertion and **pass** on the new one. No npm release in between.                                       |
+| Field | Detail                                                                                                                                                                                                                                                                                                                                                                                         |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Goal  | Binary reshape + SKILL.md shrink + docs reconciliation land in lockstep PRs that flip the drift-test expectations PR by PR. Each PR makes the drift test **fail** on the old assertion and **pass** on the new one. No npm release in between.                                                                                                                                                 |
 | How   | The drift test has its expected-symbol-list updated in the same PR that changes the binary surface. CI on each PR validates that PR's slice of the cutover is internally consistent (binary + SKILL.md + docs all updated together for that slice). Phase 2 ends when the full new surface is on `main`, all assertions are green, and the cumulative diff equals "old surface → new surface." |
-| Exit  | New surface on `main`: `pull` (local cross-agent), `fetch` (remote download), `push` (with mandatory `--from` rule), `--to` removed, supporting commands per §5.2.4. SKILL.md shrunk per §3 component table + §5.5 mapping. `docs/handoff-guide.md` reconciled.                       |
-| Risk  | Medium — the breaking change. Mitigated by lockstep PRs (small reviewable diffs), no release until Phase 2 complete (no user breakage during partial state), and the drift test forcing every component to update together.                                                          |
+| Exit  | New surface on `main`: `pull` (local cross-agent), `fetch` (remote download), `push` (with mandatory `--from` rule), `--to` removed, supporting commands per §5.2.4. SKILL.md shrunk per §3 component table + §5.5 mapping. `docs/handoff-guide.md` reconciled.                                                                                                                                |
+| Risk  | Medium — the breaking change. Mitigated by lockstep PRs (small reviewable diffs), no release until Phase 2 complete (no user breakage during partial state), and the drift test forcing every component to update together.                                                                                                                                                                    |
 
 ### Phase 3 — Cleanup
 
-| Field | Detail                                                                                                                                                                                                                |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Goal  | Dead-code removal (any compatibility shims that helped Phase 2 stay reviewable), drop legacy `metadata.tag` field per §5.1.1, drift-test refinements based on what slipped through Phase 2.                            |
-| Exit  | No legacy fields written; no compatibility shims; drift test asserts only the new shape from §5.                                                                                                                       |
-| Risk  | Low — internal cleanup, no public-surface change.                                                                                                                                                                       |
+| Field | Detail                                                                                                                                                                                      |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Goal  | Dead-code removal (any compatibility shims that helped Phase 2 stay reviewable), drop legacy `metadata.tag` field per §5.1.1, drift-test refinements based on what slipped through Phase 2. |
+| Exit  | No legacy fields written; no compatibility shims; drift test asserts only the new shape from §5.                                                                                            |
+| Risk  | Low — internal cleanup, no public-surface change.                                                                                                                                           |
 
 ### Release
 
@@ -53,13 +53,13 @@ major-version release.
 Five parallel workstreams. Dependencies (edges) determine merge ordering
 within and between phases.
 
-| ID  | Workstream                              | Files (primary)                                                                                                                  |
-| --- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| W-1 | Binary surface refactor                 | `plugins/dotclaude/bin/dotclaude-handoff.mjs`, `plugins/dotclaude/src/lib/handoff-remote.mjs`                                     |
-| W-2 | SKILL.md + references rewrite           | `skills/handoff/SKILL.md`, `skills/handoff/references/*.md`                                                                       |
-| W-3 | Tests update                            | `plugins/dotclaude/tests/bats/handoff-*.bats`, `plugins/dotclaude/tests/handoff-*.test.mjs`                                       |
-| W-4 | Drift-detection test infrastructure     | `plugins/dotclaude/tests/handoff-drift.test.mjs` (new), CI wiring in `.github/workflows/`                                         |
-| W-5 | Long-form docs reconciliation           | `docs/handoff-guide.md`                                                                                                           |
+| ID  | Workstream                          | Files (primary)                                                                               |
+| --- | ----------------------------------- | --------------------------------------------------------------------------------------------- |
+| W-1 | Binary surface refactor             | `plugins/dotclaude/bin/dotclaude-handoff.mjs`, `plugins/dotclaude/src/lib/handoff-remote.mjs` |
+| W-2 | SKILL.md + references rewrite       | `skills/handoff/SKILL.md`, `skills/handoff/references/*.md`                                   |
+| W-3 | Tests update                        | `plugins/dotclaude/tests/bats/handoff-*.bats`, `plugins/dotclaude/tests/handoff-*.test.mjs`   |
+| W-4 | Drift-detection test infrastructure | `plugins/dotclaude/tests/handoff-drift.test.mjs` (new), CI wiring in `.github/workflows/`     |
+| W-5 | Long-form docs reconciliation       | `docs/handoff-guide.md`                                                                       |
 
 ### Dependency edges
 
@@ -117,29 +117,29 @@ Per-PR prompts get written at implementation kickoff, not now.
 
 ### Phase 1
 
-| Workstream | One-line PR summary                                                                                                |
-| ---------- | ------------------------------------------------------------------------------------------------------------------ |
-| W-4        | Add `handoff-drift.test.mjs` asserting the current (old) symbol list across SKILL.md, `--help`, `docs/handoff-guide.md`. CI wires it on every PR. Test passes on green main. |
+| Workstream | One-line PR summary                                                                                                                                                                                               |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| W-4        | Add `handoff-drift.test.mjs` asserting the current (old) symbol list across SKILL.md and `--help`. CI wires it on every PR. Test passes on green main. `docs/handoff-guide.md` drift remains deferred in Phase 1. |
 
 ### Phase 2
 
-| Order | Workstream | One-line PR summary                                                                                                                                  |
-| ----- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1     | W-1 + W-3  | Add new `pull` verb (local cross-agent emit, was bare-positional). Drift test flipped for `pull`. Old bare-positional path kept temporarily.         |
-| 2     | W-1 + W-3  | Add new `fetch` verb (remote download, replaces old `pull`). Drift test flipped for `fetch`. Old `pull` kept temporarily.                            |
-| 3     | W-1 + W-3  | Make `--from` mandatory on `push` without `<query>`; remove env-detection fallback. Drift test flipped. Exit 64 with usage hint.                     |
-| 4     | W-1 + W-3  | Remove `--to` flag entirely + render single generic Next-step line per §5.1.3. Drift test flipped.                                                    |
-| 5     | W-1 + W-3  | Remove old verbs: bare-positional path, old `pull`. Remove unused `digest`, `file`, `resolve`, `remote-list` subs. Drift test flipped.                |
-| 6     | W-2        | Shrink SKILL.md per §3 component table; install §5.5 phrase mapping verbatim. Drift test asserts new SKILL.md mapping.                                |
-| 7     | W-2        | Prune `skills/handoff/references/*.md` of removed-flag references. Update `from-codex.md` for new verb names.                                         |
-| 8     | W-5        | Reconcile `docs/handoff-guide.md` against new surface. Drift test now passes against the full new symbol list.                                        |
+| Order | Workstream | One-line PR summary                                                                                                                          |
+| ----- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | W-1 + W-3  | Add new `pull` verb (local cross-agent emit, was bare-positional). Drift test flipped for `pull`. Old bare-positional path kept temporarily. |
+| 2     | W-1 + W-3  | Add new `fetch` verb (remote download, replaces old `pull`). Drift test flipped for `fetch`. Old `pull` kept temporarily.                    |
+| 3     | W-1 + W-3  | Make `--from` mandatory on `push` without `<query>`; remove env-detection fallback. Drift test flipped. Exit 64 with usage hint.             |
+| 4     | W-1 + W-3  | Remove `--to` flag entirely + render single generic Next-step line per §5.1.3. Drift test flipped.                                           |
+| 5     | W-1 + W-3  | Remove old verbs: bare-positional path, old `pull`. Remove unused `digest`, `file`, `resolve`, `remote-list` subs. Drift test flipped.       |
+| 6     | W-2        | Shrink SKILL.md per §3 component table; install §5.5 phrase mapping verbatim. Drift test asserts new SKILL.md mapping.                       |
+| 7     | W-2        | Prune `skills/handoff/references/*.md` of removed-flag references. Update `from-codex.md` for new verb names.                                |
+| 8     | W-5        | Reconcile `docs/handoff-guide.md` against new surface. Drift test now passes against the full new symbol list.                               |
 
 PRs 1-5 ship the binary cutover; PRs 6-7 ship the SKILL.md cutover; PR 8 closes docs. Within Phase 2 these can interleave but each PR must leave drift-test green for whatever subset has cut over.
 
 ### Phase 3
 
-| Workstream | One-line PR summary                                                                       |
-| ---------- | ----------------------------------------------------------------------------------------- |
+| Workstream | One-line PR summary                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------- |
 | W-1        | Drop `metadata.tag` legacy field from push writes; readers continue to accept old reads.    |
 | W-3        | Drop tests for removed surface (`--to`, env-detection, old verbs).                          |
 | W-4        | Refine drift-test assertions based on Phase 2 lessons (likely: stricter regex on prefixes). |
@@ -150,13 +150,13 @@ Reference: `docs/plans/handoff-skill-prompts.md` — **to be written at implemen
 
 ## 6.4 Testing Strategy
 
-| Workstream | UNIT                                                                                | INTEGRATION                                                                                  | POST-DEPLOY (manual)                                                            |
-| ---------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| W-1        | argv parser per command (5.2 flag matrices), exit codes per command (5.3 templates) | end-to-end `pull` / `push` / `fetch` against `file://` bare repo (existing bats pattern)      | one round-trip against the real `$DOTCLAUDE_HANDOFF_REPO` from a fresh shell    |
-| W-2        | n/a (markdown)                                                                       | drift-test asserts §5.5 mapping survives the rewrite                                          | trigger a real `/handoff` via Claude Code from a session, confirm Bash invocation matches mapping |
-| W-3        | bats coverage per command kept ≥ 90%                                                 | every primary command + every supporting command + every error path in §5.3                   | run full bats suite from `npm test` on macOS + Linux                            |
-| W-4        | unit test for the symbol-list extractor itself                                        | drift-test runs in CI on every PR; intentional drift (test fixture) must fail it              | n/a                                                                              |
-| W-5        | n/a (markdown)                                                                       | drift-test asserts `docs/handoff-guide.md` symbol list                                         | render docs locally, eyeball                                                    |
+| Workstream | UNIT                                                                                | INTEGRATION                                                                              | POST-DEPLOY (manual)                                                                              |
+| ---------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| W-1        | argv parser per command (5.2 flag matrices), exit codes per command (5.3 templates) | end-to-end `pull` / `push` / `fetch` against `file://` bare repo (existing bats pattern) | one round-trip against the real `$DOTCLAUDE_HANDOFF_REPO` from a fresh shell                      |
+| W-2        | n/a (markdown)                                                                      | drift-test asserts §5.5 mapping survives the rewrite                                     | trigger a real `/handoff` via Claude Code from a session, confirm Bash invocation matches mapping |
+| W-3        | bats coverage per command kept ≥ 90%                                                | every primary command + every supporting command + every error path in §5.3              | run full bats suite from `npm test` on macOS + Linux                                              |
+| W-4        | unit test for the symbol-list extractor itself                                      | drift-test runs in CI on every PR; intentional drift (test fixture) must fail it         | n/a                                                                                               |
+| W-5        | n/a (markdown)                                                                      | drift-test asserts `docs/handoff-guide.md` symbol list                                   | render docs locally, eyeball                                                                      |
 
 ARCH-10's drift test runs as a **gate** on every PR through CI. Local
 dev runs `npm test` to surface drift before push.
@@ -171,17 +171,17 @@ dev runs `npm test` to surface drift before push.
 
 The migration table for the major-version CHANGELOG:
 
-| Old surface (v0.x)                              | New surface (v1.x)                                   | User action required                                                                                  |
-| ----------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `dotclaude handoff <query>` (bare positional)   | `dotclaude handoff pull <query>`                     | Add the `pull` verb                                                                                    |
-| `dotclaude handoff pull <query>` (remote fetch) | `dotclaude handoff fetch <query>`                    | Rename invocation: `pull` → `fetch` for remote retrieval                                              |
-| `dotclaude handoff push --to <cli>`             | `dotclaude handoff push` (no `--to`)                 | Remove `--to`. The flag did nothing functional; it tuned a one-line Next-step text that's now generic |
+| Old surface (v0.x)                                | New surface (v1.x)                                | User action required                                                                                                                                                                                                                |
+| ------------------------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dotclaude handoff <query>` (bare positional)     | `dotclaude handoff pull <query>`                  | Add the `pull` verb                                                                                                                                                                                                                 |
+| `dotclaude handoff pull <query>` (remote fetch)   | `dotclaude handoff fetch <query>`                 | Rename invocation: `pull` → `fetch` for remote retrieval                                                                                                                                                                            |
+| `dotclaude handoff push --to <cli>`               | `dotclaude handoff push` (no `--to`)              | Remove `--to`. The flag did nothing functional; it tuned a one-line Next-step text that's now generic                                                                                                                               |
 | `dotclaude handoff push` (env-detection fallback) | `dotclaude handoff push --from <cli>` (mandatory) | When pushing without a `<query>`, pass `--from <your-cli>`. The skill's auto-trigger contract fills this for slash-command users; direct shell users must add it. **Calling `push` without either will exit 64 with a usage hint.** |
-| `dotclaude handoff digest <cli> <id>`           | `dotclaude handoff describe <id> --json`             | Use `describe --json` for scripting (preview without rendering)                                       |
-| `dotclaude handoff file <cli> <id>`             | `dotclaude handoff pull <id> > <path>`               | Pipe the rendered block to a file; the dedicated `file` sub is removed                                |
-| `dotclaude handoff resolve <cli> <id>`          | (removed)                                            | Internal sub no longer exposed; was scripting-only and unused                                         |
-| `dotclaude handoff remote-list`                 | `dotclaude handoff list --remote`                    | Use `list --remote` (and `list --local` for local sessions)                                           |
-| `metadata.json.tag` (legacy field)              | `metadata.json.tags` (array)                         | None — readers ignore unknowns, the legacy single-tag field is dropped from writes in Phase 3         |
+| `dotclaude handoff digest <cli> <id>`             | `dotclaude handoff describe <id> --json`          | Use `describe --json` for scripting (preview without rendering)                                                                                                                                                                     |
+| `dotclaude handoff file <cli> <id>`               | `dotclaude handoff pull <id> > <path>`            | Pipe the rendered block to a file; the dedicated `file` sub is removed                                                                                                                                                              |
+| `dotclaude handoff resolve <cli> <id>`            | (removed)                                         | Internal sub no longer exposed; was scripting-only and unused                                                                                                                                                                       |
+| `dotclaude handoff remote-list`                   | `dotclaude handoff list --remote`                 | Use `list --remote` (and `list --local` for local sessions)                                                                                                                                                                         |
+| `metadata.json.tag` (legacy field)                | `metadata.json.tags` (array)                      | None — readers ignore unknowns, the legacy single-tag field is dropped from writes in Phase 3                                                                                                                                       |
 
 Three user-visible breakages explicit in the table because they have
 different user-affordance shapes:
@@ -192,21 +192,21 @@ different user-affordance shapes:
 
 ## 6.6 Rollback Plan
 
-| Scenario                                                 | Action                                                                                                                                                              | Notes                                                                                            |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Critical bug discovered post-release                       | Publish a **patch release** that restores the prior surface (revert the cutover commits, bump major's first patch). Users `npm install -g @dotclaude/dotclaude@<prior-major>` to pin until fixed. | The drift test on the revert PR catches partial reverts; CI must pass before publishing.          |
-| Bug discovered between Phase 2 and release                 | Revert the offending Phase 2 PR(s) on `main`. Drift test stays green because the assertions revert with the surface change.                                          | This is the cheap rollback window — no users affected because no release has shipped.             |
-| Bug discovered during Phase 3 (post-cutover, pre-release)  | Same as above — revert offending PR. Phase 3 is internal cleanup; no user-visible state to migrate.                                                                  | Same drift-test invariant.                                                                       |
-| Phase 1 drift test itself is buggy                         | Revert W-4 PR. Phase 1 has no other artifacts.                                                                                                                       | Trivial.                                                                                          |
-| User pins to old major and never upgrades                  | Acceptable. v0.x stays on npm under its tags; users upgrade when they're ready.                                                                                      | This is what semver major is for.                                                                |
+| Scenario                                                  | Action                                                                                                                                                                                            | Notes                                                                                    |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Critical bug discovered post-release                      | Publish a **patch release** that restores the prior surface (revert the cutover commits, bump major's first patch). Users `npm install -g @dotclaude/dotclaude@<prior-major>` to pin until fixed. | The drift test on the revert PR catches partial reverts; CI must pass before publishing. |
+| Bug discovered between Phase 2 and release                | Revert the offending Phase 2 PR(s) on `main`. Drift test stays green because the assertions revert with the surface change.                                                                       | This is the cheap rollback window — no users affected because no release has shipped.    |
+| Bug discovered during Phase 3 (post-cutover, pre-release) | Same as above — revert offending PR. Phase 3 is internal cleanup; no user-visible state to migrate.                                                                                               | Same drift-test invariant.                                                               |
+| Phase 1 drift test itself is buggy                        | Revert W-4 PR. Phase 1 has no other artifacts.                                                                                                                                                    | Trivial.                                                                                 |
+| User pins to old major and never upgrades                 | Acceptable. v0.x stays on npm under its tags; users upgrade when they're ready.                                                                                                                   | This is what semver major is for.                                                        |
 
 ### Things explicitly NOT in the rollback plan
 
-| Anti-action                                                | Why not                                                                                                                                              |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `npm unpublish`                                             | 72-hour publish window only; generally a bad-idea operation that breaks lockfiles for anyone who installed during the window. Don't do it.        |
-| Hot-patching old releases with backports                    | Out of scope. v0.x is the "old major"; bug fixes there require explicit user demand and are a separate decision.                                  |
-| Dual-publishing v0.x and v1.x                               | Out of scope. The deprecation signal is the major version bump, not parallel maintenance.                                                         |
+| Anti-action                              | Why not                                                                                                                                    |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `npm unpublish`                          | 72-hour publish window only; generally a bad-idea operation that breaks lockfiles for anyone who installed during the window. Don't do it. |
+| Hot-patching old releases with backports | Out of scope. v0.x is the "old major"; bug fixes there require explicit user demand and are a separate decision.                           |
+| Dual-publishing v0.x and v1.x            | Out of scope. The deprecation signal is the major version bump, not parallel maintenance.                                                  |
 
 ### Pre-release confidence is the actual rollback insurance
 

--- a/docs/specs/handoff-skill/spec/7-non-functional-requirements.md
+++ b/docs/specs/handoff-skill/spec/7-non-functional-requirements.md
@@ -1,0 +1,248 @@
+# §7 — Non-Functional Requirements
+
+> Ordered by gravity. **REL** and **SEC** are load-bearing invariants
+> that fail closed, are testable, and protect users from concrete harm.
+> **PERF** and **OPS** are ceilings — they describe expected behavior
+> and bound future drift. The order of subsections matches the weight
+> each category carries.
+>
+> Every constraint in this section is testable: a number to assert
+> against, a behavior to verify, a regression to catch.
+
+## Reliability
+
+### REL-1 — Scrub is fail-closed.
+
+`push` aborts with exit 2 and writes nothing to the remote if any of
+the following holds:
+
+- `perl` is not on PATH.
+- `handoff-scrub.sh` exits non-zero for any reason.
+- `handoff-scrub.sh` does not emit a `scrubbed:<N>` count line on stderr.
+- The count line cannot be parsed as a non-negative integer.
+
+The error prefix is `scrub not applied:` (per §5.3.3). No partial-scrub
+mode, no "best-effort" fallback. An unscrubbed digest cannot reach the
+remote.
+
+**Test:** vitest unit + bats integration. Inject a missing-perl, a
+non-zero-exit, and a missing-count-line scenario; assert exit 2 and
+zero git operations performed.
+
+### REL-2 — Collision probe is fail-closed.
+
+`push` aborts with exit 2 if the target branch already exists on the
+remote and its `metadata.json.session_id` differs from the local
+session_id. `--force-collision` is the explicit, documented override.
+
+**Test:** bats integration against a `file://` bare repo seeded with a
+foreign-session branch; assert exit 2 without `--force-collision`,
+exit 0 with it.
+
+### REL-3 — Bootstrap is idempotent.
+
+Running `dotclaude handoff push` repeatedly when bootstrap is needed:
+
+- If `gh repo create` reports the repo already exists, the binary
+  treats it as a re-use, not an error.
+- If the persisted env file already contains a valid URL,
+  `loadPersistedEnv()` does not overwrite a caller-set
+  `DOTCLAUDE_HANDOFF_REPO`.
+- Re-running with the same `--from <cli>` and same source session
+  produces the same branch path; the second push hits the
+  same-session-id update path of REL-2, not the collision path.
+
+**Test:** bats integration that runs bootstrap → bootstrap → push
+back-to-back against a fresh `gh` mock; assert single repo creation,
+no duplicate config writes, idempotent push outcome.
+
+## Security
+
+### SEC-1 — Scrub patterns are spec-frozen.
+
+The eight perl regex passes in `handoff-scrub.sh` (GitHub tokens,
+OpenAI/sk-*, AWS access keys, Google API keys, Slack tokens,
+`Authorization: Bearer …`, `*_TOKEN`/`KEY`/`SECRET`/`PASSWORD`=…,
+PEM private keys) are the complete redaction set for v1.x. Adding,
+removing, or modifying a pattern requires:
+
+1. An amendment to this constraint.
+2. An update to `skills/handoff/references/redaction.md`.
+3. A corresponding test in `handoff-scrub.bats`.
+
+Patterns ship as a single change set, not piecemeal.
+
+**Test:** dedicated bats suite with one positive + one boundary case
+per pattern; the suite is the authoritative pattern inventory.
+
+### SEC-2 — Transport URL validator rejects exec-triggering schemes.
+
+`validateTransportUrl()` (in `plugins/dotclaude/src/lib/handoff-remote.mjs`)
+must accept only:
+
+- `https://`
+- `http://`
+- `git@`
+- `ssh://`
+- `file://`
+- absolute filesystem paths (leading `/`)
+
+Any URL matching `ext::`, `data:`, `javascript:`, or any other scheme
+is rejected with exit 2. This is the CVE-2017-1000117 class of attack
+(malicious git URLs that exec arbitrary commands when fed to git
+operations).
+
+**Test:** unit test on the validator with a fixture of known-bad
+schemes; bats integration on `push` with `DOTCLAUDE_HANDOFF_REPO=ext::…`
+asserting exit 2 before any git op fires.
+
+### SEC-3 — Persisted env file is mode 0600.
+
+`$XDG_CONFIG_HOME/dotclaude/handoff.env` (default
+`~/.config/dotclaude/handoff.env`) is written with mode `0600` and
+its parent directory with `0700`. The file may contain a path that
+embeds an SSH credential helper hint or a token in a `git@` URL with
+embedded auth; world-readable mode is unacceptable.
+
+**Test:** bats verification of `stat -c '%a' <file>` post-bootstrap.
+
+### SEC-4 — Per-branch payload ceiling.
+
+`handoff.md` written by `push` is bounded:
+
+- Typical: ≤ 50 KB.
+- Hard ceiling: 1 MB. `push` aborts with exit 2 before commit if the
+  rendered+scrubbed block exceeds 1 MB.
+
+This pairs with PERF-2's input ceiling (5 MB raw input) and bounds the
+worst-case `fetch` shallow-clone size. A handoff block that exceeds
+1 MB is unfit for its purpose anyway — it's no longer paste-able into
+a target agent's prompt window.
+
+**Test:** unit test against a synthetic prompts/turns input that
+renders a > 1 MB block; assert exit 2 with the ceiling-message error.
+
+## Performance
+
+### PERF-1 — Remote-list latency ceiling, baselined in Phase 1.
+
+`list --remote` against a store with **≤ 1000 handoff branches** on a
+warm connection should complete in **< 2 s**. This is the §3 ARCH-9
+target.
+
+**Caveat:** the 1000-branch / 2-second pair is an unvalidated estimate
+at spec time. Phase 1 (per §6.1) establishes the actual baseline by
+running `list --remote` against a synthetic 1000-branch fixture. If
+reality differs, the ceiling adjusts; the **behavior** does not. PERF-1
+is a guardrail against regression, not a contract for users to plan
+against.
+
+**Test:** Phase 1 — generate fixture, measure, record baseline.
+Subsequent PRs run the same fixture and fail CI on > 1.5x baseline
+regression.
+
+### PERF-2 — Scrub on bounded input.
+
+The scrubber must complete a single push within **< 1 s for inputs
+≤ 1 MB**. For inputs **> 5 MB**, `push` aborts with exit 2 before the
+scrubber runs (the input is unfit for purpose; see SEC-4 commentary).
+
+**Reasoning.** Eight perl regex passes against the full handoff block
+are microseconds for normal sessions, but a pathological 50 MB session
+(someone pasted a giant log as part of their conversation) could stall
+the scrubber for tens of seconds. The 5 MB pre-scrub ceiling acts as
+a smell detector before the user notices.
+
+**Test:** vitest microbenchmark against synthetic 100 KB / 1 MB / 5 MB /
+6 MB inputs; assert latency budget for ≤ 1 MB and exit-2 for > 5 MB.
+
+## Operational
+
+### OPS-1 — Drift test runs as a CI gate on every PR.
+
+ARCH-10's drift test (`plugins/dotclaude/tests/handoff-drift.test.mjs`)
+runs in CI on every PR that touches:
+
+- `skills/handoff/**`
+- `plugins/dotclaude/bin/dotclaude-handoff.mjs`
+- `plugins/dotclaude/src/lib/handoff-remote.mjs`
+- `docs/handoff-guide.md`
+
+Failing drift = failing PR. No "drift will be cleaned up later" PRs;
+the cleanup is part of the same PR that introduced the drift.
+
+**Test:** the drift test itself, plus a CI smoke that intentionally
+breaks the assertion via a fixture and expects red.
+
+### OPS-2 — Stdout determinism across TTY / non-TTY.
+
+The `<handoff>` block on `pull` / `fetch`, and the four-line success
+output on `push`, are emitted on stdout **identically** regardless of
+whether stdout is a terminal or a pipe. Specifically:
+
+- Spinners, progress indicators, and `✓` icons go to **stderr only**.
+- ANSI color codes are not emitted on stdout under any condition.
+- Interactive prompts (bootstrap, collision pick) go to stderr.
+- A consumer wrapping the binary in a shell pipeline gets the same
+  bytes as a human running it interactively.
+
+**Test:** bats integration runs each command with `< /dev/null` and
+captures stdout to a file; asserts byte-for-byte equality with the
+TTY-emulated run via `script` or equivalent.
+
+### OPS-3 — Exit codes are a public contract.
+
+The exit code set `{0, 1, 2, 64}` from §5.3 is frozen. Adding a new
+exit code (e.g. exit 3 for "partial success", exit 5 for "rate
+limited") requires a spec amendment. Reuse of an existing code is
+fine.
+
+**Test:** drift test asserts the exit-code matrix in §5.3 against
+what the binary actually emits via fixture-driven bats coverage of
+each named condition.
+
+### OPS-4 — Cross-platform support: Linux + macOS first-class, Windows via WSL.
+
+Substrate requirement: POSIX shell + GNU `jq` + `perl 5` + `git`.
+Versions are not pinned; the substrate scripts use POSIX-portable
+constructs only (`pick_newest()` per `handoff-resolve.sh:39-62` is
+already portable across GNU `find` and BSD `stat`).
+
+Native Windows (cmd / PowerShell direct) is **out of scope**. WSL
+counts as Linux; Git Bash on Windows is unsupported (best-effort).
+
+**Test:** CI matrix runs the bats suite on Ubuntu LTS + macOS latest
+on every PR. No Windows CI lane.
+
+## Concurrent Push
+
+Two machines pushing the same source short_id at the same time is
+covered by KD-1 (force-push of own branch) + REL-2 (collision probe).
+Last writer wins for same-session-id. Different-session-id collision
+exits 2 unless `--force-collision`. **No separate constraint** — this
+is a derived consequence of REL-2, not a feature to engineer.
+
+## Explicit Non-Requirements
+
+The following are explicitly **not** part of the spec's SLA. Future
+PRs that try to add them must amend this section first.
+
+| Non-requirement                                                | Why deliberately excluded                                                                                                                                                                                                  |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **GitHub availability**                                         | The skill depends on GitHub for the remote transport. When GitHub is down, `push` and `fetch` fail; the user re-runs when service returns. Building local queueing or alternate-region fallback is out of scope.       |
+| **Upstream CLI session-file format stability**                  | Claude Code, Copilot CLI, and Codex CLI may change their on-disk JSONL formats without coordination. The substrate scripts adapt as needed; the skill does not promise to work against future format changes that haven't shipped yet. |
+| **Transient network failure recovery**                          | No retry, no exponential backoff, no transient-error classifier. `git`'s defaults stand. If the network fails, the user re-runs. Adding a retry layer adds a state machine to a CLI that exits in <5s — wrong tradeoff. |
+| **Custom scrub patterns / per-user redaction rules**            | The eight patterns in SEC-1 are the redaction surface. Per-user customization adds drift between machines and risks unscrubbed leaks; out of scope.                                                                          |
+| **Encrypted-at-rest remote payloads**                           | Already in §2 out-of-scope; restated here. The private-repo + git-auth model is the threat model.                                                                                                                          |
+| **Auto-prune of old branches / TTL on the store**               | KD-3 already de-scopes this. Restated as a non-NFR so future PRs don't slip it in via an "operational" framing.                                                                                                                |
+| **Real-time push notification on the remote**                   | The user pulls when they sit down at the other machine; no webhook / push notification / server-sent event is part of this skill.                                                                                          |
+
+## Cross-references
+
+- §3 ARCH-9 — scalability target that PERF-1 sharpens.
+- §3 ARCH-10 — drift-test invariant that OPS-1 elevates to an operational gate.
+- §4 KD-1 / KD-2 — policy decisions whose enforcement lives in REL-2 and the SEC-4 ceiling.
+- §5.1 — frozen schemas; §7 doesn't change them, it bounds what they can grow to.
+- §5.3 — exit-code matrix that OPS-3 freezes as a public contract.
+- §6.4 — testing strategy that operationalizes every constraint here.
+- §8 — risks specific to leaning on these invariants (e.g. SEC-1's eight-pattern set being insufficient for an unknown future secret format).

--- a/docs/specs/handoff-skill/spec/7-non-functional-requirements.md
+++ b/docs/specs/handoff-skill/spec/7-non-functional-requirements.md
@@ -61,8 +61,8 @@ no duplicate config writes, idempotent push outcome.
 ### SEC-1 — Scrub patterns are spec-frozen.
 
 The eight perl regex passes in `handoff-scrub.sh` (GitHub tokens,
-OpenAI/sk-*, AWS access keys, Google API keys, Slack tokens,
-`Authorization: Bearer …`, `*_TOKEN`/`KEY`/`SECRET`/`PASSWORD`=…,
+OpenAI/sk-_, AWS access keys, Google API keys, Slack tokens,
+`Authorization: Bearer …`, `_\_TOKEN`/`KEY`/`SECRET`/`PASSWORD`=…,
 PEM private keys) are the complete redaction set for v1.x. Adding,
 removing, or modifying a pattern requires:
 
@@ -227,15 +227,15 @@ is a derived consequence of REL-2, not a feature to engineer.
 The following are explicitly **not** part of the spec's SLA. Future
 PRs that try to add them must amend this section first.
 
-| Non-requirement                                                | Why deliberately excluded                                                                                                                                                                                                  |
-| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **GitHub availability**                                         | The skill depends on GitHub for the remote transport. When GitHub is down, `push` and `fetch` fail; the user re-runs when service returns. Building local queueing or alternate-region fallback is out of scope.       |
-| **Upstream CLI session-file format stability**                  | Claude Code, Copilot CLI, and Codex CLI may change their on-disk JSONL formats without coordination. The substrate scripts adapt as needed; the skill does not promise to work against future format changes that haven't shipped yet. |
-| **Transient network failure recovery**                          | No retry, no exponential backoff, no transient-error classifier. `git`'s defaults stand. If the network fails, the user re-runs. Adding a retry layer adds a state machine to a CLI that exits in <5s — wrong tradeoff. |
-| **Custom scrub patterns / per-user redaction rules**            | The eight patterns in SEC-1 are the redaction surface. Per-user customization adds drift between machines and risks unscrubbed leaks; out of scope.                                                                          |
-| **Encrypted-at-rest remote payloads**                           | Already in §2 out-of-scope; restated here. The private-repo + git-auth model is the threat model.                                                                                                                          |
-| **Auto-prune of old branches / TTL on the store**               | KD-3 already de-scopes this. Restated as a non-NFR so future PRs don't slip it in via an "operational" framing.                                                                                                                |
-| **Real-time push notification on the remote**                   | The user pulls when they sit down at the other machine; no webhook / push notification / server-sent event is part of this skill.                                                                                          |
+| Non-requirement                                      | Why deliberately excluded                                                                                                                                                                                                              |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **GitHub availability**                              | The skill depends on GitHub for the remote transport. When GitHub is down, `push` and `fetch` fail; the user re-runs when service returns. Building local queueing or alternate-region fallback is out of scope.                       |
+| **Upstream CLI session-file format stability**       | Claude Code, Copilot CLI, and Codex CLI may change their on-disk JSONL formats without coordination. The substrate scripts adapt as needed; the skill does not promise to work against future format changes that haven't shipped yet. |
+| **Transient network failure recovery**               | No retry, no exponential backoff, no transient-error classifier. `git`'s defaults stand. If the network fails, the user re-runs. Adding a retry layer adds a state machine to a CLI that exits in <5s — wrong tradeoff.                |
+| **Custom scrub patterns / per-user redaction rules** | The eight patterns in SEC-1 are the redaction surface. Per-user customization adds drift between machines and risks unscrubbed leaks; out of scope.                                                                                    |
+| **Encrypted-at-rest remote payloads**                | Already in §2 out-of-scope; restated here. The private-repo + git-auth model is the threat model.                                                                                                                                      |
+| **Auto-prune of old branches / TTL on the store**    | KD-3 already de-scopes this. Restated as a non-NFR so future PRs don't slip it in via an "operational" framing.                                                                                                                        |
+| **Real-time push notification on the remote**        | The user pulls when they sit down at the other machine; no webhook / push notification / server-sent event is part of this skill.                                                                                                      |
 
 ## Cross-references
 

--- a/docs/specs/handoff-skill/spec/8-risks-alternatives.md
+++ b/docs/specs/handoff-skill/spec/8-risks-alternatives.md
@@ -17,13 +17,13 @@ behavior that prevents it) — not "we'll be careful."
 Two distinct ways the auto-trigger contract can fail; each needs a
 different mitigation.
 
-| Sub-mode | Failure                                                                                                                  | Mitigation                                                                                                                                               |
-| -------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| R-1a     | **Doc drift.** Binary surface changes; SKILL.md / `docs/handoff-guide.md` / `--help` not updated. Phrase mapping invokes a removed flag or stale verb. | ARCH-10 drift test (CI gate per OPS-1). Tests the symbol list, not prose; updates ride in the same PR as the binary change.                            |
+| Sub-mode | Failure                                                                                                                                                                                                    | Mitigation                                                                                                                                                                                                                                                                 |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R-1a     | **Doc drift.** Binary surface changes; SKILL.md / `docs/handoff-guide.md` / `--help` not updated. Phrase mapping invokes a removed flag or stale verb.                                                     | ARCH-10 drift test (CI gate per OPS-1). Tests the symbol list, not prose; updates ride in the same PR as the binary change.                                                                                                                                                |
 | R-1b     | **Runtime misinterpretation within one LLM.** SKILL.md is current, but the host LLM reads ambiguous trigger language and produces the wrong invocation (e.g. drops `--from`, picks the wrong sub-command). | SKILL.md trigger language is **imperative and example-anchored**: "when the user says X, run exactly `dotclaude handoff push --from <your-cli>`." No free-form "when the user wants to push…" phrasing. §5.5.1's mapping table is what gets quoted into SKILL.md verbatim. |
 
-| Likelihood | Impact                                                              |
-| ---------- | ------------------------------------------------------------------- |
+| Likelihood | Impact                                                                                                      |
+| ---------- | ----------------------------------------------------------------------------------------------------------- |
 | Medium     | High for R-1a (silently broken slash command); medium for R-1b (one wrong invocation, exit 64 surfaces it). |
 
 ### R-2 — Direct-shell user trips on `--from` mandatory.
@@ -39,8 +39,8 @@ usage block listing `--from claude|copilot|codex`. `docs/handoff-guide.md`
 calls this out as the #1 gotcha in the migration section. CHANGELOG entry
 for the major bump (per §6.5) lists `--from` mandatory as its own line.
 
-| Likelihood | Impact |
-| ---------- | ------ |
+| Likelihood | Impact                                     |
+| ---------- | ------------------------------------------ |
 | High       | Low (hit-once, recoverable, helpful error) |
 
 ### R-3 — Scrub pattern set misses a new secret format.
@@ -64,9 +64,9 @@ the private remote unscrubbed.
   storage; it defends against secrets in a personal store the user
   controls.
 
-| Likelihood | Impact                                                  |
-| ---------- | ------------------------------------------------------- |
-| Medium     | Medium (private repo limits blast radius; user-owned)   |
+| Likelihood | Impact                                                |
+| ---------- | ----------------------------------------------------- |
+| Medium     | Medium (private repo limits blast radius; user-owned) |
 
 ### R-4 — Cross-LLM divergence on the same SKILL.md.
 
@@ -91,9 +91,9 @@ on the same source.
   divergence is structural (Codex always uses the binary directly per
   `from-codex.md`), not a reading-comprehension failure.
 
-| Likelihood | Impact                                                  |
-| ---------- | ------------------------------------------------------- |
-| Low-Medium | Low (binary-side checks catch the consequential cases)  |
+| Likelihood | Impact                                                 |
+| ---------- | ------------------------------------------------------ |
+| Low-Medium | Low (binary-side checks catch the consequential cases) |
 
 ### R-5 — Drift-test infrastructure is brittle.
 
@@ -108,9 +108,9 @@ surfaces in Phase 1 against today's SKILL.md, not in Phase 2 against
 a moving target. The Phase 1 PR includes a fixture-based test of the
 extractor itself (per §6.4 W-4 unit test).
 
-| Likelihood | Impact                                                |
-| ---------- | ----------------------------------------------------- |
-| Medium     | Low (false-positive CI red, fixed in the same PR)     |
+| Likelihood | Impact                                            |
+| ---------- | ------------------------------------------------- |
+| Medium     | Low (false-positive CI red, fixed in the same PR) |
 
 ### R-6 — Codex's bash tool quotes arguments badly for `--from` filling.
 
@@ -126,9 +126,9 @@ no SKILL.md-mediated translation path that could double-quote.
 Codex users are pushed onto the unambiguous direct-binary surface
 by design.
 
-| Likelihood | Impact                                                              |
-| ---------- | ------------------------------------------------------------------- |
-| Low        | Low (`from-codex.md` is the documented escape hatch; user reruns)   |
+| Likelihood | Impact                                                            |
+| ---------- | ----------------------------------------------------------------- |
+| Low        | Low (`from-codex.md` is the documented escape hatch; user reruns) |
 
 ### R-7 — Multi-machine push of the same source UUID.
 
@@ -146,19 +146,19 @@ Logged here so future-you doesn't get confused investigating "why
 did my morning push disappear" — it didn't, you just pushed the
 same UUID from two machines and the later one overwrote.
 
-| Likelihood | Impact                                |
-| ---------- | ------------------------------------- |
-| Very low   | Medium (one push lost, no recovery)   |
+| Likelihood | Impact                              |
+| ---------- | ----------------------------------- |
+| Very low   | Medium (one push lost, no recovery) |
 
 ### Risks intentionally not listed
 
-| Non-risk                                                   | Why omitted                                                                                                                              |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Branch-name collision across the user's own sessions        | Birthday-paradox math on 8-hex-char short_id puts this in "more likely to be hit by lightning" tier; REL-2's collision probe handles it. |
-| Network failure mid-push                                    | Git refs are atomic; no partial state possible. The push either completed or didn't.                                                      |
-| Substrate interface drift (extract.sh / resolve.sh changes) | Covered by the bats integration suite; not a category-level risk.                                                                        |
+| Non-risk                                                    | Why omitted                                                                                                                                     |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Branch-name collision across the user's own sessions        | Birthday-paradox math on 8-hex-char short_id puts this in "more likely to be hit by lightning" tier; REL-2's collision probe handles it.        |
+| Network failure mid-push                                    | Git refs are atomic; no partial state possible. The push either completed or didn't.                                                            |
+| Substrate interface drift (extract.sh / resolve.sh changes) | Covered by the bats integration suite; not a category-level risk.                                                                               |
 | User has to relearn verbs after the major bump              | That's how semver works. Listing it as a risk implies the design is doing something wrong; it isn't. Migration table in §6.5 is the affordance. |
-| PERF-1's 1000-branch baseline turning out to be wrong       | §7 PERF-1 self-mitigates via "ceiling adjusts, behavior doesn't." Listing it here would be redundant.                                    |
+| PERF-1's 1000-branch baseline turning out to be wrong       | §7 PERF-1 self-mitigates via "ceiling adjusts, behavior doesn't." Listing it here would be redundant.                                           |
 
 ## Rejected Alternatives
 
@@ -175,8 +175,8 @@ local emit so the host LLM (or the user) can pre-tune the
 
 **Rejected.** The flag is purely cosmetic — one line of text per
 target. It requires the user (or LLM) to predict where the block
-will be pasted at the moment it's emitted; the host LLM at *paste
-time* already knows where the block is going. The ARCH-2 design
+will be pasted at the moment it's emitted; the host LLM at _paste
+time_ already knows where the block is going. The ARCH-2 design
 moves target inference to "wherever the block lands," eliminating
 the prediction. §1's "redundant requirements" grievance applies.
 
@@ -254,8 +254,8 @@ remove.
 **Path.** Surface a notification on machine B when machine A pushes
 a fresh handoff (webhook → desktop notification → IDE banner).
 
-**Rejected.** `pull` and `fetch` are intentional acts of *starting
-work*. Push notifications would mean a misfired handoff from
+**Rejected.** `pull` and `fetch` are intentional acts of _starting
+work_. Push notifications would mean a misfired handoff from
 machine A interrupts machine B mid-thought. The async-by-default
 behavior is the **feature**, not a limitation. The user pulls when
 they sit down to start the next session, not when the network tells
@@ -299,7 +299,8 @@ the user's source code (which is far more sensitive than handoff
 digests typically are). E2E adds a key-rotation problem (what
 happens when the user generates a new SSH key? are old branches
 still readable?) that §2 explicitly de-scopes. Best-effort scrub
-+ private repo + sole-owner assumption (R-3) is the threat model.
+
+- private repo + sole-owner assumption (R-3) is the threat model.
 
 ### A-11 — Auto-inject the digest into the target agent.
 

--- a/docs/specs/handoff-skill/spec/8-risks-alternatives.md
+++ b/docs/specs/handoff-skill/spec/8-risks-alternatives.md
@@ -1,0 +1,345 @@
+# §8 — Risks and Alternatives
+
+> This section does two jobs at once: it preserves design rationale so
+> future contributors don't relitigate settled decisions, and it bounds
+> scope creep so future PRs can't smuggle rejected paths back in as
+> "small improvements." Read both halves with that frame; an entry that
+> looks like preference is usually a constraint with a missing why.
+
+## Risks
+
+Each risk lists the **failure mode**, **likelihood**, **impact**, and
+**mitigation**. Mitigations are concrete (a test that catches it, a
+behavior that prevents it) — not "we'll be careful."
+
+### R-1 — SKILL.md / binary contract failure (two failure modes).
+
+Two distinct ways the auto-trigger contract can fail; each needs a
+different mitigation.
+
+| Sub-mode | Failure                                                                                                                  | Mitigation                                                                                                                                               |
+| -------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R-1a     | **Doc drift.** Binary surface changes; SKILL.md / `docs/handoff-guide.md` / `--help` not updated. Phrase mapping invokes a removed flag or stale verb. | ARCH-10 drift test (CI gate per OPS-1). Tests the symbol list, not prose; updates ride in the same PR as the binary change.                            |
+| R-1b     | **Runtime misinterpretation within one LLM.** SKILL.md is current, but the host LLM reads ambiguous trigger language and produces the wrong invocation (e.g. drops `--from`, picks the wrong sub-command). | SKILL.md trigger language is **imperative and example-anchored**: "when the user says X, run exactly `dotclaude handoff push --from <your-cli>`." No free-form "when the user wants to push…" phrasing. §5.5.1's mapping table is what gets quoted into SKILL.md verbatim. |
+
+| Likelihood | Impact                                                              |
+| ---------- | ------------------------------------------------------------------- |
+| Medium     | High for R-1a (silently broken slash command); medium for R-1b (one wrong invocation, exit 64 surfaces it). |
+
+### R-2 — Direct-shell user trips on `--from` mandatory.
+
+A user invoking `dotclaude handoff push` from a shell (not via slash
+command) without `<query>` and without `--from` gets exit 64. They
+hit it on the first major-version run after the migration; if the
+error message is unclear, they bounce.
+
+**Mitigation.** Exit-64 stderr template (per §5.3.3) reads:
+`dotclaude-handoff: push: --from required when no <query> is given` +
+usage block listing `--from claude|copilot|codex`. `docs/handoff-guide.md`
+calls this out as the #1 gotcha in the migration section. CHANGELOG entry
+for the major bump (per §6.5) lists `--from` mandatory as its own line.
+
+| Likelihood | Impact |
+| ---------- | ------ |
+| High       | Low (hit-once, recoverable, helpful error) |
+
+### R-3 — Scrub pattern set misses a new secret format.
+
+The eight perl regex passes (SEC-1) cover the secret prefixes that
+existed when this spec was written. A future cloud / API service ships
+a new key prefix the patterns don't catch; user pushes; secret reaches
+the private remote unscrubbed.
+
+**Mitigation.** Two layers:
+
+- **Process.** SEC-1 versions the pattern set; new patterns require a
+  spec amendment + a corresponding bats test. The channel is open for
+  additions.
+- **Inherent limits, accepted by spec assumption.** Scrub is
+  best-effort. The remote is private. The user is the **sole owner**
+  of `$DOTCLAUDE_HANDOFF_REPO` by spec assumption (§3 ARCH-4 — one
+  remote per user). If the user ever shares repo access (collaborator,
+  org transfer, fork), the threat model changes — that's their call,
+  not the spec's. The skill cannot defend against secrets in shared
+  storage; it defends against secrets in a personal store the user
+  controls.
+
+| Likelihood | Impact                                                  |
+| ---------- | ------------------------------------------------------- |
+| Medium     | Medium (private repo limits blast radius; user-owned)   |
+
+### R-4 — Cross-LLM divergence on the same SKILL.md.
+
+Three host LLMs (Claude Code and Copilot CLI auto-load SKILL.md;
+Codex doesn't load it at all) may interpret the **same trigger doc
+differently**. "push handoff" could resolve to `push` on one and
+`push --tag handoff` on another. This is **distinct from R-1b**:
+R-1b is a single LLM getting it wrong; R-4 is two LLMs disagreeing
+on the same source.
+
+**Mitigation.**
+
+- SKILL.md uses literal command examples in §5.5.1's mapping
+  (`dotclaude handoff push --from <your-cli> [--tag <label>]`) rather
+  than free-form descriptions of intent. Less interpretive surface
+  area.
+- Binary-side `--from` mandatory (per ARCH-3) means a misinterpretation
+  that picks the wrong source surfaces as exit 64 — not as a silent
+  push of the wrong session.
+- Codex never loads SKILL.md, so cross-LLM divergence is bounded to
+  Claude vs. Copilot — two LLMs, not three. The codex-vs-others
+  divergence is structural (Codex always uses the binary directly per
+  `from-codex.md`), not a reading-comprehension failure.
+
+| Likelihood | Impact                                                  |
+| ---------- | ------------------------------------------------------- |
+| Low-Medium | Low (binary-side checks catch the consequential cases)  |
+
+### R-5 — Drift-test infrastructure is brittle.
+
+A SKILL.md grammar quirk (a missing colon, a bullet style change, a
+heading rename) breaks the drift test's symbol extractor. CI goes
+red on PRs that didn't actually drift the contract.
+
+**Mitigation.** Phase 1 (per §6.1) lands the drift test against the
+**current (old) surface** before any cutover, so the test mechanism
+is validated on a known-good baseline. Any extractor brittleness
+surfaces in Phase 1 against today's SKILL.md, not in Phase 2 against
+a moving target. The Phase 1 PR includes a fixture-based test of the
+extractor itself (per §6.4 W-4 unit test).
+
+| Likelihood | Impact                                                |
+| ---------- | ----------------------------------------------------- |
+| Medium     | Low (false-positive CI red, fixed in the same PR)     |
+
+### R-6 — Codex's bash tool quotes arguments badly for `--from` filling.
+
+Codex's bash tool may shell-quote `--from claude` differently than
+expected when the user uses Codex's natural-language → shell
+translation (rather than typing the binary call directly).
+
+**Mitigation.** `skills/handoff/references/from-codex.md` documents
+the **direct-shell pattern explicitly**: users on Codex run
+`!dotclaude handoff <verb> --from codex …`, not "ask Codex to push
+this for me." The skill markdown is not loaded by Codex, so there's
+no SKILL.md-mediated translation path that could double-quote.
+Codex users are pushed onto the unambiguous direct-binary surface
+by design.
+
+| Likelihood | Impact                                                              |
+| ---------- | ------------------------------------------------------------------- |
+| Low        | Low (`from-codex.md` is the documented escape hatch; user reruns)   |
+
+### R-7 — Multi-machine push of the same source UUID.
+
+Edge case: the user manually copies a session JSONL from machine A to
+machine B (or has it shared via Dropbox / iCloud / similar) and pushes
+from both. Force-push policy (KD-1) means whoever pushes second wins.
+
+**Mitigation.** This isn't a workflow the spec supports — the source
+of truth for any session is the agent CLI's own session-state
+directory, which is local to one machine. Manually replicating those
+files is out of scope. KD-1's "second-writer-wins" is a derived
+consequence, not a feature.
+
+Logged here so future-you doesn't get confused investigating "why
+did my morning push disappear" — it didn't, you just pushed the
+same UUID from two machines and the later one overwrote.
+
+| Likelihood | Impact                                |
+| ---------- | ------------------------------------- |
+| Very low   | Medium (one push lost, no recovery)   |
+
+### Risks intentionally not listed
+
+| Non-risk                                                   | Why omitted                                                                                                                              |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Branch-name collision across the user's own sessions        | Birthday-paradox math on 8-hex-char short_id puts this in "more likely to be hit by lightning" tier; REL-2's collision probe handles it. |
+| Network failure mid-push                                    | Git refs are atomic; no partial state possible. The push either completed or didn't.                                                      |
+| Substrate interface drift (extract.sh / resolve.sh changes) | Covered by the bats integration suite; not a category-level risk.                                                                        |
+| User has to relearn verbs after the major bump              | That's how semver works. Listing it as a risk implies the design is doing something wrong; it isn't. Migration table in §6.5 is the affordance. |
+| PERF-1's 1000-branch baseline turning out to be wrong       | §7 PERF-1 self-mitigates via "ceiling adjusts, behavior doesn't." Listing it here would be redundant.                                    |
+
+## Rejected Alternatives
+
+Each entry preserves the **path considered** and **why it's
+rejected**, so future contributors don't relitigate the same
+decisions. Treat A-N as boundary markers: a PR proposing one of
+these must amend §8 first.
+
+### A-1 — Keep `--to <cli>` for next-step text customization.
+
+**Path.** Preserve the cosmetic `--to` flag on `push` / `pull` /
+local emit so the host LLM (or the user) can pre-tune the
+"Next step" line for the target agent.
+
+**Rejected.** The flag is purely cosmetic — one line of text per
+target. It requires the user (or LLM) to predict where the block
+will be pasted at the moment it's emitted; the host LLM at *paste
+time* already knows where the block is going. The ARCH-2 design
+moves target inference to "wherever the block lands," eliminating
+the prediction. §1's "redundant requirements" grievance applies.
+
+### A-2 — Use env-var detection for source CLI.
+
+**Path.** Probe `CLAUDECODE`, `CODEX_*`, `GITHUB_COPILOT_*` /
+`COPILOT_*` to auto-detect the source CLI at `push` time without
+requiring `--from`.
+
+**Rejected.** The probes admit `UNCONFIRMED` status in their own
+implementation comments (legacy `detectHost()` in
+`plugins/dotclaude/bin/dotclaude-handoff.mjs`).
+An unreliable signal that silently picks the wrong source is exactly
+the failure mode §1 was written to stop. KD-6 + ARCH-3 settle this:
+SKILL.md fills `--from` for slash-command users (the host LLM
+trivially knows its own identity); shell-direct users pass `--from`
+explicitly. Never silently inferred.
+
+### A-3 — Multi-PR deprecation cycle with warnings shipped to npm.
+
+**Path.** Land warnings for `--to`, old verbs, and env-detection
+fallback in one release; ship the breaking changes in the next.
+
+**Rejected.** Deprecation warnings on a personal-ish npm package
+don't reach users in time — there's no dashboard, no email blast,
+no CI fleet broadcasting them. They just create a half-state
+codebase the maintainer must test and maintain twice. **Semver
+major is the only signal that actually fires.** §6.1's release-bang
+with phased PRs is the right shape.
+
+### A-4 — Pre-write detailed per-PR prompts in §6.3.
+
+**Path.** Author 15-25 fully-fleshed implementation prompts in §6.3
+with `<read-first>` file lists, TDD test names, exact paths, etc.
+
+**Rejected.** Prompts rot. By the time PR #N is being worked on,
+the codebase has moved past PR #(N-1)'s assumptions and the
+pre-written prompt is stale. The discipline §1 wants is supplied
+by (a) the spec existing and being referenced, (b) drift-test
+failing on drift, (c) PRs scoped to single workstreams. Pre-written
+prompts aren't on that list. §6.3's skeletal layout + pointer to
+a future `docs/plans/handoff-skill-prompts.md` (written at
+implementation kickoff, not now) is the right shape.
+
+### A-5 — Auto-prune / TTL on the remote store.
+
+**Path.** Ship a `prune` sub-command (or background pruning) that
+deletes branches older than N months / past M total / not tagged.
+
+**Rejected.** No obvious default policy: delete-by-age? by project?
+keep-tagged? Shipping defaults wrong is worse than not shipping
+defaults. KD-3 explicitly de-scopes this; the user manages
+retention with regular git operations
+(`git push --delete origin <branch>` or batch-delete via `gh api`).
+Restated as anti-NFR in §7 so future PRs can't slip it in via an
+"operational" framing.
+
+### A-6 — Drop `list` / `search` / `describe` / `doctor` entirely.
+
+**Path.** Strip the supporting commands so the surface is purely
+`pull`, `push`, `fetch` and nothing else.
+
+**Rejected.** §1 says supporting commands **feed the primaries**,
+not that they don't exist. Without `list` / `search` the user has
+no way to discover the right `<query>` to pass to `pull` or `fetch`
+— they'd be back to `find ~/.codex/sessions -name 'rollout-*.jsonl'`
+and `grep` against raw JSONL. `describe` is the preview before
+committing to a paste. `doctor` is the only diagnostic when the
+remote misbehaves. Each one earns its slot by feeding the primary
+jobs; removing them re-creates the friction the redesign exists to
+remove.
+
+### A-7 — Real-time webhook / push notification on the remote.
+
+**Path.** Surface a notification on machine B when machine A pushes
+a fresh handoff (webhook → desktop notification → IDE banner).
+
+**Rejected.** `pull` and `fetch` are intentional acts of *starting
+work*. Push notifications would mean a misfired handoff from
+machine A interrupts machine B mid-thought. The async-by-default
+behavior is the **feature**, not a limitation. The user pulls when
+they sit down to start the next session, not when the network tells
+them to.
+
+### A-8 — Port the shell substrate to JS.
+
+**Path.** Move `handoff-resolve.sh`, `handoff-extract.sh`,
+`handoff-scrub.sh`, `handoff-description.sh`, `handoff-doctor.sh`
+into the `src/lib/` Node modules.
+
+**Rejected.** The per-CLI jq filters in `handoff-extract.sh` took
+multiple PRs to harden (pruning system-reminder noise from Claude
+prompts, handling Copilot's transformedContent vs content
+preference, Codex's `<environment_context>` filter). Porting buys
+nothing user-facing — `--help`, behavior, exit codes are all
+identical — and risks regression on substrate that works. §2
+explicitly froze the substrate; restated here so a future "let's
+unify the runtime" PR can't smuggle this past spec review.
+
+### A-9 — Use a non-git transport (S3, raw HTTPS, Notion, gist-token).
+
+**Path.** Replace or add to the git-repo transport with an
+alternative store.
+
+**Rejected.** Git is the substrate the user already authenticates
+against (SSH key, credential helper, or `gh` token). Commit
+messages double as an LLM-readable index without a separate index
+format. No new credential to rotate. Plus: gist transports were
+already removed in PR #68 because of the gh-scope friction; they
+should not return. Any new transport adds an authentication problem
+the spec explicitly doesn't want to own.
+
+### A-10 — E2E-encrypt payloads with the user's SSH key.
+
+**Path.** Encrypt `handoff.md` / `metadata.json` client-side before
+push using the user's existing SSH key; decrypt on fetch.
+
+**Rejected.** The repo is private; GitHub is already trusted with
+the user's source code (which is far more sensitive than handoff
+digests typically are). E2E adds a key-rotation problem (what
+happens when the user generates a new SSH key? are old branches
+still readable?) that §2 explicitly de-scopes. Best-effort scrub
++ private repo + sole-owner assumption (R-3) is the threat model.
+
+### A-11 — Auto-inject the digest into the target agent.
+
+**Path.** Use clipboard, prefilled prompt injection, or IPC to
+deliver the `<handoff>` block to the next agent without manual
+paste.
+
+**Rejected.** Paste is a **deliberate human checkpoint** per
+`SKILL.md`'s `## Out of scope` section and reaffirmed in §2. Auto-injection means a
+wrong-session handoff (e.g. R-7's "pushed wrong UUID" scenario)
+silently contaminates the next agent's context with no user
+verification step. The paste step is where the user reads the
+`<handoff origin="…" session="…" cwd="…">` attributes and confirms
+"yes, this is the session I meant." Removing it eliminates the
+audit point.
+
+### A-12 — Add Cursor / Aider / Continue / [next agent].
+
+**Path.** Extend the supported-CLI set beyond claude / copilot /
+codex.
+
+**Rejected.** Each new agent needs a substrate pair
+(`resolve_<cli>` in `handoff-resolve.sh`, per-CLI jq filters in
+`handoff-extract.sh`) and a SKILL.md trigger update. That's real
+recurring work for speculative demand. **Three agents is the user's
+actual workflow**; spec amendment is the channel for additions
+when demand is concrete. §2 already lists this as out-of-scope;
+restated here so "we should add Cursor support, it's small" can't
+slip in as a one-liner PR.
+
+## Cross-references
+
+- §1 — the "redundant requirements" framing that A-1, A-2, A-5 rejections invoke.
+- §2 — out-of-scope list that several rejections reference.
+- §3 ARCH-4 (one remote per user) — load-bearing assumption for R-3 and A-10.
+- §3 ARCH-10 — drift-test mechanism that R-1a relies on.
+- §4 KD-1 — force-push policy that R-7 derives from.
+- §4 KD-3 — store retention de-scope that A-5 reaffirms.
+- §4 KD-6 — `--from` filling rule that R-1b's mitigation depends on.
+- §5.5 — phrase mapping that the "imperative + example-anchored" mitigation in R-1b quotes verbatim.
+- §6.1 — Phase 1 baseline that R-5's mitigation depends on.
+- §7 SEC-1 — versioned scrub patterns referenced by R-3.
+- §7 anti-NFRs — A-5, A-7's secondary anchor.

--- a/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
+++ b/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
@@ -1,0 +1,70 @@
+# Handoff drift — known disagreements (Phase 1 baseline)
+
+> Fixture for `handoff-drift.test.mjs`. Documents symbols that exist in
+> one source but not the other, on `c117418` (origin/main HEAD when this
+> baseline was pinned). The Phase 1 drift test asserts agreement on the
+> _intersection_ of symbols across `--help` and `skills/handoff/SKILL.md`;
+> everything below is intentionally outside the asserted intersection
+> until the named Phase 2 PR (per `docs/specs/handoff-skill/spec/6-implementation-plan.md` §6.3) resolves it.
+>
+> When a Phase 2 PR moves a symbol from "disagreement" to "agreement," it
+> deletes the corresponding entry below and lets the test's intersection
+> assertion grow. The last Phase 2 PR (PR 8) folds in `docs/handoff-guide.md`
+> as a third source.
+>
+> **`docs/handoff-guide.md` is excluded entirely from Phase 1.** Per spec §1
+> it is heavily drifted from both `--help` and `SKILL.md` (refs removed
+> sub-commands `digest`/`file`/`describe`, says "five forms", uses `--cli`
+> legacy alias). It joins as the third source in PR 8.
+
+## Excluded sub-commands
+
+| Symbol        | Present in                                                          | Missing from               | Resolves in                                            |
+| ------------- | ------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------ |
+| `prune`       | `--help`                                                            | `SKILL.md`                 | Phase 2 PR 5 (cleanup)                                 |
+| `remote-list` | `--help`, SKILL.md (Sub-commands table only — see "Internal" below) | `SKILL.md` (argument-hint) | Phase 2 PR 5 — migration table maps to `list --remote` |
+| `resolve`     | `SKILL.md`                                                          | `--help`                   | Phase 2 PR 5 (cleanup)                                 |
+
+## Excluded flags
+
+The Phase 1 test extracts a flat global flag set from each source and
+asserts agreement on the intersection. Flags that appear in only one
+source are excluded until reconciled.
+
+| Flag                                                            | Present in                                                                     | Missing from                                                              | Resolves in                                                |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `--from-file`                                                   | `SKILL.md`                                                                     | `--help`                                                                  | Phase 2 PR 7 (references prune)                            |
+| `--all`                                                         | `--help`                                                                       | `SKILL.md` (mentioned mid-bullet under `--limit`, not a canonical entry)  | Phase 2 PR 6 (SKILL.md shrink) — promote to its own bullet |
+| `--out-dir`                                                     | `--help`                                                                       | `SKILL.md`                                                                | Phase 2 PR 4 (`--to` removal sweep)                        |
+| `--remote`, `--local`                                           | `--help`                                                                       | `SKILL.md` cross-cutting block (mentioned in prose for `list`)            | Phase 2 PR 6 (SKILL.md shrink)                             |
+| `--verify`                                                      | `--help`                                                                       | `SKILL.md`                                                                | Phase 2 PR 6 (SKILL.md shrink)                             |
+| `--force-collision`                                             | `--help`                                                                       | `SKILL.md`                                                                | Phase 2 PR 6 (SKILL.md shrink)                             |
+| `--dry-run`                                                     | `--help`                                                                       | `SKILL.md`                                                                | Phase 2 PR 6 (SKILL.md shrink)                             |
+| `--older-than`, `--yes`                                         | `--help`                                                                       | `SKILL.md`                                                                | Phase 2 PR 6 (SKILL.md shrink)                             |
+| `--cli`                                                         | `--help`, SKILL.md (mentioned as "legacy alias on `search` and `remote-list`") | (cross-cutting bullet)                                                    | Phase 2 PR 7 — migration to `--from`                       |
+| `--tags`                                                        | `--help`                                                                       | `SKILL.md` cross-cutting block (mentioned in `--tag` prose for histogram) | Phase 2 PR 6 (SKILL.md shrink)                             |
+| `--no-color`, `--verbose`/`-v`, `--help`/`-h`, `--version`/`-V` | `--help`                                                                       | `SKILL.md`                                                                | Out of scope — universal CLI flags, no spec coverage       |
+
+## from_rule baseline
+
+`from_rule = { present: false, applies_to: [], mandatory_when: null }`
+in both sources today. Spec §5.5.2 introduces the rule paragraph; the
+test will start asserting it `present: true, applies_to: ["push"],
+mandatory_when: "no <query>"` in **Phase 2 PR 3** — the same PR that
+makes `--from` mandatory on `push` without `<query>`. Both extractors
+must update in lockstep with the binary change.
+
+## Internal — SKILL.md self-disagreement
+
+Not an excluded symbol per se, but a third datapoint for §1's "patch-loop
+tax" thesis: `SKILL.md` is internally inconsistent on `c117418`.
+
+- `argument-hint` frontmatter (line 27): `pull|push|fetch|list|search|resolve|doctor` — omits `remote-list`.
+- `Sub-commands` markdown table (lines 81-90): includes `remote-list`, omits `prune`.
+
+The Phase 1 extractor pins on the `argument-hint` frontmatter line as the
+authoritative SKILL.md command source — it is structured YAML, machine-
+parseable, and matches the SKILL.md schema's contract. The Sub-commands
+table is prose documentation that drifted from the frontmatter under the
+patch-loop. Phase 2 PR 6 (SKILL.md shrink per §3 component table) is
+where the two SKILL.md sub-symbol sources reconverge.

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -283,13 +283,13 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
     skillSurface = extractFromSkillMd(skillText);
 
     // The bin sources `$XDG_CONFIG_HOME/dotclaude/handoff.env` at startup
-    // (default `$HOME/.config/...`). Point HOME at a fresh temp dir so a
-    // user's persisted handoff.env can't leak into the test, and parallel
-    // vitest workers can't collide on the same path.
+    // (default `$HOME/.config/...`). Point both HOME and XDG_CONFIG_HOME at
+    // a fresh temp dir so a user's persisted handoff.env can't leak into the
+    // test, and parallel vitest workers can't collide on the same path.
     const hermeticHome = mkdtempSync(resolve(tmpdir(), "handoff-drift-"));
-    const help = execFileSync("node", [HANDOFF_BIN, "--help"], {
+    const help = execFileSync(process.execPath, [HANDOFF_BIN, "--help"], {
       encoding: "utf8",
-      env: { ...process.env, HOME: hermeticHome },
+      env: { ...process.env, HOME: hermeticHome, XDG_CONFIG_HOME: hermeticHome },
     });
     helpSurface = extractFromHelp(help);
   });

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -43,10 +43,12 @@
 //   the test enforces the lockstep.
 
 import { describe, it, expect, beforeAll } from "vitest";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { parseFrontmatter } from "../src/index.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
@@ -132,12 +134,12 @@ const PHASE_1_BASELINE_FROM_RULE = Object.freeze({
  * @returns {HandoffSurface}
  */
 export function extractFromSkillMd(text) {
-  // argument-hint: "[pull|push|fetch|list|search|resolve|doctor] [args...]"
-  const argHintLine = text.match(/^argument-hint:\s*"([^"]+)"\s*$/m);
-  if (!argHintLine) {
-    throw new Error("SKILL.md: could not find `argument-hint:` frontmatter line");
+  const { frontmatter } = parseFrontmatter(text);
+  const argHint = frontmatter["argument-hint"];
+  if (typeof argHint !== "string") {
+    throw new Error("SKILL.md: frontmatter missing string `argument-hint` key");
   }
-  const firstGroup = argHintLine[1].match(/\[([^\]]+)\]/);
+  const firstGroup = argHint.match(/\[([^\]]+)\]/);
   if (!firstGroup) {
     throw new Error("SKILL.md: argument-hint missing `[verb1|verb2|...]` group");
   }
@@ -147,21 +149,20 @@ export function extractFromSkillMd(text) {
     .filter(Boolean)
     .sort();
 
-  // Cross-cutting flags section — bullets like `- \`--from <cli>\` ...`
-  // We capture from the section heading until the next `## ` heading.
+  // "Cross-cutting flags" lives as a paragraph inside `## Sub-commands` —
+  // not its own H2 — so the shared `extractTemplateSection` doesn't apply.
+  // Capture from the inline paragraph header to the next `##`/`#` heading.
   const flagsSection = text.match(/Cross-cutting flags[^\n]*\n[\s\S]*?(?=\n## |\n# |$)/);
   if (!flagsSection) {
     throw new Error("SKILL.md: could not find `Cross-cutting flags` section");
   }
   const flagTokens = new Set();
-  // Match the FIRST backtick-wrapped token at the start of each bullet line.
-  // SKILL.md bullets begin: `- \`--name <value>\` ...` or `- \`--name\` ...`
-  // We accept `--name`, `-x`, and `--name`/`-x` (slash-joined alias forms).
-  const bulletRegex = /^[\s]*-\s+`(--?[a-z][a-z0-9-]*(?:\/-?[a-zA-Z])?)/gm;
+  // Each bullet begins `- \`<token>\``; tokens may be slash-joined aliases
+  // (`--fixed/-F`) or comma-separated (`` `--name`, `-x` ``). Accept both.
+  const bulletRegex = /^\s*-\s+`(--?[a-z][a-zA-Z0-9-]*(?:[/,]\s*`?-?-?[a-zA-Z][a-zA-Z0-9-]*`?)*)/gm;
   let m;
   while ((m = bulletRegex.exec(flagsSection[0])) !== null) {
-    // Split slash-joined aliases (`--fixed/-F`) into both tokens.
-    for (const tok of m[1].split("/")) {
+    for (const tok of m[1].split(/[/,`\s]+/)) {
       if (tok && tok.startsWith("-")) flagTokens.add(tok);
     }
   }
@@ -169,7 +170,7 @@ export function extractFromSkillMd(text) {
   return {
     commands,
     flags_by_command: { "*": [...flagTokens].sort() },
-    from_rule: extractFromRule(text, "skill"),
+    from_rule: extractFromRule(text),
   };
 }
 
@@ -183,9 +184,11 @@ export function extractFromSkillMd(text) {
  * @returns {HandoffSurface}
  */
 export function extractFromHelp(text) {
-  const synopsisGroup = text.match(/dotclaude handoff\s+\[([^\]]+)\]\s+\[args/);
+  // Anchor only on the verb group; spec §5.0 keeps `--help` wording editable
+  // (`[args...]` may be rephrased as `[arguments]`, `<args>`, or omitted).
+  const synopsisGroup = text.match(/dotclaude handoff\s+\[([^\]]+)\]/);
   if (!synopsisGroup) {
-    throw new Error("--help: synopsis line missing `[verb1|verb2|...] [args...]` shape");
+    throw new Error("--help: synopsis line missing `[verb1|verb2|...]` group");
   }
   const commands = synopsisGroup[1]
     .split("|")
@@ -193,7 +196,9 @@ export function extractFromHelp(text) {
     .filter(Boolean)
     .sort();
 
-  const optsBlock = text.match(/^Options:\s*$([\s\S]*?)(?=^[A-Z][\w ]*:|\Z)/m);
+  // Capture from `Options:` to the next title-case section header or EOF.
+  // (`\Z` is not a JS regex anchor — `(?![\s\S])` is the EOF lookahead.)
+  const optsBlock = text.match(/^Options:\s*$([\s\S]*?)(?=^[A-Z][\w ]*:|(?![\s\S]))/m);
   if (!optsBlock) {
     throw new Error("--help: could not find `Options:` block");
   }
@@ -211,7 +216,7 @@ export function extractFromHelp(text) {
   return {
     commands,
     flags_by_command: { "*": [...flagTokens].sort() },
-    from_rule: extractFromRule(text, "help"),
+    from_rule: extractFromRule(text),
   };
 }
 
@@ -223,14 +228,18 @@ export function extractFromHelp(text) {
  * (or whatever Phase 2 freezes), and the baseline above will flip.
  *
  * @param {string} text
- * @param {"skill"|"help"} _source  — reserved for source-specific search heuristics; unused today
  * @returns {FromRule}
  */
-export function extractFromRule(text, _source) {
+export function extractFromRule(text) {
+  // Cheap absence check first: if `--from` doesn't appear at all, nothing
+  // could match the four-clause heuristic below.
+  if (!/--from\b/.test(text)) return { present: false, applies_to: [], mandatory_when: null };
+
   // Heuristic: a paragraph that mentions all of:
   //   (a) `--from` as a flag,
   //   (b) `push` (the verb the rule applies to),
-  //   (c) a "no <query>" / "without <query>" marker.
+  //   (c) a "no <query>" / "without <query>" marker (or synonym),
+  //   (d) a required/mandatory marker.
   // We avoid prose-exact matching per spec §5.0 (wording stays editable).
   // Keep this loose enough to find the §5.5.2 paragraph in any reasonable
   // wording, strict enough not to false-positive on incidental flag mentions.
@@ -242,7 +251,8 @@ export function extractFromRule(text, _source) {
     const mentionsNoQuery =
       /\bno\s*<?query>?\b/.test(lower) ||
       /\bwithout\s+(?:a\s+)?<?query>?\b/.test(lower) ||
-      /\bwhen\s+no\s+`?<?query>?`?\b/.test(lower);
+      /\bwhen\s+no\s+`?<?query>?`?\b/.test(lower) ||
+      /\b(?:omit(?:ting|ted)?|absent|missing)\s+(?:the\s+|a\s+)?<?query>?\b/.test(lower);
     const mentionsRequired =
       /\bmandator(?:y|ily)\b/.test(lower) ||
       /\brequired?\b/.test(lower) ||
@@ -272,11 +282,14 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
     const skillText = readFileSync(SKILL_MD_PATH, "utf8");
     skillSurface = extractFromSkillMd(skillText);
 
+    // The bin sources `$XDG_CONFIG_HOME/dotclaude/handoff.env` at startup
+    // (default `$HOME/.config/...`). Point HOME at a fresh temp dir so a
+    // user's persisted handoff.env can't leak into the test, and parallel
+    // vitest workers can't collide on the same path.
+    const hermeticHome = mkdtempSync(resolve(tmpdir(), "handoff-drift-"));
     const help = execFileSync("node", [HANDOFF_BIN, "--help"], {
       encoding: "utf8",
-      // The bin sources persisted env (`~/.config/dotclaude/handoff.env`)
-      // at startup; pass an empty HOME to keep the run hermetic.
-      env: { ...process.env, HOME: "/tmp" },
+      env: { ...process.env, HOME: hermeticHome },
     });
     helpSurface = extractFromHelp(help);
   });

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -1,0 +1,341 @@
+// ARCH-10 drift test (Phase 1) for the handoff skill — see
+// docs/specs/handoff-skill/spec/3-high-level-architecture.md §ARCH-10
+// and docs/specs/handoff-skill/spec/6-implementation-plan.md §6.1 Phase 1.
+//
+// What this test is.
+//   A *cross-source* drift test that asserts the handoff skill's public
+//   symbol list (sub-commands + flags + the `--from`-when-no-query rule)
+//   stays in agreement across the sources where users learn the surface:
+//   the binary's `--help` output and `skills/handoff/SKILL.md`. When any
+//   one source moves out of sync, the test fails — that is the cutover
+//   signal §6 calls for, not a bug in the test.
+//
+// What this test is not.
+//   It is not a per-source snapshot. A snapshot test fails the moment any
+//   source changes, regardless of whether the others were updated, which
+//   provides no signal for a Phase 2 PR that legitimately reshapes the
+//   surface in lockstep across sources.
+//
+// Phase 1 scope (deliberately minimal — see fixtures/handoff-drift-known-disagreements.md).
+//   - Sources: 2 of 3. Just `--help` + SKILL.md. `docs/handoff-guide.md`
+//     is heavily drifted today (per spec §1) and joins as a third source
+//     in Phase 2 PR 8 after docs reconciliation lands.
+//   - Symbols asserted: the *intersection* of stable symbols. Today that
+//     is `[doctor, fetch, list, pull, push, search]` for commands and a
+//     small intersection for global flags. As Phase 2 PRs reconcile each
+//     disagreement, the intersection grows and the fixture shrinks.
+//   - `from_rule` is asserted `{ present: false, applies_to: [], mandatory_when: null }`
+//     in both sources today; spec §5.5.2's mandatory-`--from` rule lands
+//     in Phase 2 PR 3 and both extractors flip in lockstep with the binary
+//     change.
+//
+// Mechanism.
+//   Two extractors produce a `HandoffSurface` struct from each source.
+//   The struct schema is the "test-the-test" — a shape assertion runs
+//   first and would catch an extractor that silently produced the wrong
+//   shape before anything else compared values.
+//
+// Maintenance.
+//   When a Phase 2 PR moves a symbol from "disagreement" to "agreement,"
+//   it (a) updates the relevant source(s), (b) deletes the symbol's row
+//   from `fixtures/handoff-drift-known-disagreements.md`, (c) updates
+//   `PHASE_1_BASELINE_*` here. All three changes land in the same PR;
+//   the test enforces the lockstep.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+
+const SKILL_MD_PATH = resolve(repoRoot, "skills/handoff/SKILL.md");
+const HANDOFF_BIN = resolve(repoRoot, "plugins/dotclaude/bin/dotclaude-handoff.mjs");
+
+/**
+ * @typedef {object} FromRule
+ * @property {boolean} present  — does the source document a mandatory-`--from` rule for `push` without `<query>`
+ * @property {string[]} applies_to  — sub-commands the rule applies to (e.g. `["push"]`); empty when not present
+ * @property {string|null} mandatory_when  — short structural marker of when it applies (e.g. "no <query>"); null when not present
+ */
+
+/**
+ * The minimal symbol-list surface each source contributes.
+ *
+ * `flags_by_command` uses the sentinel key `"*"` for "global flags" because
+ * neither source today disambiguates flags per sub-command rigorously enough
+ * to make per-command extraction reliable. Phase 2 PRs that introduce per-
+ * command flag rigor will populate per-command keys; this Phase 1 baseline
+ * just tracks the global flag set.
+ *
+ * @typedef {object} HandoffSurface
+ * @property {string[]} commands  — sorted, lowercase sub-command names (e.g. `["doctor", "fetch", ...]`)
+ * @property {Record<string, string[]>} flags_by_command  — `"*"` → sorted global flag tokens (each `--name` or `-x`)
+ * @property {FromRule} from_rule
+ */
+
+// ---------------------------------------------------------------------------
+// Phase 1 expected baselines
+// ---------------------------------------------------------------------------
+
+/** Cross-source intersection of sub-commands on c117418. */
+const PHASE_1_BASELINE_COMMANDS = ["doctor", "fetch", "list", "pull", "push", "search"];
+
+/**
+ * Cross-source intersection of global flags on c117418.
+ * Excluded flags + their reconciliation PR live in
+ * `fixtures/handoff-drift-known-disagreements.md`.
+ *
+ * Notes on what's IN: flags that both `--help`'s Options block AND
+ * SKILL.md's "Cross-cutting flags" bullet list mention canonically.
+ * Universal CLI flags (`--help`, `--version`, `--no-color`, `--verbose`)
+ * are excluded from spec coverage.
+ */
+const PHASE_1_BASELINE_FLAGS_INTERSECTION = [
+  "--fixed",
+  "--from",
+  "--json",
+  "--limit",
+  "--since",
+  "--summary",
+  "--tag",
+  "--to",
+  "-o",
+];
+
+/** Both sources baseline — `from_rule` is unfilled today (Phase 2 PR 3 flips this). */
+const PHASE_1_BASELINE_FROM_RULE = Object.freeze({
+  present: false,
+  applies_to: [],
+  mandatory_when: null,
+});
+
+// ---------------------------------------------------------------------------
+// Extractors
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `skills/handoff/SKILL.md`.
+ *
+ * Sub-commands come from the `argument-hint:` frontmatter line, which is
+ * structured YAML and the schema's authoritative source. The Sub-commands
+ * markdown table is prose and has internally drifted on c117418
+ * (omits `prune`); the fixture file documents that.
+ *
+ * Global flags come from the `## Cross-cutting flags ...` bullet list
+ * (the bullets that begin `- \`--<name>\``). That section is the single
+ * place SKILL.md tries to enumerate flags canonically.
+ *
+ * @param {string} text
+ * @returns {HandoffSurface}
+ */
+export function extractFromSkillMd(text) {
+  // argument-hint: "[pull|push|fetch|list|search|resolve|doctor] [args...]"
+  const argHintLine = text.match(/^argument-hint:\s*"([^"]+)"\s*$/m);
+  if (!argHintLine) {
+    throw new Error("SKILL.md: could not find `argument-hint:` frontmatter line");
+  }
+  const firstGroup = argHintLine[1].match(/\[([^\]]+)\]/);
+  if (!firstGroup) {
+    throw new Error("SKILL.md: argument-hint missing `[verb1|verb2|...]` group");
+  }
+  const commands = firstGroup[1]
+    .split("|")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+    .sort();
+
+  // Cross-cutting flags section — bullets like `- \`--from <cli>\` ...`
+  // We capture from the section heading until the next `## ` heading.
+  const flagsSection = text.match(/Cross-cutting flags[^\n]*\n[\s\S]*?(?=\n## |\n# |$)/);
+  if (!flagsSection) {
+    throw new Error("SKILL.md: could not find `Cross-cutting flags` section");
+  }
+  const flagTokens = new Set();
+  // Match the FIRST backtick-wrapped token at the start of each bullet line.
+  // SKILL.md bullets begin: `- \`--name <value>\` ...` or `- \`--name\` ...`
+  // We accept `--name`, `-x`, and `--name`/`-x` (slash-joined alias forms).
+  const bulletRegex = /^[\s]*-\s+`(--?[a-z][a-z0-9-]*(?:\/-?[a-zA-Z])?)/gm;
+  let m;
+  while ((m = bulletRegex.exec(flagsSection[0])) !== null) {
+    // Split slash-joined aliases (`--fixed/-F`) into both tokens.
+    for (const tok of m[1].split("/")) {
+      if (tok && tok.startsWith("-")) flagTokens.add(tok);
+    }
+  }
+
+  return {
+    commands,
+    flags_by_command: { "*": [...flagTokens].sort() },
+    from_rule: extractFromRule(text, "skill"),
+  };
+}
+
+/**
+ * Parse the binary's `--help` output.
+ *
+ * Sub-commands come from the synopsis line's first `[verb1|verb2|...]`
+ * group. Global flags come from the `Options:` block.
+ *
+ * @param {string} text
+ * @returns {HandoffSurface}
+ */
+export function extractFromHelp(text) {
+  const synopsisGroup = text.match(/dotclaude handoff\s+\[([^\]]+)\]\s+\[args/);
+  if (!synopsisGroup) {
+    throw new Error("--help: synopsis line missing `[verb1|verb2|...] [args...]` shape");
+  }
+  const commands = synopsisGroup[1]
+    .split("|")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+    .sort();
+
+  const optsBlock = text.match(/^Options:\s*$([\s\S]*?)(?=^[A-Z][\w ]*:|\Z)/m);
+  if (!optsBlock) {
+    throw new Error("--help: could not find `Options:` block");
+  }
+  const flagTokens = new Set();
+  // Each Options line begins with whitespace and `--name` or `--name, -x`
+  // or `-x, --name`. Capture every long-form / short-form token on the line.
+  const flagLineRegex = /^\s+(--?[a-z][a-zA-Z0-9-]*(?:,\s*--?[a-zA-Z][a-zA-Z0-9-]*)*)/gm;
+  let m;
+  while ((m = flagLineRegex.exec(optsBlock[1])) !== null) {
+    for (const tok of m[1].split(",").map((s) => s.trim())) {
+      if (tok && tok.startsWith("-")) flagTokens.add(tok);
+    }
+  }
+
+  return {
+    commands,
+    flags_by_command: { "*": [...flagTokens].sort() },
+    from_rule: extractFromRule(text, "help"),
+  };
+}
+
+/**
+ * Structural search for the `--from`-when-no-query rule paragraph.
+ * Conservative on purpose: today the rule is absent from both sources.
+ * Phase 2 PR 3 will add the §5.5.2 paragraph; this function will then
+ * find it and report `{ present: true, applies_to: ["push"], mandatory_when: "no <query>" }`
+ * (or whatever Phase 2 freezes), and the baseline above will flip.
+ *
+ * @param {string} text
+ * @param {"skill"|"help"} _source  — reserved for source-specific search heuristics; unused today
+ * @returns {FromRule}
+ */
+export function extractFromRule(text, _source) {
+  // Heuristic: a paragraph that mentions all of:
+  //   (a) `--from` as a flag,
+  //   (b) `push` (the verb the rule applies to),
+  //   (c) a "no <query>" / "without <query>" marker.
+  // We avoid prose-exact matching per spec §5.0 (wording stays editable).
+  // Keep this loose enough to find the §5.5.2 paragraph in any reasonable
+  // wording, strict enough not to false-positive on incidental flag mentions.
+  const paragraphs = text.split(/\n\s*\n/);
+  for (const p of paragraphs) {
+    const lower = p.toLowerCase();
+    const mentionsFromFlag = /(^|[^a-z-])--from\b/.test(p);
+    const mentionsPush = /\bpush\b/.test(lower);
+    const mentionsNoQuery =
+      /\bno\s*<?query>?\b/.test(lower) ||
+      /\bwithout\s+(?:a\s+)?<?query>?\b/.test(lower) ||
+      /\bwhen\s+no\s+`?<?query>?`?\b/.test(lower);
+    const mentionsRequired =
+      /\bmandator(?:y|ily)\b/.test(lower) ||
+      /\brequired?\b/.test(lower) ||
+      /\bmust\s+(?:include|pass|set)\b/.test(lower);
+    if (mentionsFromFlag && mentionsPush && mentionsNoQuery && mentionsRequired) {
+      return {
+        present: true,
+        applies_to: ["push"],
+        mandatory_when: "no <query>",
+      };
+    }
+  }
+  return { present: false, applies_to: [], mandatory_when: null };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handoff drift (ARCH-10) — Phase 1", () => {
+  /** @type {HandoffSurface} */
+  let skillSurface;
+  /** @type {HandoffSurface} */
+  let helpSurface;
+
+  beforeAll(() => {
+    const skillText = readFileSync(SKILL_MD_PATH, "utf8");
+    skillSurface = extractFromSkillMd(skillText);
+
+    const help = execFileSync("node", [HANDOFF_BIN, "--help"], {
+      encoding: "utf8",
+      // The bin sources persisted env (`~/.config/dotclaude/handoff.env`)
+      // at startup; pass an empty HOME to keep the run hermetic.
+      env: { ...process.env, HOME: "/tmp" },
+    });
+    helpSurface = extractFromHelp(help);
+  });
+
+  it("test-the-test: each extractor returns a HandoffSurface struct", () => {
+    for (const [name, surface] of [
+      ["SKILL.md", skillSurface],
+      ["--help", helpSurface],
+    ]) {
+      // Top-level shape.
+      expect(surface, name).toEqual(
+        expect.objectContaining({
+          commands: expect.any(Array),
+          flags_by_command: expect.any(Object),
+          // `mandatory_when` is `string | null`. `expect.anything()`
+          // rejects null, so the type check below covers it instead.
+          from_rule: expect.objectContaining({
+            present: expect.any(Boolean),
+            applies_to: expect.any(Array),
+          }),
+        }),
+      );
+      // Element-type checks.
+      expect(
+        surface.commands.every((c) => typeof c === "string"),
+        `${name} commands`,
+      ).toBe(true);
+      expect(
+        Object.values(surface.flags_by_command).every(
+          (v) => Array.isArray(v) && v.every((f) => typeof f === "string"),
+        ),
+        `${name} flags_by_command values`,
+      ).toBe(true);
+      expect(surface.from_rule.applies_to.every((c) => typeof c === "string")).toBe(true);
+      expect(
+        surface.from_rule.mandatory_when === null ||
+          typeof surface.from_rule.mandatory_when === "string",
+      ).toBe(true);
+      // Each extractor produced *some* commands; an empty list almost
+      // always means a parse miss.
+      expect(surface.commands.length, `${name} commands non-empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("commands intersection across sources matches Phase 1 baseline", () => {
+    const skillSet = new Set(skillSurface.commands);
+    const intersection = helpSurface.commands.filter((c) => skillSet.has(c)).sort();
+    expect(intersection).toEqual(PHASE_1_BASELINE_COMMANDS);
+  });
+
+  it("global-flag intersection across sources matches Phase 1 baseline", () => {
+    const skillFlags = new Set(skillSurface.flags_by_command["*"] ?? []);
+    const helpFlags = helpSurface.flags_by_command["*"] ?? [];
+    const intersection = helpFlags.filter((f) => skillFlags.has(f)).sort();
+    expect(intersection).toEqual(PHASE_1_BASELINE_FLAGS_INTERSECTION);
+  });
+
+  it("from_rule baseline matches in both sources (Phase 2 PR 3 flips this)", () => {
+    expect(skillSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
+    expect(helpSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
+  });
+});


### PR DESCRIPTION
## What's in this PR

This PR carries the original two landings plus review-driven fixes.

| Commit    | Subject                                                                          | Role                                                           |
| --------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| `dc32931` | `spec(handoff-skill): v2 surface redesign`                                       | The spec itself — 8 sections + `spec.json` + 47 constraint IDs |
| `ab47b2f` | `test(handoff-skill): ARCH-10 cross-source drift test`                           | **Phase 1 deliverable per spec §6.1.** Load-bearing CI gate    |
| `4afbf98` | `refactor(handoff-skill): simplify drift test extractors`                        | Use `parseFrontmatter`, fix `\Z` regex bug, hermetic temp HOME  |
| `b4d498f` | `fix(handoff-skill): address 6 Copilot review comments + prettier-clean spec docs` | KD-2 consistency, ARCH-10 phasing, §5.5.2, §2 scope, hermetic test |
| `222d849` | `fix(handoff-skill): set spec status to implementing + register PR #108`         | Unblocks check-spec-coverage CI gate (draft→implementing)      |

The Phase 1 drift test (`ab47b2f`) is not incidental scaffolding — it is
the *mechanism* spec §3 ARCH-10 mandates. Every Phase 2 PR's job is to
move symbols from the test's known-disagreements fixture into its
asserted intersection; the test enforces that SKILL.md, `--help`, and
(eventually) `docs/handoff-guide.md` move in lockstep. Without this
test landing first, the Phase 2 cutover would have nothing watching
the surface for drift.

**Why both in one PR:** Phase 1 is one workstream (W-4) producing one
file's worth of test code. Splitting it from the spec adds review
ceremony without information; bundling it lets reviewers see the
spec's first deliverable and the spec it's defending in one place.

**Tracking issues** (out of scope for this PR — separate fixes off `main`):

- **#113** — SKILL.md internal inconsistency (argument-hint omits `remote-list`, Sub-commands table includes it, both omit `prune`). Phase 1 pins on argument-hint as authoritative; resolved by Phase 2 PR 6 (SKILL.md shrink, per spec §6.3).
- **#114** — Pre-existing prettier + markdownlint failures on `dc32931`'s spec docs (`spec/2-8.md`, `README.md`, `CHANGELOG.md`). Three hypotheses logged; investigation deferred to a fresh session.
- **#115** — Lychee link-checker CI failure: install step itself is broken (`install: cannot stat '/tmp/lychee'`); PR content is not the cause. Three hypotheses logged.

---

## Summary

- New engineering spec at `docs/specs/handoff-skill/` redesigning the cross-CLI / cross-machine handoff skill: three primary verbs (`pull` / `push` / `fetch`), source CLI auto-detected from the resolved session path, target implicit ("wherever you paste"), `--to` removed, supporting commands (`list` / `search` / `describe` / `doctor`) demoted.
- Three-phase release-bang plan with a single major-version bump at cutover — no per-PR deprecation warnings ship to npm. ARCH-10 drift test becomes the load-bearing CI gate; §6.3 prompts deferred to a future `docs/plans/handoff-skill-prompts.md` written at implementation kickoff.
- Eight content sections + `spec.json` (with `linked_paths` covering the substrate so the §2 freeze is observable, and `acceptance_commands` targeting the drift test). 47 constraint IDs lock the contract; all internal cross-references resolved via dry-run consistency pass before commit.
- **Phase 1 drift test (`plugins/dotclaude/tests/handoff-drift.test.mjs`):** cross-source intersection assertion across `--help` + SKILL.md, `from_rule` placeholder for §5.5.2's mandatory-`--from` rule, known-disagreements fixture documenting each excluded symbol with its Phase 2 reconciliation PR. Verified 4/4 green when run against a `c117418` worktree.

Spec for handoff skill v2 surface. Implementation tracked in subsequent PRs (Phase 1 drift test first); major version bump at cutover.

## Test plan

- [x] All 47 constraint IDs (10 ARCH / 6 KD / 3 REL / 4 SEC / 2 PERF / 4 OPS / 7 R / 12 A) resolve internally — verified via dry-run consistency pass before commit.
- [x] `spec.json` validates as JSON.
- [x] All sub-section refs (§4.1-4.5, §5.2.4, §5.3.5, §5.5.1, §5.6.3) exist in their target files.
- [x] No stale file:line citations remain — function/heading anchors only.
- [x] `npx dotclaude-validate-specs` passes — verified locally on `222d849` (4 specs valid).
- [x] `linked_paths` covers the substrate (`handoff-resolve.sh`, `handoff-extract.sh`, `handoff-scrub.sh`, `handoff-description.sh`, `handoff-doctor.sh`) so the §2 freeze is observable to spec-aware tooling.
- [x] `npm test -- plugins/dotclaude/tests/handoff-drift.test.mjs` — 4/4 green on `c117418` worktree and on this branch.
- [x] Full vitest suite: `npm test` — 537/537 passed locally, no regressions.
- [ ] CI passes on this PR's head (drift test runs per ARCH-10).

## Spec ID

handoff-skill, dotclaude-core