### PR TITLE
ci(handoff): lock cross-CLI invocation symmetry on pull (#137)

### DIFF
--- a/.github/workflows/cross-cli-invocation.yml
+++ b/.github/workflows/cross-cli-invocation.yml
@@ -86,9 +86,16 @@ jobs:
         id: capture
         env:
           WORK: ${{ steps.seed.outputs.work }}
-          CLAUDE_SHORT: ${{ steps.seed.outputs.claude_short }}
-          COPILOT_SHORT: ${{ steps.seed.outputs.copilot_short }}
-          CODEX_SHORT: ${{ steps.seed.outputs.codex_short }}
+          # NB: deliberately NOT named CLAUDE_*/COPILOT_*/CODEX_* — those
+          # prefixes are exactly what dotclaude-handoff.mjs:detectHost matches
+          # as host-CLI markers, so naming a fixture short-id `CODEX_SHORT`
+          # would make detectHost return "codex" and corrupt the rendered
+          # `target` attribute. The scrub below is also defensive, but
+          # avoiding the collision in the first place keeps the contract
+          # legible.
+          FIXTURE_CLAUDE_SHORT: ${{ steps.seed.outputs.claude_short }}
+          FIXTURE_COPILOT_SHORT: ${{ steps.seed.outputs.copilot_short }}
+          FIXTURE_CODEX_SHORT: ${{ steps.seed.outputs.codex_short }}
           ROW: ${{ matrix.row }}
           INVOCATION_CONTEXT: ${{ matrix.invocation_context }}
         run: |
@@ -99,13 +106,24 @@ jobs:
           export DOTCLAUDE_QUIET=1
           export TZ=UTC
 
+          # Scrub host-CLI detection markers (dotclaude-handoff.mjs:detectHost).
+          # GH Actions runners are clean today, but defending against a future
+          # runner that injects a CODEX_/COPILOT_/CLAUDECODE marker keeps the
+          # symmetry contract anchored in the wrapper, not the host.
+          unset CLAUDECODE CLAUDE_CODE_SSE_PORT
+          while IFS='=' read -r _name _; do
+            case "$_name" in
+              CODEX_*|COPILOT_*|GITHUB_COPILOT_*) unset "$_name" ;;
+            esac
+          done < <(env)
+
           BIN="$GITHUB_WORKSPACE/plugins/dotclaude/bin/dotclaude-handoff.mjs"
 
           case "$ROW" in
-            claude-pull)         args=("pull" "$CLAUDE_SHORT") ;;
-            copilot-pull)        args=("pull" "$COPILOT_SHORT") ;;
-            copilot-pull-summary) args=("pull" "$COPILOT_SHORT" "--summary") ;;
-            codex-pull)          args=("pull" "$CODEX_SHORT") ;;
+            claude-pull)         args=("pull" "$FIXTURE_CLAUDE_SHORT") ;;
+            copilot-pull)        args=("pull" "$FIXTURE_COPILOT_SHORT") ;;
+            copilot-pull-summary) args=("pull" "$FIXTURE_COPILOT_SHORT" "--summary") ;;
+            codex-pull)          args=("pull" "$FIXTURE_CODEX_SHORT") ;;
             *) echo "::error::unknown row: $ROW"; exit 64 ;;
           esac
 

