### PR TITLE
fix(ci): fix markdownlint violations in handoff-skill spec files

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -7,7 +7,7 @@
     "MD024": { "siblings_only": true },
     "MD029": false,
     "MD031": false,
-    "MD033": { "allowed_elements": ["details", "summary", "kbd", "br", "sub", "sup", "previous", "current_status", "value"] },
+    "MD033": { "allowed_elements": ["details", "summary", "kbd", "br", "sub", "sup", "previous", "current_status", "value", "url", "read-first"] },
     "MD036": false,
     "MD060": false,
     "MD040": false,

--- a/docs/specs/handoff-skill/spec/4-data-flow-components.md
+++ b/docs/specs/handoff-skill/spec/4-data-flow-components.md
@@ -299,7 +299,7 @@ the migration table that retires them).
 Tagged decisions that bind the rest of the spec; later sections must not
 contradict these without amending here.
 
-### KD-1 — Re-push of same UUID + month: update branch (force), but with a collision probe.
+### KD-1 — Re-push of same UUID + month: update branch (force), but with a collision probe
 
 The branch `handoff/<project>/<cli>/<YYYY-MM>/<short>` represents "the
 latest handoff snapshot for this session UUID in this month-bucket."
@@ -328,7 +328,7 @@ disambiguation. The collision probe is the safety net against the
 1-in-2^32 short-prefix collision between distinct UUIDs — the binary
 refuses to silently overwrite a stranger's branch.
 
-### KD-2 — Tags are mutable addressable labels, materialized as `refs/tags/<label>` and mirrored in the description and `metadata.tags`.
+### KD-2 — Tags are mutable addressable labels, materialized as `refs/tags/<label>` and mirrored in the description and `metadata.tags`
 
 `push --tag <label>` (repeatable, or comma-joined) creates or updates
 a remote tag ref at `refs/tags/<label>` pointing at the pushed handoff
@@ -352,7 +352,7 @@ with standard Git primitives and with `git ls-remote refs/tags/*`, while
 the mirrored description/`metadata.tags` preserves the richer handoff
 metadata on the branch itself.
 
-### KD-3 — Store retention is the user's job, not the skill's.
+### KD-3 — Store retention is the user's job, not the skill's
 
 The remote grows forever by default. No automatic GC, no `prune`
 sub-command, no TTL on branches. Users with full stores run
@@ -364,7 +364,7 @@ default policy (delete-by-age? by project? keep-tagged?). Shipping
 defaults wrong is worse than not shipping defaults. The user has
 explicitly de-scoped this.
 
-### KD-4 — `fetch` ambiguity resolves with the same model as `pull`.
+### KD-4 — `fetch` ambiguity resolves with the same model as `pull`
 
 When `fetch <query>` matches multiple refs (tags, branches, descriptions,
 or commits), the disambiguation is:
@@ -378,7 +378,7 @@ No silent first-match, no "newest wins" heuristic, no special-casing.
 for "I gave the binary an ambiguous identifier." Heuristic
 tie-breakers introduce silent failure modes.
 
