### PR TITLE
feat(handoff): shrink SKILL.md per spec §3 + install §5.5 phrase mapping (Phase 2 PR 6)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-28T21:30:50.212Z",
+  "generatedAt": "2026-04-28T21:39:12.853Z",
   "skills": [
     {
       "name": "audit-and-fix",

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-28T21:01:10.608Z",
+  "generatedAt": "2026-04-28T21:30:50.212Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:1c17c6e3d532d1e258bf931df9a02b35f9283c0c7aabc283dd0a7348a993ee4b",
+      "checksum": "sha256:66129dd0c5c49af5e047570b9c9f2c2046f2c6e2b0c8f64a972f658f9896131c",
       "dependencies": [],
       "lastValidated": "2026-04-28"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,209 +1,209 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-25T21:28:41.035Z",
+  "generatedAt": "2026-04-28T21:01:10.608Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
       "checksum": "sha256:f7a8fa0598d7925de95ed3829ea677a2df58fa3db93e9ff290944bb686fad7d7",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
       "checksum": "sha256:cf3ac020cd3ce7d8fc11dbf4f5f5a2ffa5e1d6443e60cd10179b564bd77894cc",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
       "checksum": "sha256:cabbf4bfe2deff3a328f15e025dfc0d63369825c0c32574790251f2793e62aeb",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
       "checksum": "sha256:cf987369294337fff90fc62e1d73d235d35055055dc8e4fbfb33a492f7cd38b5",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
       "checksum": "sha256:50573c4199f27083286fdbc3760b2f684105b4a6df39b7cb47094d7c0e5327f7",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
       "checksum": "sha256:3f7b90b69172e29cdcf66713f2708f9741003d05cc12cf9d81ff79ff9c5b692c",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
       "checksum": "sha256:7d888f6964725d82687fb61b68ff961f041f95d2c9eef7b5282061229499ca90",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
       "checksum": "sha256:6ffc091e9bd421798c5b7990f21d095563d69c59c3e2bd10d35b554b3ec225d9",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
       "checksum": "sha256:d0bc84f956c0ee8c176cf76a79374e8defb0bd2487c8340a2e2a1d9e04d8a1cc",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
       "checksum": "sha256:52e610b195a43fdd460106c1bdf56b32803cb86d163a4303274773ea3900bf79",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2dc1c4213ab6650d685e7b2243ddda91fce2ceba224ca3da3951afeb37d12946",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:b212cd10c4606e36f2e99bdcd8bfc720282c7481e40e3387a01b7d351b897cbb",
+      "checksum": "sha256:1c17c6e3d532d1e258bf931df9a02b35f9283c0c7aabc283dd0a7348a993ee4b",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "review-prs",
       "path": ".claude/commands/review-prs.md",
       "checksum": "sha256:e01a0432cd1a6cf6fe4a60cfc2b02f7cab3cde418062ca85beadc5491548bc71",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:347be395b0f8003816b4f3ed3bb777a63a3f9f7ae300d6f050b499ff66cfd3b0",
       "dependencies": [],
-      "lastValidated": "2026-04-25"
+      "lastValidated": "2026-04-28"
     }
   ]
 }

--- a/agents/architect-reviewer.md
+++ b/agents/architect-reviewer.md
@@ -1,4 +1,14 @@
 ---
+id: architect-reviewer
+type: agent
+version: 1.0.0
+domain: [devex]
+platform: [none]
+task: [review]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: architect-reviewer
 description: >
   Use when evaluating system design, reviewing architectural decisions, assessing