--- a/.github/workflows/cross-cli-invocation.yml
+++ b/.github/workflows/cross-cli-invocation.yml
@@ -1,0 +1,165 @@
+name: cross-cli-invocation
+
+# Locks the cross-CLI invocation symmetry contract surfaced as a positive
+# finding in the 2026-04-29 audit (Phase 2.5, CX-2). The audit verified that
+# `dotclaude handoff pull` produces byte-equivalent stdout when launched from
+# Claude Code's bash, Copilot CLI's `!`-shell, and Codex CLI's `!`-shell. CI
+# can't run the AI hosts, but it CAN run the shell wrappers each host
+# delegates to: direct bash, `bash -c`, and `sh -c`. Catching a regression
+# under any of those is sufficient to catch a host-side regression — the
+# binary doesn't know who launched it.
+#
+# Matrix is invocation_context × pull_row = 12 cells. Each cell:
+#   1. Seeds deterministic per-CLI session trees via fixtures/.../seed.sh.
+#   2. Captures stdout for one row in one invocation context.
+#   3. Diffs against the matching section of the baseline fixture.
+# Any non-empty diff fails the cell.
+#
+# Tracking issue: #137. Audit reference:
+# docs/audits/handoff-skill-validation-2026-04-29.md § Phase 2.5.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "plugins/dotclaude/bin/**"
+      - "plugins/dotclaude/scripts/**"
+      - "plugins/dotclaude/src/**"
+      - "plugins/dotclaude/tests/fixtures/cross-cli-invocation/**"
+      - "plugins/dotclaude/tests/fixtures/cross-cli-invocation-baseline.txt"
+      - ".github/workflows/cross-cli-invocation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  baseline-fresh:
+    name: baseline-fresh (regen check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: baseline matches current binary output
+        run: bash plugins/dotclaude/tests/fixtures/cross-cli-invocation/regenerate-baseline.sh --check
+
+  symmetry:
+    name: ${{ matrix.invocation_context }} × ${{ matrix.row }}
+    needs: baseline-fresh
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        invocation_context: [direct-bash, bash-c, sh-c]
+        row:
+          - claude-pull
+          - copilot-pull
+          - copilot-pull-summary
+          - codex-pull
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+
+      - name: seed deterministic session trees
+        id: seed
+        run: |
+          set -euo pipefail
+          work=$(mktemp -d)
+          eval "$(bash plugins/dotclaude/tests/fixtures/cross-cli-invocation/seed.sh "$work")"
+          {
+            echo "work=$work"
+            echo "claude_short=$CLAUDE_SHORT"
+            echo "copilot_short=$COPILOT_SHORT"
+            echo "codex_short=$CODEX_SHORT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: capture stdout in invocation context
+        id: capture
+        env:
+          WORK: ${{ steps.seed.outputs.work }}
+          CLAUDE_SHORT: ${{ steps.seed.outputs.claude_short }}
+          COPILOT_SHORT: ${{ steps.seed.outputs.copilot_short }}
+          CODEX_SHORT: ${{ steps.seed.outputs.codex_short }}
+          ROW: ${{ matrix.row }}
+          INVOCATION_CONTEXT: ${{ matrix.invocation_context }}
+        run: |
+          set -euo pipefail
+          export HOME="$WORK"
+          export XDG_CONFIG_HOME="$WORK"
+          export DOTCLAUDE_HANDOFF_REPO="$WORK/nonexistent-handoff-repo"
+          export DOTCLAUDE_QUIET=1
+          export TZ=UTC
+
+          BIN="$GITHUB_WORKSPACE/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+          case "$ROW" in
+            claude-pull)         args=("pull" "$CLAUDE_SHORT") ;;
+            copilot-pull)        args=("pull" "$COPILOT_SHORT") ;;
+            copilot-pull-summary) args=("pull" "$COPILOT_SHORT" "--summary") ;;
+            codex-pull)          args=("pull" "$CODEX_SHORT") ;;
+            *) echo "::error::unknown row: $ROW"; exit 64 ;;
+          esac
+
+          # Build the exact command string each shell wrapper will execute.
+          cmd="node \"$BIN\" ${args[*]}"
+
+          captured=$(mktemp)
+          case "$INVOCATION_CONTEXT" in
+            direct-bash)
+              # Mirrors Claude Code's pre-spawned bash environment — args
+              # arrive as a parsed argv, no shell re-parsing.
+              node "$BIN" "${args[@]}" >"$captured" 2>/dev/null
+              ;;
+            bash-c)
+              # Mirrors Copilot's `!`-shell wrapper, which round-trips
+              # through `bash -c "<cmdline>"`. Tests that flag-prefixed
+              # args (--summary) and dash-bearing UUIDs survive a single
+              # bash re-parse.
+              bash -c "$cmd" >"$captured" 2>/dev/null
+              ;;
+            sh-c)
+              # Mirrors Codex's `!`-shell wrapper. POSIX sh on ubuntu
+              # latest is dash, which has different quoting semantics
+              # from bash — surfaces the R-7 risk class.
+              sh -c "$cmd" >"$captured" 2>/dev/null
+              ;;
+            *)
+              echo "::error::unknown invocation context: $INVOCATION_CONTEXT"
+              exit 64
+              ;;
+          esac
+          echo "captured=$captured" >> "$GITHUB_OUTPUT"
+
+      - name: diff against baseline section
+        env:
+          CAPTURED: ${{ steps.capture.outputs.captured }}
+          ROW: ${{ matrix.row }}
+        run: |
+          set -euo pipefail
+          baseline="plugins/dotclaude/tests/fixtures/cross-cli-invocation-baseline.txt"
+
+          # Extract just this row's section from the baseline file. Section
+          # markers are `=== <row> ===` / `=== /<row> ===`.
+          expected=$(mktemp)
+          awk -v row="$ROW" '
+            $0 == "=== " row " ===" { f=1; next }
+            $0 == "=== /" row " ===" { f=0 }
+            f { print }
+          ' "$baseline" > "$expected"
+
+          if ! diff -u "$expected" "$CAPTURED"; then
+            echo "::error::cross-CLI symmetry broken: $ROW under ${{ matrix.invocation_context }} diverges from baseline"
+            echo "::error::see diff above; if intentional, regenerate via:"
+            echo "::error::  bash plugins/dotclaude/tests/fixtures/cross-cli-invocation/regenerate-baseline.sh"
+            exit 1
+          fi
+          echo "✓ $ROW under ${{ matrix.invocation_context }} matches baseline"

