### PR TITLE
fix(handoff): pick_newest() busybox portability via stat probe (#129)

### DIFF
--- a/plugins/dotclaude/scripts/handoff-resolve.sh
+++ b/plugins/dotclaude/scripts/handoff-resolve.sh
@@ -34,21 +34,30 @@ EOF
 UUID_RE='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 SHORT_UUID_RE='^[0-9a-f]{8}$'
 
+# Detect stat/find flavor once at init. busybox stat accepts -f but ignores the
+# format string, dumps multi-line default output, and exits 0 — a runtime
+# fallback chain can't detect this. Probe once and take a single deterministic path.
+_STAT_FLAVOR=posix
+if stat --version 2>&1 | grep -q GNU; then
+  _STAT_FLAVOR=gnu
+elif stat -f '%m' "$0" 2>/dev/null | grep -qE '^[0-9]+$'; then
+  _STAT_FLAVOR=bsd
+fi
+
 # Pick newest by mtime from a newline-separated list on stdin. Prints path only.
 # Pure-bash loop: no word-splitting on paths with spaces, no subshell per file.
 pick_newest() {
-  local best_ms=0 best_path="" file frac secs frac_ms
+  local best_ms=0 best_path="" file frac secs frac_part frac_ms
   while IFS= read -r file; do
     [[ -n "$file" ]] || continue
-    # GNU find -printf gives fractional epoch seconds (e.g. 1700000000.123456789).
-    # BSD stat -f %Fm gives the same. Whole-second fallbacks for minimal platforms.
-    frac=$(find "$file" -maxdepth 0 -printf '%T@' 2>/dev/null \
-           || stat -f '%Fm' "$file" 2>/dev/null \
-           || stat -c '%Y' "$file" 2>/dev/null \
-           || echo 0)
+    case "$_STAT_FLAVOR" in
+      gnu) frac=$(find "$file" -maxdepth 0 -printf '%T@' 2>/dev/null || echo 0) ;;
+      bsd) frac=$(stat -f '%Fm' "$file" 2>/dev/null || echo 0) ;;
+      *)   frac=$(stat -c '%Y' "$file" 2>/dev/null || echo 0) ;;
+    esac
     if [[ "$frac" == *.* ]]; then
       secs="${frac%%.*}"
