### PR TITLE
feat(handoff): reconcile handoff-guide + third drift source (Phase 2 PR 8)

### DIFF
--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -8,23 +8,25 @@ _Last updated: v0.11.0_
 
 The `/handoff` skill moves live session context from one agentic CLI to another —
 Claude Code, GitHub Copilot CLI, OpenAI Codex CLI — on the same machine or across
-machines. Nine sub-commands, one transport (a user-owned private git repo), one
-scrubbed digest.
+machines. Seven sub-commands (doctor, fetch, list, prune, pull, push, search),
+one transport (a user-owned private git repo), one scrubbed digest.
 
 ---
 
 ## When to use it
 
-| Situation                                        | Sub-command                             |
-| ------------------------------------------------ | --------------------------------------- |
-| Continue a Claude Code session in Codex          | `digest` → paste-in                     |
-| Pick up the same work on a different laptop      | `push` (machine A) → `pull` (machine B) |
-| Persist the handoff to a markdown file for later | `file`                                  |
-| Inspect a session's purpose without loading it   | `describe`                              |
-| Find an old session by topic                     | `search "k8s networking"`               |
-| List recent sessions                             | `list`                                  |
-| Check what's waiting for you on the transport    | `remote-list`                           |
-| Diagnose why `push`/`pull` isn't working         | `doctor`                                |
+| Situation                                            | Sub-command               |
+| ---------------------------------------------------- | ------------------------- |
+| Continue a session in another CLI (in-place render)  | `pull latest`             |
+| Pick up the same work on a different machine         | `push` (A) → `pull` (B)   |
+| Persist context as a markdown file                   | `pull -o <path>`          |
+| Inspect a session's summary without loading it       | `pull --summary`          |
+| Find an old session by topic                         | `search "k8s networking"` |
+| List recent sessions                                 | `list`                    |
+| Check what's waiting on the remote                   | `list --remote`           |
+| Fetch a specific session from the remote by tag/UUID | `fetch`                   |
+| Remove old remote handoff branches                   | `prune --older-than 30d`  |
+| Diagnose why `push`/`pull` isn't working             | `doctor`                  |
 
 ---
 
@@ -59,6 +61,9 @@ source ~/.config/dotclaude/handoff.env
 ```
 
 to your `~/.bashrc` or `~/.zshrc`.
+
+When no query argument is given to `push`, `--from <cli>` is required — the flag
+identifies which local session to upload (e.g. `--from codex`).
 
 **On machine B** (any CLI):
 
@@ -128,29 +133,39 @@ wins.
 | `/handoff pull [<q>]` | Fetch from transport; zero-arg = newest branch                                              |
 | `/handoff list`       | Unified local + remote table (`--local`/`--remote`, `--from`, `--since`, `--limit`/`--all`) |
 
+Sub-commands that render content accept `--summary` (terse inline) and `-o <path|auto|->` (write to file).
+
 Every `<query>` can be a full UUID, short UUID (first 8 hex), `latest`,
 a Claude `customTitle`, or a Codex `thread_name`.
-
-Power-user sub-commands (`resolve`, `describe`, `digest`, `file`) stay
-reachable for scripting — each takes an explicit `<cli>` `<id>`. Full
-argument semantics live in [`skills/handoff/SKILL.md`](../skills/handoff/SKILL.md).
 
 ---
 
 ## Common patterns
 
-**Persist important context as a markdown file:**
+**Persist context as a markdown file:**
 
 ```
-/handoff file claude latest
-# writes to docs/handoffs/<date>-<origin>-<short-id>.md
+/handoff pull latest -o auto
+# writes to docs/handoffs/<date>-claude-<short-id>.md
 ```
 
 **Recover context after `/clear`:**
 
 ```
-/handoff search "auth middleware" --cli claude --since 2026-04-01
+/handoff search "auth middleware" --from claude --since 2026-04-01
 /handoff <uuid-from-search>      # bare <query> form drops the block in place