--- a/agents/aws-engineer.md
+++ b/agents/aws-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: aws-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [aws]
+task: [provisioning, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: aws-engineer
 description: >
   Use when designing, debugging, or reviewing AWS workloads and service

--- a/agents/azure-engineer.md
+++ b/agents/azure-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: azure-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [azure]
+task: [provisioning, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: azure-engineer
 description: >
   Use when designing, debugging, or reviewing Azure workloads and service

--- a/agents/backend-developer.md
+++ b/agents/backend-developer.md
@@ -1,4 +1,14 @@
 ---
+id: backend-developer
+type: agent
+version: 1.0.0
+domain: [backend]
+platform: [none]
+task: [scaffolding, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: backend-developer
 description: >
   Use when building or modifying server-side code: APIs, services, data models,

--- a/agents/changelog-assistant.md
+++ b/agents/changelog-assistant.md
@@ -1,4 +1,14 @@
 ---
+id: changelog-assistant
+type: agent
+version: 1.0.0
+domain: [writing, devex]
+platform: [none]
+task: [documentation]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: changelog-assistant
 description: >
   Use when generating changelog entries, drafting release notes, or summarizing

--- a/agents/compliance-auditor.md
+++ b/agents/compliance-auditor.md
@@ -1,4 +1,14 @@
 ---
+id: compliance-auditor
+type: agent
+version: 1.0.0
+domain: [security]
+platform: [none]
+task: [review, diagnostics]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: compliance-auditor
 description: >
   Use when auditing data quality gates, config-driven checks, or invariant enforcement.

--- a/agents/container-engineer.md
+++ b/agents/container-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: container-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [docker]
+task: [provisioning, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: container-engineer
 description: >
   Use when authoring, optimizing, or reviewing container images and build pipelines.

--- a/agents/crossplane-engineer.md
+++ b/agents/crossplane-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: crossplane-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [kubernetes, crossplane]
+task: [provisioning]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: crossplane-engineer
 description: >
   Use when designing, debugging, or reviewing Crossplane configurations and

--- a/agents/data-scientist.md
+++ b/agents/data-scientist.md
@@ -1,4 +1,14 @@
 ---
+id: data-scientist
+type: agent
+version: 1.0.0
+domain: [data]
+platform: [none]
+task: [review, diagnostics]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: data-scientist
 description: >
   Use when validating statistical models, scoring formulas, or config-driven math.

--- a/agents/deployment-engineer.md
+++ b/agents/deployment-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: deployment-engineer
+type: agent
+version: 1.0.0
+domain: [devex, infra]
+platform: [none]
+task: [runtime-ops]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: deployment-engineer
 description: >
   Use when planning or executing deployment strategies, release coordination, traffic

--- a/agents/devops-engineer.md
+++ b/agents/devops-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: devops-engineer
+type: agent
+version: 1.0.0
+domain: [devex]
+platform: [github-actions]
+task: [scaffolding, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: devops-engineer
 description: >
   Use when building or improving CI/CD pipelines, release workflows, build automation,

--- a/agents/docker-engineer.md
+++ b/agents/docker-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: docker-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [docker]
+task: [debugging, runtime-ops]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: docker-engineer
 description: >
   Use when designing, operating, or debugging Docker Compose stacks and running

--- a/agents/documentation-writer.md
+++ b/agents/documentation-writer.md
@@ -1,4 +1,14 @@
 ---
+id: documentation-writer
+type: agent
+version: 1.0.0
+domain: [writing, devex]
+platform: [none]
+task: [documentation]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: documentation-writer
 description: >
   Use when writing or updating documentation: user guides, READMEs, API references,

--- a/agents/frontend-developer.md
+++ b/agents/frontend-developer.md
@@ -1,4 +1,14 @@
 ---
+id: frontend-developer
+type: agent
+version: 1.0.0
+domain: [frontend]
+platform: [none]
+task: [scaffolding, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: frontend-developer
 description: >
   Use when building or modifying client-side code: UI components, pages, forms,

--- a/agents/gcp-engineer.md
+++ b/agents/gcp-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: gcp-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [gcp]
+task: [provisioning, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: gcp-engineer
 description: >
   Use when designing, debugging, or reviewing Google Cloud workloads and

--- a/agents/iac-engineer.md
+++ b/agents/iac-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: iac-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [terraform, terragrunt, pulumi]
+task: [provisioning, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: iac-engineer
 description: >
   Use when writing, reviewing, or refactoring infrastructure-as-code modules, managing

--- a/agents/kubernetes-specialist.md
+++ b/agents/kubernetes-specialist.md
@@ -1,4 +1,14 @@
 ---
+id: kubernetes-specialist
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [kubernetes]
+task: [debugging, diagnostics, runtime-ops]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: kubernetes-specialist
 description: >
   Use when designing, debugging, or reviewing Kubernetes workloads and cluster

--- a/agents/platform-engineer.md
+++ b/agents/platform-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: platform-engineer
+type: agent
+version: 1.0.0
+domain: [devex, infra]
+platform: [none]
+task: [scaffolding, provisioning]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: platform-engineer
 description: >
   Use when designing or improving internal developer platforms, golden paths, self-service

--- a/agents/pulumi-engineer.md
+++ b/agents/pulumi-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: pulumi-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [pulumi]
+task: [provisioning, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: pulumi-engineer
 description: >
   Use when working with Pulumi stacks, component resources, or the Automation

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -1,4 +1,14 @@
 ---
+id: security-auditor
+type: agent
+version: 1.0.0
+domain: [security]
+platform: [none]
+task: [review, diagnostics]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: security-auditor
 description: >
   Use when conducting security audits, reviewing code for vulnerabilities,

--- a/agents/security-engineer.md
+++ b/agents/security-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: security-engineer
+type: agent
+version: 1.0.0
+domain: [security, infra]
+platform: [kubernetes]
+task: [review, provisioning]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: security-engineer
 description: >
   Use when hardening infrastructure security posture, reviewing network policies,

--- a/agents/terragrunt-engineer.md
+++ b/agents/terragrunt-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: terragrunt-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [terragrunt, terraform]
+task: [provisioning, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: terragrunt-engineer
 description: >
   Use when working with Terragrunt configurations, DRY Terraform patterns, or

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -1,4 +1,14 @@
 ---
+id: test-engineer
+type: agent
+version: 1.0.0
+domain: [backend, frontend]
+platform: [none]
+task: [testing, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: test-engineer
 description: >
   Use when writing tests, auditing test coverage, fixing flaky tests, or setting

--- a/agents/workflow-orchestrator.md
+++ b/agents/workflow-orchestrator.md
@@ -1,4 +1,14 @@
 ---
+id: workflow-orchestrator
+type: agent
+version: 1.0.0
+domain: [devex]
+platform: [none]
+task: [scaffolding, debugging]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-04-28
+updated: 2026-04-28
 name: workflow-orchestrator
 description: >
   Use when coordinating multi-step tasks that require multiple agents, managing

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotclaude.dev/schemas/index.schema.json",
-  "generatedAt": "2026-04-23T14:45:59.879Z",
+  "generatedAt": "2026-04-28T21:39:06.712Z",
   "version": "0.11.0",
   "artifacts": [
     {
@@ -10,9 +10,15 @@
       "name": "agents-search",
       "description": "Discover, search, and manage Claude Code agents. Use when you want to find available agents, list installed agents, or refresh the agent catalog. Triggers on: \"search agents\", \"list agents\", \"find agent\", \"what agents\", \"agent catalog\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -25,11 +31,19 @@
       "name": "architect-reviewer",
       "description": "Use when evaluating system design, reviewing architectural decisions, assessing technology choices, or identifying structural anti-patterns. Triggers on: \"review architecture\", \"design review\", \"architecture concerns\", \"tech stack\", \"coupling\", \"scalability review\", \"ADR review\". Uses opus — cross-cutting architectural analysis requires deep reasoning across large codebases.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "audit-and-fix",
@@ -38,9 +52,16 @@
       "name": "audit-and-fix",
       "description": "Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to \"audit and fix\" or kicks off an overnight cleanup run.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -53,12 +74,23 @@
       "name": "aws-engineer",
       "description": "Use when designing, debugging, or reviewing AWS workloads and service integrations. Triggers on: \"AWS\", \"EC2\", \"ECS\", \"EKS\", \"Lambda\", \"S3\", \"IAM role\", \"VPC\", \"RDS\", \"DynamoDB\", \"CloudFront\", \"ALB\", \"Route53\", \"CloudFormation\", \"CDK\", \"API Gateway\", \"EventBridge\", \"SQS\", \"SNS\". Uses opus — AWS architecture spans IAM trust, multi-service interactions, and compliance tradeoffs that benefit from deep analysis.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "aws"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
       },
-      "related": ["aws-specialist"]
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha",
+      "related": [
+        "aws-specialist"
+      ]
     },
     {
       "id": "aws-specialist",
@@ -67,9 +99,16 @@
       "name": "aws-specialist",
       "description": "Deep-dive AWS architecture review, debugging, and service design. Use for structured investigations of AWS-specific issues, cost or IAM audits, and multi-service design reviews. Triggers on: \"AWS audit\", \"AWS design review\", \"IAM review\", \"cost audit AWS\", \"review my VPC\", \"AWS troubleshooting\", \"Lambda deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["aws"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "aws"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -82,11 +121,20 @@
       "name": "azure-engineer",
       "description": "Use when designing, debugging, or reviewing Azure workloads and service integrations. Triggers on: \"Azure\", \"AKS\", \"ACI\", \"App Service\", \"Azure Functions\", \"Blob Storage\", \"VNet\", \"App Gateway\", \"Front Door\", \"EntraID\", \"Managed Identity\", \"ARM template\", \"Bicep\", \"Azure DevOps\", \"ACR\", \"Service Bus\", \"Logic Apps\", \"Cosmos DB\". Uses opus — Azure spans identity, networking, and multi-subscription governance; deep reasoning reduces costly misconfigurations.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "azure"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "azure-specialist",
@@ -95,9 +143,16 @@
       "name": "azure-specialist",
       "description": "Deep-dive Azure architecture review, debugging, and service design. Use for structured investigations of Azure-specific issues, identity or cost audits, and multi-service design reviews. Triggers on: \"Azure audit\", \"Azure design review\", \"EntraID review\", \"Managed Identity debug\", \"review my Azure\", \"Azure troubleshooting\", \"AKS deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["azure"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "azure"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -110,11 +165,20 @@
       "name": "backend-developer",
       "description": "Use when building or modifying server-side code: APIs, services, data models, background jobs, or infrastructure logic. Triggers on: \"build API\", \"add endpoint\", \"database schema\", \"backend service\", \"server-side\", \"REST\", \"GraphQL\", \"background job\", \"migration\". Uses sonnet — everyday backend implementation benefits from balanced capability and throughput.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "backend"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "scaffolding",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "changelog",
@@ -123,9 +187,15 @@
       "name": "changelog",
       "description": "Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -138,11 +208,20 @@
       "name": "changelog-assistant",
       "description": "Use when generating changelog entries, drafting release notes, or summarizing git history for a release. Triggers on: \"generate changelog\", \"release notes\", \"what changed\", \"CHANGELOG\", \"summarize commits\", \"release summary\", \"version bump notes\". Uses haiku — changelog generation from git history is formulaic and lightweight; fast output benefits release flow.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "writing",
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "compliance-auditor",
@@ -151,11 +230,20 @@
       "name": "compliance-auditor",
       "description": "Use when auditing data quality gates, config-driven checks, or invariant enforcement. Cross-references declaration files against runtime enforcement code to find declared-not-enforced and enforced-not-declared gaps. Read-only — produces a coverage matrix, never modifies code or config. Triggers on: \"gate coverage\", \"quality check audit\", \"data invariants\", \"declared vs enforced\", \"config vs code gaps\", \"quality gate completeness\".\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "security"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "diagnostics"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "container-engineer",
@@ -164,11 +252,20 @@
       "name": "container-engineer",
       "description": "Use when authoring, optimizing, or reviewing container images and build pipelines. Triggers on: \"Dockerfile\", \"container image\", \"multi-stage build\", \"image size\", \"OCI\", \"Docker Compose\", \"container registry\", \"base image\", \"layer cache\". Uses sonnet — container image optimization is structured and pattern-driven; sonnet provides the right depth without excess cost.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "docker"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "create-assessment",
@@ -177,9 +274,16 @@
       "name": "create-assessment",
       "description": "Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -192,9 +296,16 @@
       "name": "create-audit",
       "description": "Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -207,9 +318,16 @@
       "name": "create-inspection",
       "description": "Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -222,11 +340,20 @@
       "name": "crossplane-engineer",
       "description": "Use when designing, debugging, or reviewing Crossplane configurations and Kubernetes-native IaC. Triggers on: \"Crossplane\", \"XRD\", \"Composition\", \"CompositeResource\", \"Claim\", \"managed resource\", \"provider config\", \"ProviderConfig\", \"composite resource definition\", \"Crossplane package\". Uses sonnet — Crossplane Composition authoring is well-specified; sonnet covers the depth needed.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "kubernetes",
+          "crossplane"
+        ],
+        "task": [
+          "provisioning"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "crossplane-specialist",
@@ -235,9 +362,17 @@
       "name": "crossplane-specialist",
       "description": "Deep-dive Crossplane platform review: XRD design, Composition correctness, provider config audit, managed resource health, and GitOps integration. Use for structured investigations of stuck Claims, composition pipeline bugs, and credential injection patterns. Triggers on: \"Crossplane audit\", \"XRD review\", \"Composition debug\", \"stuck Claim\", \"managed resource stuck\", \"provider config review\", \"Crossplane GitOps\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["crossplane", "kubernetes"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "crossplane",
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -250,11 +385,20 @@
       "name": "data-scientist",
       "description": "Use when validating statistical models, scoring formulas, or config-driven math. Audits formula correctness, boundary conditions, config-vs-code drift, and output scale changes. Read-only — surfaces findings, never modifies code. Triggers on: \"validate scoring math\", \"check formula\", \"config drift\", \"boundary conditions\", \"statistical model audit\", \"rating algorithm review\".\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "data"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "diagnostics"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "dependabot-sweep",
@@ -263,9 +407,16 @@
       "name": "dependabot-sweep",
       "description": "Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.\n",
       "facets": {
-        "domain": ["devex", "security"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex",
+          "security"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -278,11 +429,20 @@
       "name": "deployment-engineer",
       "description": "Use when planning or executing deployment strategies, release coordination, traffic shifting, or rollback procedures. Triggers on: \"deployment strategy\", \"blue/green\", \"canary release\", \"rolling update\", \"traffic shifting\", \"rollback\", \"release coordination\", \"feature flag\", \"progressive delivery\", \"deploy to production\". Uses sonnet — deployment strategy execution is structured; sonnet handles the reasoning without over-provisioning cost.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "devex",
+          "infra"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "runtime-ops"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "detect-flaky",
@@ -291,9 +451,16 @@
       "name": "detect-flaky",
       "description": "Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["testing", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "testing",
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -306,11 +473,20 @@
       "name": "devops-engineer",
       "description": "Use when building or improving CI/CD pipelines, release workflows, build automation, or developer tooling. Triggers on: \"CI pipeline\", \"CD workflow\", \"GitHub Actions\", \"build automation\", \"artifact\", \"release workflow\", \"environment promotion\", \"pipeline stage\", \"deploy pipeline\", \"lint CI\". Uses sonnet — CI/CD pipeline work is structured and iterative; sonnet matches the workload.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "scaffolding",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "docker-engineer",
@@ -319,11 +495,20 @@
       "name": "docker-engineer",
       "description": "Use when designing, operating, or debugging Docker Compose stacks and running containers. Triggers on: \"docker compose up\", \"docker compose exec\", \"docker compose ps\", \"docker compose down\", \"docker compose restart\", \"compose stack\", \"multi-service compose\", \"service dependencies\", \"docker exec\", \"inspect container\", \"container logs\", \"docker logs\", \"container networking\", \"docker network\", \"running container\", \"container debug\", \"docker stats\", \"docker scout\". Uses sonnet — Compose design and runtime ops are structured; sonnet provides the right depth.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "docker"
+        ],
+        "task": [
+          "debugging",
+          "runtime-ops"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "documentation-writer",
@@ -332,11 +517,20 @@
       "name": "documentation-writer",
       "description": "Use when writing or updating documentation: user guides, READMEs, API references, onboarding materials, docstrings, or inline docs. Triggers on: \"write docs\", \"update README\", \"API documentation\", \"document this\", \"user guide\", \"onboarding guide\", \"add examples\", \"explain how\". Uses haiku — documentation writing is templated and fast-turnaround; throughput matters more than deep reasoning.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "writing",
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "fix-with-evidence",
@@ -345,9 +539,16 @@
       "name": "fix-with-evidence",
       "description": "Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -360,11 +561,20 @@
       "name": "frontend-developer",
       "description": "Use when building or modifying client-side code: UI components, pages, forms, state management, or client-side data fetching. Triggers on: \"build UI\", \"React component\", \"frontend\", \"CSS\", \"accessibility\", \"form validation\", \"client-side\", \"Next.js page\", \"Tailwind\". Uses sonnet — everyday frontend implementation benefits from balanced capability and response speed.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "frontend"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "scaffolding",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "gcp-engineer",
@@ -373,11 +583,20 @@
       "name": "gcp-engineer",
       "description": "Use when designing, debugging, or reviewing Google Cloud workloads and service integrations. Triggers on: \"GCP\", \"Google Cloud\", \"GKE\", \"Cloud Run\", \"GCE\", \"Cloud Functions\", \"Pub/Sub\", \"GCS\", \"BigQuery\", \"Cloud Build\", \"Workload Identity\", \"Service Account\", \"VPC\", \"Cloud Armor\", \"Cloud CDN\", \"Deployment Manager\", \"Config Connector\". Uses opus — GCP architecture across Workload Identity, VPC networks, and IAM hierarchies requires deep reasoning to avoid security gaps.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "gcp"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "gcp-specialist",
@@ -386,9 +605,16 @@
       "name": "gcp-specialist",
       "description": "Deep-dive Google Cloud architecture review, debugging, and service design. Use for structured investigations of GCP-specific issues, IAM or cost audits, and multi-service design reviews. Triggers on: \"GCP audit\", \"GCP design review\", \"Workload Identity debug\", \"IAM review GCP\", \"review my GKE\", \"GCP troubleshooting\", \"Cloud Run deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["gcp"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "gcp"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -401,9 +627,15 @@
       "name": "git",
       "description": "Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -416,9 +648,16 @@
       "name": "ground-first",
       "description": "Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -431,12 +670,19 @@
       "name": "handoff",
       "description": "Transfer conversation context between agentic CLIs (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a source session transcript by UUID and produces either an inline summary, a paste-ready handoff digest, a written markdown file, or a branch in a user-owned private git repo that another machine can fetch. Use when switching agents mid-task, recovering context, or moving between Windows/Linux/macOS setups. Triggers on: \"handoff\", \"transfer context\", \"continue in codex\", \"continue in claude\", \"continue in copilot\", \"switch to codex\", \"switch to claude\", \"what was that session about\", \"claude --resume\", \"copilot --resume\", \"codex resume\", \"find the session where\", \"search sessions\", \"which session did I\", \"push handoff\", \"fetch handoff\", \"handoff to other machine\", \"resume on my other laptop\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation",
+          "debugging"
+        ],
         "maturity": "draft"
       },
-      "version": "1.1.0",
+      "version": "1.2.0",
       "owner": "@kaiohenricunha"
     },
     {
@@ -446,11 +692,22 @@
       "name": "iac-engineer",
       "description": "Use when writing, reviewing, or refactoring infrastructure-as-code modules, managing state, or handling drift detection. Triggers on: \"Terraform\", \"Pulumi\", \"OpenTofu\", \"infrastructure as code\", \"IaC module\", \"state file\", \"drift detection\", \"resource graph\", \"provider\", \"workspace\", \"remote state\". Uses sonnet — IaC authoring is structured and pattern-driven; sonnet covers the depth needed without excess cost.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform",
+          "terragrunt",
+          "pulumi"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "kubernetes-specialist",
@@ -459,12 +716,24 @@
       "name": "kubernetes-specialist",
       "description": "Use when designing, debugging, or reviewing Kubernetes workloads and cluster configuration. Triggers on: \"kubernetes\", \"k8s\", \"pod\", \"deployment\", \"cluster\", \"kubectl\", \"namespace\", \"ingress\", \"helm chart\", \"workload\", \"node not ready\". Uses opus — Kubernetes troubleshooting spans scheduler decisions, network policy semantics, and control-plane interactions; deep reasoning prevents misdiagnosis.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "diagnostics",
+          "runtime-ops"
+        ],
         "maturity": "draft"
       },
-      "related": ["kubernetes-specialist"]
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha",
+      "related": [
+        "kubernetes-specialist"
+      ]
     },
     {
       "id": "kubernetes-specialist",
@@ -473,9 +742,16 @@
       "name": "kubernetes-specialist",
       "description": "Deep-dive Kubernetes troubleshooting, workload design, and cluster health review. Use when you need a structured investigation of a cluster issue, a design review of Kubernetes manifests, or a health audit of a namespace or workload. Triggers on: \"debug kubernetes\", \"why is my pod\", \"review my manifests\", \"cluster health\", \"kubernetes design review\", \"k8s audit\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["kubernetes"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -488,9 +764,16 @@
       "name": "markdown",
       "description": "Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.\n",
       "facets": {
-        "domain": ["devex", "writing"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex",
+          "writing"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -503,9 +786,16 @@
       "name": "merge-pr",
       "description": "Merge a pull request only after full local verification, with an optional data-regression gate for paths configured in docs/repo-facts.json.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -518,11 +808,21 @@
       "name": "platform-engineer",
       "description": "Use when designing or improving internal developer platforms, golden paths, self-service tooling, or environment parity. Triggers on: \"developer platform\", \"internal tooling\", \"golden path\", \"paved road\", \"developer experience\", \"self-service\", \"environment parity\", \"platform team\", \"scaffolding\", \"service catalog\". Uses opus — platform design decisions compound over time; deep reasoning prevents golden-path choices that become maintenance burdens.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "devex",
+          "infra"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "scaffolding",
+          "provisioning"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "pre-pr",
@@ -531,9 +831,16 @@
       "name": "pre-pr",
       "description": "Pre-PR quality gate: simplify changed code, security-review the diff, run the full test suite, and surface a go/no-go summary before opening a pull request.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -546,11 +853,20 @@
       "name": "pulumi-engineer",
       "description": "Use when working with Pulumi stacks, component resources, or the Automation API. Triggers on: \"Pulumi\", \"pulumi up\", \"pulumi stack\", \"ComponentResource\", \"Pulumi ESC\", \"Automation API\", \"pulumi.Config\", \"pulumi new\", \"stack reference\", \"StackReference\". Uses sonnet — Pulumi stack work is code-first and structured; sonnet matches the task depth.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "pulumi"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "pulumi-specialist",
@@ -559,9 +875,16 @@
       "name": "pulumi-specialist",
       "description": "Deep-dive Pulumi stack review, component design, Automation API audit, and secrets management. Use for structured investigations of Pulumi stack drift, ComponentResource coupling, ESC configuration, and Automation API workflows. Triggers on: \"Pulumi audit\", \"stack review\", \"Automation API review\", \"ComponentResource design\", \"ESC audit\", \"Pulumi secrets\", \"Pulumi testing\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["pulumi"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "pulumi"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -574,9 +897,15 @@
       "name": "review-pr",
       "description": "Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -589,9 +918,15 @@
       "name": "review-prs",
       "description": "Batch-review multiple PRs in parallel: dispatch one sub-agent per PR in an isolated worktree, aggregate results into a summary table.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -604,11 +939,20 @@
       "name": "security-auditor",
       "description": "Use when conducting security audits, reviewing code for vulnerabilities, assessing secrets exposure, or evaluating compliance posture. Triggers on: \"audit security\", \"find vulnerabilities\", \"check secrets\", \"OWASP review\", \"security scan\", \"CVE\", \"threat model\". Uses opus — security analysis requires thorough reasoning; false negatives have high downstream cost.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "security"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "diagnostics"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "security-engineer",
@@ -617,11 +961,21 @@
       "name": "security-engineer",
       "description": "Use when hardening infrastructure security posture, reviewing network policies, managing secrets, or assessing supply-chain risks. Triggers on: \"infrastructure hardening\", \"network policy\", \"secrets management\", \"RBAC\", \"admission controller\", \"mTLS\", \"supply chain\", \"image signing\", \"privilege escalation\", \"security posture\". Uses opus — infrastructure hardening and privilege analysis require deep reasoning; a missed vector has high downstream cost.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "security",
+          "infra"
+        ],
+        "platform": [
+          "kubernetes"
+        ],
+        "task": [
+          "review",
+          "provisioning"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "security-review",
@@ -630,9 +984,16 @@
       "name": "security-review",
       "description": "Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.\n",
       "facets": {
-        "domain": ["devex", "security"],
-        "platform": ["none"],
-        "task": ["review"],
+        "domain": [
+          "devex",
+          "security"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -645,9 +1006,15 @@
       "name": "spec",
       "description": "Create structured engineering specs through interactive pairing. Use when the user wants to create a spec, design doc, technical specification, architecture document, RFC, or engineering plan. Triggers on \"let's spec this out\", \"create a spec\", \"design doc\", \"write a technical plan\", \"plan the architecture\". Works for greenfield and brownfield projects. Outputs to docs/specs/.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -660,9 +1027,16 @@
       "name": "terraform-specialist",
       "description": "Deep-dive Terraform architecture review, module design, state management, and migration. Use for structured investigations of Terraform workspaces, provider configuration, module coupling, import workflows, and test coverage. Triggers on: \"Terraform audit\", \"module review\", \"state management\", \"Terraform import\", \"workspace design\", \"provider config review\", \"Terraform testing\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terraform"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -675,11 +1049,21 @@
       "name": "terragrunt-engineer",
       "description": "Use when working with Terragrunt configurations, DRY Terraform patterns, or multi-environment root-module hierarchies. Triggers on: \"Terragrunt\", \"terragrunt.hcl\", \"run-all\", \"DRY Terraform\", \"dependency block\", \"env hierarchy\", \"root module\", \"terragrunt hooks\", \"generate block\". Uses sonnet — Terragrunt DRY patterns are well-specified; sonnet handles the reasoning without over-provisioning cost.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terragrunt",
+          "terraform"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "terragrunt-specialist",
@@ -688,9 +1072,17 @@
       "name": "terragrunt-specialist",
       "description": "Deep-dive Terragrunt hierarchy review, DRY pattern audits, and run-all orchestration analysis. Use for structured investigations of multi-environment Terragrunt layouts, dependency graphs, remote state config, and hook correctness. Triggers on: \"Terragrunt audit\", \"run-all review\", \"dependency block\", \"DRY pattern review\", \"env hierarchy audit\", \"mock_outputs\", \"terragrunt hooks\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terraform", "terragrunt"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform",
+          "terragrunt"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -703,11 +1095,21 @@
       "name": "test-engineer",
       "description": "Use when writing tests, auditing test coverage, fixing flaky tests, or setting up test infrastructure. Triggers on: \"write tests\", \"add test coverage\", \"fix flaky test\", \"integration test\", \"test suite\", \"coverage report\", \"missing tests\", \"test CI\". Uses sonnet — test design benefits from reasoning about edge cases and failure modes; sonnet balances depth and speed.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "backend",
+          "frontend"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "testing",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     },
     {
       "id": "validate-spec",
@@ -716,9 +1118,16 @@
       "name": "validate-spec",
       "description": "Audit an already-implemented spec against the codebase. Walks each constraint (ARCH-N, PERF-N, KD-N, etc.) and acceptance criterion, grounds findings in file:line evidence, runs the spec.json acceptance_commands, and writes a single audit doc to docs/audits/. Use whenever the user asks to \"validate a spec\", \"audit a spec\", \"check if spec is implemented\", \"verify the spec is done\", \"is this spec really done\", or otherwise wants closure on spec-driven work. Read-only against the spec — produces an audit, never modifies the spec itself.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -731,9 +1140,16 @@
       "name": "veracity-audit",
       "description": "Audit a data pipeline for Veracity and Value. Dispatches data-scientist, compliance-auditor, and data-engineer agents with project context injected at dispatch time. All source paths are supplied via flags — no defaults, no project assumptions. Subcommands: audit (full pipeline walk), score-check (scoring math only), gate-check (gate coverage only), source-trace <label> (single source end-to-end). Invoke when: \"audit pipeline\", \"veracity check\", \"scoring math correct?\", \"check gates\", \"trace source\", \"verify quality gates\", \"formula correct?\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -746,11 +1162,20 @@
       "name": "workflow-orchestrator",
       "description": "Use when coordinating multi-step tasks that require multiple agents, managing parallel workstreams, or planning and delegating complex implementation efforts. Triggers on: \"orchestrate\", \"coordinate agents\", \"parallel tasks\", \"multi-step plan\", \"delegate work\", \"break down\", \"dispatch subagents\". Uses opus — orchestration quality compounds across delegated agents; poor decomposition cascades into downstream failures.\n",
       "facets": {
-        "domain": [],
-        "platform": [],
-        "task": [],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "scaffolding",
+          "debugging"
+        ],
         "maturity": "draft"
-      }
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
     }
   ]
 }

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -10,15 +10,9 @@
       "name": "agents-search",
       "description": "Discover, search, and manage Claude Code agents. Use when you want to find available agents, list installed agents, or refresh the agent catalog. Triggers on: \"search agents\", \"list agents\", \"find agent\", \"what agents\", \"agent catalog\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -31,15 +25,9 @@
       "name": "architect-reviewer",
       "description": "Use when evaluating system design, reviewing architectural decisions, assessing technology choices, or identifying structural anti-patterns. Triggers on: \"review architecture\", \"design review\", \"architecture concerns\", \"tech stack\", \"coupling\", \"scalability review\", \"ADR review\". Uses opus — cross-cutting architectural analysis requires deep reasoning across large codebases.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -52,16 +40,9 @@
       "name": "audit-and-fix",
       "description": "Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to \"audit and fix\" or kicks off an overnight cleanup run.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -74,23 +55,14 @@
       "name": "aws-engineer",
       "description": "Use when designing, debugging, or reviewing AWS workloads and service integrations. Triggers on: \"AWS\", \"EC2\", \"ECS\", \"EKS\", \"Lambda\", \"S3\", \"IAM role\", \"VPC\", \"RDS\", \"DynamoDB\", \"CloudFront\", \"ALB\", \"Route53\", \"CloudFormation\", \"CDK\", \"API Gateway\", \"EventBridge\", \"SQS\", \"SNS\". Uses opus — AWS architecture spans IAM trust, multi-service interactions, and compliance tradeoffs that benefit from deep analysis.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "aws"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["aws"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha",
-      "related": [
-        "aws-specialist"
-      ]
+      "related": ["aws-specialist"]
     },
     {
       "id": "aws-specialist",
@@ -99,16 +71,9 @@
       "name": "aws-specialist",
       "description": "Deep-dive AWS architecture review, debugging, and service design. Use for structured investigations of AWS-specific issues, cost or IAM audits, and multi-service design reviews. Triggers on: \"AWS audit\", \"AWS design review\", \"IAM review\", \"cost audit AWS\", \"review my VPC\", \"AWS troubleshooting\", \"Lambda deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "aws"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["aws"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -121,16 +86,9 @@
       "name": "azure-engineer",
       "description": "Use when designing, debugging, or reviewing Azure workloads and service integrations. Triggers on: \"Azure\", \"AKS\", \"ACI\", \"App Service\", \"Azure Functions\", \"Blob Storage\", \"VNet\", \"App Gateway\", \"Front Door\", \"EntraID\", \"Managed Identity\", \"ARM template\", \"Bicep\", \"Azure DevOps\", \"ACR\", \"Service Bus\", \"Logic Apps\", \"Cosmos DB\". Uses opus — Azure spans identity, networking, and multi-subscription governance; deep reasoning reduces costly misconfigurations.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "azure"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["azure"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -143,16 +101,9 @@
       "name": "azure-specialist",
       "description": "Deep-dive Azure architecture review, debugging, and service design. Use for structured investigations of Azure-specific issues, identity or cost audits, and multi-service design reviews. Triggers on: \"Azure audit\", \"Azure design review\", \"EntraID review\", \"Managed Identity debug\", \"review my Azure\", \"Azure troubleshooting\", \"AKS deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "azure"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["azure"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -165,16 +116,9 @@
       "name": "backend-developer",
       "description": "Use when building or modifying server-side code: APIs, services, data models, background jobs, or infrastructure logic. Triggers on: \"build API\", \"add endpoint\", \"database schema\", \"backend service\", \"server-side\", \"REST\", \"GraphQL\", \"background job\", \"migration\". Uses sonnet — everyday backend implementation benefits from balanced capability and throughput.\n",
       "facets": {
-        "domain": [
-          "backend"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "scaffolding",
-          "debugging"
-        ],
+        "domain": ["backend"],
+        "platform": ["none"],
+        "task": ["scaffolding", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -187,15 +131,9 @@
       "name": "changelog",
       "description": "Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -208,16 +146,9 @@
       "name": "changelog-assistant",
       "description": "Use when generating changelog entries, drafting release notes, or summarizing git history for a release. Triggers on: \"generate changelog\", \"release notes\", \"what changed\", \"CHANGELOG\", \"summarize commits\", \"release summary\", \"version bump notes\". Uses haiku — changelog generation from git history is formulaic and lightweight; fast output benefits release flow.\n",
       "facets": {
-        "domain": [
-          "writing",
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["writing", "devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -230,16 +161,9 @@
       "name": "compliance-auditor",
       "description": "Use when auditing data quality gates, config-driven checks, or invariant enforcement. Cross-references declaration files against runtime enforcement code to find declared-not-enforced and enforced-not-declared gaps. Read-only — produces a coverage matrix, never modifies code or config. Triggers on: \"gate coverage\", \"quality check audit\", \"data invariants\", \"declared vs enforced\", \"config vs code gaps\", \"quality gate completeness\".\n",
       "facets": {
-        "domain": [
-          "security"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "diagnostics"
-        ],
+        "domain": ["security"],
+        "platform": ["none"],
+        "task": ["review", "diagnostics"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -252,16 +176,9 @@
       "name": "container-engineer",
       "description": "Use when authoring, optimizing, or reviewing container images and build pipelines. Triggers on: \"Dockerfile\", \"container image\", \"multi-stage build\", \"image size\", \"OCI\", \"Docker Compose\", \"container registry\", \"base image\", \"layer cache\". Uses sonnet — container image optimization is structured and pattern-driven; sonnet provides the right depth without excess cost.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "docker"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["docker"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -274,16 +191,9 @@
       "name": "create-assessment",
       "description": "Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -296,16 +206,9 @@
       "name": "create-audit",
       "description": "Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -318,16 +221,9 @@
       "name": "create-inspection",
       "description": "Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -340,16 +236,9 @@
       "name": "crossplane-engineer",
       "description": "Use when designing, debugging, or reviewing Crossplane configurations and Kubernetes-native IaC. Triggers on: \"Crossplane\", \"XRD\", \"Composition\", \"CompositeResource\", \"Claim\", \"managed resource\", \"provider config\", \"ProviderConfig\", \"composite resource definition\", \"Crossplane package\". Uses sonnet — Crossplane Composition authoring is well-specified; sonnet covers the depth needed.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "kubernetes",
-          "crossplane"
-        ],
-        "task": [
-          "provisioning"
-        ],
+        "domain": ["infra"],
+        "platform": ["kubernetes", "crossplane"],
+        "task": ["provisioning"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -362,17 +251,9 @@
       "name": "crossplane-specialist",
       "description": "Deep-dive Crossplane platform review: XRD design, Composition correctness, provider config audit, managed resource health, and GitOps integration. Use for structured investigations of stuck Claims, composition pipeline bugs, and credential injection patterns. Triggers on: \"Crossplane audit\", \"XRD review\", \"Composition debug\", \"stuck Claim\", \"managed resource stuck\", \"provider config review\", \"Crossplane GitOps\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "crossplane",
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["crossplane", "kubernetes"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -385,16 +266,9 @@
       "name": "data-scientist",
       "description": "Use when validating statistical models, scoring formulas, or config-driven math. Audits formula correctness, boundary conditions, config-vs-code drift, and output scale changes. Read-only — surfaces findings, never modifies code. Triggers on: \"validate scoring math\", \"check formula\", \"config drift\", \"boundary conditions\", \"statistical model audit\", \"rating algorithm review\".\n",
       "facets": {
-        "domain": [
-          "data"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "diagnostics"
-        ],
+        "domain": ["data"],
+        "platform": ["none"],
+        "task": ["review", "diagnostics"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -407,16 +281,9 @@
       "name": "dependabot-sweep",
       "description": "Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "security"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex", "security"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -429,16 +296,9 @@
       "name": "deployment-engineer",
       "description": "Use when planning or executing deployment strategies, release coordination, traffic shifting, or rollback procedures. Triggers on: \"deployment strategy\", \"blue/green\", \"canary release\", \"rolling update\", \"traffic shifting\", \"rollback\", \"release coordination\", \"feature flag\", \"progressive delivery\", \"deploy to production\". Uses sonnet — deployment strategy execution is structured; sonnet handles the reasoning without over-provisioning cost.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "infra"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "runtime-ops"
-        ],
+        "domain": ["devex", "infra"],
+        "platform": ["none"],
+        "task": ["runtime-ops"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -451,16 +311,9 @@
       "name": "detect-flaky",
       "description": "Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "testing",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["testing", "debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -473,16 +326,9 @@
       "name": "devops-engineer",
       "description": "Use when building or improving CI/CD pipelines, release workflows, build automation, or developer tooling. Triggers on: \"CI pipeline\", \"CD workflow\", \"GitHub Actions\", \"build automation\", \"artifact\", \"release workflow\", \"environment promotion\", \"pipeline stage\", \"deploy pipeline\", \"lint CI\". Uses sonnet — CI/CD pipeline work is structured and iterative; sonnet matches the workload.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "scaffolding",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["scaffolding", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -495,16 +341,9 @@
       "name": "docker-engineer",
       "description": "Use when designing, operating, or debugging Docker Compose stacks and running containers. Triggers on: \"docker compose up\", \"docker compose exec\", \"docker compose ps\", \"docker compose down\", \"docker compose restart\", \"compose stack\", \"multi-service compose\", \"service dependencies\", \"docker exec\", \"inspect container\", \"container logs\", \"docker logs\", \"container networking\", \"docker network\", \"running container\", \"container debug\", \"docker stats\", \"docker scout\". Uses sonnet — Compose design and runtime ops are structured; sonnet provides the right depth.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "docker"
-        ],
-        "task": [
-          "debugging",
-          "runtime-ops"
-        ],
+        "domain": ["infra"],
+        "platform": ["docker"],
+        "task": ["debugging", "runtime-ops"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -517,16 +356,9 @@
       "name": "documentation-writer",
       "description": "Use when writing or updating documentation: user guides, READMEs, API references, onboarding materials, docstrings, or inline docs. Triggers on: \"write docs\", \"update README\", \"API documentation\", \"document this\", \"user guide\", \"onboarding guide\", \"add examples\", \"explain how\". Uses haiku — documentation writing is templated and fast-turnaround; throughput matters more than deep reasoning.\n",
       "facets": {
-        "domain": [
-          "writing",
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["writing", "devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -539,16 +371,9 @@
       "name": "fix-with-evidence",
       "description": "Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -561,16 +386,9 @@
       "name": "frontend-developer",
       "description": "Use when building or modifying client-side code: UI components, pages, forms, state management, or client-side data fetching. Triggers on: \"build UI\", \"React component\", \"frontend\", \"CSS\", \"accessibility\", \"form validation\", \"client-side\", \"Next.js page\", \"Tailwind\". Uses sonnet — everyday frontend implementation benefits from balanced capability and response speed.\n",
       "facets": {
-        "domain": [
-          "frontend"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "scaffolding",
-          "debugging"
-        ],
+        "domain": ["frontend"],
+        "platform": ["none"],
+        "task": ["scaffolding", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -583,16 +401,9 @@
       "name": "gcp-engineer",
       "description": "Use when designing, debugging, or reviewing Google Cloud workloads and service integrations. Triggers on: \"GCP\", \"Google Cloud\", \"GKE\", \"Cloud Run\", \"GCE\", \"Cloud Functions\", \"Pub/Sub\", \"GCS\", \"BigQuery\", \"Cloud Build\", \"Workload Identity\", \"Service Account\", \"VPC\", \"Cloud Armor\", \"Cloud CDN\", \"Deployment Manager\", \"Config Connector\". Uses opus — GCP architecture across Workload Identity, VPC networks, and IAM hierarchies requires deep reasoning to avoid security gaps.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "gcp"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["gcp"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -605,16 +416,9 @@
       "name": "gcp-specialist",
       "description": "Deep-dive Google Cloud architecture review, debugging, and service design. Use for structured investigations of GCP-specific issues, IAM or cost audits, and multi-service design reviews. Triggers on: \"GCP audit\", \"GCP design review\", \"Workload Identity debug\", \"IAM review GCP\", \"review my GKE\", \"GCP troubleshooting\", \"Cloud Run deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "gcp"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["gcp"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -627,15 +431,9 @@
       "name": "git",
       "description": "Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -648,16 +446,9 @@
       "name": "ground-first",
       "description": "Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -670,16 +461,9 @@
       "name": "handoff",
       "description": "Transfer conversation context between agentic CLIs (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a source session transcript by UUID and produces either an inline summary, a paste-ready handoff digest, a written markdown file, or a branch in a user-owned private git repo that another machine can fetch. Use when switching agents mid-task, recovering context, or moving between Windows/Linux/macOS setups. Triggers on: \"handoff\", \"transfer context\", \"continue in codex\", \"continue in claude\", \"continue in copilot\", \"switch to codex\", \"switch to claude\", \"what was that session about\", \"claude --resume\", \"copilot --resume\", \"codex resume\", \"find the session where\", \"search sessions\", \"which session did I\", \"push handoff\", \"fetch handoff\", \"handoff to other machine\", \"resume on my other laptop\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation", "debugging"],
         "maturity": "draft"
       },
       "version": "1.2.0",
@@ -692,18 +476,9 @@
       "name": "iac-engineer",
       "description": "Use when writing, reviewing, or refactoring infrastructure-as-code modules, managing state, or handling drift detection. Triggers on: \"Terraform\", \"Pulumi\", \"OpenTofu\", \"infrastructure as code\", \"IaC module\", \"state file\", \"drift detection\", \"resource graph\", \"provider\", \"workspace\", \"remote state\". Uses sonnet — IaC authoring is structured and pattern-driven; sonnet covers the depth needed without excess cost.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform",
-          "terragrunt",
-          "pulumi"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform", "terragrunt", "pulumi"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -716,24 +491,14 @@
       "name": "kubernetes-specialist",
       "description": "Use when designing, debugging, or reviewing Kubernetes workloads and cluster configuration. Triggers on: \"kubernetes\", \"k8s\", \"pod\", \"deployment\", \"cluster\", \"kubectl\", \"namespace\", \"ingress\", \"helm chart\", \"workload\", \"node not ready\". Uses opus — Kubernetes troubleshooting spans scheduler decisions, network policy semantics, and control-plane interactions; deep reasoning prevents misdiagnosis.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "diagnostics",
-          "runtime-ops"
-        ],
+        "domain": ["infra"],
+        "platform": ["kubernetes"],
+        "task": ["debugging", "diagnostics", "runtime-ops"],
         "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha",
-      "related": [
-        "kubernetes-specialist"
-      ]
+      "related": ["kubernetes-specialist"]
     },
     {
       "id": "kubernetes-specialist",
@@ -742,16 +507,9 @@
       "name": "kubernetes-specialist",
       "description": "Deep-dive Kubernetes troubleshooting, workload design, and cluster health review. Use when you need a structured investigation of a cluster issue, a design review of Kubernetes manifests, or a health audit of a namespace or workload. Triggers on: \"debug kubernetes\", \"why is my pod\", \"review my manifests\", \"cluster health\", \"kubernetes design review\", \"k8s audit\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["kubernetes"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -764,16 +522,9 @@
       "name": "markdown",
       "description": "Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "writing"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex", "writing"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -786,16 +537,9 @@
       "name": "merge-pr",
       "description": "Merge a pull request only after full local verification, with an optional data-regression gate for paths configured in docs/repo-facts.json.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -808,17 +552,9 @@
       "name": "platform-engineer",
       "description": "Use when designing or improving internal developer platforms, golden paths, self-service tooling, or environment parity. Triggers on: \"developer platform\", \"internal tooling\", \"golden path\", \"paved road\", \"developer experience\", \"self-service\", \"environment parity\", \"platform team\", \"scaffolding\", \"service catalog\". Uses opus — platform design decisions compound over time; deep reasoning prevents golden-path choices that become maintenance burdens.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "infra"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "scaffolding",
-          "provisioning"
-        ],
+        "domain": ["devex", "infra"],
+        "platform": ["none"],
+        "task": ["scaffolding", "provisioning"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -831,16 +567,9 @@
       "name": "pre-pr",
       "description": "Pre-PR quality gate: simplify changed code, security-review the diff, run the full test suite, and surface a go/no-go summary before opening a pull request.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -853,16 +582,9 @@
       "name": "pulumi-engineer",
       "description": "Use when working with Pulumi stacks, component resources, or the Automation API. Triggers on: \"Pulumi\", \"pulumi up\", \"pulumi stack\", \"ComponentResource\", \"Pulumi ESC\", \"Automation API\", \"pulumi.Config\", \"pulumi new\", \"stack reference\", \"StackReference\". Uses sonnet — Pulumi stack work is code-first and structured; sonnet matches the task depth.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "pulumi"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["pulumi"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -875,16 +597,9 @@
       "name": "pulumi-specialist",
       "description": "Deep-dive Pulumi stack review, component design, Automation API audit, and secrets management. Use for structured investigations of Pulumi stack drift, ComponentResource coupling, ESC configuration, and Automation API workflows. Triggers on: \"Pulumi audit\", \"stack review\", \"Automation API review\", \"ComponentResource design\", \"ESC audit\", \"Pulumi secrets\", \"Pulumi testing\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "pulumi"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["pulumi"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -897,15 +612,9 @@
       "name": "review-pr",
       "description": "Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -918,15 +627,9 @@
       "name": "review-prs",
       "description": "Batch-review multiple PRs in parallel: dispatch one sub-agent per PR in an isolated worktree, aggregate results into a summary table.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -939,16 +642,9 @@
       "name": "security-auditor",
       "description": "Use when conducting security audits, reviewing code for vulnerabilities, assessing secrets exposure, or evaluating compliance posture. Triggers on: \"audit security\", \"find vulnerabilities\", \"check secrets\", \"OWASP review\", \"security scan\", \"CVE\", \"threat model\". Uses opus — security analysis requires thorough reasoning; false negatives have high downstream cost.\n",
       "facets": {
-        "domain": [
-          "security"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "diagnostics"
-        ],
+        "domain": ["security"],
+        "platform": ["none"],
+        "task": ["review", "diagnostics"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -961,17 +657,9 @@
       "name": "security-engineer",
       "description": "Use when hardening infrastructure security posture, reviewing network policies, managing secrets, or assessing supply-chain risks. Triggers on: \"infrastructure hardening\", \"network policy\", \"secrets management\", \"RBAC\", \"admission controller\", \"mTLS\", \"supply chain\", \"image signing\", \"privilege escalation\", \"security posture\". Uses opus — infrastructure hardening and privilege analysis require deep reasoning; a missed vector has high downstream cost.\n",
       "facets": {
-        "domain": [
-          "security",
-          "infra"
-        ],
-        "platform": [
-          "kubernetes"
-        ],
-        "task": [
-          "review",
-          "provisioning"
-        ],
+        "domain": ["security", "infra"],
+        "platform": ["kubernetes"],
+        "task": ["review", "provisioning"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -984,16 +672,9 @@
       "name": "security-review",
       "description": "Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "security"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex", "security"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1006,15 +687,9 @@
       "name": "spec",
       "description": "Create structured engineering specs through interactive pairing. Use when the user wants to create a spec, design doc, technical specification, architecture document, RFC, or engineering plan. Triggers on \"let's spec this out\", \"create a spec\", \"design doc\", \"write a technical plan\", \"plan the architecture\". Works for greenfield and brownfield projects. Outputs to docs/specs/.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1027,16 +702,9 @@
       "name": "terraform-specialist",
       "description": "Deep-dive Terraform architecture review, module design, state management, and migration. Use for structured investigations of Terraform workspaces, provider configuration, module coupling, import workflows, and test coverage. Triggers on: \"Terraform audit\", \"module review\", \"state management\", \"Terraform import\", \"workspace design\", \"provider config review\", \"Terraform testing\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1049,17 +717,9 @@
       "name": "terragrunt-engineer",
       "description": "Use when working with Terragrunt configurations, DRY Terraform patterns, or multi-environment root-module hierarchies. Triggers on: \"Terragrunt\", \"terragrunt.hcl\", \"run-all\", \"DRY Terraform\", \"dependency block\", \"env hierarchy\", \"root module\", \"terragrunt hooks\", \"generate block\". Uses sonnet — Terragrunt DRY patterns are well-specified; sonnet handles the reasoning without over-provisioning cost.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terragrunt",
-          "terraform"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["terragrunt", "terraform"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -1072,17 +732,9 @@
       "name": "terragrunt-specialist",
       "description": "Deep-dive Terragrunt hierarchy review, DRY pattern audits, and run-all orchestration analysis. Use for structured investigations of multi-environment Terragrunt layouts, dependency graphs, remote state config, and hook correctness. Triggers on: \"Terragrunt audit\", \"run-all review\", \"dependency block\", \"DRY pattern review\", \"env hierarchy audit\", \"mock_outputs\", \"terragrunt hooks\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform",
-          "terragrunt"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform", "terragrunt"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1095,17 +747,9 @@
       "name": "test-engineer",
       "description": "Use when writing tests, auditing test coverage, fixing flaky tests, or setting up test infrastructure. Triggers on: \"write tests\", \"add test coverage\", \"fix flaky test\", \"integration test\", \"test suite\", \"coverage report\", \"missing tests\", \"test CI\". Uses sonnet — test design benefits from reasoning about edge cases and failure modes; sonnet balances depth and speed.\n",
       "facets": {
-        "domain": [
-          "backend",
-          "frontend"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "testing",
-          "debugging"
-        ],
+        "domain": ["backend", "frontend"],
+        "platform": ["none"],
+        "task": ["testing", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -1118,16 +762,9 @@
       "name": "validate-spec",
       "description": "Audit an already-implemented spec against the codebase. Walks each constraint (ARCH-N, PERF-N, KD-N, etc.) and acceptance criterion, grounds findings in file:line evidence, runs the spec.json acceptance_commands, and writes a single audit doc to docs/audits/. Use whenever the user asks to \"validate a spec\", \"audit a spec\", \"check if spec is implemented\", \"verify the spec is done\", \"is this spec really done\", or otherwise wants closure on spec-driven work. Read-only against the spec — produces an audit, never modifies the spec itself.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1140,16 +777,9 @@
       "name": "veracity-audit",
       "description": "Audit a data pipeline for Veracity and Value. Dispatches data-scientist, compliance-auditor, and data-engineer agents with project context injected at dispatch time. All source paths are supplied via flags — no defaults, no project assumptions. Subcommands: audit (full pipeline walk), score-check (scoring math only), gate-check (gate coverage only), source-trace <label> (single source end-to-end). Invoke when: \"audit pipeline\", \"veracity check\", \"scoring math correct?\", \"check gates\", \"trace source\", \"verify quality gates\", \"formula correct?\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -1162,16 +792,9 @@
       "name": "workflow-orchestrator",
       "description": "Use when coordinating multi-step tasks that require multiple agents, managing parallel workstreams, or planning and delegating complex implementation efforts. Triggers on: \"orchestrate\", \"coordinate agents\", \"parallel tasks\", \"multi-step plan\", \"delegate work\", \"break down\", \"dispatch subagents\". Uses opus — orchestration quality compounds across delegated agents; poor decomposition cascades into downstream failures.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "scaffolding",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["scaffolding", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -2,95 +2,206 @@
   "domain": {
     "devex": [
       "agents-search",
+      "architect-reviewer",
       "audit-and-fix",
       "changelog",
+      "changelog-assistant",
       "create-assessment",
       "create-audit",
       "create-inspection",
       "dependabot-sweep",
+      "deployment-engineer",
       "detect-flaky",
+      "devops-engineer",
+      "documentation-writer",
       "fix-with-evidence",
       "git",
       "ground-first",
       "handoff",
       "markdown",
       "merge-pr",
+      "platform-engineer",
       "pre-pr",
       "review-pr",
       "review-prs",
       "security-review",
       "spec",
       "validate-spec",
-      "veracity-audit"
+      "veracity-audit",
+      "workflow-orchestrator"
     ],
     "infra": [
+      "aws-engineer",
       "aws-specialist",
+      "azure-engineer",
       "azure-specialist",
+      "container-engineer",
+      "crossplane-engineer",
       "crossplane-specialist",
+      "deployment-engineer",
+      "docker-engineer",
+      "gcp-engineer",
       "gcp-specialist",
+      "iac-engineer",
       "kubernetes-specialist",
+      "kubernetes-specialist",
+      "platform-engineer",
+      "pulumi-engineer",
       "pulumi-specialist",
+      "security-engineer",
       "terraform-specialist",
+      "terragrunt-engineer",
       "terragrunt-specialist"
     ],
-    "security": ["dependabot-sweep", "security-review"],
-    "writing": ["markdown"]
+    "backend": [
+      "backend-developer",
+      "test-engineer"
+    ],
+    "writing": [
+      "changelog-assistant",
+      "documentation-writer",
+      "markdown"
+    ],
+    "security": [
+      "compliance-auditor",
+      "dependabot-sweep",
+      "security-auditor",
+      "security-engineer",
+      "security-review"
+    ],
+    "data": [
+      "data-scientist"
+    ],
+    "frontend": [
+      "frontend-developer",
+      "test-engineer"
+    ]
   },
   "platform": {
     "none": [
       "agents-search",
+      "architect-reviewer",
       "audit-and-fix",
+      "backend-developer",
       "changelog",
+      "changelog-assistant",
+      "compliance-auditor",
       "create-assessment",
       "create-audit",
       "create-inspection",
+      "data-scientist",
+      "deployment-engineer",
       "detect-flaky",
+      "documentation-writer",
       "fix-with-evidence",
+      "frontend-developer",
       "git",
       "ground-first",
       "handoff",
       "markdown",
+      "platform-engineer",
       "pre-pr",
+      "security-auditor",
       "security-review",
       "spec",
+      "test-engineer",
       "validate-spec",
-      "veracity-audit"
+      "veracity-audit",
+      "workflow-orchestrator"
     ],
-    "aws": ["aws-specialist"],
-    "azure": ["azure-specialist"],
-    "crossplane": ["crossplane-specialist"],
-    "kubernetes": ["crossplane-specialist", "kubernetes-specialist"],
-    "github-actions": ["dependabot-sweep", "merge-pr", "review-pr", "review-prs"],
-    "gcp": ["gcp-specialist"],
-    "pulumi": ["pulumi-specialist"],
-    "terraform": ["terraform-specialist", "terragrunt-specialist"],
-    "terragrunt": ["terragrunt-specialist"]
+    "aws": [
+      "aws-engineer",
+      "aws-specialist"
+    ],
+    "azure": [
+      "azure-engineer",
+      "azure-specialist"
+    ],
+    "docker": [
+      "container-engineer",
+      "docker-engineer"
+    ],
+    "kubernetes": [
+      "crossplane-engineer",
+      "crossplane-specialist",
+      "kubernetes-specialist",
+      "kubernetes-specialist",
+      "security-engineer"
+    ],
+    "crossplane": [
+      "crossplane-engineer",
+      "crossplane-specialist"
+    ],
+    "github-actions": [
+      "dependabot-sweep",
+      "devops-engineer",
+      "merge-pr",
+      "review-pr",
+      "review-prs"
+    ],
+    "gcp": [
+      "gcp-engineer",
+      "gcp-specialist"
+    ],
+    "terraform": [
+      "iac-engineer",
+      "terraform-specialist",
+      "terragrunt-engineer",
+      "terragrunt-specialist"
+    ],
+    "terragrunt": [
+      "iac-engineer",
+      "terragrunt-engineer",
+      "terragrunt-specialist"
+    ],
+    "pulumi": [
+      "iac-engineer",
+      "pulumi-engineer",
+      "pulumi-specialist"
+    ]
   },
   "task": {
     "debugging": [
       "agents-search",
       "audit-and-fix",
+      "aws-engineer",
       "aws-specialist",
+      "azure-engineer",
       "azure-specialist",
+      "backend-developer",
+      "container-engineer",
       "create-inspection",
       "crossplane-specialist",
       "detect-flaky",
+      "devops-engineer",
+      "docker-engineer",
       "fix-with-evidence",
+      "frontend-developer",
+      "gcp-engineer",
       "gcp-specialist",
       "ground-first",
       "handoff",
+      "iac-engineer",
       "kubernetes-specialist",
+      "kubernetes-specialist",
+      "pulumi-engineer",
       "pulumi-specialist",
       "terraform-specialist",
-      "terragrunt-specialist"
+      "terragrunt-engineer",
+      "terragrunt-specialist",
+      "test-engineer",
+      "workflow-orchestrator"
     ],
     "review": [
+      "architect-reviewer",
       "audit-and-fix",
       "aws-specialist",
       "azure-specialist",
+      "compliance-auditor",
       "create-assessment",
       "create-audit",
       "crossplane-specialist",
+      "data-scientist",
       "dependabot-sweep",
       "gcp-specialist",
       "git",
@@ -101,26 +212,61 @@
       "pulumi-specialist",
       "review-pr",
       "review-prs",
+      "security-auditor",
+      "security-engineer",
       "security-review",
       "terraform-specialist",
       "terragrunt-specialist",
       "validate-spec",
       "veracity-audit"
     ],
+    "provisioning": [
+      "aws-engineer",
+      "azure-engineer",
+      "container-engineer",
+      "crossplane-engineer",
+      "gcp-engineer",
+      "iac-engineer",
+      "platform-engineer",
+      "pulumi-engineer",
+      "security-engineer",
+      "terragrunt-engineer"
+    ],
+    "scaffolding": [
+      "backend-developer",
+      "devops-engineer",
+      "frontend-developer",
+      "platform-engineer",
+      "workflow-orchestrator"
+    ],
     "documentation": [
       "changelog",
+      "changelog-assistant",
       "create-assessment",
       "create-audit",
       "create-inspection",
+      "documentation-writer",
       "handoff",
       "markdown",
       "spec"
+    ],
+    "diagnostics": [
+      "compliance-auditor",
+      "data-scientist",
+      "kubernetes-specialist",
+      "security-auditor"
+    ],
+    "runtime-ops": [
+      "deployment-engineer",
+      "docker-engineer",
+      "kubernetes-specialist"
     ],
     "testing": [
       "detect-flaky",
       "fix-with-evidence",
       "merge-pr",
       "pre-pr",
+      "test-engineer",
       "validate-spec",
       "veracity-audit"
     ]

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -53,15 +53,8 @@
       "terragrunt-engineer",
       "terragrunt-specialist"
     ],
-    "backend": [
-      "backend-developer",
-      "test-engineer"
-    ],
-    "writing": [
-      "changelog-assistant",
-      "documentation-writer",
-      "markdown"
-    ],
+    "backend": ["backend-developer", "test-engineer"],
+    "writing": ["changelog-assistant", "documentation-writer", "markdown"],
     "security": [
       "compliance-auditor",
       "dependabot-sweep",
@@ -69,13 +62,8 @@
       "security-engineer",
       "security-review"
     ],
-    "data": [
-      "data-scientist"
-    ],
-    "frontend": [
-      "frontend-developer",
-      "test-engineer"
-    ]
+    "data": ["data-scientist"],
+    "frontend": ["frontend-developer", "test-engineer"]
   },
   "platform": {
     "none": [
@@ -109,18 +97,9 @@
       "veracity-audit",
       "workflow-orchestrator"
     ],
-    "aws": [
-      "aws-engineer",
-      "aws-specialist"
-    ],
-    "azure": [
-      "azure-engineer",
-      "azure-specialist"
-    ],
-    "docker": [
-      "container-engineer",
-      "docker-engineer"
-    ],
+    "aws": ["aws-engineer", "aws-specialist"],
+    "azure": ["azure-engineer", "azure-specialist"],
+    "docker": ["container-engineer", "docker-engineer"],
     "kubernetes": [
       "crossplane-engineer",
       "crossplane-specialist",
@@ -128,10 +107,7 @@
       "kubernetes-specialist",
       "security-engineer"
     ],
-    "crossplane": [
-      "crossplane-engineer",
-      "crossplane-specialist"
-    ],
+    "crossplane": ["crossplane-engineer", "crossplane-specialist"],
     "github-actions": [
       "dependabot-sweep",
       "devops-engineer",
@@ -139,26 +115,15 @@
       "review-pr",
       "review-prs"
     ],
-    "gcp": [
-      "gcp-engineer",
-      "gcp-specialist"
-    ],
+    "gcp": ["gcp-engineer", "gcp-specialist"],
     "terraform": [
       "iac-engineer",
       "terraform-specialist",
       "terragrunt-engineer",
       "terragrunt-specialist"
     ],
-    "terragrunt": [
-      "iac-engineer",
-      "terragrunt-engineer",
-      "terragrunt-specialist"
-    ],
-    "pulumi": [
-      "iac-engineer",
-      "pulumi-engineer",
-      "pulumi-specialist"
-    ]
+    "terragrunt": ["iac-engineer", "terragrunt-engineer", "terragrunt-specialist"],
+    "pulumi": ["iac-engineer", "pulumi-engineer", "pulumi-specialist"]
   },
   "task": {
     "debugging": [
@@ -256,11 +221,7 @@
       "kubernetes-specialist",
       "security-auditor"
     ],
-    "runtime-ops": [
-      "deployment-engineer",
-      "docker-engineer",
-      "kubernetes-specialist"
-    ],
+    "runtime-ops": ["deployment-engineer", "docker-engineer", "kubernetes-specialist"],
     "testing": [
       "detect-flaky",
       "fix-with-evidence",

--- a/plugins/dotclaude/templates/claude/agents/architect-reviewer.md
+++ b/plugins/dotclaude/templates/claude/agents/architect-reviewer.md
@@ -1,4 +1,11 @@
 ---
+id: architect-reviewer
+type: agent
+version: 1.0.0
+domain: [devex]
+platform: [none]
+task: [review]
+maturity: draft
 name: architect-reviewer
 description: >
   Use when evaluating system design, reviewing architectural decisions, assessing

--- a/plugins/dotclaude/templates/claude/agents/aws-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/aws-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: aws-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [aws]
+task: [provisioning, debugging]
+maturity: draft
 name: aws-engineer
 description: >
   Use when designing, debugging, or reviewing AWS workloads and service

--- a/plugins/dotclaude/templates/claude/agents/azure-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/azure-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: azure-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [azure]
+task: [provisioning, debugging]
+maturity: draft
 name: azure-engineer
 description: >
   Use when designing, debugging, or reviewing Azure workloads and service

--- a/plugins/dotclaude/templates/claude/agents/backend-developer.md
+++ b/plugins/dotclaude/templates/claude/agents/backend-developer.md
@@ -1,4 +1,11 @@
 ---
+id: backend-developer
+type: agent
+version: 1.0.0
+domain: [backend]
+platform: [none]
+task: [scaffolding, debugging]
+maturity: draft
 name: backend-developer
 description: >
   Use when building or modifying server-side code: APIs, services, data models,

--- a/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
+++ b/plugins/dotclaude/templates/claude/agents/changelog-assistant.md
@@ -1,4 +1,11 @@
 ---
+id: changelog-assistant
+type: agent
+version: 1.0.0
+domain: [writing, devex]
+platform: [none]
+task: [documentation]
+maturity: draft
 name: changelog-assistant
 description: >
   Use when generating changelog entries, drafting release notes, or summarizing

--- a/plugins/dotclaude/templates/claude/agents/compliance-auditor.md
+++ b/plugins/dotclaude/templates/claude/agents/compliance-auditor.md
@@ -1,4 +1,11 @@
 ---
+id: compliance-auditor
+type: agent
+version: 1.0.0
+domain: [security]
+platform: [none]
+task: [review, diagnostics]
+maturity: draft
 name: compliance-auditor
 description: >
   Use when auditing data quality gates, config-driven checks, or invariant enforcement.

--- a/plugins/dotclaude/templates/claude/agents/container-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/container-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: container-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [docker]
+task: [provisioning, debugging]
+maturity: draft
 name: container-engineer
 description: >
   Use when authoring, optimizing, or reviewing container images and build pipelines.

--- a/plugins/dotclaude/templates/claude/agents/crossplane-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/crossplane-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: crossplane-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [kubernetes, crossplane]
+task: [provisioning]
+maturity: draft
 name: crossplane-engineer
 description: >
   Use when designing, debugging, or reviewing Crossplane configurations and

--- a/plugins/dotclaude/templates/claude/agents/data-scientist.md
+++ b/plugins/dotclaude/templates/claude/agents/data-scientist.md
@@ -1,4 +1,11 @@
 ---
+id: data-scientist
+type: agent
+version: 1.0.0
+domain: [data]
+platform: [none]
+task: [review, diagnostics]
+maturity: draft
 name: data-scientist
 description: >
   Use when validating statistical models, scoring formulas, or config-driven math.

--- a/plugins/dotclaude/templates/claude/agents/deployment-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/deployment-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: deployment-engineer
+type: agent
+version: 1.0.0
+domain: [devex, infra]
+platform: [none]
+task: [runtime-ops]
+maturity: draft
 name: deployment-engineer
 description: >
   Use when planning or executing deployment strategies, release coordination, traffic

--- a/plugins/dotclaude/templates/claude/agents/devops-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/devops-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: devops-engineer
+type: agent
+version: 1.0.0
+domain: [devex]
+platform: [github-actions]
+task: [scaffolding, debugging]
+maturity: draft
 name: devops-engineer
 description: >
   Use when building or improving CI/CD pipelines, release workflows, build automation,

--- a/plugins/dotclaude/templates/claude/agents/docker-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/docker-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: docker-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [docker]
+task: [debugging, runtime-ops]
+maturity: draft
 name: docker-engineer
 description: >
   Use when designing, operating, or debugging Docker Compose stacks and running

--- a/plugins/dotclaude/templates/claude/agents/documentation-writer.md
+++ b/plugins/dotclaude/templates/claude/agents/documentation-writer.md
@@ -1,4 +1,11 @@
 ---
+id: documentation-writer
+type: agent
+version: 1.0.0
+domain: [writing, devex]
+platform: [none]
+task: [documentation]
+maturity: draft
 name: documentation-writer
 description: >
   Use when writing or updating documentation: user guides, READMEs, API references,

--- a/plugins/dotclaude/templates/claude/agents/frontend-developer.md
+++ b/plugins/dotclaude/templates/claude/agents/frontend-developer.md
@@ -1,4 +1,11 @@
 ---
+id: frontend-developer
+type: agent
+version: 1.0.0
+domain: [frontend]
+platform: [none]
+task: [scaffolding, debugging]
+maturity: draft
 name: frontend-developer
 description: >
   Use when building or modifying client-side code: UI components, pages, forms,

--- a/plugins/dotclaude/templates/claude/agents/gcp-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/gcp-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: gcp-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [gcp]
+task: [provisioning, debugging]
+maturity: draft
 name: gcp-engineer
 description: >
   Use when designing, debugging, or reviewing Google Cloud workloads and

--- a/plugins/dotclaude/templates/claude/agents/iac-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/iac-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: iac-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [terraform, terragrunt, pulumi]
+task: [provisioning, debugging]
+maturity: draft
 name: iac-engineer
 description: >
   Use when writing, reviewing, or refactoring infrastructure-as-code modules, managing

--- a/plugins/dotclaude/templates/claude/agents/kubernetes-specialist.md
+++ b/plugins/dotclaude/templates/claude/agents/kubernetes-specialist.md
@@ -1,4 +1,11 @@
 ---
+id: kubernetes-specialist
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [kubernetes]
+task: [debugging, diagnostics, runtime-ops]
+maturity: draft
 name: kubernetes-specialist
 description: >
   Use when designing, debugging, or reviewing Kubernetes workloads and cluster

--- a/plugins/dotclaude/templates/claude/agents/platform-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/platform-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: platform-engineer
+type: agent
+version: 1.0.0
+domain: [devex, infra]
+platform: [none]
+task: [scaffolding, provisioning]
+maturity: draft
 name: platform-engineer
 description: >
   Use when designing or improving internal developer platforms, golden paths, self-service

--- a/plugins/dotclaude/templates/claude/agents/pulumi-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/pulumi-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: pulumi-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [pulumi]
+task: [provisioning, debugging]
+maturity: draft
 name: pulumi-engineer
 description: >
   Use when working with Pulumi stacks, component resources, or the Automation

--- a/plugins/dotclaude/templates/claude/agents/security-auditor.md
+++ b/plugins/dotclaude/templates/claude/agents/security-auditor.md
@@ -1,4 +1,11 @@
 ---
+id: security-auditor
+type: agent
+version: 1.0.0
+domain: [security]
+platform: [none]
+task: [review, diagnostics]
+maturity: draft
 name: security-auditor
 description: >
   Use when conducting security audits, reviewing code for vulnerabilities,

--- a/plugins/dotclaude/templates/claude/agents/security-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/security-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: security-engineer
+type: agent
+version: 1.0.0
+domain: [security, infra]
+platform: [kubernetes]
+task: [review, provisioning]
+maturity: draft
 name: security-engineer
 description: >
   Use when hardening infrastructure security posture, reviewing network policies,

--- a/plugins/dotclaude/templates/claude/agents/terragrunt-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/terragrunt-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: terragrunt-engineer
+type: agent
+version: 1.0.0
+domain: [infra]
+platform: [terragrunt, terraform]
+task: [provisioning, debugging]
+maturity: draft
 name: terragrunt-engineer
 description: >
   Use when working with Terragrunt configurations, DRY Terraform patterns, or

--- a/plugins/dotclaude/templates/claude/agents/test-engineer.md
+++ b/plugins/dotclaude/templates/claude/agents/test-engineer.md
@@ -1,4 +1,11 @@
 ---
+id: test-engineer
+type: agent
+version: 1.0.0
+domain: [backend, frontend]
+platform: [none]
+task: [testing, debugging]
+maturity: draft
 name: test-engineer
 description: >
   Use when writing tests, auditing test coverage, fixing flaky tests, or setting

--- a/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
+++ b/plugins/dotclaude/templates/claude/agents/workflow-orchestrator.md
@@ -1,4 +1,11 @@
 ---
+id: workflow-orchestrator
+type: agent
+version: 1.0.0
+domain: [devex]
+platform: [none]
+task: [scaffolding, debugging]
+maturity: draft
 name: workflow-orchestrator
 description: >
   Use when coordinating multi-step tasks that require multiple agents, managing

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -42,7 +42,7 @@ the right invocation.
 | `continue in <cli>` / `switch to <cli>` / `pull from <cli>`            | `dotclaude handoff pull <id> --from <cli>`           |
 | `what was that session about` + identifier                             | `dotclaude handoff pull <id> --summary`              |
 | `push handoff` / `send to other machine` / `save this`                 | `dotclaude handoff push --from <host-cli> [--tag …]` |
-| `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch <query-or-prompt>`          |
+| `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch [<query>]`                  |
 
 Extract `<id>` from the user message (UUID, short UUID, or named alias).
 The resolver probes Claude / Copilot / Codex roots automatically. If the
@@ -61,7 +61,7 @@ is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
 
 Brief reference. `dotclaude handoff --help` is authoritative.
 
-- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`, `pull`; filters `list` and `search`.
+- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`, `pull`; filters `list`, `search`, and `prune`.
 - `--summary` (on `pull`) emits a prose summary instead of the full `<handoff>` block.
 - `-o <path>` (on `pull`) controls output: `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`; any other string is a literal path.
 - `--since <ISO>` cuts off `list` and `search` (default 30 days for `search`).

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -2,7 +2,7 @@
 id: handoff
 name: handoff
 type: skill
-version: 1.1.0
+version: 1.2.0
 domain: [devex]
 platform: [none]
 task: [documentation, debugging]
@@ -21,7 +21,7 @@ description: >
   "find the session where", "search sessions", "which session did I",
   "push handoff", "fetch handoff", "handoff to other machine",
   "resume on my other laptop".
-argument-hint: "[pull|push|fetch|list|search|resolve|doctor] [args...]"
+argument-hint: "[pull|push|fetch|list|search|prune|doctor] [args...]"
 tools: Glob, Read, Grep, Bash, Write
 effort: medium
 model: sonnet
@@ -29,195 +29,56 @@ model: sonnet
 
 # Handoff — Cross-CLI Session Context Transfer
 
-This skill is a thin wrapper around the `dotclaude handoff` binary.
-The binary is the executable contract; the skill exists to map natural
-language ("continue this in codex") into the right invocation and to
-document the public surface in one place. Every form below also works
-verbatim as `!dotclaude handoff …` from any shell — including Codex's
-bash tool.
+Thin wrapper around the `dotclaude handoff` binary. The binary is the
+authoritative contract; run `dotclaude handoff --help` for the full
+sub-command list and flag reference. This file maps natural language to
+the right invocation.
 
-## The four forms
+## Auto-trigger phrase mapping
 
-```
-/handoff pull [<id>] [--from <cli>] [--to <cli>] [--summary] [-o <path>]
-/handoff push [<query>] [--from <cli>] [--tag <label> ...]
-/handoff fetch [<query>] [--from <cli>] [--verify]
-/handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all] [--tag <name>] [--tags]
-```
+| Trigger phrase                                                         | Invocation                                           |
+| ---------------------------------------------------------------------- | ---------------------------------------------------- |
+| `handoff <id>` / resume-command fragments                              | `dotclaude handoff pull <id>`                        |
+| `continue in <cli>` / `switch to <cli>` / `pull from <cli>`            | `dotclaude handoff pull <id> --from <cli>`           |
+| `what was that session about` + identifier                             | `dotclaude handoff pull <id> --summary`              |
+| `push handoff` / `send to other machine` / `save this`                 | `dotclaude handoff push --from <host-cli> [--tag …]` |
+| `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch <query-or-prompt>`          |
 
-A bare `/handoff` with no arguments prints usage and exits 0. Every
-remote verb (`push`, `fetch`) is explicit.
-
-If `--from` is set, resolution narrows to that CLI; otherwise the host is
-auto-detected; otherwise all three roots are scanned.
-
-`<id>` / `<query>` auto-detects across `~/.claude/projects`,
-`~/.copilot/session-state`, and `~/.codex/sessions`. Accepted forms:
-full UUID, short UUID (first 8 hex), `latest`, Claude `customTitle`
-alias, Codex `thread_name` alias.
-
-**`latest` is host-scoped.** When the binary identifies the invoking
-CLI (via `--from` or host-specific env-var probes such as `CLAUDECODE=1`,
-`CLAUDE_CODE_SSE_PORT`, `CODEX_*`, `COPILOT_*`, and `GITHUB_COPILOT_*`),
-`latest` resolves within that CLI's root only — so inside Claude Code
-it picks the newest `~/.claude/projects` session even when a newer
-Codex JSONL exists on disk. Explicit UUIDs and aliases are never
-narrowed. Without a host signal `latest` falls back to the union
-resolver (globally newest across all roots) and stderr names the
-picked session. Pass `--from <cli>` to force a specific root.
-
-**Collision model.** When `<query>` matches multiple roots (or two
-remote handoffs on `fetch`): TTY → interactive prompt; non-TTY → exit 2
-with a TSV candidate list on stderr.
-
-## Sub-commands
-
-The binary's `--help` lists the full surface and authoritative flag
-semantics. Brief summary:
-
-| Sub                  | Purpose                                                                                                               |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk                      |
-| `resolve <cli> <id>` | Print the absolute JSONL path                                                                                         |
-| `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`, `--tag <name>`, `--tags`) |
-| `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json`                  |
-| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                                            |
-| `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                                       |
-| `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                                      |
-| `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                                              |
-
-Cross-cutting flags (consult `--help` for the canonical list):
-
-- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`,
-  `pull`, and filters `list`, `search`, and `remote-list` to one root.
-  Without it, the resolver probes all three roots. `--cli` is accepted
-  as a legacy alias on `search` and `remote-list`.
-  For `push` without a query, `--from` is required.
-- `--to <cli>` tunes the `<handoff>` block's next-step wording for a
-  target agent. Defaults to the auto-detected host. `--from` narrows
-  the source root; `--to` still resolves to the invoking host unless
-  explicitly overridden.
-- `--summary` (on `pull`) emits a prose summary + verbatim user prompts
-  instead of the full `<handoff>` block.
-- `-o <path>` (on `pull`) controls the output destination:
-  `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`
-  (falling back to `~/.claude/handoffs/` when off-repo) and prints the
-  file path on stdout; any other string is used as the literal output path.
-- `--since <ISO>` cuts off `list` when explicitly provided, and
-  cuts off `search` and `remote-list` (default 30 days).
-- `--limit <N>` caps the row count (default 20). `--all` (on `list`)
-  disables the cap.
-- `--fixed` / `-F` treats the `search` query as a literal string
-  instead of a regex.
-- `--tag <label>` annotates a `push`. Repeatable for multi-tag
-  (`--tag shipping --tag perf`). On `list --remote`, `--tag <name>`
-  filters by exact tag and `--tags` switches to a tag-frequency
-  histogram. On `fetch <tag>`, exact-tag matches are preferred over
-  description substring fallback.
-- `--from-file <path>` lets `fetch` load a local markdown file written
-  by `pull -o`. Works without network access.
-- `--json` is honoured by `list`, `pull`, `remote-list`, `search`.
-
-## Cross-agent behavior
-
-(a) **`pull` stdout is the transport into the model's context.** All three
-host runtimes (Claude Code, Copilot CLI, Codex via its bash tool) capture
-stdout the same way. `pull` to stdout; the runtime delivers it.
-
-(b) **`--to` on `pull` defaults to the detected host, not `--from`.** When
-`--from` is set without `--to`, `--to` still resolves to the invoking host.
-`--from` narrows the source root; `--to` tunes the next-step wording for
-where the output will be read.
-
-(c) **Self-referential pull is allowed and renders normally.** When
-host-scoped `latest` resolves to the session the command was run from,
-the digest renders the current session into its own context. Occasionally
-useful for capturing the current session via `-o auto`.
-
-(d) **`pull <unmatched>` does not auto-forward to `fetch`.** If the local
-resolver returns no match and `$DOTCLAUDE_HANDOFF_REPO` is set, a single
-stderr hint suggests `fetch <id>`. If the variable is unset, only the
-standard no-match error appears. No silent source override.
-
-## Prerequisites
-
-Local sub-commands need only `jq` and the session files on disk.
-
-The remote transport (`push`/`fetch`/`remote-list`/`doctor`) is a
-user-owned private git repo (any provider — GitHub, GitLab, Gitea,
-self-hosted). Required:
-
-- `git` on PATH.
-- Either `$DOTCLAUDE_HANDOFF_REPO` set to a repo URL, **or** the binary
-  will auto-bootstrap on first `push` when stdin is a TTY and `gh` is
-  authenticated — it offers to `gh repo create` a private store and
-  persists the URL to `$XDG_CONFIG_HOME/dotclaude/handoff.env` (default:
-  `~/.config/dotclaude/handoff.env`) for future runs.
-- Working SSH or credential-helper auth for the resulting repo.
-
-That's it. No `init` step, no schema pin, no ceremony. Run
-`dotclaude handoff doctor` for a sanity check; see
-`references/prerequisites.md` for the full install matrix.
-
-## Repo layout
-
-Each handoff is a branch:
-
-```
-handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
-```
-
-e.g. `handoff/dotclaude/claude/2026-04/aaaa1111`. The store needs no
-setup beyond "be a reachable git repo"; `main` is never touched by
-`push` / `fetch` / `remote-list`. GitHub UI + `git ls-remote` render
-the branches directly.
-
-## Auto-trigger contract
-
-When the user message matches any of these patterns, run `pull` (local
-cross-agent digest) by default:
-
-- Resume-command fragments: `claude --resume <uuid>`,
-  `claude --resume "<name>"`, `copilot --resume=<uuid>`,
-  `codex resume <uuid>`, `codex resume <name>`.
-- Natural language: "what was that session about", "continue in X",
-  "switch to X", "handoff".
-
-Extract the `<id>` from the user message (UUID, short UUID, or named
-alias). The skill probes all three roots — no `--from` argument needed.
-If the query is missing or ambiguous, ask one clarifying question before
+Extract `<id>` from the user message (UUID, short UUID, or named alias).
+The resolver probes Claude / Copilot / Codex roots automatically. If the
+query is missing or ambiguous, ask one clarifying question before
 proceeding.
+
+## The `--from` filling rule
+
+When invoking `dotclaude handoff push` without a query positional,
+include `--from <your-cli>` where `<your-cli>` is the agent the host LLM
+is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
+`codex` for Codex). The flag is required in that mode; the binary exits
+64 without it.
+
+## Cross-cutting flags
+
+Brief reference. `dotclaude handoff --help` is authoritative.
+
+- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`, `pull`; filters `list` and `search`.
+- `--summary` (on `pull`) emits a prose summary instead of the full `<handoff>` block.
+- `-o <path>` (on `pull`) controls output: `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`; any other string is a literal path.
+- `--since <ISO>` cuts off `list` and `search` (default 30 days for `search`).
+- `--limit <N>` caps the row count.
+- `--tag <label>` annotates a `push` (repeatable). On `fetch <tag>`, exact-tag matches are preferred over description substring fallback.
+- `--fixed` / `-F` treats the `search` query as a literal string instead of a regex.
+- `--json` is honoured by `list`, `pull`, `search`.
 
 ## Out of scope
 
-- **Invoking the target CLI directly.** The skill prints; the user
-  pastes. This is deliberate — keeps the transfer auditable and
-  prevents unintended cross-session execution.
-- **End-to-end encryption.** The git transport is access-controlled
-  by the host (private repo + push-side auth), but content is stored
-  in plaintext on the remote. Every `push` runs the scrubber before
-  uploading and reports `[scrubbed N secrets]` as the final stdout
-  line; the push fails closed (exit 2, no commit written) if the
-  scrubber cannot run. Scrubbing is a best-effort pattern pass (see
-  `references/redaction.md`) — do not rely on it to catch bespoke
-  or obfuscated secrets.
+- **Invoking the target CLI directly.** The skill prints; the user pastes. Keeps the transfer auditable.
+- **End-to-end encryption.** The git transport is access-controlled by the host (private repo + auth); content is plaintext on the remote. `push` runs the scrubber and fails closed (exit 2) if it can't run. Best-effort pattern pass — see `references/redaction.md`.
 - **Fuzzy or semantic search.** `search` is substring/regex only.
-- **Persistent indexing.** Grep-at-query-time is fast enough for
-  local session volumes; revisit only if p95 exceeds ~2s.
 
-## Deprecated aliases
+## Internal references
 
-The following forms are deprecated as of 0.12.0 and removed in 0.14.0.
-They still function but emit a stderr warning on every invocation.
-
-| Old form                      | New form                     |
-| ----------------------------- | ---------------------------- |
-| `describe <cli> <id>`         | `pull <id> --summary`        |
-| `describe <cli> <id> --json`  | `pull <id> --summary --json` |
-| `digest <cli> <id>`           | `pull <id>`                  |
-| `file <cli> <id>`             | `pull <id> -o auto`          |
-| `pull <query>` (remote fetch) | `fetch <query>`              |
-
-Set `DOTCLAUDE_QUIET=1` to suppress deprecation stderr in CI pipelines
-that cannot update callers immediately. Real errors (exit 2 / exit 64)
-are never suppressed.
+- `dotclaude handoff --help` — authoritative flag and sub-command list.
+- `references/prerequisites.md` — install matrix and remote-transport setup.
+- `references/from-codex.md` — Codex-specific notes.
+- `references/redaction.md` — scrubber behavior.

--- a/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
+++ b/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
@@ -1,11 +1,11 @@
 # Handoff drift — known disagreements (Phase 1 baseline)
 
 > Fixture for `handoff-drift.test.mjs`. Documents symbols that exist in
-> one source but not the other, on `c117418` (origin/main HEAD when this
-> baseline was pinned). The Phase 1 drift test asserts agreement on the
-> _intersection_ of symbols across `--help` and `skills/handoff/SKILL.md`;
-> everything below is intentionally outside the asserted intersection
-> until the named Phase 2 PR (per `docs/specs/handoff-skill/spec/6-implementation-plan.md` §6.3) resolves it.
+> one source but not the other. The Phase 1 drift test asserts agreement
+> on the _intersection_ of symbols across `--help` and
+> `skills/handoff/SKILL.md`; everything below is intentionally outside the
+> asserted intersection until the named Phase 2 PR (per
+> `docs/specs/handoff-skill/spec/6-implementation-plan.md` §6.3) resolves it.
 >
 > When a Phase 2 PR moves a symbol from "disagreement" to "agreement," it
 > deletes the corresponding entry below and lets the test's intersection
@@ -17,46 +17,13 @@
 > sub-commands `digest`/`file`/`describe`, says "five forms", uses `--cli`
 > legacy alias). It joins as the third source in PR 8.
 
-## Excluded sub-commands
-
-| Symbol        | Present in                                         | Missing from | Resolves in                                                                            |
-| ------------- | -------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------- |
-| `prune`       | `--help`                                           | `SKILL.md`   | Phase 2 PR 6 (SKILL.md shrink) — sub-commands table gains `prune`                      |
-| `remote-list` | `SKILL.md` (Sub-commands table only)               | `--help`     | Phase 2 PR 6 (SKILL.md shrink) — `remote-list` row removed in favor of `list --remote` |
-| `resolve`     | `SKILL.md` (argument-hint frontmatter + sub-table) | `--help`     | Phase 2 PR 6 (SKILL.md shrink) — `resolve` removed from frontmatter and sub-table      |
-
 ## Excluded flags
 
 The Phase 1 test extracts a flat global flag set from each source and
 asserts agreement on the intersection. Flags that appear in only one
 source are excluded until reconciled.
 
-| Flag                                                            | Present in                                                                                                                                                       | Missing from                                                                       | Resolves in                                                                   |
-| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `--from-file`                                                   | `SKILL.md`                                                                                                                                                       | `--help`                                                                           | Phase 2 PR 7 (references prune)                                               |
-| `--all`                                                         | `--help`                                                                                                                                                         | `SKILL.md` (mentioned mid-bullet under `--limit`, not a canonical entry)           | Phase 2 PR 6 (SKILL.md shrink) — promote to its own bullet                    |
-| `--out-dir`                                                     | `--help`                                                                                                                                                         | `SKILL.md`                                                                         | Phase 2 PR 4 (`--to` removal sweep)                                           |
-| `--remote`, `--local`                                           | `--help`                                                                                                                                                         | `SKILL.md` cross-cutting block (mentioned in prose for `list`)                     | Phase 2 PR 6 (SKILL.md shrink)                                                |
-| `--verify`                                                      | `--help`                                                                                                                                                         | `SKILL.md`                                                                         | Phase 2 PR 6 (SKILL.md shrink)                                                |
-| `--force-collision`                                             | `--help`                                                                                                                                                         | `SKILL.md`                                                                         | Phase 2 PR 6 (SKILL.md shrink)                                                |
-| `--dry-run`                                                     | `--help`                                                                                                                                                         | `SKILL.md`                                                                         | Phase 2 PR 6 (SKILL.md shrink)                                                |
-| `--older-than`, `--yes`                                         | `--help`                                                                                                                                                         | `SKILL.md`                                                                         | Phase 2 PR 6 (SKILL.md shrink)                                                |
-| `--cli`                                                         | `--help` (`search` only — `remote-list` removed from binary in PR 5), SKILL.md (mentions "legacy alias on `search` and `remote-list`" — stale until PR 6 shrink) | (cross-cutting bullet)                                                             | Phase 2 PR 7 — migration to `--from`                                          |
-| `--tags`                                                        | `--help`                                                                                                                                                         | `SKILL.md` cross-cutting block (mentioned in `--tag` prose for histogram)          | Phase 2 PR 6 (SKILL.md shrink)                                                |
-| `--to`                                                          | `SKILL.md` (synopsis line 45 + cross-cutting bullet 98-101 + cross-agent rule §b 129-132)                                                                        | `--help` (binary dropped in PR 4 — `pull` next-step now always uses detected host) | Phase 2 PR 6 (SKILL.md shrink) — drop the cross-cutting bullet + §b paragraph |
-| `--no-color`, `--verbose`/`-v`, `--help`/`-h`, `--version`/`-V` | `--help`                                                                                                                                                         | `SKILL.md`                                                                         | Out of scope — universal CLI flags, no spec coverage                          |
-
-## Internal — SKILL.md self-disagreement
-
-Not an excluded symbol per se, but a third datapoint for §1's "patch-loop
-tax" thesis: `SKILL.md` is internally inconsistent on `c117418`.
-
-- `argument-hint` frontmatter (line 27): `pull|push|fetch|list|search|resolve|doctor` — omits `remote-list`.
-- `Sub-commands` markdown table (lines 81-90): includes `remote-list`, omits `prune`.
-
-The Phase 1 extractor pins on the `argument-hint` frontmatter line as the
-authoritative SKILL.md command source — it is structured YAML, machine-
-parseable, and matches the SKILL.md schema's contract. The Sub-commands
-table is prose documentation that drifted from the frontmatter under the
-patch-loop. Phase 2 PR 6 (SKILL.md shrink per §3 component table) is
-where the two SKILL.md sub-symbol sources reconverge.
+| Flag                                                            | Present in | Missing from | Resolves in                                                               |
+| --------------------------------------------------------------- | ---------- | ------------ | ------------------------------------------------------------------------- |
+| `--cli`                                                         | `--help`   | `SKILL.md`   | Phase 2 PR 7 — `--cli` removed from binary in favor of canonical `--from` |
+| `--no-color`, `--verbose`/`-v`, `--help`/`-h`, `--version`/`-V` | `--help`   | `SKILL.md`   | Out of scope — universal CLI flags, no spec coverage                      |

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -82,8 +82,8 @@ const HANDOFF_BIN = resolve(repoRoot, "plugins/dotclaude/bin/dotclaude-handoff.m
 // Phase 1 expected baselines
 // ---------------------------------------------------------------------------
 
-/** Cross-source intersection of sub-commands on c117418. */
-const PHASE_1_BASELINE_COMMANDS = ["doctor", "fetch", "list", "pull", "push", "search"];
+/** Cross-source intersection of sub-commands. `prune` joined in Phase 2 PR 6. */
+const PHASE_1_BASELINE_COMMANDS = ["doctor", "fetch", "list", "prune", "pull", "push", "search"];
 
 /**
  * Cross-source intersection of global flags on c117418.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -45,7 +45,7 @@ the right invocation.
 | `continue in <cli>` / `switch to <cli>` / `pull from <cli>`            | `dotclaude handoff pull <id> --from <cli>`           |
 | `what was that session about` + identifier                             | `dotclaude handoff pull <id> --summary`              |
 | `push handoff` / `send to other machine` / `save this`                 | `dotclaude handoff push --from <host-cli> [--tag …]` |
-| `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch <query-or-prompt>`          |
+| `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch [<query>]`                  |
 
 Extract `<id>` from the user message (UUID, short UUID, or named alias).
 The resolver probes Claude / Copilot / Codex roots automatically. If the
@@ -64,7 +64,7 @@ is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
 
 Brief reference. `dotclaude handoff --help` is authoritative.
 
-- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`, `pull`; filters `list` and `search`.
+- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`, `pull`; filters `list`, `search`, and `prune`.
 - `--summary` (on `pull`) emits a prose summary instead of the full `<handoff>` block.
 - `-o <path>` (on `pull`) controls output: `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`; any other string is a literal path.
 - `--since <ISO>` cuts off `list` and `search` (default 30 days for `search`).

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -2,14 +2,14 @@
 id: handoff
 name: handoff
 type: skill
-version: 1.1.0
+version: 1.2.0
 domain: [devex]
 platform: [none]
 task: [documentation, debugging]
 maturity: draft
 owner: "@kaiohenricunha"
 created: 2026-04-17
-updated: 2026-04-23
+updated: 2026-04-28
 description: >
   Transfer conversation context between agentic CLIs (Claude Code, GitHub
   Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a
@@ -24,7 +24,7 @@ description: >
   "find the session where", "search sessions", "which session did I",
   "push handoff", "fetch handoff", "handoff to other machine",
   "resume on my other laptop".
-argument-hint: "[pull|push|fetch|list|search|resolve|doctor] [args...]"
+argument-hint: "[pull|push|fetch|list|search|prune|doctor] [args...]"
 tools: Glob, Read, Grep, Bash, Write
 effort: medium
 model: sonnet
@@ -32,195 +32,56 @@ model: sonnet
 
 # Handoff — Cross-CLI Session Context Transfer
 
-This skill is a thin wrapper around the `dotclaude handoff` binary.
-The binary is the executable contract; the skill exists to map natural
-language ("continue this in codex") into the right invocation and to
-document the public surface in one place. Every form below also works
-verbatim as `!dotclaude handoff …` from any shell — including Codex's
-bash tool.
+Thin wrapper around the `dotclaude handoff` binary. The binary is the
+authoritative contract; run `dotclaude handoff --help` for the full
+sub-command list and flag reference. This file maps natural language to
+the right invocation.
 
-## The four forms
+## Auto-trigger phrase mapping
 
-```
-/handoff pull [<id>] [--from <cli>] [--to <cli>] [--summary] [-o <path>]
-/handoff push [<query>] [--from <cli>] [--tag <label> ...]
-/handoff fetch [<query>] [--from <cli>] [--verify]
-/handoff list [--local|--remote] [--from <cli>] [--since <ISO>] [--limit N|--all] [--tag <name>] [--tags]
-```
+| Trigger phrase                                                         | Invocation                                           |
+| ---------------------------------------------------------------------- | ---------------------------------------------------- |
+| `handoff <id>` / resume-command fragments                              | `dotclaude handoff pull <id>`                        |
+| `continue in <cli>` / `switch to <cli>` / `pull from <cli>`            | `dotclaude handoff pull <id> --from <cli>`           |
+| `what was that session about` + identifier                             | `dotclaude handoff pull <id> --summary`              |
+| `push handoff` / `send to other machine` / `save this`                 | `dotclaude handoff push --from <host-cli> [--tag …]` |
+| `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch <query-or-prompt>`          |
 
-A bare `/handoff` with no arguments prints usage and exits 0. Every
-remote verb (`push`, `fetch`) is explicit.
-
-If `--from` is set, resolution narrows to that CLI; otherwise the host is
-auto-detected; otherwise all three roots are scanned.
-
-`<id>` / `<query>` auto-detects across `~/.claude/projects`,
-`~/.copilot/session-state`, and `~/.codex/sessions`. Accepted forms:
-full UUID, short UUID (first 8 hex), `latest`, Claude `customTitle`
-alias, Codex `thread_name` alias.
-
-**`latest` is host-scoped.** When the binary identifies the invoking
-CLI (via `--from` or host-specific env-var probes such as `CLAUDECODE=1`,
-`CLAUDE_CODE_SSE_PORT`, `CODEX_*`, `COPILOT_*`, and `GITHUB_COPILOT_*`),
-`latest` resolves within that CLI's root only — so inside Claude Code
-it picks the newest `~/.claude/projects` session even when a newer
-Codex JSONL exists on disk. Explicit UUIDs and aliases are never
-narrowed. Without a host signal `latest` falls back to the union
-resolver (globally newest across all roots) and stderr names the
-picked session. Pass `--from <cli>` to force a specific root.
-
-**Collision model.** When `<query>` matches multiple roots (or two
-remote handoffs on `fetch`): TTY → interactive prompt; non-TTY → exit 2
-with a TSV candidate list on stderr.
-
-## Sub-commands
-
-The binary's `--help` lists the full surface and authoritative flag
-semantics. Brief summary:
-
-| Sub                  | Purpose                                                                                                               |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `pull [<id>]`        | Render local session to stdout (`<handoff>` block); `--summary` for prose; `-o` to write to disk                      |
-| `resolve <cli> <id>` | Print the absolute JSONL path                                                                                         |
-| `list`               | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`, `--tag <name>`, `--tags`) |
-| `search <query>`     | Substring/regex match across local sessions; `--from` / `--since` / `--limit` / `--fixed` / `--json`                  |
-| `push [<query>]`     | Push to `$DOTCLAUDE_HANDOFF_REPO`; `--tag`                                                                            |
-| `fetch [<handle>]`   | Fetch from `$DOTCLAUDE_HANDOFF_REPO`; `--from-file` for offline                                                       |
-| `remote-list`        | List handoffs on the transport; `--from` / `--since` / `--limit`                                                      |
-| `doctor`             | Verify `git` + `$DOTCLAUDE_HANDOFF_REPO` + `gh` fallback                                                              |
-
-Cross-cutting flags (consult `--help` for the canonical list):
-
-- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`,
-  `pull`, and filters `list`, `search`, and `remote-list` to one root.
-  Without it, the resolver probes all three roots. `--cli` is accepted
-  as a legacy alias on `search` and `remote-list`.
-  For `push` without a query, `--from` is required.
-- `--to <cli>` tunes the `<handoff>` block's next-step wording for a
-  target agent. Defaults to the auto-detected host. `--from` narrows
-  the source root; `--to` still resolves to the invoking host unless
-  explicitly overridden.
-- `--summary` (on `pull`) emits a prose summary + verbatim user prompts
-  instead of the full `<handoff>` block.
-- `-o <path>` (on `pull`) controls the output destination:
-  `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`
-  (falling back to `~/.claude/handoffs/` when off-repo) and prints the
-  file path on stdout; any other string is used as the literal output path.
-- `--since <ISO>` cuts off `list` when explicitly provided, and
-  cuts off `search` and `remote-list` (default 30 days).
-- `--limit <N>` caps the row count (default 20). `--all` (on `list`)
-  disables the cap.
-- `--fixed` / `-F` treats the `search` query as a literal string
-  instead of a regex.
-- `--tag <label>` annotates a `push`. Repeatable for multi-tag
-  (`--tag shipping --tag perf`). On `list --remote`, `--tag <name>`
-  filters by exact tag and `--tags` switches to a tag-frequency
-  histogram. On `fetch <tag>`, exact-tag matches are preferred over
-  description substring fallback.
-- `--from-file <path>` lets `fetch` load a local markdown file written
-  by `pull -o`. Works without network access.
-- `--json` is honoured by `list`, `pull`, `remote-list`, `search`.
-
-## Cross-agent behavior
-
-(a) **`pull` stdout is the transport into the model's context.** All three
-host runtimes (Claude Code, Copilot CLI, Codex via its bash tool) capture
-stdout the same way. `pull` to stdout; the runtime delivers it.
-
-(b) **`--to` on `pull` defaults to the detected host, not `--from`.** When
-`--from` is set without `--to`, `--to` still resolves to the invoking host.
-`--from` narrows the source root; `--to` tunes the next-step wording for
-where the output will be read.
-
-(c) **Self-referential pull is allowed and renders normally.** When
-host-scoped `latest` resolves to the session the command was run from,
-the digest renders the current session into its own context. Occasionally
-useful for capturing the current session via `-o auto`.
-
-(d) **`pull <unmatched>` does not auto-forward to `fetch`.** If the local
-resolver returns no match and `$DOTCLAUDE_HANDOFF_REPO` is set, a single
-stderr hint suggests `fetch <id>`. If the variable is unset, only the
-standard no-match error appears. No silent source override.
-
-## Prerequisites
-
-Local sub-commands need only `jq` and the session files on disk.
-
-The remote transport (`push`/`fetch`/`remote-list`/`doctor`) is a
-user-owned private git repo (any provider — GitHub, GitLab, Gitea,
-self-hosted). Required:
-
-- `git` on PATH.
-- Either `$DOTCLAUDE_HANDOFF_REPO` set to a repo URL, **or** the binary
-  will auto-bootstrap on first `push` when stdin is a TTY and `gh` is
-  authenticated — it offers to `gh repo create` a private store and
-  persists the URL to `$XDG_CONFIG_HOME/dotclaude/handoff.env` (default:
-  `~/.config/dotclaude/handoff.env`) for future runs.
-- Working SSH or credential-helper auth for the resulting repo.
-
-That's it. No `init` step, no schema pin, no ceremony. Run
-`dotclaude handoff doctor` for a sanity check; see
-`references/prerequisites.md` for the full install matrix.
-
-## Repo layout
-
-Each handoff is a branch:
-
-```
-handoff/<project>/<cli>/<YYYY-MM>/<short-uuid>
-```
-
-e.g. `handoff/dotclaude/claude/2026-04/aaaa1111`. The store needs no
-setup beyond "be a reachable git repo"; `main` is never touched by
-`push` / `fetch` / `remote-list`. GitHub UI + `git ls-remote` render
-the branches directly.
-
-## Auto-trigger contract
-
-When the user message matches any of these patterns, run `pull` (local
-cross-agent digest) by default:
-
-- Resume-command fragments: `claude --resume <uuid>`,
-  `claude --resume "<name>"`, `copilot --resume=<uuid>`,
-  `codex resume <uuid>`, `codex resume <name>`.
-- Natural language: "what was that session about", "continue in X",
-  "switch to X", "handoff".
-
-Extract the `<id>` from the user message (UUID, short UUID, or named
-alias). The skill probes all three roots — no `--from` argument needed.
-If the query is missing or ambiguous, ask one clarifying question before
+Extract `<id>` from the user message (UUID, short UUID, or named alias).
+The resolver probes Claude / Copilot / Codex roots automatically. If the
+query is missing or ambiguous, ask one clarifying question before
 proceeding.
+
+## The `--from` filling rule
+
+When invoking `dotclaude handoff push` without a query positional,
+include `--from <your-cli>` where `<your-cli>` is the agent the host LLM
+is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
+`codex` for Codex). The flag is required in that mode; the binary exits
+64 without it.
+
+## Cross-cutting flags
+
+Brief reference. `dotclaude handoff --help` is authoritative.
+
+- `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`, `pull`; filters `list` and `search`.
+- `--summary` (on `pull`) emits a prose summary instead of the full `<handoff>` block.
+- `-o <path>` (on `pull`) controls output: `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`; any other string is a literal path.
+- `--since <ISO>` cuts off `list` and `search` (default 30 days for `search`).
+- `--limit <N>` caps the row count.
+- `--tag <label>` annotates a `push` (repeatable). On `fetch <tag>`, exact-tag matches are preferred over description substring fallback.
+- `--fixed` / `-F` treats the `search` query as a literal string instead of a regex.
+- `--json` is honoured by `list`, `pull`, `search`.
 
 ## Out of scope
 
-- **Invoking the target CLI directly.** The skill prints; the user
-  pastes. This is deliberate — keeps the transfer auditable and
-  prevents unintended cross-session execution.
-- **End-to-end encryption.** The git transport is access-controlled
-  by the host (private repo + push-side auth), but content is stored
-  in plaintext on the remote. Every `push` runs the scrubber before
-  uploading and reports `[scrubbed N secrets]` as the final stdout
-  line; the push fails closed (exit 2, no commit written) if the
-  scrubber cannot run. Scrubbing is a best-effort pattern pass (see
-  `references/redaction.md`) — do not rely on it to catch bespoke
-  or obfuscated secrets.
+- **Invoking the target CLI directly.** The skill prints; the user pastes. Keeps the transfer auditable.
+- **End-to-end encryption.** The git transport is access-controlled by the host (private repo + auth); content is plaintext on the remote. `push` runs the scrubber and fails closed (exit 2) if it can't run. Best-effort pattern pass — see `references/redaction.md`.
 - **Fuzzy or semantic search.** `search` is substring/regex only.
-- **Persistent indexing.** Grep-at-query-time is fast enough for
-  local session volumes; revisit only if p95 exceeds ~2s.
 
-## Deprecated aliases
+## Internal references
 
-The following forms are deprecated as of 0.12.0 and removed in 0.14.0.
-They still function but emit a stderr warning on every invocation.
-
-| Old form                      | New form                     |
-| ----------------------------- | ---------------------------- |
-| `describe <cli> <id>`         | `pull <id> --summary`        |
-| `describe <cli> <id> --json`  | `pull <id> --summary --json` |
-| `digest <cli> <id>`           | `pull <id>`                  |
-| `file <cli> <id>`             | `pull <id> -o auto`          |
-| `pull <query>` (remote fetch) | `fetch <query>`              |
-
-Set `DOTCLAUDE_QUIET=1` to suppress deprecation stderr in CI pipelines
-that cannot update callers immediately. Real errors (exit 2 / exit 64)
-are never suppressed.
+- `dotclaude handoff --help` — authoritative flag and sub-command list.
+- `references/prerequisites.md` — install matrix and remote-transport setup.
+- `references/from-codex.md` — Codex-specific notes.
+- `references/redaction.md` — scrubber behavior.


### PR DESCRIPTION
## Summary

- **Phase 2 PR 6** of the handoff-skill rollout per spec §6.3 row 133. Shrinks `skills/handoff/SKILL.md` from 226 lines to 87 lines per §3 component table line 125 ("points at binary `--help`"), installs the §5.5 phrase mapping, and collapses 11 drift-fixture rows + the entire Internal SKILL.md self-disagreement section.
- **§5.5 deviation:** the spec maps `what was that session about` → `describe <id>`, but `describe` was removed in PR 5. SKILL.md installs the equivalent post-PR-5 form `pull <id> --summary` per §6.5 migration table line 180. Same intent, working verb. The PR body is the reviewer's signal that this is intentional, not drift.
- **Argument-hint frontmatter** drops `resolve` (binary-removed in PR 5) and adds `prune` (canonical since #106). Drift baseline `PHASE_1_BASELINE_COMMANDS` grows from 6 → 7 verbs in lockstep. `PHASE_1_BASELINE_FLAGS_INTERSECTION` is unchanged (slim SKILL.md keeps the 8-flag intersection: `--from`, `--summary`, `-o`, `--since`, `--limit`, `--tag`, `--fixed`, `--json`).
- **Cross-cutting flags section preserved.** The drift extractor pins on the literal phrase `Cross-cutting flags` and **throws** if absent (`handoff-drift.test.mjs:155`). The slim SKILL.md keeps the section with the 8 baseline-intersection bullets so the regex anchor still resolves; everything else in the original 226-line SKILL.md (cross-agent §a-§d, prerequisites, repo layout, deprecated aliases, Sub-commands table, "The four forms" code block) is removed as duplicate of `--help` or `references/*`.
- **§5.5.2 frozen text wording**: the regex `\bwithout\s+(?:a\s+)?<?query>?\b` doesn't match `without a \`<query>\`` (backticks break the boundary), and `\brequired?\b` doesn't match `requires` (no word boundary between "e" and "s"). The installed paragraph uses "without a query positional" and "is required" to match. Semantic content unchanged.
- **References files** (`from-codex.md`, `prerequisites.md`, `codex.md`, `digest-schema.md`) still contain stale `describe`/`digest`/`file`/`resolve`/`remote-list`/`--cli` examples — explicit per spec §6.3 row 134. PR 7's job.
- **Manifest checksum** regenerated via `dotclaude-validate-skills.mjs --update`. Plugin templates regenerated via `scripts/build-plugin.mjs`.

## Test plan

- [x] `npm test -- handoff-drift` — 4/4 green (commands intersection grew, flags intersection unchanged, from_rule still asserted in both sources).
- [x] `npm test` (full vitest) — 549/549 green.
- [x] `npx bats plugins/dotclaude/tests/bats/` — 320/320 green (no test count change — PR 6 only edits docs + baseline + fixture).
- [x] `node plugins/dotclaude/bin/dotclaude-validate-skills.mjs` — manifest valid (29 skills).
- [x] `node plugins/dotclaude/bin/dotclaude-validate-specs.mjs` — 4 spec(s) valid.
- [x] `node plugins/dotclaude/bin/dotclaude-check-instruction-drift.mjs` — instruction files match repo facts.
- [x] `node scripts/build-plugin.mjs --check` — plugin templates fresh (115 files + manifest).
- [x] `npx prettier --check skills/handoff/SKILL.md plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md` — clean.
- [x] `wc -l skills/handoff/SKILL.md` — 87 lines (down from 226).
- [x] CI passes on this PR's head.

## Spec ID

handoff-skill