### PR TITLE
fix(ci): strip tarball directory wrapper in lychee install step

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           curl -sSL -o /tmp/lychee.tgz \
             https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz
-          tar -xzf /tmp/lychee.tgz -C /tmp
+          tar -xzf /tmp/lychee.tgz -C /tmp --strip-components=1
           sudo install -m 0755 /tmp/lychee /usr/local/bin/lychee
           lychee --version
       - name: Check links


### PR DESCRIPTION
## Summary

- Fixes the `links / lychee` CI job that has failed on every PR since the upstream `lychee-x86_64-unknown-linux-gnu.tar.gz` release changed its archive structure.
- The tarball now contains a top-level subdirectory (`lychee-x86_64-unknown-linux-gnu/`) wrapping the binary; `--strip-components=1` on the `tar` extraction flattens it so the binary lands at `/tmp/lychee` as the `install` step expects.
- One-line change, no functional behavior change to link-checking.

## Test plan

- [x] Verified root cause against failing CI log: `install: cannot stat '/tmp/lychee': No such file or directory` fires at the extract→install step (not during lychee invocation) — rules out hypotheses 2 and 3
- [x] Confirmed tarball structure changed: binary is now at `lychee-x86_64-unknown-linux-gnu/lychee` inside the archive
- [ ] Push branch → `links / lychee` job passes in CI (cannot verify locally without installing lychee)

## No-spec rationale

CI infrastructure fix — corrects a broken install step caused by an upstream release artifact change. No feature work, no API change.
