### PR TITLE
fix(handoff): remove dead --out-dir flag from META.flags (Phase 3 W-3)

### DIFF
--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -112,7 +112,6 @@ const META = {
     from: { type: "string" },
     limit: { type: "string" },
     since: { type: "string" },
-    "out-dir": { type: "string" },
     output: { type: "string", short: "o" },
     local: { type: "boolean" },
     remote: { type: "boolean" },


### PR DESCRIPTION
## Summary

- **Phase 3 W-3**: Remove the dead `--out-dir` flag definition from `META.flags` in `plugins/dotclaude/bin/dotclaude-handoff.mjs`. The flag was defined but never read anywhere (`argv.flags["out-dir"]` has no callers); spec §5 interfaces explicitly lists "No `--out-dir`."
- The other deprecated surface (`--to` flag, `describe`/`digest`/`file` verb shims, old `<cli> <query>` positional form) was already removed in Phase 2 PRs 4–5; no further test cleanup needed.

## Test plan

- [x] `npm test` — 549/549 green.
- [x] `npx bats plugins/dotclaude/tests/bats/` — 319/319 green (count unchanged — deprecated-surface tests were already removed in Phase 2).
- [x] `node plugins/dotclaude/bin/dotclaude-validate-skills.mjs` — manifest valid.
- [x] `node plugins/dotclaude/bin/dotclaude-validate-specs.mjs` — 4 specs valid.
- [x] `node plugins/dotclaude/bin/dotclaude-check-instruction-drift.mjs` — instruction files match.
- [x] `node scripts/build-plugin.mjs --check` — templates fresh.
- [x] `npx prettier@3 --check "**/*.{json,yml,yaml,md}"` — clean.
- [x] CI passes on this PR's head.

## Spec ID

handoff-skill