### PR TITLE
fix(handoff): three v1.0.x patches — stderr template, narrowed-error spec amend, lazy yaml (#135 #136 #130)

### DIFF
--- a/docs/audits/handoff-skill-validation-2026-04-29.md
+++ b/docs/audits/handoff-skill-validation-2026-04-29.md
@@ -939,18 +939,19 @@ semantic-correctness check.
 
 | Blocker                                                               | Status                                                                                                                                                                                                               |
 | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **#129**                                                              | Open. Substrate portability (busybox/Alpine `pick_newest`). Code-fix needed in `plugins/dotclaude/scripts/handoff-resolve.sh:39–62`.                                                                                 |
+| **#129**                                                              | **Closed** in [#139](https://github.com/kaiohenricunha/dotclaude/pull/139). Substrate portability fixed via `_STAT_FLAVOR` probe-once in `handoff-resolve.sh`.                                                       |
 | **#133**                                                              | Open, **not a code bug**. Release-pipeline action only: bump version, tag, `npm publish`. Repo binary @ `be25258` is functionally green per the 13-row matrix above. Verbatim diff evidence in Phase 1.              |
 | #134 (new)                                                            | Process bug: `package.json:version` not bumped between npm publish and 17+ post-publish commits. Filed as [#134](https://github.com/kaiohenricunha/dotclaude/issues/134). Root cause behind #133. v1.0.x mitigation. |
-| #135 (new)                                                            | INFO — Pull stderr leaks `handoff-resolve:` prefix. Filed as [#135](https://github.com/kaiohenricunha/dotclaude/issues/135). v1.0.x patch material.                                                                  |
-| #136 (new)                                                            | INFO — Pull `--from <cli>` no-match stderr is CLI-narrowed; spec drift. Filed as [#136](https://github.com/kaiohenricunha/dotclaude/issues/136). v1.0.x patch material.                                              |
+| #135 (new)                                                            | **Closed** — Pull stderr `handoff-resolve:` double-prefix stripped in `dotclaude-handoff.mjs`. Spec §5.3.2 template now matches actual output.                                                                       |
+| #136 (new)                                                            | **Closed** — Spec §5.3.2 amended to formalize narrowed `no <cli> session matches` form when `--from` is set, alongside the unnarrowed form. No code change.                                                          |
+| #130                                                                  | **Closed** — `js-yaml` import in `build-index.mjs` made lazy via `createRequire`; `dotclaude-handoff --help` no longer requires `js-yaml` to be present.                                                             |
 | CP-1                                                                  | INFO — Copilot's slash-handler rejects `--summary` / `-o` flags before invoking the binary. Documentation-only; not a dotclaude bug. v1.0 release-notes material.                                                    |
 | CX-1                                                                  | INFO — Codex's `!`-shell capture displays interleaved stream; OPS-2 is honored on the binary side. Documentation-only; not a dotclaude bug. v1.0 release-notes material.                                             |
 | CX-2 / [#137](https://github.com/kaiohenricunha/dotclaude/issues/137) | **Positive** — R-7 quoting risk does not materialize; bare-binary surface is symmetric across CC / Copilot `!` / Codex `!`. Tracking issue filed to lock the symmetry in CI. v1.0.x or v1.1.                         |
 
-**v1.0 = unblocked once both ship**: #129 needs a one-liner in the
-resolver; #133 needs a release. After that, #134 / #135 / #136 and any
-Phase 2.5 / Phase 4 findings can ride the v1.0 release notes — none are
+**v1.0 = unblocked once #133 ships**: #129 closed via #139; #135 / #136
+/ #130 closed in this PR's bundle. #133 still needs a release.
+Phase 2.5 / Phase 4 findings remain release-notes material — none are
 blockers on their own.
 
 Closing note on the audit-coverage gap that let #133 ship: the

--- a/docs/specs/handoff-skill/spec/5-interfaces-apis.md
+++ b/docs/specs/handoff-skill/spec/5-interfaces-apis.md
@@ -275,12 +275,18 @@ command and locks the **prefix** of the stderr template.
 
 ### 5.3.2 `pull`-specific exits
 
-| Code | Condition                         | Stderr template                                                                    |
-| ---- | --------------------------------- | ---------------------------------------------------------------------------------- |
-| 2    | no session matches                | `dotclaude-handoff: no session matches: <query>`                                   |
-| 2    | multiple sessions match (non-TTY) | header `dotclaude-handoff: multiple sessions match "<query>":` + TSV lines (5.3.5) |
-| 64   | unknown flag                      | `dotclaude-handoff: unknown flag: <flag>` + usage                                  |
-| 64   | missing `<query>`                 | `dotclaude-handoff: pull requires a <query>` + usage                               |
+| Code | Condition                                | Stderr template                                                                    |
+| ---- | ---------------------------------------- | ---------------------------------------------------------------------------------- |
+| 2    | no session matches (no `--from`)         | `dotclaude-handoff: no session matches: <query>`                                   |
+| 2    | no session matches (with `--from <cli>`) | `dotclaude-handoff: no <cli> session matches: <query>`                             |
+| 2    | multiple sessions match (non-TTY)        | header `dotclaude-handoff: multiple sessions match "<query>":` + TSV lines (5.3.5) |
+| 64   | unknown flag                             | `dotclaude-handoff: unknown flag: <flag>` + usage                                  |
+| 64   | missing `<query>`                        | `dotclaude-handoff: pull requires a <query>` + usage                               |
+
+When `--from <cli>` is set the no-match message is narrowed to the requested
+CLI ("no `<cli>` session matches"), giving a clearer diagnostic when the user
+has scoped the lookup. The unnarrowed form remains the contract for union
+lookups (no `--from`). Both forms are stable public output (#136).
 
 ### 5.3.3 `push`-specific exits
 

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -157,6 +157,18 @@ function parseSinceOrFail(raw, { defaultDays = null } = {}) {
  */
 
 /**
+ * Strip the resolver-script's `handoff-resolve:` prefix from captured stderr
+ * so the binary's own `dotclaude-handoff:` prefix doesn't double up (#135).
+ * Returns the trimmed remainder.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function stripResolverPrefix(raw) {
+  return raw.trim().replace(/^handoff-resolve:\s*/, "");
+}
+
+/**
  * Call `handoff-resolve.sh any <query>`. Handles the collision contract:
  *   - 0 hits: exits 2 (bubble up)
  *   - 1 hit:  returns {cli, path}
@@ -177,7 +189,10 @@ async function resolveAny(query) {
   // collision. Otherwise it's "no session matches" or an env error.
   const stderr = r.stderr;
   if (!stderr.includes("multiple sessions match")) {
-    fail(r.status === 64 ? EXIT_CODES.USAGE : 2, stderr.trim() || `no session matches: ${query}`);
+    fail(
+      r.status === 64 ? EXIT_CODES.USAGE : 2,
+      stripResolverPrefix(stderr) || `no session matches: ${query}`,
+    );
   }
   // Parse candidate TSV lines (4 fields: cli\tsid\tpath\tquery).
   const candidates = [];
@@ -209,7 +224,7 @@ function resolveNarrowed(cli, id) {
   if (r.status !== 0) {
     fail(
       r.status === 64 ? EXIT_CODES.USAGE : 2,
-      r.stderr.trim() || `no ${cli} session matches: ${id}`,
+      stripResolverPrefix(r.stderr) || `no ${cli} session matches: ${id}`,
     );
   }
   return { cli, path: r.stdout.trim() };
@@ -240,7 +255,7 @@ async function resolveLocalForPull(id, narrowTo) {
     return await resolveAny(id);
   }
   const msg =
-    stderr.trim() ||
+    stripResolverPrefix(stderr) ||
     (narrowTo ? `no ${narrowTo} session matches: ${id}` : `no session matches: ${id}`);
   process.stderr.write(`dotclaude-handoff: ${msg}\n`);
   if (process.env.DOTCLAUDE_HANDOFF_REPO) {

--- a/plugins/dotclaude/src/build-index.mjs
+++ b/plugins/dotclaude/src/build-index.mjs
@@ -35,9 +35,18 @@
 import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
 import { join, relative, sep, basename, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import yaml from "js-yaml";
+import { createRequire } from "node:module";
 import Ajv from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
+
+// js-yaml is loaded lazily so importers that never touch the index path
+// (e.g. dotclaude-handoff via src/index.mjs re-exports) don't pay the load
+// cost or break in environments where js-yaml is unavailable (#130).
+const require = createRequire(import.meta.url);
+let _yamlMod;
+function getYaml() {
+  return (_yamlMod ??= require("js-yaml"));
+}
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const DEFAULT_SCHEMAS_DIR = resolve(__dirname, "..", "..", "..", "schemas");
@@ -87,7 +96,7 @@ export function parseFrontmatter(content) {
   }
   const block = lines.slice(1, closeIdx).join("\n");
   try {
-    const parsed = yaml.load(block);
+    const parsed = getYaml().load(block);
     if (parsed === null || parsed === undefined) {
       return { frontmatter: {}, warnings };
     }
@@ -242,7 +251,7 @@ function loadTemplateArtifact(repoRoot, absPath) {
   const warnings = [];
   let frontmatter = {};
   try {
-    const parsed = yaml.load(content);
+    const parsed = getYaml().load(content);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       frontmatter = normalizeDates(parsed);
     } else if (parsed !== null && parsed !== undefined) {


### PR DESCRIPTION
## Summary

Bundles three v1.0.x-tier patches:

- **#135** — Strip the resolver script's `handoff-resolve:` prefix in the binary so stderr no longer double-prefixes (`dotclaude-handoff: no session matches: <q>` per spec §5.3.2). Adds `stripResolverPrefix()` and applies it at the three `runScript` callsites.
- **#136** — Amend spec `docs/specs/handoff-skill/spec/5-interfaces-apis.md` §5.3.2 to formalize the narrowed `no <cli> session matches: <q>` form when `--from <cli>` is set, alongside the unnarrowed form for union lookups. No code change — the binary's narrowed form is the better UX.
- **#130** — Make `js-yaml` lazy in `plugins/dotclaude/src/build-index.mjs` via `createRequire` so consumers of `src/index.mjs` (including `dotclaude-handoff` through re-exports) don't pay the load cost or break when js-yaml is unavailable.

Audit verdict table in `docs/audits/handoff-skill-validation-2026-04-29.md` updated to mark the three issues closed.

## Test plan

- [x] `npm test` — 549 vitest assertions pass
- [x] `bats plugins/dotclaude/tests/bats/` — 320 tests, 0 failures
- [x] `dotclaude handoff pull deadbeef` → `dotclaude-handoff: no session matches: deadbeef` (single prefix; #135 verified)
- [x] `dotclaude handoff pull deadbeef --from claude` → `dotclaude-handoff: no claude session matches: deadbeef` (matches new spec row; #136 verified)
- [x] `mv node_modules/js-yaml /tmp/ && node plugins/dotclaude/bin/dotclaude-handoff.mjs --help` exits 0 (#130 verified)
- [x] `prettier --check` and `markdownlint-cli2` clean on changed `.md` files

## Spec ID

handoff-skill, dotclaude-core
