### PR TITLE
test(handoff): lock fetch verb's §4.3 remote-download contract (Phase 2 PR 2)

### DIFF
--- a/plugins/dotclaude/tests/bats/handoff-fetch-remote-download.bats
+++ b/plugins/dotclaude/tests/bats/handoff-fetch-remote-download.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Phase 2 PR 2 — lock the `fetch` verb's §4.3 remote-download contract.
+#
+# The current binary already implements §4.3; this file pins that behavior so
+# later phase-2 PRs (PR 4 `--to` removal, PR 5 alias removal) cannot regress
+# the remote-download data flow. See docs/specs/handoff-skill/spec/4-data-flow-components.md §4.3
+# and docs/specs/handoff-skill/spec/5-interfaces-apis.md §5.2.3.
+#
+# Pinned contract:
+#   1. `fetch <query>` returns the matched branch's handoff.md content
+#      to stdout (§4.3 step 7).
+#   2. `fetch` requires DOTCLAUDE_HANDOFF_REPO; unset → non-zero exit
+#      (§4.3 step 2 requireTransportRepoStrict, no auto-bootstrap).
+#   3. `fetch <query>` with no remote match exits non-zero (§5.3.4
+#      "no remote handoffs match").
+#   4. `fetch --from <wrong-cli>` filters out branches not in <cli>'s
+#      segment of the branch path (§4.3 step 4f).
+#
+# Deliberately NOT pinned (extra-spec but tolerated; future PR may tighten):
+#   --verify (currently accepted; not in §5.2.3).
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  export XDG_CONFIG_HOME="$TEST_HOME"
+  TRANSPORT_REPO=$(make_transport_repo "$(mktemp -d)")
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+  export DOTCLAUDE_QUIET=1
+
+  CLAUDE_UUID="bbbb2222-7777-7777-7777-777777777777"
+  make_claude_session_tree "$TEST_HOME" "$CLAUDE_UUID"
+  CLAUDE_SHORT="${CLAUDE_UUID:0:8}"
+  export CLAUDE_UUID CLAUDE_SHORT TRANSPORT_REPO
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+}
+
+@test "fetch <query>: returns the matched branch's handoff.md content (§4.3 step 7)" {
+  # Push first so the bare repo has a branch to fetch.
+  run node "$BIN" push "$CLAUDE_SHORT"
+  [ "$status" -eq 0 ]
+
+  run node "$BIN" fetch "$CLAUDE_SHORT"
+  [ "$status" -eq 0 ]
+  # The fetched content is the rendered <handoff> block from the push.
+  [[ "$output" == *"<handoff "* ]]
+  [[ "$output" == *"</handoff>"* ]]
+  [[ "$output" == *"origin=\"claude\""* ]]
+}
+
+@test "fetch with DOTCLAUDE_HANDOFF_REPO unset: exits non-zero (§4.3 step 2)" {
+  unset DOTCLAUDE_HANDOFF_REPO
+  run node "$BIN" fetch "$CLAUDE_SHORT"
+  [ "$status" -ne 0 ]
+}
+
+@test "fetch <query>: no remote match exits non-zero (§5.3.4)" {
+  # Bare repo is initialized but empty (no push). Fetching anything must
+  # fail with a "no match" code path, not silently return empty content.
+  run node "$BIN" fetch "deadbeef"
+  [ "$status" -ne 0 ]
+}
+
+@test "fetch --from codex: filters out claude-segment branches (§4.3 step 4f)" {
+  # Push from the claude root. The branch lands under the claude <cli>
+  # segment. Fetching with --from codex must filter it out and fail rather
+  # than fall back to other CLIs.
+  run node "$BIN" push "$CLAUDE_SHORT"
+  [ "$status" -eq 0 ]
+
+  run node "$BIN" fetch "$CLAUDE_SHORT" --from codex
+  [ "$status" -ne 0 ]
+}

