### PR TITLE
feat(handoff): make --from mandatory on push without <query>; flip drift test (Phase 2 PR 3)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:d1d06474379bea85663678429b0ed54d5ce5571fe07649041320d3fd1edd834f",
+      "checksum": "sha256:b212cd10c4606e36f2e99bdcd8bfc720282c7481e40e3387a01b7d351b897cbb",
       "dependencies": [],
       "lastValidated": "2026-04-25"
     },

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -110,7 +110,7 @@ const META = {
   synopsis:
     "dotclaude handoff [pull|fetch|list|search|push|prune|doctor|remote-list] [args...] [--from <cli>] [--to <cli>] [--summary] [-o <path>] [--tag <label>...] [--tags] [--cli <cli>] [--since <ISO>] [--limit <N>] [--verify] [--dry-run] [--older-than <30d|6m|1y|YYYY-MM-DD>] [--yes]",
   description:
-    "Cross-agent and cross-machine session handoff. `pull <id>` renders a local session as <handoff> block (or --summary / -o <path>). push/fetch handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO). push/fetch auto-run a preflight check (cached 5 min); --verify forces re-run.",
+    "Cross-agent and cross-machine session handoff. `pull <id>` renders a local session as <handoff> block (or --summary / -o <path>). push/fetch handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO). push/fetch auto-run a preflight check (cached 5 min); --verify forces re-run.\n\nFor push without a query, --from <cli> is required. Omitting --from exits 64 with a usage hint.",
   flags: {
     // #91 Gap 7: tag is multi-valued for push (--tag foo --tag bar) and a
     // single-value filter on `list --remote --tag <name>`. argv.mjs always
@@ -969,6 +969,13 @@ async function main() {
         ? resolveNarrowed(fromCli, explicitQuery)
         : await resolveAny(explicitQuery);
     } else {
+      // §5.5.2: --from is required when push has no <query>.
+      if (!fromCli) {
+        fail(
+          EXIT_CODES.USAGE,
+          `push without a <query> requires --from <cli>\n  usage: dotclaude handoff push --from <${[...CLIS].join("|")}>`,
+        );
+      }
       ({ hit: sessionHit, note: fallbackNote } = await resolveLatestWithHostScope({
         fromCli,
         detectedHost,

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -92,6 +92,7 @@ Cross-cutting flags (consult `--help` for the canonical list):
   `pull`, and filters `list`, `search`, and `remote-list` to one root.
   Without it, the resolver probes all three roots. `--cli` is accepted
   as a legacy alias on `search` and `remote-list`.
+  For `push` without a query, `--from` is required.
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
   target agent. Defaults to the auto-detected host. `--from` narrows
   the source root; `--to` still resolves to the invoking host unless

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -219,11 +219,10 @@ teardown() {
   [[ "$output" == *"finishing-auth"* ]]
 }
 
-@test "push (zero-arg) pushes host's latest session" {
-  run node "$BIN" push
-  [ "$status" -eq 0 ]
-  run bash -c "git --git-dir='$TRANSPORT_REPO' branch -a"
-  [[ "$output" == *"handoff/"* ]]
+@test "push (zero-arg, no --from) exits 64 — §5.5.2 mandatory --from" {
+  run --separate-stderr node "$BIN" push
+  [ "$status" -eq 64 ]
+  [[ "$stderr" == *"requires --from"* ]]
 }
 
 # -- fetch (remote git transport, formerly `pull`) -----------------------
@@ -364,22 +363,20 @@ teardown() {
 
 # -- honest stderr fallback notes ----------------------------------------
 
-@test "push (no args, no host signal) emits stderr note about unknown host" {
+@test "push (no args, no host signal) exits 64 — §5.5.2 mandatory --from" {
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
     DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO" \
     node "$BIN" push
-  [ "$status" -eq 0 ]
-  [[ "$stderr" == *"host not detected"* ]]
-  [[ "$stderr" == *"latest across all clis"* ]]
+  [ "$status" -eq 64 ]
+  [[ "$stderr" == *"requires --from"* ]]
 }
 
-@test "push (no args, CLAUDECODE=1) emits stderr note about claude" {
+@test "push (no args, CLAUDECODE=1) exits 64 — §5.5.2 mandatory --from" {
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" \
     DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO" CLAUDECODE=1 \
     node "$BIN" push
-  [ "$status" -eq 0 ]
-  [[ "$stderr" == *"latest claude session"* ]]
-  [[ "$stderr" == *"aaaa1111"* ]]
+  [ "$status" -eq 64 ]
+  [[ "$stderr" == *"requires --from"* ]]
 }
 
 # -- cross-agent regression tests (#87) ----------------------------------

--- a/plugins/dotclaude/tests/bats/handoff-error-normalization.bats
+++ b/plugins/dotclaude/tests/bats/handoff-error-normalization.bats
@@ -68,7 +68,7 @@ if [[ "$1" == "push" ]]; then
 fi
 exec /usr/bin/git "$@"
 '
-  run --separate-stderr node "$BIN" push
+  run --separate-stderr node "$BIN" push --from claude
   [ "$status" -eq 2 ]
   [[ "$stderr" == *"stage:  upload"* ]]
   [[ "$stderr" == *"push failed"* ]]

--- a/plugins/dotclaude/tests/bats/handoff-push-dryrun.bats
+++ b/plugins/dotclaude/tests/bats/handoff-push-dryrun.bats
@@ -46,7 +46,7 @@ teardown() {
 # ---- test 1: happy path prints DRY-RUN banner, exits 0, no branches -------
 
 @test "push --dry-run: exits 0, prints DRY-RUN banner, writes no branches" {
-  run --separate-stderr node "$BIN" push --dry-run
+  run --separate-stderr node "$BIN" push --from claude --dry-run
   [ "$status" -eq 0 ]
   [[ "$output" == *"DRY-RUN (no network calls)"* ]]
   [[ "$output" == *"branch:"* ]]
@@ -64,7 +64,7 @@ teardown() {
 # ---- test 2: --json emits parseable JSON with dryRun=true -----------------
 
 @test "push --dry-run --json: parseable JSON with dryRun=true" {
-  run --separate-stderr node "$BIN" push --dry-run --json
+  run --separate-stderr node "$BIN" push --from claude --dry-run --json
   [ "$status" -eq 0 ]
   # Sanity: jq can parse it and the marker is set.
   echo "$output" | jq -e '.dryRun == true' >/dev/null
@@ -79,7 +79,7 @@ teardown() {
   unset DOTCLAUDE_HANDOFF_REPO
   # Also clear the persisted config file path in case a prior test wrote one.
   rm -f "$TEST_HOME/.config/dotclaude/handoff.env" 2>/dev/null || true
-  run --separate-stderr node "$BIN" push --dry-run
+  run --separate-stderr node "$BIN" push --from claude --dry-run
   [ "$status" -eq 2 ]
   [[ "$stderr" == *"stage:  preflight"* ]]
   [[ "$stderr" == *"push failed"* ]]
@@ -101,7 +101,7 @@ exit 1
 SH
   chmod +x "$STUB_DOCTOR"
 
-  run --separate-stderr node "$BIN" push --dry-run
+  run --separate-stderr node "$BIN" push --from claude --dry-run
   [ "$status" -eq 0 ]
   [ ! -f "$sentinel" ]
   rm -rf "$sentinel_dir"

--- a/plugins/dotclaude/tests/bats/handoff-push-from-mandatory.bats
+++ b/plugins/dotclaude/tests/bats/handoff-push-from-mandatory.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# Phase 2 PR 3 — lock the `push` verb's §5.5.2 mandatory-`--from` contract.
+#
+# Pinned contract (§5.5.2):
+#   1. `push` without <query> and without --from: exits 64 (usage error).
+#   2. `push --from <cli>` without <query>: exits 0 (resolves latest in CLI root).
+#   3. `push <query>` without --from: exits 0 (explicit query exempts the rule).
+#   4. `push <query> --from <cli>`: exits 0 (narrowed push unchanged).
+#
+# Deliberately NOT pinned:
+#   env-detection fallback (removed; not in §5.5.2 new surface).
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  export XDG_CONFIG_HOME="$TEST_HOME"
+  TRANSPORT_REPO=$(make_transport_repo "$(mktemp -d)")
+  export DOTCLAUDE_HANDOFF_REPO="$TRANSPORT_REPO"
+  export DOTCLAUDE_QUIET=1
+
+  CLAUDE_UUID="dddd4444-9999-9999-9999-999999999999"
+  make_claude_session_tree "$TEST_HOME" "$CLAUDE_UUID"
+  CLAUDE_SHORT="${CLAUDE_UUID:0:8}"
+  export CLAUDE_UUID CLAUDE_SHORT TRANSPORT_REPO
+}
+
+teardown() {
+  rm -rf "$TEST_HOME" "$TRANSPORT_REPO"
+}
+
+@test "push without <query> and without --from: exits 64 (§5.5.2)" {
+  run node "$BIN" push
+  [ "$status" -eq 64 ]
+}
+
+@test "push --from claude without <query>: exits 0 (§5.5.2 happy path)" {
+  run node "$BIN" push --from claude
+  [ "$status" -eq 0 ]
+}
+
+@test "push <query> without --from: exits 0 (explicit query exempts the rule)" {
+  run node "$BIN" push "$CLAUDE_SHORT"
+  [ "$status" -eq 0 ]
+}
+
+@test "push <query> --from claude: exits 0 (narrowed explicit push)" {
+  run node "$BIN" push "$CLAUDE_SHORT" --from claude
+  [ "$status" -eq 0 ]
+}

--- a/plugins/dotclaude/tests/bats/handoff-tags.bats
+++ b/plugins/dotclaude/tests/bats/handoff-tags.bats
@@ -75,7 +75,7 @@ teardown() {
 # ---- 1: multi-tag push writes both tags array and legacy tag field --------
 
 @test "push --tag foo --tag bar: writes metadata.tags=[foo,bar] and tag=foo" {
-  run --separate-stderr node "$BIN" push --tag foo --tag bar
+  run --separate-stderr node "$BIN" push --from claude --tag foo --tag bar
   [ "$status" -eq 0 ]
 
   # Fetch the branch and inspect metadata.json.
@@ -167,7 +167,7 @@ teardown() {
 
 @test "fetch \"Foo Bar!\": matches a branch tagged foo-bar (slug-aware exact match)" {
   # Push with raw special-char tag — encoder slugifies into description.
-  run --separate-stderr node "$BIN" push --tag 'Foo Bar!'
+  run --separate-stderr node "$BIN" push --from claude --tag 'Foo Bar!'
   [ "$status" -eq 0 ]
   # Fetch with the SAME raw user input — resolver must slugify before
   # comparing to description-side tags so this exact-tag hit lands.
@@ -181,7 +181,7 @@ teardown() {
 # ---- 6: special-char tag slugify round-trip -------------------------------
 
 @test "push --tag 'Foo Bar!': slugifies to foo-bar and round-trips" {
-  run --separate-stderr node "$BIN" push --tag 'Foo Bar!'
+  run --separate-stderr node "$BIN" push --from claude --tag 'Foo Bar!'
   [ "$status" -eq 0 ]
 
   local branch; branch=$(echo "$output" | head -1)

--- a/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
+++ b/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
@@ -45,15 +45,6 @@ source are excluded until reconciled.
 | `--tags`                                                        | `--help`                                                                       | `SKILL.md` cross-cutting block (mentioned in `--tag` prose for histogram) | Phase 2 PR 6 (SKILL.md shrink)                             |
 | `--no-color`, `--verbose`/`-v`, `--help`/`-h`, `--version`/`-V` | `--help`                                                                       | `SKILL.md`                                                                | Out of scope — universal CLI flags, no spec coverage       |
 
-## from_rule baseline
-
-`from_rule = { present: false, applies_to: [], mandatory_when: null }`
-in both sources today. Spec §5.5.2 introduces the rule paragraph; the
-test will start asserting it `present: true, applies_to: ["push"],
-mandatory_when: "no <query>"` in **Phase 2 PR 3** — the same PR that
-makes `--from` mandatory on `push` without `<query>`. Both extractors
-must update in lockstep with the binary change.
-
 ## Internal — SKILL.md self-disagreement
 
 Not an excluded symbol per se, but a third datapoint for §1's "patch-loop

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -107,11 +107,11 @@ const PHASE_1_BASELINE_FLAGS_INTERSECTION = [
   "-o",
 ];
 
-/** Both sources baseline — `from_rule` is unfilled today (Phase 2 PR 3 flips this). */
+/** Both sources baseline — flipped in Phase 2 PR 3 when §5.5.2 mandatory-`--from` landed. */
 const PHASE_1_BASELINE_FROM_RULE = Object.freeze({
-  present: false,
-  applies_to: [],
-  mandatory_when: null,
+  present: true,
+  applies_to: ["push"],
+  mandatory_when: "no <query>",
 });
 
 // ---------------------------------------------------------------------------
@@ -347,7 +347,7 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
     expect(intersection).toEqual(PHASE_1_BASELINE_FLAGS_INTERSECTION);
   });
 
-  it("from_rule baseline matches in both sources (Phase 2 PR 3 flips this)", () => {
+  it("from_rule baseline matches in both sources (Phase 2 PR 3: present: true, applies_to: [push])", () => {
     expect(skillSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
     expect(helpSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
   });

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -347,7 +347,7 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
     expect(intersection).toEqual(PHASE_1_BASELINE_FLAGS_INTERSECTION);
   });
 
-  it("from_rule baseline matches in both sources (Phase 2 PR 3: present: true, applies_to: [push])", () => {
+  it("from_rule baseline matches in both sources", () => {
     expect(skillSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
     expect(helpSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
   });

--- a/plugins/dotclaude/tests/handoff-push-from-contract.test.mjs
+++ b/plugins/dotclaude/tests/handoff-push-from-contract.test.mjs
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -23,26 +23,22 @@ const repoRoot = resolve(__dirname, "../../..");
 const HANDOFF_BIN = resolve(repoRoot, "plugins/dotclaude/bin/dotclaude-handoff.mjs");
 
 function runHandoff(args, hermeticHome) {
-  try {
-    const stdout = execFileSync(process.execPath, [HANDOFF_BIN, ...args], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: hermeticHome,
-        XDG_CONFIG_HOME: hermeticHome,
-        DOTCLAUDE_HANDOFF_REPO: "/nonexistent/handoff-push-from-contract",
-        DOTCLAUDE_QUIET: "1",
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    return { status: 0, stdout, stderr: "" };
-  } catch (err) {
-    return {
-      status: err.status ?? 1,
-      stdout: err.stdout?.toString("utf8") ?? "",
-      stderr: err.stderr?.toString("utf8") ?? "",
-    };
-  }
+  const result = spawnSync(process.execPath, [HANDOFF_BIN, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: hermeticHome,
+      XDG_CONFIG_HOME: hermeticHome,
+      DOTCLAUDE_HANDOFF_REPO: "/nonexistent/handoff-push-from-contract",
+      DOTCLAUDE_QUIET: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
 }
 
 describe("handoff push — §5.5.2 mandatory-`--from` contract (Phase 2 PR 3)", () => {

--- a/plugins/dotclaude/tests/handoff-push-from-contract.test.mjs
+++ b/plugins/dotclaude/tests/handoff-push-from-contract.test.mjs
@@ -1,0 +1,85 @@
+// Phase 2 PR 3 — argv contract test for push's §5.5.2 mandatory-`--from` rule.
+//
+// Pins the §5.5.2 minimum surface as a vitest contract:
+//   - `push` without <query> and without --from exits 64
+//   - `push --from <cli>` without <query> is accepted (exits non-64)
+//   - `push <query>` without --from is accepted (explicit query exempts the rule)
+//   - unknown flag exits 64 (§5.3.1)
+//
+// Hermetic env: DOTCLAUDE_HANDOFF_REPO pointing at a non-existent path.
+// The argv rejection (exit 64) happens before any transport touch; positive
+// cases exit non-64 on a transport/session-lookup error, which is a different
+// path from argv rejection.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+const HANDOFF_BIN = resolve(repoRoot, "plugins/dotclaude/bin/dotclaude-handoff.mjs");
+
+function runHandoff(args, hermeticHome) {
+  try {
+    const stdout = execFileSync(process.execPath, [HANDOFF_BIN, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: hermeticHome,
+        XDG_CONFIG_HOME: hermeticHome,
+        DOTCLAUDE_HANDOFF_REPO: "/nonexistent/handoff-push-from-contract",
+        DOTCLAUDE_QUIET: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout?.toString("utf8") ?? "",
+      stderr: err.stderr?.toString("utf8") ?? "",
+    };
+  }
+}
+
+describe("handoff push — §5.5.2 mandatory-`--from` contract (Phase 2 PR 3)", () => {
+  /** @type {string} */
+  let hermeticHome;
+
+  beforeAll(() => {
+    hermeticHome = mkdtempSync(resolve(tmpdir(), "handoff-push-from-contract-"));
+  });
+
+  afterAll(() => {
+    rmSync(hermeticHome, { recursive: true, force: true });
+  });
+
+  it("push without <query> and without --from exits 64 (§5.5.2)", () => {
+    const result = runHandoff(["push"], hermeticHome);
+    expect(result.status).toBe(64);
+    expect(result.stderr).toMatch(/requires --from/i);
+  });
+
+  it("push --from claude without <query> is accepted (parser does not reject)", () => {
+    // No real session under hermeticHome, so exits non-zero (session-lookup
+    // error), but NOT 64 — argv and mandatory-from checks both passed.
+    const result = runHandoff(["push", "--from", "claude"], hermeticHome);
+    expect(result.status).not.toBe(64);
+    expect(result.stderr).not.toMatch(/requires --from/i);
+  });
+
+  it("push <query> without --from is accepted (explicit query exempts the rule)", () => {
+    const result = runHandoff(["push", "deadbeef"], hermeticHome);
+    expect(result.status).not.toBe(64);
+    expect(result.stderr).not.toMatch(/requires --from/i);
+  });
+
+  it("exits 64 on an unknown flag (§5.3.1)", () => {
+    const result = runHandoff(["push", "--bogus"], hermeticHome);
+    expect(result.status).toBe(64);
+    expect(result.stderr).toMatch(/unknown option/i);
+  });
+});

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -95,6 +95,7 @@ Cross-cutting flags (consult `--help` for the canonical list):
   `pull`, and filters `list`, `search`, and `remote-list` to one root.
   Without it, the resolver probes all three roots. `--cli` is accepted
   as a legacy alias on `search` and `remote-list`.
+  For `push` without a query, `--from` is required.
 - `--to <cli>` tunes the `<handoff>` block's next-step wording for a
   target agent. Defaults to the auto-detected host. `--from` narrows
   the source root; `--to` still resolves to the invoking host unless


### PR DESCRIPTION
## Summary

- **Phase 2 PR 3** of the handoff-skill rollout per spec §6.3. Implements §5.5.2: `push` without an explicit `<query>` now requires `--from <cli>`; omitting it exits 64 with a usage hint. The env-detection fallback path is removed from the `push` no-query branch.
- Binary: adds the mandatory-from guard + extends `META.description` with the §5.5.2 rule paragraph so `--help` output satisfies `extractFromRule`'s four-clause heuristic.
- SKILL.md: adds "For `push` without a query, `--from` is required." to the `--from <cli>` bullet so `extractFromRule` finds the rule in the SKILL.md source.
- Drift test: flips `PHASE_1_BASELINE_FROM_RULE` to `{ present: true, applies_to: ["push"], mandatory_when: "no <query>" }`. Removes the `from_rule baseline` section from `handoff-drift-known-disagreements.md` (now an agreement).
- New: `plugins/dotclaude/tests/bats/handoff-push-from-mandatory.bats` — 4 integration tests (exit-64 on no-from, success with --from, success with explicit query, success with both).
- New: `plugins/dotclaude/tests/handoff-push-from-contract.test.mjs` — 4 vitest argv contract tests.

## Test plan

- [x] `npx bats plugins/dotclaude/tests/bats/handoff-push-from-mandatory.bats` — 4/4 green locally on `9f72266`.
- [x] `npm test -- handoff-push-from-contract` — 4/4 green locally.
- [x] `npm test -- handoff-drift` — 4/4 green with flipped baseline.
- [x] `npm test` (full vitest suite) — 549/549 green locally (was 545 before, +4 new).
- [x] `npx prettier --check plugins/dotclaude/tests/handoff-push-from-contract.test.mjs skills/handoff/SKILL.md` — clean.
- [x] CI passes on this PR's head.

## Spec ID

handoff-skill