### PR TITLE
fix(handoff): drop metadata.tag write-side (Phase 3 W-1)

### DIFF
--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -572,7 +572,7 @@ function renderDryRunPreview(r) {
     `  description:   ${r.description}`,
     `  digest size:   ${r.digestBytes} bytes (after scrub)`,
     `  scrub count:   ${r.scrubbedCount} secrets redacted`,
-    `  tag:           ${r.tag ?? "(none)"}`,
+    `  tags:          ${r.tags?.length > 0 ? r.tags.join(", ") : "(none)"}`,
     `  metadata:      cli=${m.cli} session=${m.short_id} project=${m.project} host=${m.hostname} month=${m.month}`,
     "",
     "run without --dry-run to push.",

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -789,12 +789,7 @@ export async function pushRemote({
     hostname: host,
     created_at: new Date().toISOString(),
     scrubbed_count: scrubbedCount,
-    // #91 Gap 7: write both shapes for one release cycle so deployed installs
-    // that only know about `metadata.tag` keep working. New readers prefer
-    // `metadata.tags` via tagsFromMeta().
-    // TODO(#91 Gap 7 follow-up, after 0.13.0): drop the legacy `tag` field.
     tags: tagList,
-    tag: tagList[0] ?? null,
   };
 
   const branch = v2BranchName({ project, cli: meta.cli, month, shortId });
@@ -809,7 +804,6 @@ export async function pushRemote({
       digestBytes: Buffer.byteLength(scrubbed, "utf8"),
       metadata,
       tags: tagList,
-      tag: tagList[0] ?? null,
     };
   }
 

--- a/plugins/dotclaude/tests/bats/handoff-tags.bats
+++ b/plugins/dotclaude/tests/bats/handoff-tags.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 # Integration tests for #91 Gap 7: tags first-class.
 #
-# Covers (a) multi-tag push writes both metadata.tags and legacy
-# metadata.tag, (b) exact-tag pull resolution beats substring,
+# Covers (a) multi-tag push writes metadata.tags without legacy metadata.tag,
+# (b) exact-tag pull resolution beats substring,
 # (c) `list --remote --tag <name>` filter, (d) `list --remote --tags`
 # histogram, (e) legacy single-tag metadata still resolves through
 # the migration helper, (f) special-char tag slugification round-trip.

--- a/plugins/dotclaude/tests/bats/handoff-tags.bats
+++ b/plugins/dotclaude/tests/bats/handoff-tags.bats
@@ -72,9 +72,9 @@ teardown() {
   [ -f "${STUB_DOCTOR:-}" ] && rm -f "$STUB_DOCTOR"
 }
 
-# ---- 1: multi-tag push writes both tags array and legacy tag field --------
+# ---- 1: multi-tag push writes tags array (no legacy tag field) ------------
 
-@test "push --tag foo --tag bar: writes metadata.tags=[foo,bar] and tag=foo" {
+@test "push --tag foo --tag bar: writes metadata.tags=[foo,bar] without legacy tag field" {
   run --separate-stderr node "$BIN" push --from claude --tag foo --tag bar
   [ "$status" -eq 0 ]
 
@@ -85,7 +85,7 @@ teardown() {
   echo "$checkout/metadata.json:"
   cat "$checkout/metadata.json"
   jq -e '.tags == ["foo","bar"]' "$checkout/metadata.json" >/dev/null
-  jq -e '.tag == "foo"' "$checkout/metadata.json" >/dev/null
+  jq -e 'has("tag") | not' "$checkout/metadata.json" >/dev/null
   rm -rf "$checkout"
 }
 


### PR DESCRIPTION
## Summary

- **Phase 3 W-1**: Drop the legacy `metadata.tag` write-side from `plugins/dotclaude/src/lib/handoff-remote.mjs`. The field was emitted for one release cycle so installs that only knew about the old single-string shape kept working; the cycle is complete.
- Removes `tag: tagList[0] ?? null` from both the real push write and the dry-run result object, plus the TODO comment block that scheduled this removal.
- **Keeps** the read fallback in `tagsFromMeta()` — existing remote branches still carry the `tag` field and backward-compat reads are retained per spec.
- Also updates `handoff-tags.bats` test that verified the legacy field is written (now verifies it is absent).

## Test plan

- [x] `npm test` — 549/549 green.
- [x] `npx bats plugins/dotclaude/tests/bats/` — 319/319 green.
- [x] `node plugins/dotclaude/bin/dotclaude-validate-skills.mjs` — manifest valid.
- [x] `node plugins/dotclaude/bin/dotclaude-validate-specs.mjs` — 4 specs valid.
- [x] `node plugins/dotclaude/bin/dotclaude-check-instruction-drift.mjs` — instruction files match.
- [x] `node scripts/build-plugin.mjs --check` — templates fresh.
- [x] `npx prettier@3 --check "**/*.{json,yml,yaml,md}"` — clean.
- [ ] CI passes on this PR's head.

## Spec ID

handoff-skill