--- a/plugins/dotclaude/tests/handoff-fetch-contract.test.mjs
+++ b/plugins/dotclaude/tests/handoff-fetch-contract.test.mjs
@@ -1,0 +1,99 @@
+// Phase 2 PR 2 — argv contract test for the `fetch` verb.
+//
+// Pins the §5.2.3 minimum surface as a vitest contract:
+//   - <query> positional accepted
+//   - --from <cli> accepted
+//   - --limit <N> accepted
+//   - unknown flag exits 64 (§4.3 step 1, §5.3.1)
+//
+// Companion to plugins/dotclaude/tests/bats/handoff-fetch-remote-download.bats
+// which covers the §4.3 data-flow path (push then fetch, transport required,
+// --from filtering). This file scopes to argv-shape only and does NOT need a
+// real transport repo — argv parsing happens before the transport check, so
+// negative cases that exit 64 work even with DOTCLAUDE_HANDOFF_REPO unset.
+//
+// Deliberately NOT pinned (extra-spec but tolerated):
+//   --verify (currently accepted; not in §5.2.3).
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+const HANDOFF_BIN = resolve(repoRoot, "plugins/dotclaude/bin/dotclaude-handoff.mjs");
+
+/**
+ * Run the handoff bin with the given args under a hermetic env. Returns
+ * `{ status, stdout, stderr }` regardless of exit code (does not throw).
+ *
+ * Hermetic env: HOME + XDG_CONFIG_HOME point at a fresh temp dir so persisted
+ * handoff.env cannot leak in. DOTCLAUDE_HANDOFF_REPO is deliberately set to a
+ * non-existent path — for argv-rejection tests the parser exits before any
+ * transport touch, and for argv-acceptance tests we use queries that never
+ * resolve so exit-2-on-no-remote-match comes after argv parsing.
+ */
+function runHandoff(args, hermeticHome) {
+  try {
+    const stdout = execFileSync(process.execPath, [HANDOFF_BIN, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: hermeticHome,
+        XDG_CONFIG_HOME: hermeticHome,
+        DOTCLAUDE_HANDOFF_REPO: "/nonexistent/handoff-fetch-contract",
+        DOTCLAUDE_QUIET: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout?.toString("utf8") ?? "",
+      stderr: err.stderr?.toString("utf8") ?? "",
+    };
+  }
+}
+
+describe("handoff fetch — §5.2.3 argv contract (Phase 2 PR 2)", () => {
+  /** @type {string} */
+  let hermeticHome;
+
+  beforeAll(() => {
+    hermeticHome = mkdtempSync(resolve(tmpdir(), "handoff-fetch-contract-"));
+  });
+
+  afterAll(() => {
+    rmSync(hermeticHome, { recursive: true, force: true });
+  });
+
+  it("accepts <query> positional (parser does not reject before transport check)", () => {
+    // The query won't resolve (no real transport), so we expect a non-64
+    // exit that's NOT an argv error. The parser must accept the positional.
+    const result = runHandoff(["fetch", "deadbeef"], hermeticHome);
+    expect(result.status).not.toBe(64);
+    expect(result.stderr).not.toMatch(/unknown option/i);
+  });
+
+  it("accepts --from <cli>", () => {
+    const result = runHandoff(["fetch", "deadbeef", "--from", "claude"], hermeticHome);
+    expect(result.status).not.toBe(64);
+    expect(result.stderr).not.toMatch(/unknown option/i);
+  });
+
+  it("accepts --limit <N>", () => {
+    const result = runHandoff(["fetch", "deadbeef", "--limit", "5"], hermeticHome);
+    expect(result.status).not.toBe(64);
+    expect(result.stderr).not.toMatch(/unknown option/i);
+  });
+
+  it("exits 64 on an unknown flag (§4.3 step 1, §5.3.1)", () => {
+    const result = runHandoff(["fetch", "deadbeef", "--bogus"], hermeticHome);
+    expect(result.status).toBe(64);
+    expect(result.stderr).toMatch(/unknown option/i);
+  });
+});

--- a/plugins/dotclaude/tests/handoff-fetch-contract.test.mjs
+++ b/plugins/dotclaude/tests/handoff-fetch-contract.test.mjs
@@ -10,7 +10,8 @@
 // which covers the §4.3 data-flow path (push then fetch, transport required,
 // --from filtering). This file scopes to argv-shape only and does NOT need a
 // real transport repo — argv parsing happens before the transport check, so
-// negative cases that exit 64 work even with DOTCLAUDE_HANDOFF_REPO unset.
+// negative cases that exit 64 work even with DOTCLAUDE_HANDOFF_REPO pointing
+// at a non-existent path (as runHandoff() sets it to /nonexistent/...).
 //
 // Deliberately NOT pinned (extra-spec but tolerated):
 //   --verify (currently accepted; not in §5.2.3).


### PR DESCRIPTION
## Summary

- **Phase 2 PR 2** of the handoff-skill rollout per spec §6.3. Locks the `fetch` verb's §4.3 remote-download data flow + §5.2.3 argv minimum via two new test files. **No binary changes** — the bin already implements both contracts; this PR pins them so later phase-2 PRs cannot regress the remote-download path without the test catching it.
- New: `plugins/dotclaude/tests/bats/handoff-fetch-remote-download.bats` — integration tests asserting `fetch <query>` returns the matched branch's `handoff.md` content, `DOTCLAUDE_HANDOFF_REPO` unset exits non-zero (no auto-bootstrap on fetch), no-remote-match exits non-zero, and `--from <wrong-cli>` filters out branches not in that CLI's segment.
- New: `plugins/dotclaude/tests/handoff-fetch-contract.test.mjs` — vitest argv contract asserting `<query>`, `--from`, `--limit` accepted (parser passes argv before the transport check) and unknown flag exits 64.

Both new files scope to the §5.2.3 _minimum_ surface — they deliberately do NOT exercise `--verify` (extra-spec but tolerated today). Survives any future tightening unchanged.

The drift test baseline already includes `fetch` in `PHASE_1_BASELINE_COMMANDS`, so no drift-test edits required at the symbol-list level.

Same shape as #118 (Phase 2 PR 1).

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/handoff-fetch-remote-download.bats` — 4/4 green locally on `6faee01`.
- [x] `npm test -- handoff-fetch-contract` — 4/4 green locally.
- [x] `npm test` (full vitest suite) — 545/545 green locally (was 541 before, +4 new).
- [x] `npm test -- handoff-drift` — 4/4 still green; baseline unchanged.
- [x] `npx prettier --check plugins/dotclaude/tests/handoff-fetch-contract.test.mjs` — clean.
- [x] CI passes on this PR's head.

## Spec ID

handoff-skill