--- a/.github/workflows/cross-cli-invocation.yml
+++ b/.github/workflows/cross-cli-invocation.yml
@@ -139,9 +139,9 @@ jobs:
               ;;
             bash-c)
               # Mirrors Copilot's `!`-shell wrapper, which round-trips
-              # through `bash -c "<cmdline>"`. Tests that flag-prefixed
-              # args (--summary) and dash-bearing UUIDs survive a single
-              # bash re-parse.
+              # through `bash -c "<cmdline>"`. Tests that the command
+              # string — including flag-prefixed args such as --summary —
+              # survives a single bash re-parse.
               bash -c "$cmd" >"$captured" 2>/dev/null
               ;;
             sh-c)

--- a/plugins/dotclaude/tests/fixtures/cross-cli-invocation-baseline.txt
+++ b/plugins/dotclaude/tests/fixtures/cross-cli-invocation-baseline.txt
@@ -1,0 +1,57 @@
+=== claude-pull ===
+<handoff origin="claude" session="aaaa1111" cwd="/seed/claude" target="claude">
+
+**Summary.** Session opened with: "(no user prompts captured)". Last assistant output (truncated): "(no assistant turns captured)". Full prompt log and assistant tail follow for context.
+
+**User prompts (last 10, in order).**
+
+1. (no user prompts captured)
+
+**Last assistant turns (tail).**
+
+_(no assistant output captured)_
+**Next step.** Continue from the last assistant turn using the same file scope and goals summarized above.
+
+</handoff>
+=== /claude-pull ===
+=== copilot-pull ===
+<handoff origin="copilot" session="bbbb1111" cwd="/seed/copilot" target="claude">
+
+**Summary.** Session opened with: "(no user prompts captured)". Last assistant output (truncated): "(no assistant turns captured)". Full prompt log and assistant tail follow for context.
+
+**User prompts (last 10, in order).**
+
+1. (no user prompts captured)
+
+**Last assistant turns (tail).**
+
+_(no assistant output captured)_
+**Next step.** Continue from the last assistant turn using the same file scope and goals summarized above.
+
+</handoff>
+=== /copilot-pull ===
+=== copilot-pull-summary ===
+**copilot** `bbbb1111` — `/seed/copilot` — 2026-04-29T12:00:00Z
+
+**User prompts:**
+
+- (no user prompts captured)
+
+**Prompt count:** 0
+=== /copilot-pull-summary ===
+=== codex-pull ===
+<handoff origin="codex" session="cccc1111" cwd="/seed/codex" target="claude">
+
+**Summary.** Session opened with: "(no user prompts captured)". Last assistant output (truncated): "(no assistant turns captured)". Full prompt log and assistant tail follow for context.
+
+**User prompts (last 10, in order).**
+
+1. (no user prompts captured)
+
+**Last assistant turns (tail).**
+
+_(no assistant output captured)_
+**Next step.** Continue from the last assistant turn using the same file scope and goals summarized above.
+
+</handoff>
+=== /codex-pull ===