-### KD-5 — Source CLI is determined by path, not by env.
+### KD-5 — Source CLI is determined by path, not by env
 
 Once the resolver returns an absolute JSONL path, the path's root
 prefix (`~/.claude/projects/`, `~/.copilot/session-state/`,
@@ -390,7 +390,7 @@ through `--from`, and only on the `push --no-query` path.
 in their own probe code. Eliminating env-detection eliminates the
 "silently picks wrong source" failure mode §1 was written to stop.
 
-### KD-6 — SKILL.md auto-trigger contract pre-fills `--from`.
+### KD-6 — SKILL.md auto-trigger contract pre-fills `--from`
 
 The skill markdown explicitly instructs Claude / Copilot host LLMs to
 include `--from <its-own-cli-name>` when invoking `dotclaude handoff

--- a/docs/specs/handoff-skill/spec/7-non-functional-requirements.md
+++ b/docs/specs/handoff-skill/spec/7-non-functional-requirements.md
@@ -11,7 +11,7 @@
 
 ## Reliability
 
-### REL-1 — Scrub is fail-closed.
+### REL-1 — Scrub is fail-closed
 
 `push` aborts with exit 2 and writes nothing to the remote if any of
 the following holds:
@@ -29,7 +29,7 @@ remote.
 non-zero-exit, and a missing-count-line scenario; assert exit 2 and
 zero git operations performed.
 
-### REL-2 — Collision probe is fail-closed.
+### REL-2 — Collision probe is fail-closed
 
 `push` aborts with exit 2 if the target branch already exists on the
 remote and its `metadata.json.session_id` differs from the local
@@ -39,7 +39,7 @@ session_id. `--force-collision` is the explicit, documented override.
 foreign-session branch; assert exit 2 without `--force-collision`,
 exit 0 with it.
 
-### REL-3 — Bootstrap is idempotent.
+### REL-3 — Bootstrap is idempotent
 
 Running `dotclaude handoff push` repeatedly when bootstrap is needed:
 
@@ -58,7 +58,7 @@ no duplicate config writes, idempotent push outcome.
 
 ## Security
 
-### SEC-1 — Scrub patterns are spec-frozen.
+### SEC-1 — Scrub patterns are spec-frozen
 
 The eight perl regex passes in `handoff-scrub.sh` (GitHub tokens,
 OpenAI/sk-_, AWS access keys, Google API keys, Slack tokens,
@@ -75,7 +75,7 @@ Patterns ship as a single change set, not piecemeal.
 **Test:** dedicated bats suite with one positive + one boundary case
 per pattern; the suite is the authoritative pattern inventory.
 
-### SEC-2 — Transport URL validator rejects exec-triggering schemes.
+### SEC-2 — Transport URL validator rejects exec-triggering schemes
 
 `validateTransportUrl()` (in `plugins/dotclaude/src/lib/handoff-remote.mjs`)
 must accept only:
@@ -96,7 +96,7 @@ operations).
 schemes; bats integration on `push` with `DOTCLAUDE_HANDOFF_REPO=ext::…`
 asserting exit 2 before any git op fires.
 
-### SEC-3 — Persisted env file is mode 0600.
+### SEC-3 — Persisted env file is mode 0600
 
 `$XDG_CONFIG_HOME/dotclaude/handoff.env` (default
 `~/.config/dotclaude/handoff.env`) is written with mode `0600` and
@@ -106,7 +106,7 @@ embedded auth; world-readable mode is unacceptable.
 
 **Test:** bats verification of `stat -c '%a' <file>` post-bootstrap.
 
-### SEC-4 — Per-branch payload ceiling.
+### SEC-4 — Per-branch payload ceiling
 
 `handoff.md` written by `push` is bounded:
 
@@ -124,7 +124,7 @@ renders a > 1 MB block; assert exit 2 with the ceiling-message error.
 
 ## Performance
 
-### PERF-1 — Remote-list latency ceiling, baselined in Phase 1.
+### PERF-1 — Remote-list latency ceiling, baselined in Phase 1
 
 `list --remote` against a store with **≤ 1000 handoff branches** on a
 warm connection should complete in **< 2 s**. This is the §3 ARCH-9
@@ -141,7 +141,7 @@ against.
 Subsequent PRs run the same fixture and fail CI on > 1.5x baseline
 regression.
 
-### PERF-2 — Scrub on bounded input.
+### PERF-2 — Scrub on bounded input
 
 The scrubber must complete a single push within **< 1 s for inputs
 ≤ 1 MB**. For inputs **> 5 MB**, `push` aborts with exit 2 before the
@@ -158,7 +158,7 @@ a smell detector before the user notices.
 
 ## Operational
 
-### OPS-1 — Drift test runs as a CI gate on every PR.
+### OPS-1 — Drift test runs as a CI gate on every PR
 
 ARCH-10's drift test (`plugins/dotclaude/tests/handoff-drift.test.mjs`)
 runs in CI on every PR that touches:
@@ -174,7 +174,7 @@ the cleanup is part of the same PR that introduced the drift.
 **Test:** the drift test itself, plus a CI smoke that intentionally
 breaks the assertion via a fixture and expects red.
 
-### OPS-2 — Stdout determinism across TTY / non-TTY.
+### OPS-2 — Stdout determinism across TTY / non-TTY
 
 The `<handoff>` block on `pull` / `fetch`, and the four-line success
 output on `push`, are emitted on stdout **identically** regardless of
@@ -190,7 +190,7 @@ whether stdout is a terminal or a pipe. Specifically:
 captures stdout to a file; asserts byte-for-byte equality with the
 TTY-emulated run via `script` or equivalent.
 
-### OPS-3 — Exit codes are a public contract.
+### OPS-3 — Exit codes are a public contract
 
 The exit code set `{0, 1, 2, 64}` from §5.3 is frozen. Adding a new
 exit code (e.g. exit 3 for "partial success", exit 5 for "rate
@@ -201,7 +201,7 @@ fine.
 what the binary actually emits via fixture-driven bats coverage of
 each named condition.
 
-### OPS-4 — Cross-platform support: Linux + macOS first-class, Windows via WSL.
+### OPS-4 — Cross-platform support: Linux + macOS first-class, Windows via WSL
 
 Substrate requirement: POSIX shell + GNU `jq` + `perl 5` + `git`.
 Versions are not pinned; the substrate scripts use POSIX-portable

--- a/docs/specs/handoff-skill/spec/8-risks-alternatives.md
+++ b/docs/specs/handoff-skill/spec/8-risks-alternatives.md
@@ -12,7 +12,7 @@ Each risk lists the **failure mode**, **likelihood**, **impact**, and
 **mitigation**. Mitigations are concrete (a test that catches it, a
 behavior that prevents it) — not "we'll be careful."
 
-### R-1 — SKILL.md / binary contract failure (two failure modes).
+### R-1 — SKILL.md / binary contract failure (two failure modes)
 
 Two distinct ways the auto-trigger contract can fail; each needs a
 different mitigation.
@@ -26,7 +26,7 @@ different mitigation.
 | ---------- | ----------------------------------------------------------------------------------------------------------- |
 | Medium     | High for R-1a (silently broken slash command); medium for R-1b (one wrong invocation, exit 64 surfaces it). |
 
-### R-2 — Direct-shell user trips on `--from` mandatory.
+### R-2 — Direct-shell user trips on `--from` mandatory
 
 A user invoking `dotclaude handoff push` from a shell (not via slash
 command) without `<query>` and without `--from` gets exit 64. They
@@ -43,7 +43,7 @@ for the major bump (per §6.5) lists `--from` mandatory as its own line.
 | ---------- | ------------------------------------------ |
 | High       | Low (hit-once, recoverable, helpful error) |
 
-### R-3 — Scrub pattern set misses a new secret format.
+### R-3 — Scrub pattern set misses a new secret format
 
 The eight perl regex passes (SEC-1) cover the secret prefixes that
 existed when this spec was written. A future cloud / API service ships
@@ -68,7 +68,7 @@ the private remote unscrubbed.
 | ---------- | ----------------------------------------------------- |
 | Medium     | Medium (private repo limits blast radius; user-owned) |
 
-### R-4 — Cross-LLM divergence on the same SKILL.md.
+### R-4 — Cross-LLM divergence on the same SKILL.md
 
 Three host LLMs (Claude Code and Copilot CLI auto-load SKILL.md;
 Codex doesn't load it at all) may interpret the **same trigger doc
@@ -95,7 +95,7 @@ on the same source.
 | ---------- | ------------------------------------------------------ |
 | Low-Medium | Low (binary-side checks catch the consequential cases) |
 
-### R-5 — Drift-test infrastructure is brittle.
+### R-5 — Drift-test infrastructure is brittle
 
 A SKILL.md grammar quirk (a missing colon, a bullet style change, a
 heading rename) breaks the drift test's symbol extractor. CI goes
@@ -112,7 +112,7 @@ extractor itself (per §6.4 W-4 unit test).
 | ---------- | ------------------------------------------------- |
 | Medium     | Low (false-positive CI red, fixed in the same PR) |
 
-### R-6 — Codex's bash tool quotes arguments badly for `--from` filling.
+### R-6 — Codex's bash tool quotes arguments badly for `--from` filling
 
 Codex's bash tool may shell-quote `--from claude` differently than
 expected when the user uses Codex's natural-language → shell
@@ -130,7 +130,7 @@ by design.
 | ---------- | ----------------------------------------------------------------- |
 | Low        | Low (`from-codex.md` is the documented escape hatch; user reruns) |
 
-### R-7 — Multi-machine push of the same source UUID.
+### R-7 — Multi-machine push of the same source UUID
 
 Edge case: the user manually copies a session JSONL from machine A to
 machine B (or has it shared via Dropbox / iCloud / similar) and pushes
@@ -167,7 +167,7 @@ rejected**, so future contributors don't relitigate the same
 decisions. Treat A-N as boundary markers: a PR proposing one of
 these must amend §8 first.
 
-### A-1 — Keep `--to <cli>` for next-step text customization.
+### A-1 — Keep `--to <cli>` for next-step text customization
 
 **Path.** Preserve the cosmetic `--to` flag on `push` / `pull` /
 local emit so the host LLM (or the user) can pre-tune the
@@ -180,7 +180,7 @@ time_ already knows where the block is going. The ARCH-2 design
 moves target inference to "wherever the block lands," eliminating
 the prediction. §1's "redundant requirements" grievance applies.
 
-### A-2 — Use env-var detection for source CLI.
+### A-2 — Use env-var detection for source CLI
 
 **Path.** Probe `CLAUDECODE`, `CODEX_*`, `GITHUB_COPILOT_*` /
 `COPILOT_*` to auto-detect the source CLI at `push` time without
@@ -195,7 +195,7 @@ SKILL.md fills `--from` for slash-command users (the host LLM
 trivially knows its own identity); shell-direct users pass `--from`
 explicitly. Never silently inferred.
 
-### A-3 — Multi-PR deprecation cycle with warnings shipped to npm.
+### A-3 — Multi-PR deprecation cycle with warnings shipped to npm
 
 **Path.** Land warnings for `--to`, old verbs, and env-detection
 fallback in one release; ship the breaking changes in the next.
@@ -207,7 +207,7 @@ codebase the maintainer must test and maintain twice. **Semver
 major is the only signal that actually fires.** §6.1's release-bang
 with phased PRs is the right shape.
 
-### A-4 — Pre-write detailed per-PR prompts in §6.3.
+### A-4 — Pre-write detailed per-PR prompts in §6.3
 
 **Path.** Author 15-25 fully-fleshed implementation prompts in §6.3
 with `<read-first>` file lists, TDD test names, exact paths, etc.
@@ -221,7 +221,7 @@ prompts aren't on that list. §6.3's skeletal layout + pointer to
 a future `docs/plans/handoff-skill-prompts.md` (written at
 implementation kickoff, not now) is the right shape.
 
-### A-5 — Auto-prune / TTL on the remote store.
+### A-5 — Auto-prune / TTL on the remote store
 
 **Path.** Ship a `prune` sub-command (or background pruning) that
 deletes branches older than N months / past M total / not tagged.
@@ -234,7 +234,7 @@ retention with regular git operations
 Restated as anti-NFR in §7 so future PRs can't slip it in via an
 "operational" framing.
 
-### A-6 — Drop `list` / `search` / `describe` / `doctor` entirely.
+### A-6 — Drop `list` / `search` / `describe` / `doctor` entirely
 
 **Path.** Strip the supporting commands so the surface is purely
 `pull`, `push`, `fetch` and nothing else.
@@ -249,7 +249,7 @@ remote misbehaves. Each one earns its slot by feeding the primary
 jobs; removing them re-creates the friction the redesign exists to
 remove.
 
-### A-7 — Real-time webhook / push notification on the remote.
+### A-7 — Real-time webhook / push notification on the remote
 
 **Path.** Surface a notification on machine B when machine A pushes
 a fresh handoff (webhook → desktop notification → IDE banner).
@@ -261,7 +261,7 @@ behavior is the **feature**, not a limitation. The user pulls when
 they sit down to start the next session, not when the network tells
 them to.
 
-### A-8 — Port the shell substrate to JS.
+### A-8 — Port the shell substrate to JS
 
 **Path.** Move `handoff-resolve.sh`, `handoff-extract.sh`,
 `handoff-scrub.sh`, `handoff-description.sh`, `handoff-doctor.sh`
@@ -276,7 +276,7 @@ identical — and risks regression on substrate that works. §2
 explicitly froze the substrate; restated here so a future "let's
 unify the runtime" PR can't smuggle this past spec review.
 
-### A-9 — Use a non-git transport (S3, raw HTTPS, Notion, gist-token).
+### A-9 — Use a non-git transport (S3, raw HTTPS, Notion, gist-token)
 
 **Path.** Replace or add to the git-repo transport with an
 alternative store.
@@ -289,7 +289,7 @@ already removed in PR #68 because of the gh-scope friction; they
 should not return. Any new transport adds an authentication problem
 the spec explicitly doesn't want to own.
 
-### A-10 — E2E-encrypt payloads with the user's SSH key.
+### A-10 — E2E-encrypt payloads with the user's SSH key
 
 **Path.** Encrypt `handoff.md` / `metadata.json` client-side before
 push using the user's existing SSH key; decrypt on fetch.
@@ -302,7 +302,7 @@ still readable?) that §2 explicitly de-scopes. Best-effort scrub
 
 - private repo + sole-owner assumption (R-3) is the threat model.
 
-### A-11 — Auto-inject the digest into the target agent.
+### A-11 — Auto-inject the digest into the target agent
 
 **Path.** Use clipboard, prefilled prompt injection, or IPC to
 deliver the `<handoff>` block to the next agent without manual
@@ -317,7 +317,7 @@ verification step. The paste step is where the user reads the
 "yes, this is the session I meant." Removing it eliminates the
 audit point.
 
-### A-12 — Add Cursor / Aider / Continue / [next agent].
+### A-12 — Add Cursor / Aider / Continue / [next agent]
 
 **Path.** Extend the supported-CLI set beyond claude / copilot /
 codex.


### PR DESCRIPTION
## Summary

- Fixes the `lint / markdownlint` CI job that has failed on every PR since the `spec/handoff-skill` spec files landed on `main` via PR #108 without ever being linted.
- 38 MD026 violations (headings ending with a period) across `spec/4`, `spec/7`, `spec/8` — trailing period stripped from each heading.
- 2 MD033 violations (`<url>` in `spec/5`, `<read-first>` in `spec/6`) — both are intentional structural markers consistent with the existing `allowed_elements` list; added to allowlist rather than rewriting content.
- `npx markdownlint-cli2 "**/*.md" "#node_modules" "#.claude/worktrees"` → 0 errors locally.

## Test plan

- [x] Root cause confirmed: spec files authored in feature branch, never linted against main's `.markdownlint-cli2.jsonc`; config is correct, files violated it
- [x] Ran linter before fix: 40 errors (38×MD026, 2×MD033)
- [x] Applied fixes: stripped trailing periods from 38 headings via `sed`, added `url` and `read-first` to `MD033.allowed_elements`
- [x] Ran linter after fix: `Summary: 0 error(s)`
- [ ] CI `lint / markdownlint` passes on push

## No-spec rationale

CI conformance fix — aligns spec files that landed on `main` with the pre-existing markdownlint config. No feature work, no API change, no behavior change.