-      local frac_part="${frac#*.}000"          # pad to ≥3 digits
+      frac_part="${frac#*.}000"
       frac_ms=$(( ${secs:-0} * 1000 + 10#${frac_part:0:3} ))
     else
       frac_ms=$(( ${frac:-0} * 1000 ))

--- a/plugins/dotclaude/tests/bats/handoff-portability.bats
+++ b/plugins/dotclaude/tests/bats/handoff-portability.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
-# Force each branch of the GNU/BSD fallback chains in handoff-resolve
-# (pick_newest: find -printf %T@ → stat -f %Fm → stat -c %Y) and
-# handoff-extract (file_iso_mtime: date -r → date -d @stat) by shimming
-# PATH so the higher-precedence tool exits non-zero.
+# Portability tests for handoff-resolve (GNU primary path) and handoff-extract.
+# pick_newest now uses a probe-once approach (_STAT_FLAVOR) rather than a
+# runtime fallback chain; busybox substrate coverage lives in
+# handoff-resolve-busybox.bats.
 
 load helpers
 
@@ -40,71 +40,11 @@ seed_fractional_pair() {
 }
 
 @test "pick_newest picks newest via find -printf %T@ (GNU primary)" {
-  # Baseline for the fallback tests: without a shim, the resolver should
-  # resolve the fractional-ms delta via find -printf.
+  # Verifies the gnu probe path: on a GNU/Linux system _STAT_FLAVOR=gnu and
+  # pick_newest uses find -printf %T@ for fractional-ms resolution.
   local older="aaaa1111-1111-1111-1111-111111111111"
   local newer="bbbb2222-2222-2222-2222-222222222222"
   seed_fractional_pair "$older" "$newer"
-  run "$RESOLVE" claude latest
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"$newer.jsonl" ]]
-}
-
-@test "pick_newest falls back to BSD stat -f %Fm when find -printf fails" {
-  local older="cccc3333-3333-3333-3333-333333333333"
-  local newer="dddd4444-4444-4444-4444-444444444444"
-  seed_fractional_pair "$older" "$newer"
-
-  # Shim: exit 1 on pick_newest's `-printf '%T@'` probe, delegate
-  # everything else to the real `find`.
-  local shim
-  shim=$(with_fake_tool_bin find '
-for arg in "$@"; do
-  if [[ "$arg" == "%T@" ]]; then
-    exit 1
-  fi
-done
-exec /usr/bin/find "$@"
-')
-  SHIM_DIRS+=("$shim")
-
-  run "$RESOLVE" claude latest
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"$newer.jsonl" ]]
-}
-
-@test "pick_newest falls back to stat -c %Y when find -printf and stat -f fail" {
-  # With both fractional-precision paths disabled, pick_newest falls back
-  # to whole-second mtime — so stamps must be ≥1s apart to resolve order.
-  local older="eeee5555-5555-5555-5555-555555555555"
-  local newer="ffff6666-6666-6666-6666-666666666666"
-  local dir="$TEST_HOME/.claude/projects/-demo"
-  mkdir -p "$dir"
-  printf '{"cwd":"/x","sessionId":"%s"}\n' "$older" > "$dir/$older.jsonl"
-  printf '{"cwd":"/x","sessionId":"%s"}\n' "$newer" > "$dir/$newer.jsonl"
-  touch -d '2026-04-18 10:00:00' "$dir/$older.jsonl"
-  touch -d '2026-04-18 10:00:02' "$dir/$newer.jsonl"
-
-  # Shim find to reject -printf, and stat to reject -f %Fm.
-  local find_shim stat_shim
-  find_shim=$(with_fake_tool_bin find '
-for arg in "$@"; do
-  [[ "$arg" == "%T@" ]] && exit 1
-done
-exec /usr/bin/find "$@"
-')
-  stat_shim=$(with_fake_tool_bin stat '
-prev=""
-for arg in "$@"; do
-  if [[ "$prev" == "-f" && "$arg" == "%Fm" ]]; then
-    exit 1
-  fi
-  prev="$arg"
-done
-exec /usr/bin/stat "$@"
-')
-  SHIM_DIRS+=("$find_shim" "$stat_shim")
-
   run "$RESOLVE" claude latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"$newer.jsonl" ]]

--- a/plugins/dotclaude/tests/bats/handoff-resolve-busybox.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve-busybox.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+# Verify pick_newest() works correctly on a busybox substrate where
+# `stat -f` accepts the flag but ignores the format string, dumps
+# multi-line default output, and exits 0 (so a runtime fallback chain
+# cannot detect the failure). The stat probe at init detects this case
+# and sets _STAT_FLAVOR=posix, causing pick_newest to use `stat -c %Y`.
+
+load helpers
+
+RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
+
+# Shim body that simulates busybox stat behavior:
+#   --version  → non-GNU string (probe falls through to bsd check)
+#   -f         → multi-line default output + exit 0 (bsd probe grep fails → posix)
+#   *          → delegate to real stat (stat -c %Y works correctly on busybox)
+BUSYBOX_STAT_BODY='
+case "$1" in
+  --version)
+    printf "BusyBox v1.36.1 multi-call binary\n"
+    exit 0
+    ;;
+  -f)
+    printf "  File: \"stub\"\n  Size: 1234\tBlocks: 8\tIO Block: 4096 regular file\n"
+    printf "Device: fd01h/64769d\tInode: 123456\tLinks: 1\n"
+    exit 0
+    ;;
+  *)
+    exec /usr/bin/stat "$@"
+    ;;
+esac
+'
+
+setup() {
+  [ -x "$RESOLVE" ] || chmod +x "$RESOLVE"
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  SHIM_DIRS=()
+}
+
+teardown() {
+  local d
+  for d in "${SHIM_DIRS[@]}"; do
+    rm -rf "$d"
+  done
+  rm -rf "$TEST_HOME"
+}
+
+@test "pick_newest selects newer file on busybox substrate (stat -c %Y path)" {
+  local older="aaaa1111-1111-1111-1111-111111111111"
+  local newer="bbbb2222-2222-2222-2222-222222222222"
+  local dir="$TEST_HOME/.claude/projects/-demo"
+  mkdir -p "$dir"
+  printf '{"cwd":"/x","sessionId":"%s"}\n' "$older" > "$dir/$older.jsonl"
+  printf '{"cwd":"/x","sessionId":"%s"}\n' "$newer" > "$dir/$newer.jsonl"
+  # Whole-second resolution — files must be ≥1 s apart for stat -c %Y to distinguish
+  touch -d '2026-04-18 10:00:00' "$dir/$older.jsonl"
+  touch -d '2026-04-18 10:00:02' "$dir/$newer.jsonl"
+
+  local shim
+  shim=$(with_fake_tool_bin stat "$BUSYBOX_STAT_BODY")
+  SHIM_DIRS+=("$shim")
+
+  run "$RESOLVE" claude latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$newer.jsonl" ]]
+}
+
+@test "resolve does not crash when stat -f returns multi-line garbage" {
+  # Regression for the busybox bug: stat -f exits 0 with multi-line output,
+  # causing secs to capture a path fragment and set -u fires on unbound var.
+  local uuid="cccc3333-3333-3333-3333-333333333333"
+  local dir="$TEST_HOME/.claude/projects/-demo"
+  mkdir -p "$dir"
+  printf '{"cwd":"/x","sessionId":"%s"}\n' "$uuid" > "$dir/$uuid.jsonl"
+
+  local shim
+  shim=$(with_fake_tool_bin stat "$BUSYBOX_STAT_BODY")
+  SHIM_DIRS+=("$shim")
+
+  run "$RESOLVE" claude latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$uuid.jsonl" ]]
+}
+
+@test "pick_newest returns a file gracefully when stat -c returns 0 for all" {
+  # If all timestamps compare equal (frac_ms stays 0), pick_newest should still
+  # return the last file seen rather than crashing or returning empty.
+  local uuid="dddd4444-4444-4444-4444-444444444444"
+  local dir="$TEST_HOME/.claude/projects/-demo"
+  mkdir -p "$dir"
+  printf '{"cwd":"/x","sessionId":"%s"}\n' "$uuid" > "$dir/$uuid.jsonl"
+
+  # Shim that returns 0 for all stat -c calls (simulates timestamp unavailable)
+  local shim
+  shim=$(with_fake_tool_bin stat '
+case "$1" in
+  --version) printf "BusyBox v1.36.1 multi-call binary\n"; exit 0 ;;
+  -f)        printf "  File: \"stub\"\n  Size: 0\n"; exit 0 ;;
+  -c)        printf "0\n"; exit 0 ;;
+  *)         exec /usr/bin/stat "$@" ;;
+esac
+')
+  SHIM_DIRS+=("$shim")
+
+  run "$RESOLVE" claude latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$uuid.jsonl" ]]
+}


### PR DESCRIPTION
## Summary

- Replace `pick_newest()`'s runtime `||` fallback chain with a single probe at script init that sets `_STAT_FLAVOR` (`gnu` | `bsd` | `posix`).
- Fixes the busybox crash: busybox `stat` accepted `-f` but ignored the format string, dumped multi-line output, and exited 0 — so `||` never fired and bash arithmetic exploded on an unbound variable.
- Adds `handoff-resolve-busybox.bats` (3 cases) and removes two now-dead fallback tests from `handoff-portability.bats`.

## Test plan

- [x] `bats tests/bats/handoff-portability.bats` — 2 tests pass (removed 2 dead fallback tests)
- [x] `bats tests/bats/handoff-resolve-busybox.bats` — 3 tests pass (stat shim simulates busybox behavior)
- [x] `bats tests/bats/` — 320 tests, 0 failures
- [x] `npm test` — 549 vitest assertions, 37 files, all pass

## No-spec rationale

Shell script fix in `plugins/dotclaude/scripts/` (not a protected path). No public API surface changed; `pick_newest` is an internal function. Behavior is identical on GNU and BSD substrates; only busybox/unknown substrates see a fix.