--- a/plugins/dotclaude/tests/fixtures/cross-cli-invocation/regenerate-baseline.sh
+++ b/plugins/dotclaude/tests/fixtures/cross-cli-invocation/regenerate-baseline.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Regenerate the cross-CLI invocation baseline fixture.
+#
+# Captures stdout from the four pin-stable Phase 2.5 invocations under direct
+# bash, sectioned by row marker, and writes the result to
+# plugins/dotclaude/tests/fixtures/cross-cli-invocation-baseline.txt.
+#
+# This is the single source of truth that the cross-cli-invocation workflow
+# diffs every shell invocation context against. Regenerate after any
+# intentional change to <handoff> / --summary output (e.g., template tweak,
+# new attribute on the opening tag) and commit the regenerated baseline in
+# the same PR.
+#
+# Usage:
+#   regenerate-baseline.sh                # writes baseline.txt next to fixtures/
+#   regenerate-baseline.sh --check        # exit 1 if current baseline drifts
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+fixture_dir="$(cd "$here/.." && pwd)"
+repo_root="$(cd "$fixture_dir/../../../.." && pwd)"
+baseline_path="$fixture_dir/cross-cli-invocation-baseline.txt"
+seed_script="$here/seed.sh"
+bin="$repo_root/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+mode="${1:-write}"
+case "$mode" in
+  ""|write|--check) ;;
+  *) echo "usage: $0 [--check]" >&2; exit 64 ;;
+esac
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+eval "$(bash "$seed_script" "$work")"
+
+# Force the same env every run so the baseline never picks up host noise.
+# DOTCLAUDE_HANDOFF_REPO must point somewhere that does not exist, so any
+# accidental remote-transport codepath surfaces as an immediate failure
+# instead of silently mutating output.
+export HOME="$work"
+export XDG_CONFIG_HOME="$work"
+export DOTCLAUDE_HANDOFF_REPO="$work/nonexistent-handoff-repo"
+export DOTCLAUDE_QUIET=1
+export TZ=UTC
+unset DOTCLAUDE_HANDOFF_DEBUG || true
+
+# Row format: <section-marker>\t<bin-args>
+# Section markers double as awk extraction keys in the workflow.
+rows=(
+  "claude-pull	pull ${CLAUDE_SHORT}"
+  "copilot-pull	pull ${COPILOT_SHORT}"
+  "copilot-pull-summary	pull ${COPILOT_SHORT} --summary"
+  "codex-pull	pull ${CODEX_SHORT}"
+)
+
+generated=$(mktemp)
+{
+  for entry in "${rows[@]}"; do
+    marker="${entry%%	*}"
+    args="${entry#*	}"
+    printf '=== %s ===\n' "$marker"
+    # shellcheck disable=SC2086
+    node "$bin" $args 2>/dev/null
+    printf '=== /%s ===\n' "$marker"
+  done
+} > "$generated"
+
+if [ "$mode" = "--check" ]; then
+  if ! diff -q "$baseline_path" "$generated" >/dev/null 2>&1; then
+    echo "baseline drift detected. Run:" >&2
+    echo "  bash $here/regenerate-baseline.sh" >&2
+    echo "and commit the updated baseline in the same PR." >&2
+    diff "$baseline_path" "$generated" >&2 || true
+    exit 1
+  fi
+  echo "✓ baseline up-to-date"
+else
+  mv "$generated" "$baseline_path"
+  echo "✓ regenerated $baseline_path"
+fi

--- a/plugins/dotclaude/tests/fixtures/cross-cli-invocation/regenerate-baseline.sh
+++ b/plugins/dotclaude/tests/fixtures/cross-cli-invocation/regenerate-baseline.sh
@@ -45,6 +45,19 @@ export DOTCLAUDE_QUIET=1
 export TZ=UTC
 unset DOTCLAUDE_HANDOFF_DEBUG || true
 
