### PR TITLE
test(handoff): lock pull verb's §4.1 local-emit contract (Phase 2 PR 1)

### DIFF
--- a/plugins/dotclaude/tests/bats/handoff-pull-local-emit.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-local-emit.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# Phase 2 PR 1 — lock the `pull` verb's §4.1 local-emit contract.
+#
+# The current binary already implements §4.1; this file pins that behavior so
+# later phase-2 PRs (PR 4 `--to` removal, PR 5 alias removal) cannot regress
+# the local-emit data flow. See docs/specs/handoff-skill/spec/4-data-flow-components.md §4.1
+# and docs/specs/handoff-skill/spec/5-interfaces-apis.md §5.2.1.
+#
+# Pinned contract:
+#   1. `pull <query>` renders the <handoff> block to stdout (§4.1 step 5/6).
+#   2. `pull` is local-only — DOTCLAUDE_HANDOFF_REPO pointing at a non-existent
+#      path must not break it; nothing reaches the remote (§4.1 "No transport").
+#   3. `pull --from <cli>` narrows resolution to that CLI's root (§4.1 step 2a,
+#      ARCH-3 priority order).
+#   4. `pull --from <cli>` against a query that doesn't exist in <cli>'s root
+#      exits non-zero (§5.3.2 "no session matches").
+#
+# Deliberately NOT pinned (out-of-spec per §5.2.1; removed in later PRs):
+#   --to (PR 4), --summary / -o / `--out-dir` (PR 5).
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  export XDG_CONFIG_HOME="$TEST_HOME"
+  # Repo path that does not exist. If any pull codepath touches git, the
+  # path-not-found error surfaces immediately. Pull must succeed regardless.
+  export DOTCLAUDE_HANDOFF_REPO="/nonexistent/dotclaude-pull-contract-$$"
+  # `pull` itself does not deprecate-warn; this guards against an incidental
+  # collapse-to-bare-positional regression from leaking stderr noise.
+  export DOTCLAUDE_QUIET=1
+
+  CLAUDE_UUID="aaaa1111-2222-2222-2222-222222222222"
+  CODEX_UUID="eeee5555-6666-6666-6666-666666666666"
+  make_claude_session_tree "$TEST_HOME" "$CLAUDE_UUID"
+  make_codex_session_tree "$TEST_HOME" "$CODEX_UUID"
+  CLAUDE_SHORT="${CLAUDE_UUID:0:8}"
+  CODEX_SHORT="${CODEX_UUID:0:8}"
+  export CLAUDE_UUID CODEX_UUID CLAUDE_SHORT CODEX_SHORT
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+@test "pull <query>: renders <handoff> block with origin/session/cwd attrs (§4.1 step 5)" {
+  run node "$BIN" pull "$CLAUDE_SHORT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<handoff "* ]]
+  [[ "$output" == *"</handoff>"* ]]
+  [[ "$output" == *"origin=\"claude\""* ]]
+  [[ "$output" == *"session=\"$CLAUDE_SHORT\""* ]]
+  [[ "$output" == *"cwd="* ]]
+}
+
+@test "pull <query>: never touches \$DOTCLAUDE_HANDOFF_REPO (§4.1 'no transport')" {
+  # The repo path is bogus. If any pull codepath reaches git, we'd see a
+  # path-not-found error in stderr or a non-zero exit. Neither must happen.
+  run node "$BIN" pull "$CLAUDE_SHORT"
+  [ "$status" -eq 0 ]
+  # Defensive: fail loudly if any git invocation trace appears. This catches
+  # accidental coupling to remote codepaths under future refactors.
+  [[ "$output" != *"git: "* ]]
+  [[ "$output" != *"could not"* ]]
+  [[ "$output" != *"/nonexistent/"* ]]
+}
+
+@test "pull --from claude <query>: narrows to claude root and renders" {
+  # Both claude (CLAUDE_UUID) and codex (CODEX_UUID) sessions are seeded.
+  # `--from claude` must filter to the claude root; the claude short-id
+  # resolves there.
+  run node "$BIN" pull "$CLAUDE_SHORT" --from claude
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"origin=\"claude\""* ]]
+}
+
+@test "pull --from codex <claude-short>: rejects with non-zero exit (§5.3.2 no session matches)" {
+  # The claude short-id is not present in the codex root. With --from codex,
+  # the resolver MUST fail rather than falling back to other roots — that's
+  # the ARCH-3 single-pathed contract (--from pins the source, no implicit
+  # widening).
+  run node "$BIN" pull "$CLAUDE_SHORT" --from codex
+  [ "$status" -ne 0 ]
+}