+```
+
+**Search with exact-string match (no regex):**
+
+```
+/handoff search "auth middleware" --from claude --fixed
+```
+
+**Scripting with structured output:**
+
+```bash
+dotclaude handoff pull latest --json | jq '.summary'
 ```
 
 **Scheduled remote handoff** (e.g. running as a /loop or cron):

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -62,8 +62,9 @@ source ~/.config/dotclaude/handoff.env
 
 to your `~/.bashrc` or `~/.zshrc`.
 
-When no query argument is given to `push`, `--from <cli>` is required — the flag
-identifies which local session to upload (e.g. `--from codex`).
+When calling `dotclaude handoff push` with no query argument, `--from <cli>` is
+required — the flag identifies which local session to upload (e.g. `--from codex`).
+Skill invocations (`/handoff push`) auto-fill `--from` from the host session.
 
 **On machine B** (any CLI):
 

--- a/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
+++ b/plugins/dotclaude/tests/fixtures/handoff-drift-known-disagreements.md
@@ -1,28 +1,23 @@
 # Handoff drift — known disagreements (Phase 1 baseline)
 
 > Fixture for `handoff-drift.test.mjs`. Documents symbols that exist in
-> one source but not the other. The Phase 1 drift test asserts agreement
-> on the _intersection_ of symbols across `--help` and
-> `skills/handoff/SKILL.md`; everything below is intentionally outside the
-> asserted intersection until the named Phase 2 PR (per
-> `docs/specs/handoff-skill/spec/6-implementation-plan.md` §6.3) resolves it.
+> one source but not all three. The Phase 1 drift test asserts agreement
+> on the _intersection_ of symbols across `--help`, `skills/handoff/SKILL.md`,
+> and `docs/handoff-guide.md`; everything below is intentionally outside the
+> asserted intersection (per
+> `docs/specs/handoff-skill/spec/6-implementation-plan.md` §6.3).
 >
-> When a Phase 2 PR moves a symbol from "disagreement" to "agreement," it
-> deletes the corresponding entry below and lets the test's intersection
-> assertion grow. The last Phase 2 PR (PR 8) folds in `docs/handoff-guide.md`
-> as a third source.
->
-> **`docs/handoff-guide.md` is excluded entirely from Phase 1.** Per spec §1
-> it is heavily drifted from both `--help` and `SKILL.md` (refs removed
-> sub-commands `digest`/`file`/`describe`, says "five forms", uses `--cli`
-> legacy alias). It joins as the third source in PR 8.
+> All Phase 2 PRs (6–8) are complete. The three sources are reconciled.
+> Remaining disagreements are out of scope for Phase 1 (no spec coverage
+> or deferred to Phase 3 per-command flag rigor).
 
 ## Excluded flags
 
 The Phase 1 test extracts a flat global flag set from each source and
-asserts agreement on the intersection. Flags that appear in only one
-source are excluded until reconciled.
+asserts agreement on the intersection. Flags that appear in only a subset
+of sources are listed here.
 
-| Flag                                                            | Present in | Missing from | Resolves in                                          |
-| --------------------------------------------------------------- | ---------- | ------------ | ---------------------------------------------------- |
-| `--no-color`, `--verbose`/`-v`, `--help`/`-h`, `--version`/`-V` | `--help`   | `SKILL.md`   | Out of scope — universal CLI flags, no spec coverage |
+| Flag                                                            | Present in       | Missing from                   | Resolves in                                          |
+| --------------------------------------------------------------- | ---------------- | ------------------------------ | ---------------------------------------------------- |
+| `--no-color`, `--verbose`/`-v`, `--help`/`-h`, `--version`/`-V` | `--help`         | `SKILL.md`, guide              | Out of scope — universal CLI flags, no spec coverage |
+| `--local`, `--remote`                                           | guide + `--help` | `SKILL.md` cross-cutting flags | Out of scope — per-command flags, Phase 3 flag rigor |

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -17,13 +17,12 @@
 //   surface in lockstep across sources.
 //
 // Phase 1 scope (deliberately minimal — see fixtures/handoff-drift-known-disagreements.md).
-//   - Sources: 2 of 3. Just `--help` + SKILL.md. `docs/handoff-guide.md`
-//     is heavily drifted today (per spec §1) and joins as a third source
-//     in Phase 2 PR 8 after docs reconciliation lands.
-//   - Symbols asserted: the *intersection* of stable symbols. Today that
-//     is `[doctor, fetch, list, pull, push, search]` for commands and a
-//     small intersection for global flags. As Phase 2 PRs reconcile each
-//     disagreement, the intersection grows and the fixture shrinks.
+//   - Sources: 3 of 3. `--help`, SKILL.md, and `docs/handoff-guide.md`.
+//     All three sources are reconciled as of Phase 2 PR 8.
+//   - Symbols asserted: the *intersection* of stable symbols across all
+//     three sources. That is `[doctor, fetch, list, prune, pull, push, search]`
+//     for commands and 8 global flags. The fixture documents the small set
+//     of symbols present in only one or two sources.
 //   - `from_rule` is asserted `{ present: false, applies_to: [], mandatory_when: null }`
 //     in both sources today; spec §5.5.2's mandatory-`--from` rule lands
 //     in Phase 2 PR 3 and both extractors flip in lockstep with the binary
@@ -55,6 +54,7 @@ const repoRoot = resolve(__dirname, "../../..");
 
 const SKILL_MD_PATH = resolve(repoRoot, "skills/handoff/SKILL.md");
 const HANDOFF_BIN = resolve(repoRoot, "plugins/dotclaude/bin/dotclaude-handoff.mjs");
+const GUIDE_MD_PATH = resolve(repoRoot, "docs/handoff-guide.md");
 
 /**
  * @typedef {object} FromRule
@@ -267,6 +267,58 @@ export function extractFromRule(text) {
   return { present: false, applies_to: [], mandatory_when: null };
 }
 
+/**
+ * Parse `docs/handoff-guide.md`.
+ *
+ * Sub-commands come from the `## When to use it` table's second column —
+ * each non-header row's cell is scanned for backtick-wrapped lowercase-alpha
+ * tokens (the verb names). Global flags come from the `## The five forms`
+ * and `## Common patterns` sections, scanned for `--flag` and `-o` tokens.
+ *
+ * @param {string} text
+ * @returns {HandoffSurface}
+ */
+export function extractFromGuide(text) {
+  // Commands: parse second column of "When to use it" table.
+  const whenSection = text.match(/## When to use it\s+([\s\S]*?)(?=\n## |\n# |$)/);
+  if (!whenSection) {
+    throw new Error("handoff-guide.md: could not find `## When to use it` section");
+  }
+  const commandSet = new Set();
+  // Each non-header row: | <situation> | <sub-command cell> |
+  // Extract all `word` tokens from second column where word is lowercase alpha.
+  const rowRegex = /^\|[^|]+\|([^|]+)\|/gm;
+  let m;
+  while ((m = rowRegex.exec(whenSection[1])) !== null) {
+    const cell = m[1];
+    const verbRegex = /`([a-z]+)/g;
+    let vm;
+    while ((vm = verbRegex.exec(cell)) !== null) {
+      commandSet.add(vm[1]);
+    }
+  }
+  const commands = [...commandSet].sort();
+
+  // Flags: scan "The five forms" and "Common patterns" sections.
+  const flagSections = text.match(
+    /(?:## The five forms|## Common patterns)[\s\S]*?(?=\n## |$)/g,
+  );
+  const flagTokens = new Set();
+  for (const section of flagSections ?? []) {
+    const flagRegex = /(?<![a-zA-Z0-9])(--[a-z][a-zA-Z0-9-]+|-o)(?![a-zA-Z0-9-])/g;
+    let fm;
+    while ((fm = flagRegex.exec(section)) !== null) {
+      flagTokens.add(fm[1]);
+    }
+  }
+
+  return {
+    commands,
+    flags_by_command: { "*": [...flagTokens].sort() },
+    from_rule: extractFromRule(text),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -276,6 +328,8 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
   let skillSurface;
   /** @type {HandoffSurface} */
   let helpSurface;
+  /** @type {HandoffSurface} */
+  let guideSurface;
 
   beforeAll(() => {
     const skillText = readFileSync(SKILL_MD_PATH, "utf8");
@@ -291,12 +345,16 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
       env: { ...process.env, HOME: hermeticHome, XDG_CONFIG_HOME: hermeticHome },
     });
     helpSurface = extractFromHelp(help);
+
+    const guideText = readFileSync(GUIDE_MD_PATH, "utf8");
+    guideSurface = extractFromGuide(guideText);
   });
 
   it("test-the-test: each extractor returns a HandoffSurface struct", () => {
     for (const [name, surface] of [
       ["SKILL.md", skillSurface],
       ["--help", helpSurface],
+      ["guide", guideSurface],
     ]) {
       // Top-level shape.
       expect(surface, name).toEqual(
@@ -335,19 +393,26 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
 
   it("commands intersection across sources matches Phase 1 baseline", () => {
     const skillSet = new Set(skillSurface.commands);
-    const intersection = helpSurface.commands.filter((c) => skillSet.has(c)).sort();
+    const guideSet = new Set(guideSurface.commands);
+    const intersection = helpSurface.commands
+      .filter((c) => skillSet.has(c) && guideSet.has(c))
+      .sort();
     expect(intersection).toEqual(PHASE_1_BASELINE_COMMANDS);
   });
 
   it("global-flag intersection across sources matches Phase 1 baseline", () => {
     const skillFlags = new Set(skillSurface.flags_by_command["*"] ?? []);
+    const guideFlags = new Set(guideSurface.flags_by_command["*"] ?? []);
     const helpFlags = helpSurface.flags_by_command["*"] ?? [];
-    const intersection = helpFlags.filter((f) => skillFlags.has(f)).sort();
+    const intersection = helpFlags
+      .filter((f) => skillFlags.has(f) && guideFlags.has(f))
+      .sort();
     expect(intersection).toEqual(PHASE_1_BASELINE_FLAGS_INTERSECTION);
   });
 
-  it("from_rule baseline matches in both sources", () => {
+  it("from_rule baseline matches in all sources", () => {
     expect(skillSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
     expect(helpSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
+    expect(guideSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
   });
 });

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -272,8 +272,10 @@ export function extractFromRule(text) {
  *
  * Sub-commands come from the `## When to use it` table's second column —
  * each non-header row's cell is scanned for backtick-wrapped lowercase-alpha
- * tokens (the verb names). Global flags come from the `## The five forms`
+ * tokens (the verb names). Flat flag tokens come from the `## The five forms`
  * and `## Common patterns` sections, scanned for `--flag` and `-o` tokens.
+ * Note: per-command flags (e.g. `--local`, `--remote`) are included; the
+ * intersection logic, not this extractor, limits what reaches the baseline.
  *
  * @param {string} text
  * @returns {HandoffSurface}


### PR DESCRIPTION
## Summary

- **Phase 2 PR 8** (final) of the handoff-skill rollout per spec §6.3 row 135. Reconciles `docs/handoff-guide.md` against the current surface and folds it in as the third source in the ARCH-10 drift test.
- **Guide changes:** "Nine sub-commands" → seven; `describe`/`digest`/`file`/`remote-list` rows replaced with current verbs (`pull --summary`, `pull -o <path>`, `list --remote`); `fetch` and `prune` rows added; mandatory-`--from` note added for `push` without a query; "Power-user sub-commands" paragraph deleted; `/handoff file` example → `pull -o auto`; `--cli` → `--from` in search example; `--fixed` and `--json` examples added (needed to land all 8 flags in the 3-way intersection).
- **Drift test:** `extractFromGuide()` added (commands from "When to use it" table, flags from "The five forms" + "Common patterns" sections, from_rule via shared `extractFromRule`). All three intersection assertions upgraded to 3-way. Baselines **unchanged** — the reconciled guide agrees on all 7 commands and all 8 flags.
- **Fixture:** "guide excluded entirely" note removed; `--local`/`--remote` guide-exclusive row added (Phase 3 per-command flag rigor).

## Test plan

- [x] `npm test -- handoff-drift` — 4/4 green (3-way intersection; baselines unchanged).
- [x] `npm test` (full vitest) — 549/549 green.
- [x] `npx bats plugins/dotclaude/tests/bats/` — 319/319 green.
- [x] `node plugins/dotclaude/bin/dotclaude-validate-skills.mjs` — manifest valid (29 skills).
- [x] `node plugins/dotclaude/bin/dotclaude-validate-specs.mjs` — 4 spec(s) valid.
- [x] `node plugins/dotclaude/bin/dotclaude-check-instruction-drift.mjs` — instruction files match repo facts.
- [x] `node scripts/build-plugin.mjs --check` — plugin templates fresh (115 files + manifest).
- [x] `npx prettier@3 --check "**/*.{json,yml,yaml,md}"` — clean.
- [x] CI passes on this PR's head.

## Spec ID

handoff-skill