+# Scrub host-CLI detection env vars (see dotclaude-handoff.mjs:detectHost).
+# Without this, local regeneration inside Claude Code / Codex / Copilot picks
+# up the host's marker, sets target=<host>, and emits the host-flavored "Next
+# step" hint — producing a baseline that does not match the host-agnostic
+# output CI produces. Symmetric scrubbing happens in the workflow's capture
+# step so both producers always agree.
+unset CLAUDECODE CLAUDE_CODE_SSE_PORT
+while IFS='=' read -r _name _; do
+  case "$_name" in
+    CODEX_*|COPILOT_*|GITHUB_COPILOT_*) unset "$_name" ;;
+  esac
+done < <(env)
+
 # Row format: <section-marker>\t<bin-args>
 # Section markers double as awk extraction keys in the workflow.
 rows=(

--- a/plugins/dotclaude/tests/fixtures/cross-cli-invocation/seed.sh
+++ b/plugins/dotclaude/tests/fixtures/cross-cli-invocation/seed.sh
@@ -10,8 +10,10 @@
 # Usage:
 #   seed.sh <target-home>
 #
-# The caller must export DOTCLAUDE_HANDOFF_REPO=/nonexistent and DOTCLAUDE_QUIET=1
-# in the invocation environment so pull stays local-only and quiet.
+# Seeding only requires <target-home>. For the LATER `dotclaude handoff pull`
+# invocation against the seeded tree, the caller should export
+# DOTCLAUDE_HANDOFF_REPO=/nonexistent and DOTCLAUDE_QUIET=1 so pull stays
+# local-only and quiet — but those vars are not consumed by this script.
 set -euo pipefail
 
 target_home="${1:?usage: seed.sh <target-home>}"
@@ -28,26 +30,37 @@ COPILOT_CWD="/seed/copilot"
 CODEX_CWD="/seed/codex"
 
 # Fixed mtime keeps `--summary`'s timestamp byte-stable across regens.
+# `touch -d <ISO>` is GNU-only; BSD/macOS need `touch -t <stamp>`. Probe both
+# so maintainers can run regenerate-baseline.sh from either substrate.
 FIXED_MTIME="2026-04-29T12:00:00Z"
+FIXED_MTIME_TOUCH_T="202604291200.00"
+
+set_fixed_mtime() {
+  local path="${1:?usage: set_fixed_mtime <path>}"
+  if touch -d "$FIXED_MTIME" "$path" 2>/dev/null; then
+    return 0
+  fi
+  TZ=UTC touch -t "$FIXED_MTIME_TOUCH_T" "$path"
+}
 
 mkdir -p "$target_home/.claude/projects/-seed-claude"
 printf '{"cwd":"%s","sessionId":"%s","version":"2.1"}\n' \
   "$CLAUDE_CWD" "$CLAUDE_UUID" \
   > "$target_home/.claude/projects/-seed-claude/$CLAUDE_UUID.jsonl"
-touch -d "$FIXED_MTIME" "$target_home/.claude/projects/-seed-claude/$CLAUDE_UUID.jsonl"
+set_fixed_mtime "$target_home/.claude/projects/-seed-claude/$CLAUDE_UUID.jsonl"
 
 mkdir -p "$target_home/.copilot/session-state/$COPILOT_UUID"
 printf '{"type":"session.start","data":{"cwd":"%s","model":"gpt","sessionId":"%s"}}\n' \
   "$COPILOT_CWD" "$COPILOT_UUID" \
   > "$target_home/.copilot/session-state/$COPILOT_UUID/events.jsonl"
-touch -d "$FIXED_MTIME" "$target_home/.copilot/session-state/$COPILOT_UUID/events.jsonl"
+set_fixed_mtime "$target_home/.copilot/session-state/$COPILOT_UUID/events.jsonl"
 
 mkdir -p "$target_home/.codex/sessions/2026/04/29"
 codex_path="$target_home/.codex/sessions/2026/04/29/rollout-2026-04-29T12-00-00-$CODEX_UUID.jsonl"
 printf '{"type":"session_meta","payload":{"id":"%s","cwd":"%s"}}\n' \
   "$CODEX_UUID" "$CODEX_CWD" \
   > "$codex_path"
-touch -d "$FIXED_MTIME" "$codex_path"
+set_fixed_mtime "$codex_path"
 
 # Print the short-ids so callers can compose invocation rows without
 # re-hardcoding them. Stable under regeneration.

--- a/plugins/dotclaude/tests/fixtures/cross-cli-invocation/seed.sh
+++ b/plugins/dotclaude/tests/fixtures/cross-cli-invocation/seed.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Seed deterministic per-CLI session trees for the cross-CLI invocation
+# symmetry harness. Mirrors the F-2 fixture pattern from
+# plugins/dotclaude/tests/bats/handoff-pull-local-emit.bats but locks every
+# input that influences the rendered <handoff> / --summary output:
+#
+#   - JSONL contents (cwd, sessionId)
+#   - File mtime (consumed by --summary as the rendered timestamp)
+#
+# Usage:
+#   seed.sh <target-home>
+#
+# The caller must export DOTCLAUDE_HANDOFF_REPO=/nonexistent and DOTCLAUDE_QUIET=1
+# in the invocation environment so pull stays local-only and quiet.
+set -euo pipefail
+
+target_home="${1:?usage: seed.sh <target-home>}"
+
+# Pin-stable UUIDs. Distinct enough from the bats fixture UUIDs to avoid any
+# accidental cross-suite collision. Short-IDs (first 8 chars) are what the
+# resolver matches on.
+CLAUDE_UUID="aaaa1111-2222-3333-4444-555555555555"
+COPILOT_UUID="bbbb1111-2222-3333-4444-555555555555"
+CODEX_UUID="cccc1111-2222-3333-4444-555555555555"
+
+CLAUDE_CWD="/seed/claude"
+COPILOT_CWD="/seed/copilot"
+CODEX_CWD="/seed/codex"
+
+# Fixed mtime keeps `--summary`'s timestamp byte-stable across regens.
+FIXED_MTIME="2026-04-29T12:00:00Z"
+
+mkdir -p "$target_home/.claude/projects/-seed-claude"
+printf '{"cwd":"%s","sessionId":"%s","version":"2.1"}\n' \
+  "$CLAUDE_CWD" "$CLAUDE_UUID" \
+  > "$target_home/.claude/projects/-seed-claude/$CLAUDE_UUID.jsonl"
+touch -d "$FIXED_MTIME" "$target_home/.claude/projects/-seed-claude/$CLAUDE_UUID.jsonl"
+
+mkdir -p "$target_home/.copilot/session-state/$COPILOT_UUID"
+printf '{"type":"session.start","data":{"cwd":"%s","model":"gpt","sessionId":"%s"}}\n' \
+  "$COPILOT_CWD" "$COPILOT_UUID" \
+  > "$target_home/.copilot/session-state/$COPILOT_UUID/events.jsonl"
+touch -d "$FIXED_MTIME" "$target_home/.copilot/session-state/$COPILOT_UUID/events.jsonl"
+
+mkdir -p "$target_home/.codex/sessions/2026/04/29"
+codex_path="$target_home/.codex/sessions/2026/04/29/rollout-2026-04-29T12-00-00-$CODEX_UUID.jsonl"
+printf '{"type":"session_meta","payload":{"id":"%s","cwd":"%s"}}\n' \
+  "$CODEX_UUID" "$CODEX_CWD" \
+  > "$codex_path"
+touch -d "$FIXED_MTIME" "$codex_path"
+
+# Print the short-ids so callers can compose invocation rows without
+# re-hardcoding them. Stable under regeneration.
+echo "CLAUDE_SHORT=${CLAUDE_UUID:0:8}"
+echo "COPILOT_SHORT=${COPILOT_UUID:0:8}"
+echo "CODEX_SHORT=${CODEX_UUID:0:8}"


### PR DESCRIPTION
## Summary

Locks the cross-CLI invocation symmetry property surfaced in the 2026-04-29 audit (Phase 2.5, CX-2 positive finding) so future substrate or refactor drift surfaces as a fast-fail rather than a slow regression. Closes #137.

- **Workflow** at `.github/workflows/cross-cli-invocation.yml`. Two jobs: `baseline-fresh` (regen-check) and `symmetry` (12-cell matrix: `direct-bash | bash-c | sh-c` × 4 pin-stable rows). Each cell seeds, captures stdout, diffs against the baseline section.
- **Fixture scripts** at `plugins/dotclaude/tests/fixtures/cross-cli-invocation/seed.sh` and `regenerate-baseline.sh`. The seed pins JSONL contents AND mtime — the mtime feeds `--summary`'s rendered timestamp, so any unfixed mtime would make output non-deterministic.
- **Baseline** at `plugins/dotclaude/tests/fixtures/cross-cli-invocation-baseline.txt`, sectioned by row marker (awk-extractable). Regenerate via the script and commit alongside any intentional output template change.

CI can't launch the AI hosts, but each host delegates to a shell wrapper (direct argv, `bash -c "<cmdline>"`, `sh -c "<cmdline>"`). The binary doesn't know who launched it — catching a regression under any of those wrappers catches a host-side regression too. The R-7 quoting risk class is exactly what the `bash -c` and `sh -c` legs cover.

Pin-stable rows match the audit Phase 2.5 § "pin-stable fixtures" set:

- `pull <claude-uuid>` — bare `<handoff>` block
- `pull <copilot-uuid>` — bare `<handoff>` block
- `pull <copilot-uuid> --summary` — inline summary markdown (mtime-pinned timestamp)
- `pull <codex-uuid>` — bare `<handoff>` block

## Test plan

- [x] Smoke-tested all 12 cells locally (each row × each invocation context) — passed; will repeat in CI.
- [x] `regenerate-baseline.sh --check` exits 0 against the committed baseline (regen drift gate).
- [x] CI's `cross-cli-invocation` workflow runs and is green on this PR.
- [x] `prettier --check` passes on the new workflow YAML.

## Spec ID

dotclaude-core