### PR TITLE
feat(handoff): prune references stale verbs + remove --cli flag (Phase 2 PR 7)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-28T21:39:12.853Z",
+  "generatedAt": "2026-04-28T21:54:02.280Z",
   "skills": [
     {
       "name": "audit-and-fix",

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -715,10 +715,9 @@ async function main() {
   if (first === "search") {
     const query = second;
     if (!query) fail(EXIT_CODES.USAGE, "search requires a <query> argument");
-    const filterCli = fromCli;
     const hits = searchSessions({
       query,
-      cli: filterCli,
+      cli: fromCli,
       since: argv.flags.since ? String(argv.flags.since) : null,
       limit: limit.toString(),
       fixed: Boolean(argv.flags.fixed),

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -99,7 +99,7 @@ const CLIS = new Set(["claude", "copilot", "codex"]);
 const META = {
   name: "dotclaude-handoff",
   synopsis:
-    "dotclaude handoff [pull|fetch|list|search|push|prune|doctor] [args...] [--from <cli>] [--summary] [-o <path>] [--tag <label>...] [--tags] [--cli <cli>] [--since <ISO>] [--limit <N>] [--verify] [--dry-run] [--older-than <30d|6m|1y|YYYY-MM-DD>] [--yes]",
+    "dotclaude handoff [pull|fetch|list|search|push|prune|doctor] [args...] [--from <cli>] [--summary] [-o <path>] [--tag <label>...] [--tags] [--since <ISO>] [--limit <N>] [--verify] [--dry-run] [--older-than <30d|6m|1y|YYYY-MM-DD>] [--yes]",
   description:
     "Cross-agent and cross-machine session handoff. `pull <id>` renders a local session as <handoff> block (or --summary / -o <path>). push/fetch handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO). push/fetch auto-run a preflight check (cached 5 min); --verify forces re-run.\n\nFor push without a query, --from <cli> is required. Omitting --from exits 64 with a usage hint.",
   flags: {
@@ -112,7 +112,6 @@ const META = {
     from: { type: "string" },
     limit: { type: "string" },
     since: { type: "string" },
-    cli: { type: "string" },
     "out-dir": { type: "string" },
     output: { type: "string", short: "o" },
     local: { type: "boolean" },
@@ -682,17 +681,6 @@ async function resolveLatestWithHostScope({ fromCli, detectedHost }) {
   return { hit, note: `host not detected, using latest across all clis: ${shortId}` };
 }
 
-// Resolve the CLI filter for sub-commands that accept `--from` with a
-// `--cli` legacy alias (search). Fails USAGE on an unknown value.
-// Returns null when neither flag was passed.
-function resolveFilterCli() {
-  const v = fromCli ?? (argv.flags.cli ? String(argv.flags.cli) : null);
-  if (v !== null && !CLIS.has(v)) {
-    fail(EXIT_CODES.USAGE, `--from must be one of: ${[...CLIS].join(", ")}`);
-  }
-  return v;
-}
-
 async function main() {
   if (argv.positional.length === 0) {
     process.stdout.write(helpText(META) + "\n");
@@ -727,7 +715,7 @@ async function main() {
   if (first === "search") {
     const query = second;
     if (!query) fail(EXIT_CODES.USAGE, "search requires a <query> argument");
-    const filterCli = resolveFilterCli();
+    const filterCli = fromCli;
     const hits = searchSessions({
       query,
       cli: filterCli,

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/codex.md
@@ -157,7 +157,7 @@ session without it.
 ## Notes
 
 - Codex sessions routinely exceed 100k lines because tool-call output
-  is logged inline. For the `describe` sub-command, truncate the
+  is logged inline. For the `pull --summary` verb, truncate the
   assistant transcript to the last ~20 turns before summarizing.
 - `payload.content` is always an array. `content[0].text` is the
   common case but probe with `content | length` before trusting it.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/digest-schema.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/digest-schema.md
@@ -33,7 +33,7 @@ next_step_suggestion: |
   One sentence the target agent should pick up from.
 ```
 
-## Rendering: `<handoff>` block (for `digest` and `file` sub-commands)
+## Rendering: `<handoff>` block (`pull` verb)
 
 ```markdown
 <handoff origin="<cli>" session="<short-id>" cwd="<cwd>">
@@ -63,7 +63,7 @@ next_step_suggestion: |
 The `<handoff>` tag is intentional: target agents can detect it
 reliably and distinguish digest content from surrounding commentary.
 
-## Rendering: `describe` sub-command (terse inline summary)
+## Rendering: `pull --summary` output (terse inline summary)
 
 ```markdown
 **<cli>** `<short-id>` — `<cwd>` — <started-at>
@@ -77,9 +77,9 @@ reliably and distinguish digest content from surrounding commentary.
 ```
 
 No `<handoff>` wrapper. No key findings, artifacts, or next step —
-those belong in `digest`/`file`.
+those belong in `pull` (full block) or `pull -o auto` (file output).
 
-## Rendering: `file` sub-command (markdown doc)
+## Rendering: `pull -o <path>` output (markdown doc)
 
 ```markdown
 # Handoff: <origin.cli> → <target.cli>
@@ -108,19 +108,6 @@ _Origin session: `<full-uuid>` (cwd: `<cwd>`)_
 File path: `docs/handoffs/<YYYY-MM-DD>-<origin.cli>-<short-id>.md` when
 a `docs/` directory exists at the repo root, else
 `~/.claude/handoffs/<YYYY-MM-DD>-<origin.cli>-<short-id>.md`.
-
-## Target-CLI tuning (the `--to` flag)
-
-The only field that changes with `--to` is `next_step_suggestion`:
-
-- `--to claude` — phrase the next step as an imperative Claude can
-  follow directly ("Continue the refactor by editing …").
-- `--to codex` — include explicit filepaths and a concrete sub-task,
-  since Codex prefers task-shaped inputs.
-- `--to copilot` — phrase as a question or "help me with …" since
-  Copilot pairs with the user.
-
-All other fields are identical regardless of target.
 
 ## Size bounds
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/from-codex.md
@@ -85,20 +85,7 @@ binary:
 - Non-TTY (scripts/CI): exits 2 with a TSV candidate list on stderr so
   the caller can parse and retry with a more specific query.
 
-## Power-user sub-commands
-
-The five-form shape above is the primary surface. For scripting you
-can still use:
-
-```
-dotclaude handoff resolve  <cli> <id>        # file path only
-dotclaude handoff describe <cli> <id>        # inline markdown summary
-dotclaude handoff digest   <cli> <id>        # full <handoff> block
-dotclaude handoff file     <cli> <id>        # write to docs/handoffs/
-```
-
-All subcommands support `--help`, `--version`, `--json`, `--verbose`,
-`--no-color`. Exit codes: 0 ok, 2 not found / parse error, 64 usage.
+See `dotclaude handoff --help` for the full sub-command and flag reference.
 
 ## Why the binary and not the skill file?
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/prerequisites.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/prerequisites.md
@@ -1,6 +1,6 @@
 # Handoff prerequisites — git transport checklist and remediation
 
-The remote sub-commands (`push`, `pull`, `remote-list`) require a
+The remote sub-commands (`push`, `pull`, `fetch`) require a
 working git transport. `/handoff doctor` runs the checklist below and
 prints a remediation block on failure. The reusable implementation
 lives at `plugins/dotclaude/scripts/handoff-doctor.sh`.
@@ -85,8 +85,7 @@ warn: system clock reports year <YYYY>; git auth may fail with signature errors 
 
 ## Air-gapped / offline path
 
-`/handoff file <cli> <uuid>` writes a local markdown artifact with a
-`<handoff>` block at the top. Move it via any out-of-band channel
-(USB stick, secure copy, encrypted email) and run
-`/handoff pull --from-file <path>` on the destination machine. No
-network required.
+Run `dotclaude handoff pull <uuid> -o <path>` on the source machine to write
+a local markdown file. Move it via any out-of-band channel (USB stick, secure
+copy, encrypted email), then paste the file's markdown content into the target
+session. No network or binary required on the destination.

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/prerequisites.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/prerequisites.md
@@ -1,8 +1,9 @@
 # Handoff prerequisites — git transport checklist and remediation
 
-The remote sub-commands (`push`, `pull`, `fetch`) require a
-working git transport. `/handoff doctor` runs the checklist below and
-prints a remediation block on failure. The reusable implementation
+Remote transport operations (`push`, `fetch`, `list --remote`, `prune`)
+require a working git transport. `/handoff doctor` runs the checklist
+below and prints a remediation block on failure. (`pull` is a local
+render verb and does not need git transport.) The reusable implementation
 lives at `plugins/dotclaude/scripts/handoff-doctor.sh`.
 
 ## Output contract

--- a/plugins/dotclaude/templates/claude/skills/handoff/references/redaction.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/references/redaction.md
@@ -69,4 +69,4 @@ Scrubbing is best-effort. It does not catch:
 - Anything the user consciously wrote in prose ("my password is …").
 
 Before pushing sensitive sessions, review the digest locally with
-`/handoff digest <cli> <uuid>` first.
+`dotclaude handoff pull <uuid>` first.

--- a/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
+++ b/plugins/dotclaude/tests/bats/handoff-binary-subs.bats
@@ -72,13 +72,6 @@ teardown() {
   [[ "$output" == *"migration"* ]]
 }
 
-@test "search --cli codex narrows to the codex root only" {
-  run node "$BIN" search migration --cli codex
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"bbbb2222"* ]]
-  [[ "$output" != *"aaaa1111"* ]]
-}
-
 @test "search with no match exits 0 with 'No sessions matching'" {
   run node "$BIN" search absolutelynothingmatches
   [ "$status" -eq 0 ]

--- a/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
+++ b/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
@@ -23,7 +23,6 @@ The Phase 1 test extracts a flat global flag set from each source and
 asserts agreement on the intersection. Flags that appear in only one
 source are excluded until reconciled.
 
-| Flag                                                            | Present in | Missing from | Resolves in                                                               |
-| --------------------------------------------------------------- | ---------- | ------------ | ------------------------------------------------------------------------- |
-| `--cli`                                                         | `--help`   | `SKILL.md`   | Phase 2 PR 7 — `--cli` removed from binary in favor of canonical `--from` |
-| `--no-color`, `--verbose`/`-v`, `--help`/`-h`, `--version`/`-V` | `--help`   | `SKILL.md`   | Out of scope — universal CLI flags, no spec coverage                      |
+| Flag                                                            | Present in | Missing from | Resolves in                                          |
+| --------------------------------------------------------------- | ---------- | ------------ | ---------------------------------------------------- |
+| `--no-color`, `--verbose`/`-v`, `--help`/`-h`, `--version`/`-V` | `--help`   | `SKILL.md`   | Out of scope — universal CLI flags, no spec coverage |

--- a/skills/handoff/references/codex.md
+++ b/skills/handoff/references/codex.md
@@ -157,7 +157,7 @@ session without it.
 ## Notes
 
 - Codex sessions routinely exceed 100k lines because tool-call output
-  is logged inline. For the `describe` sub-command, truncate the
+  is logged inline. For the `pull --summary` verb, truncate the
   assistant transcript to the last ~20 turns before summarizing.
 - `payload.content` is always an array. `content[0].text` is the
   common case but probe with `content | length` before trusting it.

--- a/skills/handoff/references/digest-schema.md
+++ b/skills/handoff/references/digest-schema.md
@@ -33,7 +33,7 @@ next_step_suggestion: |
   One sentence the target agent should pick up from.
 ```
 
-## Rendering: `<handoff>` block (for `digest` and `file` sub-commands)
+## Rendering: `<handoff>` block (`pull` verb)
 
 ```markdown
 <handoff origin="<cli>" session="<short-id>" cwd="<cwd>">
@@ -63,7 +63,7 @@ next_step_suggestion: |
 The `<handoff>` tag is intentional: target agents can detect it
 reliably and distinguish digest content from surrounding commentary.
 
-## Rendering: `describe` sub-command (terse inline summary)
+## Rendering: `pull --summary` output (terse inline summary)
 
 ```markdown
 **<cli>** `<short-id>` — `<cwd>` — <started-at>
@@ -77,9 +77,9 @@ reliably and distinguish digest content from surrounding commentary.
 ```
 
 No `<handoff>` wrapper. No key findings, artifacts, or next step —
-those belong in `digest`/`file`.
+those belong in `pull` (full block) or `pull -o auto` (file output).
 
-## Rendering: `file` sub-command (markdown doc)
+## Rendering: `pull -o <path>` output (markdown doc)
 
 ```markdown
 # Handoff: <origin.cli> → <target.cli>
@@ -108,19 +108,6 @@ _Origin session: `<full-uuid>` (cwd: `<cwd>`)_
 File path: `docs/handoffs/<YYYY-MM-DD>-<origin.cli>-<short-id>.md` when
 a `docs/` directory exists at the repo root, else
 `~/.claude/handoffs/<YYYY-MM-DD>-<origin.cli>-<short-id>.md`.
-
-## Target-CLI tuning (the `--to` flag)
-
-The only field that changes with `--to` is `next_step_suggestion`:
-
-- `--to claude` — phrase the next step as an imperative Claude can
-  follow directly ("Continue the refactor by editing …").
-- `--to codex` — include explicit filepaths and a concrete sub-task,
-  since Codex prefers task-shaped inputs.
-- `--to copilot` — phrase as a question or "help me with …" since
-  Copilot pairs with the user.
-
-All other fields are identical regardless of target.
 
 ## Size bounds
 

--- a/skills/handoff/references/from-codex.md
+++ b/skills/handoff/references/from-codex.md
@@ -85,20 +85,7 @@ binary:
 - Non-TTY (scripts/CI): exits 2 with a TSV candidate list on stderr so
   the caller can parse and retry with a more specific query.
 
-## Power-user sub-commands
-
-The five-form shape above is the primary surface. For scripting you
-can still use:
-
-```
-dotclaude handoff resolve  <cli> <id>        # file path only
-dotclaude handoff describe <cli> <id>        # inline markdown summary
-dotclaude handoff digest   <cli> <id>        # full <handoff> block
-dotclaude handoff file     <cli> <id>        # write to docs/handoffs/
-```
-
-All subcommands support `--help`, `--version`, `--json`, `--verbose`,
-`--no-color`. Exit codes: 0 ok, 2 not found / parse error, 64 usage.
+See `dotclaude handoff --help` for the full sub-command and flag reference.
 
 ## Why the binary and not the skill file?
 

--- a/skills/handoff/references/prerequisites.md
+++ b/skills/handoff/references/prerequisites.md
@@ -1,6 +1,6 @@
 # Handoff prerequisites — git transport checklist and remediation
 
-The remote sub-commands (`push`, `pull`, `remote-list`) require a
+The remote sub-commands (`push`, `pull`, `fetch`) require a
 working git transport. `/handoff doctor` runs the checklist below and
 prints a remediation block on failure. The reusable implementation
 lives at `plugins/dotclaude/scripts/handoff-doctor.sh`.
@@ -85,8 +85,7 @@ warn: system clock reports year <YYYY>; git auth may fail with signature errors 
 
 ## Air-gapped / offline path
 
-`/handoff file <cli> <uuid>` writes a local markdown artifact with a
-`<handoff>` block at the top. Move it via any out-of-band channel
-(USB stick, secure copy, encrypted email) and run
-`/handoff pull --from-file <path>` on the destination machine. No
-network required.
+Run `dotclaude handoff pull <uuid> -o <path>` on the source machine to write
+a local markdown file. Move it via any out-of-band channel (USB stick, secure
+copy, encrypted email), then paste the file's markdown content into the target
+session. No network or binary required on the destination.

--- a/skills/handoff/references/prerequisites.md
+++ b/skills/handoff/references/prerequisites.md
@@ -1,8 +1,9 @@
 # Handoff prerequisites — git transport checklist and remediation
 
-The remote sub-commands (`push`, `pull`, `fetch`) require a
-working git transport. `/handoff doctor` runs the checklist below and
-prints a remediation block on failure. The reusable implementation
+Remote transport operations (`push`, `fetch`, `list --remote`, `prune`)
+require a working git transport. `/handoff doctor` runs the checklist
+below and prints a remediation block on failure. (`pull` is a local
+render verb and does not need git transport.) The reusable implementation
 lives at `plugins/dotclaude/scripts/handoff-doctor.sh`.
 
 ## Output contract

--- a/skills/handoff/references/redaction.md
+++ b/skills/handoff/references/redaction.md
@@ -69,4 +69,4 @@ Scrubbing is best-effort. It does not catch:
 - Anything the user consciously wrote in prose ("my password is …").
 
 Before pushing sensitive sessions, review the digest locally with
-`/handoff digest <cli> <uuid>` first.
+`dotclaude handoff pull <uuid>` first.


### PR DESCRIPTION
## Summary

- **Phase 2 PR 7** of the handoff-skill rollout per spec §6.3 row 134. Prunes `skills/handoff/references/*.md` of stale sub-command names (`describe`, `digest`, `file`, `resolve`, `remote-list`) and removes the `--cli` legacy alias from the binary entirely.
- **`--cli` removal:** `META.flags.cli` deleted, `resolveFilterCli()` function deleted, `search` handler updated to use `fromCli` directly (already parsed at the top-level from `--from`). Drift fixture `--cli` row deleted — symbol is no longer in `--help`'s Options block.
- **References pruned:**
  - `from-codex.md`: "Power-user sub-commands" section (`resolve`/`describe`/`digest`/`file`) replaced with a one-line `--help` pointer.
  - `digest-schema.md`: Section headings updated (`digest`/`file` → `pull`, `describe` → `pull --summary`, `file` → `pull -o <path>`); `--to` tuning section deleted (flag removed in PR 4).
  - `codex.md`: `describe` sub-command reference → `pull --summary`.
  - `prerequisites.md`: `remote-list` removed from remote sub-commands list; air-gapped section rewritten to use `pull -o <path>` (the `--from-file` flag was removed in an earlier PR).
  - `redaction.md`: `/handoff digest <cli> <uuid>` → `dotclaude handoff pull <uuid>`.
- **Drift baseline unchanged.** `PHASE_1_BASELINE_FLAGS_INTERSECTION` stays the same 8 flags — `--cli` was only in the excluded fixture, never in the intersection. `PHASE_1_BASELINE_COMMANDS` unchanged. Only the fixture row is deleted.
- **`docs/handoff-guide.md`** still references `--cli`/removed verbs — explicit per spec §6.3 row 135. PR 8's job.

## Test plan

- [x] `npm test -- handoff-drift` — 4/4 green (baseline unchanged; --cli row removed from fixture).
- [x] `npm test` (full vitest) — 549/549 green.
- [x] `npx bats plugins/dotclaude/tests/bats/` — 319/319 green (1 deleted: search --cli, covered by --from).
- [x] `node plugins/dotclaude/bin/dotclaude-validate-skills.mjs` — manifest valid (29 skills).
- [x] `node plugins/dotclaude/bin/dotclaude-validate-specs.mjs` — 4 spec(s) valid.
- [x] `node plugins/dotclaude/bin/dotclaude-check-instruction-drift.mjs` — instruction files match repo facts.
- [x] `node scripts/build-plugin.mjs --check` — plugin templates fresh (115 files + manifest).
- [x] `npx prettier@3 --check "**/*.{json,yml,yaml,md}"` — clean.
- [ ] CI passes on this PR's head.

## Spec ID

handoff-skill