--- a/plugins/dotclaude/tests/handoff-pull-contract.test.mjs
+++ b/plugins/dotclaude/tests/handoff-pull-contract.test.mjs
@@ -1,0 +1,107 @@
+// Phase 2 PR 1 — argv contract test for the `pull` verb.
+//
+// Pins the §5.2.1 minimum surface as a vitest contract:
+//   - <query> positional accepted
+//   - --from <cli> accepted
+//   - --limit <N> accepted
+//   - unknown flag exits 64 (§4.1 step 1, §5.3.1)
+//
+// Companion to plugins/dotclaude/tests/bats/handoff-pull-local-emit.bats which
+// covers the §4.1 data-flow path. This file scopes to argv-shape only and
+// spawns the bin to exercise it end-to-end through the parser.
+//
+// Deliberately NOT pinned (out-of-spec per §5.2.1; removed in later PRs):
+//   --to (PR 4), --summary / -o (PR 5).
+// We allow the bin to accept those without asserting either way.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+import { makeClaudeSession } from "./fixtures/handoff-sessions.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+const HANDOFF_BIN = resolve(repoRoot, "plugins/dotclaude/bin/dotclaude-handoff.mjs");
+
+const CLAUDE_UUID = "aaaa1111-3333-3333-3333-333333333333";
+const CLAUDE_SHORT = CLAUDE_UUID.slice(0, 8);
+
+/**
+ * Run the handoff bin with the given args and a hermetic env. Returns
+ * `{ status, stdout, stderr }` regardless of exit code (does not throw).
+ *
+ * Hermetic env covers HOME + XDG_CONFIG_HOME so persisted handoff.env
+ * cannot leak in, plus DOTCLAUDE_HANDOFF_REPO set to a non-existent path
+ * so any inadvertent remote call surfaces as a non-zero exit.
+ */
+function runHandoff(args, hermeticHome) {
+  try {
+    const stdout = execFileSync(process.execPath, [HANDOFF_BIN, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: hermeticHome,
+        XDG_CONFIG_HOME: hermeticHome,
+        DOTCLAUDE_HANDOFF_REPO: "/nonexistent/handoff-pull-contract",
+        DOTCLAUDE_QUIET: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout?.toString("utf8") ?? "",
+      stderr: err.stderr?.toString("utf8") ?? "",
+    };
+  }
+}
+
+describe("handoff pull — §5.2.1 argv contract (Phase 2 PR 1)", () => {
+  /** @type {string} */
+  let hermeticHome;
+
+  beforeAll(() => {
+    hermeticHome = mkdtempSync(resolve(tmpdir(), "handoff-pull-contract-"));
+    makeClaudeSession(hermeticHome, { uuid: CLAUDE_UUID });
+  });
+
+  afterAll(() => {
+    rmSync(hermeticHome, { recursive: true, force: true });
+  });
+
+  it("accepts <query> positional and renders the <handoff> block", () => {
+    const result = runHandoff(["pull", CLAUDE_SHORT], hermeticHome);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("<handoff ");
+    expect(result.stdout).toContain("</handoff>");
+    expect(result.stdout).toContain('origin="claude"');
+    expect(result.stdout).toContain(`session="${CLAUDE_SHORT}"`);
+  });
+
+  it("accepts --from <cli>", () => {
+    const result = runHandoff(["pull", CLAUDE_SHORT, "--from", "claude"], hermeticHome);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('origin="claude"');
+  });
+
+  it("accepts --limit <N>", () => {
+    // Just assert the parser accepts the flag and the bin completes
+    // successfully. We do NOT assert the exact turn count — that's a
+    // §4.1 data-flow detail covered by the bats integration test, and
+    // per-extractor turn semantics aren't part of the §5.2.1 argv contract.
+    const result = runHandoff(["pull", CLAUDE_SHORT, "--limit", "5"], hermeticHome);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("<handoff ");
+  });
+
+  it("exits 64 on an unknown flag (§4.1 step 1, §5.3.1)", () => {
+    const result = runHandoff(["pull", CLAUDE_SHORT, "--bogus"], hermeticHome);
+    expect(result.status).toBe(64);
+    expect(result.stderr).toMatch(/unknown option/i);
+  });
+});


### PR DESCRIPTION
## Summary

- **Phase 2 PR 1** of the handoff-skill rollout per spec §6.3. Locks the `pull` verb's §4.1 local-emit data flow + §5.2.1 argv minimum via two new test files. **No binary changes** — the bin already implements both contracts; this PR pins them so later phase-2 PRs (PR 4 `--to` removal, PR 5 alias cleanup) cannot regress the local-emit path without the test catching it.
- New: `plugins/dotclaude/tests/bats/handoff-pull-local-emit.bats` — integration tests asserting `pull <query>` renders the `<handoff>` block, `--from` narrows resolution, non-existent `$DOTCLAUDE_HANDOFF_REPO` does not break pull (proves no remote call), and `--from <wrong-cli>` exits non-zero per ARCH-3's single-pathed contract.
- New: `plugins/dotclaude/tests/handoff-pull-contract.test.mjs` — vitest argv contract asserting `<query>`, `--from`, `--limit` accepted and unknown flag exits 64.

Both new files scope to the §5.2.1 _minimum_ surface — they deliberately do NOT exercise `--to`, `--summary`, or `-o`. That's how they survive PR 4 (which removes `--to` + per-target Next-step branching) and PR 5 (which retires the deprecated `describe`/`digest`/`file`/`resolve` aliases) unchanged.

The drift test baseline at `plugins/dotclaude/tests/handoff-drift.test.mjs:86` already includes `pull` in `PHASE_1_BASELINE_COMMANDS`, so no drift-test edits are required at the symbol-list level.

## Branch naming note

The §6.3 prompt sketch said `feat/handoff-pull-verb`, but a long-merged branch from PR #87 (which originally introduced the verb structure) still occupies that name on a worktree. To respect existing branches per CLAUDE.md, this PR uses `test/handoff-pull-contract` — which also better describes the scope (test lock-in, not verb addition).

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/handoff-pull-local-emit.bats` — 4/4 green locally on `fc4e7df`.
- [x] `npm test -- handoff-pull-contract` — 4/4 green locally.
- [x] `npm test` (full vitest suite) — 541/541 green locally (was 537 before, +4 new).
- [x] `npm test -- handoff-drift` — 4/4 still green; baseline unchanged.
- [x] `npx prettier --check plugins/dotclaude/tests/handoff-pull-contract.test.mjs` — clean.
- [x] `node plugins/dotclaude/bin/dotclaude-validate-specs.mjs` — `✓ 4 spec(s) valid`.
- [x] `node plugins/dotclaude/bin/dotclaude-doctor.mjs` — all green.
- [ ] CI passes on this PR's head.

## Spec ID

handoff-skill
