### PR TITLE
feat(commands): add /create-experiment sandboxed exploration skill

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,214 +1,214 @@
 {
   "version": 1,
-  "generatedAt": "2026-04-28T21:54:02.280Z",
+  "generatedAt": "2026-04-30T13:37:25.082Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/commands/audit-and-fix.md",
       "checksum": "sha256:f7a8fa0598d7925de95ed3829ea677a2df58fa3db93e9ff290944bb686fad7d7",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "create-assessment",
       "path": ".claude/commands/create-assessment.md",
       "checksum": "sha256:cf3ac020cd3ce7d8fc11dbf4f5f5a2ffa5e1d6443e60cd10179b564bd77894cc",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "create-audit",
       "path": ".claude/commands/create-audit.md",
       "checksum": "sha256:cabbf4bfe2deff3a328f15e025dfc0d63369825c0c32574790251f2793e62aeb",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/commands/detect-flaky.md",
       "checksum": "sha256:cf987369294337fff90fc62e1d73d235d35055055dc8e4fbfb33a492f7cd38b5",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/commands/fix-with-evidence.md",
       "checksum": "sha256:50573c4199f27083286fdbc3760b2f684105b4a6df39b7cb47094d7c0e5327f7",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "git",
       "path": ".claude/commands/git.md",
       "checksum": "sha256:3f7b90b69172e29cdcf66713f2708f9741003d05cc12cf9d81ff79ff9c5b692c",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "ground-first",
       "path": ".claude/commands/ground-first.md",
       "checksum": "sha256:7d888f6964725d82687fb61b68ff961f041f95d2c9eef7b5282061229499ca90",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
       "checksum": "sha256:6ffc091e9bd421798c5b7990f21d095563d69c59c3e2bd10d35b554b3ec225d9",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "review-pr",
       "path": ".claude/commands/review-pr.md",
       "checksum": "sha256:d0bc84f956c0ee8c176cf76a79374e8defb0bd2487c8340a2e2a1d9e04d8a1cc",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "security-review",
       "path": ".claude/commands/security-review.md",
       "checksum": "sha256:52e610b195a43fdd460106c1bdf56b32803cb86d163a4303274773ea3900bf79",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2dc1c4213ab6650d685e7b2243ddda91fce2ceba224ca3da3951afeb37d12946",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
       "checksum": "sha256:66129dd0c5c49af5e047570b9c9f2c2046f2c6e2b0c8f64a972f658f9896131c",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "review-prs",
       "path": ".claude/commands/review-prs.md",
       "checksum": "sha256:e01a0432cd1a6cf6fe4a60cfc2b02f7cab3cde418062ca85beadc5491548bc71",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:347be395b0f8003816b4f3ed3bb777a63a3f9f7ae300d6f050b499ff66cfd3b0",
       "dependencies": [],
-      "lastValidated": "2026-04-28"
+      "lastValidated": "2026-04-30"
     },
     {
       "name": "create-experiment",
       "path": ".claude/commands/create-experiment.md",
-      "checksum": "sha256:4753333a2accc36379fa84ff2e1ef491be7e0ddce21707e17e4edba5fec1c972",
+      "checksum": "sha256:4fced15096e27f695a6be5cbb192c2fb9bbca3d7b6dd082f982dc00421928de8",
       "dependencies": [],
       "lastValidated": "2026-04-30"
     }

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -204,6 +204,13 @@
       "checksum": "sha256:347be395b0f8003816b4f3ed3bb777a63a3f9f7ae300d6f050b499ff66cfd3b0",
       "dependencies": [],
       "lastValidated": "2026-04-28"
+    },
+    {
+      "name": "create-experiment",
+      "path": ".claude/commands/create-experiment.md",
+      "checksum": "sha256:bf797e14ec8dc20261abb78b7099a3a08615ab2abc4608c5c006422f7b46e9d5",
+      "dependencies": [],
+      "lastValidated": "2026-04-30"
     }
   ]
 }

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -208,7 +208,7 @@
     {
       "name": "create-experiment",
       "path": ".claude/commands/create-experiment.md",
-      "checksum": "sha256:bf797e14ec8dc20261abb78b7099a3a08615ab2abc4608c5c006422f7b46e9d5",
+      "checksum": "sha256:4753333a2accc36379fa84ff2e1ef491be7e0ddce21707e17e4edba5fec1c972",
       "dependencies": [],
       "lastValidated": "2026-04-30"
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,17 +160,17 @@ or a `## No-spec rationale` section in its body.
 
 Quick-invoke disciplines for recurring friction:
 
-| Command                        | When                                                                                                      |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| `/ground-first <subject>`      | Before any non-trivial fix — forces code-inspection analysis before edits                                 |
-| `/merge-pr <N>`                | Before merging any PR — full local verification with optional data-regression gate via `regression_paths` |
-| `/pre-pr [base-branch]`        | Quality gate before opening a PR — simplify, security-review, full test suite                             |
-| `/fix-with-evidence <issue>`   | For any bug fix — enforces Reproduce → Fix → Verify → PR loop                                             |
-| `/dependabot-sweep`            | Batch-triage all open Dependabot PRs with parallel subagents                                              |
-| `/review-prs <N1> [N2 ...]`    | Batch-review multiple PRs in parallel — one sub-agent per PR, aggregated summary table                    |
-| `/audit-and-fix <domain>`      | Long-running audit-then-implement pipeline across many PRs                                                |
-| `/create-audit <subject>`      | Evidence-based audit doc to `docs/audits/`                                                                |
-| `/create-assessment <target>`  | 0–10 graded assessment doc to `docs/assessments/`                                                         |
-| `/create-inspection <problem>` | Investigate a problem and surface viable fix options to `docs/inspections/`                               |
+| Command                        | When                                                                                                       |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `/ground-first <subject>`      | Before any non-trivial fix — forces code-inspection analysis before edits                                  |
+| `/merge-pr <N>`                | Before merging any PR — full local verification with optional data-regression gate via `regression_paths`  |
+| `/pre-pr [base-branch]`        | Quality gate before opening a PR — simplify, security-review, full test suite                              |
+| `/fix-with-evidence <issue>`   | For any bug fix — enforces Reproduce → Fix → Verify → PR loop                                              |
+| `/dependabot-sweep`            | Batch-triage all open Dependabot PRs with parallel subagents                                               |
+| `/review-prs <N1> [N2 ...]`    | Batch-review multiple PRs in parallel — one sub-agent per PR, aggregated summary table                     |
+| `/audit-and-fix <domain>`      | Long-running audit-then-implement pipeline across many PRs                                                 |
+| `/create-audit <subject>`      | Evidence-based audit doc to `docs/audits/`                                                                 |
+| `/create-assessment <target>`  | 0–10 graded assessment doc to `docs/assessments/`                                                          |
+| `/create-inspection <problem>` | Investigate a problem and surface viable fix options to `docs/inspections/`                                |
 | `/create-experiment <topic>`   | Run a local sandboxed experiment to try options before committing to a spec — saves to `docs/experiments/` |
-| `/spec <subject>`              | Only when a spec/design doc is explicitly requested                                                       |
+| `/spec <subject>`              | Only when a spec/design doc is explicitly requested                                                        |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,4 +172,5 @@ Quick-invoke disciplines for recurring friction:
 | `/create-audit <subject>`      | Evidence-based audit doc to `docs/audits/`                                                                |
 | `/create-assessment <target>`  | 0–10 graded assessment doc to `docs/assessments/`                                                         |
 | `/create-inspection <problem>` | Investigate a problem and surface viable fix options to `docs/inspections/`                               |
+| `/create-experiment <topic>`   | Run a local sandboxed experiment to try options before committing to a spec — saves to `docs/experiments/` |
 | `/spec <subject>`              | Only when a spec/design doc is explicitly requested                                                       |

--- a/commands/create-experiment.md
+++ b/commands/create-experiment.md
@@ -9,7 +9,7 @@ task: [exploration, prototyping, documentation]
 maturity: validated
 owner: "@kaiohenricunha"
 created: 2026-04-29
-updated: 2026-04-29
+updated: 2026-04-30
 description: >
   Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /create-spec (which is heavier and design-oriented).
 argument-hint: "[topic or hypothesis]"
@@ -28,30 +28,31 @@ Arguments: `$ARGUMENTS` — a topic or hypothesis (e.g. "ripgrep vs grep on this
 
 The output is a dated markdown file under `docs/experiments/` plus a sandbox directory containing the runnable artifacts. Both are left untracked for the user to review.
 
-## Phases
+## Steps
 
-### Phase 0 — Refine the goal (interactive, blocking)
+### Step 0 — Refine the goal (interactive, blocking)
 
-Before running anything, ask the user up to 5 short questions. Skip any already answered in `$ARGUMENTS` or recent context. Do not infer answers — ask.
+If `$ARGUMENTS` already covers hypothesis + observable success signal, echo the refined goal back as a paragraph + bulleted success criteria and **wait for user sign-off** before proceeding. Skip questions already answered in `$ARGUMENTS` or recent context.
+
+Otherwise, ask up to 4 short questions:
 
 1. **What are you trying to learn?** — one-sentence hypothesis.
 2. **What does "it worked" look like?** — concrete, observable signal (a benchmark number, a working prototype, a config that boots, a passing test).
 3. **What's out of scope?** — what should NOT be touched.
 4. **Time-box** — sketch (≤30 min), half-day (≤4 hr), or full-day (≤8 hr).
-5. **Environment** — repo / language / runtime, plus any external services that need stubbing or mocking.
 
-Echo the refined goal back as a paragraph + bulleted success criteria. **Wait for explicit user sign-off before continuing.** Do not proceed to Phase 1 until the user confirms.
+Echo the refined goal back as a paragraph + bulleted success criteria. **Wait for explicit user sign-off before continuing.** Do not proceed to Step 1 until the user confirms.
 
-### Phase 1 — Plan the experiment
+### Step 1 — Plan the experiment
 
 - Propose 1–3 approaches to try. Each is a distinct path to the same hypothesis.
 - For each approach, sketch: what gets installed, what runs, what's measured.
 - Pick the sandbox target:
-  - **Default:** a fresh git worktree at `.claude/worktrees/experiment-<slug>/` branched from the latest `origin/main` (per the dotclaude *Worktree discipline* rule). Run `git fetch origin main` first.
+  - **Default:** a fresh git worktree at `.claude/worktrees/experiment-<slug>/` branched from the latest `origin/main`. Run `git fetch origin main` first.
   - **Fallback:** `~/experiments/<slug>/` if there is no enclosing git repo.
 - Show this plan to the user and get a final go-ahead before touching the system.
 
-### Phase 2 — Set up the environment
+### Step 2 — Set up the environment
 
 Execute setup commands in the sandbox. **Capture every command and its full output** — this is the reproducibility ledger and goes verbatim into the report. Examples:
 
@@ -63,20 +64,22 @@ Execute setup commands in the sandbox. **Capture every command and its full outp
 
 If a setup step fails, document the failure, attempt **one** recovery (e.g. install a missing system dep), and proceed only if it succeeds. Do not silently swallow errors.
 
-### Phase 3 — Execute the approaches
+### Step 3 — Execute the approaches
+
+Approaches are independent by default — execute concurrently when possible (parallel tool calls or background jobs with per-approach log files). Fall back to serial execution only when one approach depends on another's artifact.
 
 For each approach:
 
 - Save code/config under `experiments/<slug>/<approach>/` inside the sandbox.
-- Run the approach. Capture stdout/stderr — keep at least the **last 10 lines** of every non-trivial command (per the dotclaude *Test Plan Verification* rule).
-- Evaluate against the success criteria from Phase 0. Record the result as **PASS**, **PARTIAL**, or **FAIL**.
+- Run the approach. For measurement commands and any failing command, capture full output — at minimum the last 10 lines.
+- Evaluate against the success criteria from Step 0. Record the result as **PASS**, **PARTIAL**, or **FAIL**.
 - If an approach surfaces a blocker that invalidates the hypothesis itself, stop and surface that to the user before continuing — they may want to refine the goal.
 
-### Phase 4 — Compare & recommend
+### Step 4 — Compare & recommend
 
 Build a comparison table that maps each approach against the agreed success criteria. Pick a recommendation, **or** explicitly say "none of these — here's why and what to try next." A clean negative result is a complete experiment.
 
-### Phase 5 — Write the report
+### Step 5 — Write the report
 
 Generate a filename: `<topic-slug>-<YYYY-MM-DD>.md` in lowercase kebab-case (e.g. `ripgrep-vs-grep-2026-04-29.md`). Create `docs/experiments/` if it doesn't exist. Use this structure:
 
@@ -96,13 +99,13 @@ Generate a filename: `<topic-slug>-<YYYY-MM-DD>.md` in lowercase kebab-case (e.g
 
 ## Environment Setup
 
-Sandbox: `<absolute path to worktree or ~/experiments/<slug>/>`
+Sandbox: `<absolute path chosen in Step 1>`
 
 ```bash
 <exact commands run, in order>
 ```
 
-<key output snippets — last 10 lines per command if non-trivial>
+<output snippets for any measurement or failing command — last 10 lines minimum>
 
 ## Approaches Tried
 
@@ -117,13 +120,13 @@ Sandbox: `<absolute path to worktree or ~/experiments/<slug>/>`
 - **Result:** PASS | PARTIAL | FAIL — <observed signal vs criterion>
 - **Notes:** <gotchas, surprises, dead-ends>
 
-### Approach 2: …
+<!-- Add sections for each approach tried; omit if only one approach was attempted -->
 
 ## Comparison
 
-| Approach | Result | Effort | Risk | Criterion 1 | Criterion 2 |
-| -------- | ------ | ------ | ---- | ----------- | ----------- |
-| ...      | ...    | ...    | ...  | ...         | ...         |
+| Approach | Result | <Criterion 1> | <Criterion 2> | Effort |
+| -------- | ------ | ------------- | ------------- | ------ |
+| ...      | ...    | ...           | ...           | ...    |
 
 ## Recommendation
 
@@ -147,19 +150,16 @@ rm -rf ~/experiments/<slug>
 ```
 ```
 
-### Phase 6 — Report back
+### Step 6 — Report back
 
-Show the user: the doc path, the recommendation in one sentence, and the sandbox path so they can re-enter it. **Do not dump the full document into chat.**
+Reply with: doc path, one-sentence recommendation, and sandbox path. **Do not paste the full document into chat.**
 
 ## Rules
 
-- Refine the goal **before** running anything. No code executes until success criteria are agreed and the user signs off.
 - All work runs **locally**. No production endpoints, no cloud writes, no real auth tokens, no shared infrastructure. If the experiment needs an external service, mock it or use a disposable test account.
 - Environment setup is part of the experiment — every install/config/boot command must appear in the report. Reproducibility is the bar.
 - Capture failed approaches too. Negative results are valuable signal and **must** be in the report.
-- Cite `file:line` for any code referenced. Paste the last 10 lines of any command output claimed.
-- Default sandbox is a git worktree at `.claude/worktrees/experiment-<slug>/`. Fall back to `~/experiments/<slug>/` only when there is no enclosing git repo.
 - Do not commit the experiment doc or the sandbox. Leave both untracked for the user.
-- Do not install global tools (`apt`, `brew`, `npm i -g`) without explicit user approval during Phase 1.
+- Do not install global tools (`apt`, `brew`, `npm i -g`) without explicit user approval during Step 1.
 - Tables and code blocks over prose. No filler.
 - An experiment is **done when success criteria are evaluated** — not when "everything works." A clean failure is a finished experiment.

--- a/commands/create-experiment.md
+++ b/commands/create-experiment.md
@@ -1,0 +1,165 @@
+---
+id: create-experiment
+name: create-experiment
+type: command
+version: 1.0.0
+domain: [devex]
+platform: [none]
+task: [exploration, prototyping, documentation]
+maturity: validated
+owner: "@kaiohenricunha"
+created: 2026-04-29
+updated: 2026-04-29
+description: >
+  Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /create-spec (which is heavier and design-oriented).
+argument-hint: "[topic or hypothesis]"
+model: sonnet
+---
+
+Run a scoped, local-only experiment and produce a structured report saved to the project's `docs/experiments/` directory.
+
+Trigger: when the user asks "let's try X", "I want to compare A vs B", "can we prototype Y", "explore Z before we commit", or invokes `/create-experiment` directly. Use this skill **before** `/create-spec` (which is for design docs, not exploratory probes) and **after** plain shell tinkering becomes too messy to track.
+
+Arguments: `$ARGUMENTS` — a topic or hypothesis (e.g. "ripgrep vs grep on this repo", "switch from pnpm to bun", "does Postgres LISTEN/NOTIFY scale to N clients"). Required — if empty, ask the user what they want to explore.
+
+## Purpose
+
+`/create-experiment` is **not** a spec (no formal design), **not** an audit (it doesn't enumerate issues), **not** a fix (it doesn't ship anything). It is a **decision-grade probe**: refine a hypothesis, run it locally, capture results — including negative ones — and recommend a next move.
+
+The output is a dated markdown file under `docs/experiments/` plus a sandbox directory containing the runnable artifacts. Both are left untracked for the user to review.
+
+## Phases
+
+### Phase 0 — Refine the goal (interactive, blocking)
+
+Before running anything, ask the user up to 5 short questions. Skip any already answered in `$ARGUMENTS` or recent context. Do not infer answers — ask.
+
+1. **What are you trying to learn?** — one-sentence hypothesis.
+2. **What does "it worked" look like?** — concrete, observable signal (a benchmark number, a working prototype, a config that boots, a passing test).
+3. **What's out of scope?** — what should NOT be touched.
+4. **Time-box** — sketch (≤30 min), half-day (≤4 hr), or full-day (≤8 hr).
+5. **Environment** — repo / language / runtime, plus any external services that need stubbing or mocking.
+
+Echo the refined goal back as a paragraph + bulleted success criteria. **Wait for explicit user sign-off before continuing.** Do not proceed to Phase 1 until the user confirms.
+
+### Phase 1 — Plan the experiment
+
+- Propose 1–3 approaches to try. Each is a distinct path to the same hypothesis.
+- For each approach, sketch: what gets installed, what runs, what's measured.
+- Pick the sandbox target:
+  - **Default:** a fresh git worktree at `.claude/worktrees/experiment-<slug>/` branched from the latest `origin/main` (per the dotclaude *Worktree discipline* rule). Run `git fetch origin main` first.
+  - **Fallback:** `~/experiments/<slug>/` if there is no enclosing git repo.
+- Show this plan to the user and get a final go-ahead before touching the system.
+
+### Phase 2 — Set up the environment
+
+Execute setup commands in the sandbox. **Capture every command and its full output** — this is the reproducibility ledger and goes verbatim into the report. Examples:
+
+- `git worktree add .claude/worktrees/experiment-<slug> -b experiment/<slug> origin/main`
+- `npm i <pkg>` / `pnpm add <pkg>` / `bun add <pkg>`
+- `python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`
+- `docker compose up -d`
+- `cargo new <name> && cd <name>`
+
+If a setup step fails, document the failure, attempt **one** recovery (e.g. install a missing system dep), and proceed only if it succeeds. Do not silently swallow errors.
+
+### Phase 3 — Execute the approaches
+
+For each approach:
+
+- Save code/config under `experiments/<slug>/<approach>/` inside the sandbox.
+- Run the approach. Capture stdout/stderr — keep at least the **last 10 lines** of every non-trivial command (per the dotclaude *Test Plan Verification* rule).
+- Evaluate against the success criteria from Phase 0. Record the result as **PASS**, **PARTIAL**, or **FAIL**.
+- If an approach surfaces a blocker that invalidates the hypothesis itself, stop and surface that to the user before continuing — they may want to refine the goal.
+
+### Phase 4 — Compare & recommend
+
+Build a comparison table that maps each approach against the agreed success criteria. Pick a recommendation, **or** explicitly say "none of these — here's why and what to try next." A clean negative result is a complete experiment.
+
+### Phase 5 — Write the report
+
+Generate a filename: `<topic-slug>-<YYYY-MM-DD>.md` in lowercase kebab-case (e.g. `ripgrep-vs-grep-2026-04-29.md`). Create `docs/experiments/` if it doesn't exist. Use this structure:
+
+```markdown
+# Experiment: <Topic> — <YYYY-MM-DD>
+
+<One-sentence hypothesis.>
+
+## Goal
+
+<2–3 sentences. What we're learning and why this experiment was run now.>
+
+## Success Criteria
+
+- <observable signal 1>
+- <observable signal 2>
+
+## Environment Setup
+
+Sandbox: `<absolute path to worktree or ~/experiments/<slug>/>`
+
+```bash
+<exact commands run, in order>
+```
+
+<key output snippets — last 10 lines per command if non-trivial>
+
+## Approaches Tried
+
+### Approach 1: <Name>
+
+- **Idea:** <one line>
+- **Code/config:** `<path-in-sandbox>`
+- **Commands:**
+  ```bash
+  <commands>
+  ```
+- **Result:** PASS | PARTIAL | FAIL — <observed signal vs criterion>
+- **Notes:** <gotchas, surprises, dead-ends>
+
+### Approach 2: …
+
+## Comparison
+
+| Approach | Result | Effort | Risk | Criterion 1 | Criterion 2 |
+| -------- | ------ | ------ | ---- | ----------- | ----------- |
+| ...      | ...    | ...    | ...  | ...         | ...         |
+
+## Recommendation
+
+**<Adopt Approach N | Iterate further | Abandon>**
+
+<2–3 sentences. Why this conclusion best matches the success criteria. Call out
+assumptions or unresolved questions.>
+
+## Next Step
+
+- Promote to `/create-spec <topic>` to formalize the chosen approach, OR
+- Run `/fix-with-evidence <topic>` to implement directly, OR
+- Re-run `/create-experiment` with a refined hypothesis, OR
+- Drop it — this document is the negative-result record.
+
+## Sandbox Cleanup
+
+```bash
+git worktree remove .claude/worktrees/experiment-<slug>   # or
+rm -rf ~/experiments/<slug>
+```
+```
+
+### Phase 6 — Report back
+
+Show the user: the doc path, the recommendation in one sentence, and the sandbox path so they can re-enter it. **Do not dump the full document into chat.**
+
+## Rules
+
+- Refine the goal **before** running anything. No code executes until success criteria are agreed and the user signs off.
+- All work runs **locally**. No production endpoints, no cloud writes, no real auth tokens, no shared infrastructure. If the experiment needs an external service, mock it or use a disposable test account.
+- Environment setup is part of the experiment — every install/config/boot command must appear in the report. Reproducibility is the bar.
+- Capture failed approaches too. Negative results are valuable signal and **must** be in the report.
+- Cite `file:line` for any code referenced. Paste the last 10 lines of any command output claimed.
+- Default sandbox is a git worktree at `.claude/worktrees/experiment-<slug>/`. Fall back to `~/experiments/<slug>/` only when there is no enclosing git repo.
+- Do not commit the experiment doc or the sandbox. Leave both untracked for the user.
+- Do not install global tools (`apt`, `brew`, `npm i -g`) without explicit user approval during Phase 1.
+- Tables and code blocks over prose. No filler.
+- An experiment is **done when success criteria are evaluated** — not when "everything works." A clean failure is a finished experiment.

--- a/commands/create-experiment.md
+++ b/commands/create-experiment.md
@@ -5,20 +5,20 @@ type: command
 version: 1.0.0
 domain: [devex]
 platform: [none]
-task: [exploration, prototyping, documentation]
+task: [review, documentation]
 maturity: validated
 owner: "@kaiohenricunha"
 created: 2026-04-29
 updated: 2026-04-30
 description: >
-  Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /create-spec (which is heavier and design-oriented).
+  Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /spec (which is heavier and design-oriented).
 argument-hint: "[topic or hypothesis]"
 model: sonnet
 ---
 
 Run a scoped, local-only experiment and produce a structured report saved to the project's `docs/experiments/` directory.
 
-Trigger: when the user asks "let's try X", "I want to compare A vs B", "can we prototype Y", "explore Z before we commit", or invokes `/create-experiment` directly. Use this skill **before** `/create-spec` (which is for design docs, not exploratory probes) and **after** plain shell tinkering becomes too messy to track.
+Trigger: when the user asks "let's try X", "I want to compare A vs B", "can we prototype Y", "explore Z before we commit", or invokes `/create-experiment` directly. Use this skill **before** `/spec` (which is for design docs, not exploratory probes) and **after** plain shell tinkering becomes too messy to track.
 
 Arguments: `$ARGUMENTS` — a topic or hypothesis (e.g. "ripgrep vs grep on this repo", "switch from pnpm to bun", "does Postgres LISTEN/NOTIFY scale to N clients"). Required — if empty, ask the user what they want to explore.
 
@@ -54,7 +54,7 @@ Echo the refined goal back as a paragraph + bulleted success criteria. **Wait fo
 
 ### Step 2 — Set up the environment
 
-Execute setup commands in the sandbox. **Capture every command and its full output** — this is the reproducibility ledger and goes verbatim into the report. Examples:
+Execute setup commands in the sandbox. **Capture every command and its output** as the reproducibility ledger — redact any tokens or credentials before including output in the report. Examples:
 
 - `git worktree add .claude/worktrees/experiment-<slug> -b experiment/<slug> origin/main`
 - `npm i <pkg>` / `pnpm add <pkg>` / `bun add <pkg>`
@@ -83,7 +83,7 @@ Build a comparison table that maps each approach against the agreed success crit
 
 Generate a filename: `<topic-slug>-<YYYY-MM-DD>.md` in lowercase kebab-case (e.g. `ripgrep-vs-grep-2026-04-29.md`). Create `docs/experiments/` if it doesn't exist. Use this structure:
 
-```markdown
+````markdown
 # Experiment: <Topic> — <YYYY-MM-DD>
 
 <One-sentence hypothesis.>
@@ -114,9 +114,11 @@ Sandbox: `<absolute path chosen in Step 1>`
 - **Idea:** <one line>
 - **Code/config:** `<path-in-sandbox>`
 - **Commands:**
+
   ```bash
   <commands>
   ```
+
 - **Result:** PASS | PARTIAL | FAIL — <observed signal vs criterion>
 - **Notes:** <gotchas, surprises, dead-ends>
 
@@ -137,7 +139,7 @@ assumptions or unresolved questions.>
 
 ## Next Step
 
-- Promote to `/create-spec <topic>` to formalize the chosen approach, OR
+- Promote to `/spec <topic>` to formalize the chosen approach, OR
 - Run `/fix-with-evidence <topic>` to implement directly, OR
 - Re-run `/create-experiment` with a refined hypothesis, OR
 - Drop it — this document is the negative-result record.
@@ -148,7 +150,7 @@ assumptions or unresolved questions.>
 git worktree remove .claude/worktrees/experiment-<slug>   # or
 rm -rf ~/experiments/<slug>
 ```
-```
+````
 
 ### Step 6 — Report back
 

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotclaude.dev/schemas/index.schema.json",
-  "generatedAt": "2026-04-29T22:16:23.815Z",
+  "generatedAt": "2026-04-30T13:37:16.375Z",
   "version": "1.0.1",
   "artifacts": [
     {
@@ -10,9 +10,15 @@
       "name": "agents-search",
       "description": "Discover, search, and manage Claude Code agents. Use when you want to find available agents, list installed agents, or refresh the agent catalog. Triggers on: \"search agents\", \"list agents\", \"find agent\", \"what agents\", \"agent catalog\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -25,9 +31,15 @@
       "name": "architect-reviewer",
       "description": "Use when evaluating system design, reviewing architectural decisions, assessing technology choices, or identifying structural anti-patterns. Triggers on: \"review architecture\", \"design review\", \"architecture concerns\", \"tech stack\", \"coupling\", \"scalability review\", \"ADR review\". Uses opus — cross-cutting architectural analysis requires deep reasoning across large codebases.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -40,9 +52,16 @@
       "name": "audit-and-fix",
       "description": "Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to \"audit and fix\" or kicks off an overnight cleanup run.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -55,14 +74,23 @@
       "name": "aws-engineer",
       "description": "Use when designing, debugging, or reviewing AWS workloads and service integrations. Triggers on: \"AWS\", \"EC2\", \"ECS\", \"EKS\", \"Lambda\", \"S3\", \"IAM role\", \"VPC\", \"RDS\", \"DynamoDB\", \"CloudFront\", \"ALB\", \"Route53\", \"CloudFormation\", \"CDK\", \"API Gateway\", \"EventBridge\", \"SQS\", \"SNS\". Uses opus — AWS architecture spans IAM trust, multi-service interactions, and compliance tradeoffs that benefit from deep analysis.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["aws"],
-        "task": ["provisioning", "debugging"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "aws"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha",
-      "related": ["aws-specialist"]
+      "related": [
+        "aws-specialist"
+      ]
     },
     {
       "id": "aws-specialist",
@@ -71,9 +99,16 @@
       "name": "aws-specialist",
       "description": "Deep-dive AWS architecture review, debugging, and service design. Use for structured investigations of AWS-specific issues, cost or IAM audits, and multi-service design reviews. Triggers on: \"AWS audit\", \"AWS design review\", \"IAM review\", \"cost audit AWS\", \"review my VPC\", \"AWS troubleshooting\", \"Lambda deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["aws"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "aws"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -86,9 +121,16 @@
       "name": "azure-engineer",
       "description": "Use when designing, debugging, or reviewing Azure workloads and service integrations. Triggers on: \"Azure\", \"AKS\", \"ACI\", \"App Service\", \"Azure Functions\", \"Blob Storage\", \"VNet\", \"App Gateway\", \"Front Door\", \"EntraID\", \"Managed Identity\", \"ARM template\", \"Bicep\", \"Azure DevOps\", \"ACR\", \"Service Bus\", \"Logic Apps\", \"Cosmos DB\". Uses opus — Azure spans identity, networking, and multi-subscription governance; deep reasoning reduces costly misconfigurations.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["azure"],
-        "task": ["provisioning", "debugging"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "azure"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -101,9 +143,16 @@
       "name": "azure-specialist",
       "description": "Deep-dive Azure architecture review, debugging, and service design. Use for structured investigations of Azure-specific issues, identity or cost audits, and multi-service design reviews. Triggers on: \"Azure audit\", \"Azure design review\", \"EntraID review\", \"Managed Identity debug\", \"review my Azure\", \"Azure troubleshooting\", \"AKS deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["azure"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "azure"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -116,9 +165,16 @@
       "name": "backend-developer",
       "description": "Use when building or modifying server-side code: APIs, services, data models, background jobs, or infrastructure logic. Triggers on: \"build API\", \"add endpoint\", \"database schema\", \"backend service\", \"server-side\", \"REST\", \"GraphQL\", \"background job\", \"migration\". Uses sonnet — everyday backend implementation benefits from balanced capability and throughput.\n",
       "facets": {
-        "domain": ["backend"],
-        "platform": ["none"],
-        "task": ["scaffolding", "debugging"],
+        "domain": [
+          "backend"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "scaffolding",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -131,9 +187,15 @@
       "name": "changelog",
       "description": "Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -146,9 +208,16 @@
       "name": "changelog-assistant",
       "description": "Use when generating changelog entries, drafting release notes, or summarizing git history for a release. Triggers on: \"generate changelog\", \"release notes\", \"what changed\", \"CHANGELOG\", \"summarize commits\", \"release summary\", \"version bump notes\". Uses haiku — changelog generation from git history is formulaic and lightweight; fast output benefits release flow.\n",
       "facets": {
-        "domain": ["writing", "devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "writing",
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -161,9 +230,16 @@
       "name": "compliance-auditor",
       "description": "Use when auditing data quality gates, config-driven checks, or invariant enforcement. Cross-references declaration files against runtime enforcement code to find declared-not-enforced and enforced-not-declared gaps. Read-only — produces a coverage matrix, never modifies code or config. Triggers on: \"gate coverage\", \"quality check audit\", \"data invariants\", \"declared vs enforced\", \"config vs code gaps\", \"quality gate completeness\".\n",
       "facets": {
-        "domain": ["security"],
-        "platform": ["none"],
-        "task": ["review", "diagnostics"],
+        "domain": [
+          "security"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "diagnostics"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -176,9 +252,16 @@
       "name": "container-engineer",
       "description": "Use when authoring, optimizing, or reviewing container images and build pipelines. Triggers on: \"Dockerfile\", \"container image\", \"multi-stage build\", \"image size\", \"OCI\", \"Docker Compose\", \"container registry\", \"base image\", \"layer cache\". Uses sonnet — container image optimization is structured and pattern-driven; sonnet provides the right depth without excess cost.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["docker"],
-        "task": ["provisioning", "debugging"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "docker"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -191,9 +274,16 @@
       "name": "create-assessment",
       "description": "Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -206,9 +296,38 @@
       "name": "create-audit",
       "description": "Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "documentation"
+        ],
+        "maturity": "validated"
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
+    },
+    {
+      "id": "create-experiment",
+      "type": "command",
+      "path": "commands/create-experiment.md",
+      "name": "create-experiment",
+      "description": "Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /spec (which is heavier and design-oriented).\n",
+      "facets": {
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -221,9 +340,16 @@
       "name": "create-inspection",
       "description": "Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -236,9 +362,16 @@
       "name": "crossplane-engineer",
       "description": "Use when designing, debugging, or reviewing Crossplane configurations and Kubernetes-native IaC. Triggers on: \"Crossplane\", \"XRD\", \"Composition\", \"CompositeResource\", \"Claim\", \"managed resource\", \"provider config\", \"ProviderConfig\", \"composite resource definition\", \"Crossplane package\". Uses sonnet — Crossplane Composition authoring is well-specified; sonnet covers the depth needed.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["kubernetes", "crossplane"],
-        "task": ["provisioning"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "kubernetes",
+          "crossplane"
+        ],
+        "task": [
+          "provisioning"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -251,9 +384,17 @@
       "name": "crossplane-specialist",
       "description": "Deep-dive Crossplane platform review: XRD design, Composition correctness, provider config audit, managed resource health, and GitOps integration. Use for structured investigations of stuck Claims, composition pipeline bugs, and credential injection patterns. Triggers on: \"Crossplane audit\", \"XRD review\", \"Composition debug\", \"stuck Claim\", \"managed resource stuck\", \"provider config review\", \"Crossplane GitOps\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["crossplane", "kubernetes"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "crossplane",
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -266,9 +407,16 @@
       "name": "data-scientist",
       "description": "Use when validating statistical models, scoring formulas, or config-driven math. Audits formula correctness, boundary conditions, config-vs-code drift, and output scale changes. Read-only — surfaces findings, never modifies code. Triggers on: \"validate scoring math\", \"check formula\", \"config drift\", \"boundary conditions\", \"statistical model audit\", \"rating algorithm review\".\n",
       "facets": {
-        "domain": ["data"],
-        "platform": ["none"],
-        "task": ["review", "diagnostics"],
+        "domain": [
+          "data"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "diagnostics"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -281,9 +429,16 @@
       "name": "dependabot-sweep",
       "description": "Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.\n",
       "facets": {
-        "domain": ["devex", "security"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex",
+          "security"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -296,9 +451,16 @@
       "name": "deployment-engineer",
       "description": "Use when planning or executing deployment strategies, release coordination, traffic shifting, or rollback procedures. Triggers on: \"deployment strategy\", \"blue/green\", \"canary release\", \"rolling update\", \"traffic shifting\", \"rollback\", \"release coordination\", \"feature flag\", \"progressive delivery\", \"deploy to production\". Uses sonnet — deployment strategy execution is structured; sonnet handles the reasoning without over-provisioning cost.\n",
       "facets": {
-        "domain": ["devex", "infra"],
-        "platform": ["none"],
-        "task": ["runtime-ops"],
+        "domain": [
+          "devex",
+          "infra"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "runtime-ops"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -311,9 +473,16 @@
       "name": "detect-flaky",
       "description": "Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["testing", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "testing",
+          "debugging"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -326,9 +495,16 @@
       "name": "devops-engineer",
       "description": "Use when building or improving CI/CD pipelines, release workflows, build automation, or developer tooling. Triggers on: \"CI pipeline\", \"CD workflow\", \"GitHub Actions\", \"build automation\", \"artifact\", \"release workflow\", \"environment promotion\", \"pipeline stage\", \"deploy pipeline\", \"lint CI\". Uses sonnet — CI/CD pipeline work is structured and iterative; sonnet matches the workload.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["scaffolding", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "scaffolding",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -341,9 +517,16 @@
       "name": "docker-engineer",
       "description": "Use when designing, operating, or debugging Docker Compose stacks and running containers. Triggers on: \"docker compose up\", \"docker compose exec\", \"docker compose ps\", \"docker compose down\", \"docker compose restart\", \"compose stack\", \"multi-service compose\", \"service dependencies\", \"docker exec\", \"inspect container\", \"container logs\", \"docker logs\", \"container networking\", \"docker network\", \"running container\", \"container debug\", \"docker stats\", \"docker scout\". Uses sonnet — Compose design and runtime ops are structured; sonnet provides the right depth.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["docker"],
-        "task": ["debugging", "runtime-ops"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "docker"
+        ],
+        "task": [
+          "debugging",
+          "runtime-ops"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -356,9 +539,16 @@
       "name": "documentation-writer",
       "description": "Use when writing or updating documentation: user guides, READMEs, API references, onboarding materials, docstrings, or inline docs. Triggers on: \"write docs\", \"update README\", \"API documentation\", \"document this\", \"user guide\", \"onboarding guide\", \"add examples\", \"explain how\". Uses haiku — documentation writing is templated and fast-turnaround; throughput matters more than deep reasoning.\n",
       "facets": {
-        "domain": ["writing", "devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "writing",
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -371,9 +561,16 @@
       "name": "fix-with-evidence",
       "description": "Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -386,9 +583,16 @@
       "name": "frontend-developer",
       "description": "Use when building or modifying client-side code: UI components, pages, forms, state management, or client-side data fetching. Triggers on: \"build UI\", \"React component\", \"frontend\", \"CSS\", \"accessibility\", \"form validation\", \"client-side\", \"Next.js page\", \"Tailwind\". Uses sonnet — everyday frontend implementation benefits from balanced capability and response speed.\n",
       "facets": {
-        "domain": ["frontend"],
-        "platform": ["none"],
-        "task": ["scaffolding", "debugging"],
+        "domain": [
+          "frontend"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "scaffolding",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -401,9 +605,16 @@
       "name": "gcp-engineer",
       "description": "Use when designing, debugging, or reviewing Google Cloud workloads and service integrations. Triggers on: \"GCP\", \"Google Cloud\", \"GKE\", \"Cloud Run\", \"GCE\", \"Cloud Functions\", \"Pub/Sub\", \"GCS\", \"BigQuery\", \"Cloud Build\", \"Workload Identity\", \"Service Account\", \"VPC\", \"Cloud Armor\", \"Cloud CDN\", \"Deployment Manager\", \"Config Connector\". Uses opus — GCP architecture across Workload Identity, VPC networks, and IAM hierarchies requires deep reasoning to avoid security gaps.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["gcp"],
-        "task": ["provisioning", "debugging"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "gcp"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -416,9 +627,16 @@
       "name": "gcp-specialist",
       "description": "Deep-dive Google Cloud architecture review, debugging, and service design. Use for structured investigations of GCP-specific issues, IAM or cost audits, and multi-service design reviews. Triggers on: \"GCP audit\", \"GCP design review\", \"Workload Identity debug\", \"IAM review GCP\", \"review my GKE\", \"GCP troubleshooting\", \"Cloud Run deep-dive\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["gcp"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "gcp"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -431,9 +649,15 @@
       "name": "git",
       "description": "Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -446,9 +670,16 @@
       "name": "ground-first",
       "description": "Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -461,9 +692,16 @@
       "name": "handoff",
       "description": "Transfer conversation context between agentic CLIs (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a source session transcript by UUID and produces either an inline summary, a paste-ready handoff digest, a written markdown file, or a branch in a user-owned private git repo that another machine can fetch. Use when switching agents mid-task, recovering context, or moving between Windows/Linux/macOS setups. Triggers on: \"handoff\", \"transfer context\", \"continue in codex\", \"continue in claude\", \"continue in copilot\", \"switch to codex\", \"switch to claude\", \"what was that session about\", \"claude --resume\", \"copilot --resume\", \"codex resume\", \"find the session where\", \"search sessions\", \"which session did I\", \"push handoff\", \"fetch handoff\", \"handoff to other machine\", \"resume on my other laptop\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.2.0",
@@ -476,9 +714,18 @@
       "name": "iac-engineer",
       "description": "Use when writing, reviewing, or refactoring infrastructure-as-code modules, managing state, or handling drift detection. Triggers on: \"Terraform\", \"Pulumi\", \"OpenTofu\", \"infrastructure as code\", \"IaC module\", \"state file\", \"drift detection\", \"resource graph\", \"provider\", \"workspace\", \"remote state\". Uses sonnet — IaC authoring is structured and pattern-driven; sonnet covers the depth needed without excess cost.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terraform", "terragrunt", "pulumi"],
-        "task": ["provisioning", "debugging"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform",
+          "terragrunt",
+          "pulumi"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -491,14 +738,24 @@
       "name": "kubernetes-specialist",
       "description": "Use when designing, debugging, or reviewing Kubernetes workloads and cluster configuration. Triggers on: \"kubernetes\", \"k8s\", \"pod\", \"deployment\", \"cluster\", \"kubectl\", \"namespace\", \"ingress\", \"helm chart\", \"workload\", \"node not ready\". Uses opus — Kubernetes troubleshooting spans scheduler decisions, network policy semantics, and control-plane interactions; deep reasoning prevents misdiagnosis.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["kubernetes"],
-        "task": ["debugging", "diagnostics", "runtime-ops"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "diagnostics",
+          "runtime-ops"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha",
-      "related": ["kubernetes-specialist"]
+      "related": [
+        "kubernetes-specialist"
+      ]
     },
     {
       "id": "kubernetes-specialist",
@@ -507,9 +764,16 @@
       "name": "kubernetes-specialist",
       "description": "Deep-dive Kubernetes troubleshooting, workload design, and cluster health review. Use when you need a structured investigation of a cluster issue, a design review of Kubernetes manifests, or a health audit of a namespace or workload. Triggers on: \"debug kubernetes\", \"why is my pod\", \"review my manifests\", \"cluster health\", \"kubernetes design review\", \"k8s audit\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["kubernetes"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "kubernetes"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -522,9 +786,16 @@
       "name": "markdown",
       "description": "Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.\n",
       "facets": {
-        "domain": ["devex", "writing"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex",
+          "writing"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -537,9 +808,16 @@
       "name": "merge-pr",
       "description": "Merge a pull request only after full local verification, with an optional data-regression gate for paths configured in docs/repo-facts.json.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -552,9 +830,17 @@
       "name": "platform-engineer",
       "description": "Use when designing or improving internal developer platforms, golden paths, self-service tooling, or environment parity. Triggers on: \"developer platform\", \"internal tooling\", \"golden path\", \"paved road\", \"developer experience\", \"self-service\", \"environment parity\", \"platform team\", \"scaffolding\", \"service catalog\". Uses opus — platform design decisions compound over time; deep reasoning prevents golden-path choices that become maintenance burdens.\n",
       "facets": {
-        "domain": ["devex", "infra"],
-        "platform": ["none"],
-        "task": ["scaffolding", "provisioning"],
+        "domain": [
+          "devex",
+          "infra"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "scaffolding",
+          "provisioning"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -567,9 +853,16 @@
       "name": "pre-pr",
       "description": "Pre-PR quality gate: simplify changed code, security-review the diff, run the full test suite, and surface a go/no-go summary before opening a pull request.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -582,9 +875,16 @@
       "name": "pulumi-engineer",
       "description": "Use when working with Pulumi stacks, component resources, or the Automation API. Triggers on: \"Pulumi\", \"pulumi up\", \"pulumi stack\", \"ComponentResource\", \"Pulumi ESC\", \"Automation API\", \"pulumi.Config\", \"pulumi new\", \"stack reference\", \"StackReference\". Uses sonnet — Pulumi stack work is code-first and structured; sonnet matches the task depth.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["pulumi"],
-        "task": ["provisioning", "debugging"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "pulumi"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -597,9 +897,16 @@
       "name": "pulumi-specialist",
       "description": "Deep-dive Pulumi stack review, component design, Automation API audit, and secrets management. Use for structured investigations of Pulumi stack drift, ComponentResource coupling, ESC configuration, and Automation API workflows. Triggers on: \"Pulumi audit\", \"stack review\", \"Automation API review\", \"ComponentResource design\", \"ESC audit\", \"Pulumi secrets\", \"Pulumi testing\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["pulumi"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "pulumi"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -612,9 +919,15 @@
       "name": "review-pr",
       "description": "Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -627,9 +940,15 @@
       "name": "review-prs",
       "description": "Batch-review multiple PRs in parallel: dispatch one sub-agent per PR in an isolated worktree, aggregate results into a summary table.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["github-actions"],
-        "task": ["review"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "github-actions"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -642,9 +961,16 @@
       "name": "security-auditor",
       "description": "Use when conducting security audits, reviewing code for vulnerabilities, assessing secrets exposure, or evaluating compliance posture. Triggers on: \"audit security\", \"find vulnerabilities\", \"check secrets\", \"OWASP review\", \"security scan\", \"CVE\", \"threat model\". Uses opus — security analysis requires thorough reasoning; false negatives have high downstream cost.\n",
       "facets": {
-        "domain": ["security"],
-        "platform": ["none"],
-        "task": ["review", "diagnostics"],
+        "domain": [
+          "security"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "diagnostics"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -657,9 +983,17 @@
       "name": "security-engineer",
       "description": "Use when hardening infrastructure security posture, reviewing network policies, managing secrets, or assessing supply-chain risks. Triggers on: \"infrastructure hardening\", \"network policy\", \"secrets management\", \"RBAC\", \"admission controller\", \"mTLS\", \"supply chain\", \"image signing\", \"privilege escalation\", \"security posture\". Uses opus — infrastructure hardening and privilege analysis require deep reasoning; a missed vector has high downstream cost.\n",
       "facets": {
-        "domain": ["security", "infra"],
-        "platform": ["kubernetes"],
-        "task": ["review", "provisioning"],
+        "domain": [
+          "security",
+          "infra"
+        ],
+        "platform": [
+          "kubernetes"
+        ],
+        "task": [
+          "review",
+          "provisioning"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -672,9 +1006,16 @@
       "name": "security-review",
       "description": "Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.\n",
       "facets": {
-        "domain": ["devex", "security"],
-        "platform": ["none"],
-        "task": ["review"],
+        "domain": [
+          "devex",
+          "security"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -687,9 +1028,15 @@
       "name": "spec",
       "description": "Create structured engineering specs through interactive pairing. Use when the user wants to create a spec, design doc, technical specification, architecture document, RFC, or engineering plan. Triggers on \"let's spec this out\", \"create a spec\", \"design doc\", \"write a technical plan\", \"plan the architecture\". Works for greenfield and brownfield projects. Outputs to docs/specs/.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["documentation"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "documentation"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -702,9 +1049,16 @@
       "name": "terraform-specialist",
       "description": "Deep-dive Terraform architecture review, module design, state management, and migration. Use for structured investigations of Terraform workspaces, provider configuration, module coupling, import workflows, and test coverage. Triggers on: \"Terraform audit\", \"module review\", \"state management\", \"Terraform import\", \"workspace design\", \"provider config review\", \"Terraform testing\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terraform"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -717,9 +1071,17 @@
       "name": "terragrunt-engineer",
       "description": "Use when working with Terragrunt configurations, DRY Terraform patterns, or multi-environment root-module hierarchies. Triggers on: \"Terragrunt\", \"terragrunt.hcl\", \"run-all\", \"DRY Terraform\", \"dependency block\", \"env hierarchy\", \"root module\", \"terragrunt hooks\", \"generate block\". Uses sonnet — Terragrunt DRY patterns are well-specified; sonnet handles the reasoning without over-provisioning cost.\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terragrunt", "terraform"],
-        "task": ["provisioning", "debugging"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terragrunt",
+          "terraform"
+        ],
+        "task": [
+          "provisioning",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -732,9 +1094,17 @@
       "name": "terragrunt-specialist",
       "description": "Deep-dive Terragrunt hierarchy review, DRY pattern audits, and run-all orchestration analysis. Use for structured investigations of multi-environment Terragrunt layouts, dependency graphs, remote state config, and hook correctness. Triggers on: \"Terragrunt audit\", \"run-all review\", \"dependency block\", \"DRY pattern review\", \"env hierarchy audit\", \"mock_outputs\", \"terragrunt hooks\".\n",
       "facets": {
-        "domain": ["infra"],
-        "platform": ["terraform", "terragrunt"],
-        "task": ["debugging", "review"],
+        "domain": [
+          "infra"
+        ],
+        "platform": [
+          "terraform",
+          "terragrunt"
+        ],
+        "task": [
+          "debugging",
+          "review"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -747,9 +1117,17 @@
       "name": "test-engineer",
       "description": "Use when writing tests, auditing test coverage, fixing flaky tests, or setting up test infrastructure. Triggers on: \"write tests\", \"add test coverage\", \"fix flaky test\", \"integration test\", \"test suite\", \"coverage report\", \"missing tests\", \"test CI\". Uses sonnet — test design benefits from reasoning about edge cases and failure modes; sonnet balances depth and speed.\n",
       "facets": {
-        "domain": ["backend", "frontend"],
-        "platform": ["none"],
-        "task": ["testing", "debugging"],
+        "domain": [
+          "backend",
+          "frontend"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "testing",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -762,9 +1140,16 @@
       "name": "validate-spec",
       "description": "Audit an already-implemented spec against the codebase. Walks each constraint (ARCH-N, PERF-N, KD-N, etc.) and acceptance criterion, grounds findings in file:line evidence, runs the spec.json acceptance_commands, and writes a single audit doc to docs/audits/. Use whenever the user asks to \"validate a spec\", \"audit a spec\", \"check if spec is implemented\", \"verify the spec is done\", \"is this spec really done\", or otherwise wants closure on spec-driven work. Read-only against the spec — produces an audit, never modifies the spec itself.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -777,9 +1162,16 @@
       "name": "veracity-audit",
       "description": "Audit a data pipeline for Veracity and Value. Dispatches data-scientist, compliance-auditor, and data-engineer agents with project context injected at dispatch time. All source paths are supplied via flags — no defaults, no project assumptions. Subcommands: audit (full pipeline walk), score-check (scoring math only), gate-check (gate coverage only), source-trace <label> (single source end-to-end). Invoke when: \"audit pipeline\", \"veracity check\", \"scoring math correct?\", \"check gates\", \"trace source\", \"verify quality gates\", \"formula correct?\".\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["review", "testing"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "review",
+          "testing"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -792,9 +1184,16 @@
       "name": "workflow-orchestrator",
       "description": "Use when coordinating multi-step tasks that require multiple agents, managing parallel workstreams, or planning and delegating complex implementation efforts. Triggers on: \"orchestrate\", \"coordinate agents\", \"parallel tasks\", \"multi-step plan\", \"delegate work\", \"break down\", \"dispatch subagents\". Uses opus — orchestration quality compounds across delegated agents; poor decomposition cascades into downstream failures.\n",
       "facets": {
-        "domain": ["devex"],
-        "platform": ["none"],
-        "task": ["scaffolding", "debugging"],
+        "domain": [
+          "devex"
+        ],
+        "platform": [
+          "none"
+        ],
+        "task": [
+          "scaffolding",
+          "debugging"
+        ],
         "maturity": "draft"
       },
       "version": "1.0.0",

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -10,15 +10,9 @@
       "name": "agents-search",
       "description": "Discover, search, and manage Claude Code agents. Use when you want to find available agents, list installed agents, or refresh the agent catalog. Triggers on: \"search agents\", \"list agents\", \"find agent\", \"what agents\", \"agent catalog\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -31,15 +25,9 @@
       "name": "architect-reviewer",
       "description": "Use when evaluating system design, reviewing architectural decisions, assessing technology choices, or identifying structural anti-patterns. Triggers on: \"review architecture\", \"design review\", \"architecture concerns\", \"tech stack\", \"coupling\", \"scalability review\", \"ADR review\". Uses opus — cross-cutting architectural analysis requires deep reasoning across large codebases.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -52,16 +40,9 @@
       "name": "audit-and-fix",
       "description": "Run an audit-then-implement pipeline: produce an audit, cluster findings into PR-sized chunks, and spawn parallel subagents to implement fixes as draft PRs. Trigger: user asks to \"audit and fix\" or kicks off an overnight cleanup run.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -74,23 +55,14 @@
       "name": "aws-engineer",
       "description": "Use when designing, debugging, or reviewing AWS workloads and service integrations. Triggers on: \"AWS\", \"EC2\", \"ECS\", \"EKS\", \"Lambda\", \"S3\", \"IAM role\", \"VPC\", \"RDS\", \"DynamoDB\", \"CloudFront\", \"ALB\", \"Route53\", \"CloudFormation\", \"CDK\", \"API Gateway\", \"EventBridge\", \"SQS\", \"SNS\". Uses opus — AWS architecture spans IAM trust, multi-service interactions, and compliance tradeoffs that benefit from deep analysis.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "aws"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["aws"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha",
-      "related": [
-        "aws-specialist"
-      ]
+      "related": ["aws-specialist"]
     },
     {
       "id": "aws-specialist",
@@ -99,16 +71,9 @@
       "name": "aws-specialist",
       "description": "Deep-dive AWS architecture review, debugging, and service design. Use for structured investigations of AWS-specific issues, cost or IAM audits, and multi-service design reviews. Triggers on: \"AWS audit\", \"AWS design review\", \"IAM review\", \"cost audit AWS\", \"review my VPC\", \"AWS troubleshooting\", \"Lambda deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "aws"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["aws"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -121,16 +86,9 @@
       "name": "azure-engineer",
       "description": "Use when designing, debugging, or reviewing Azure workloads and service integrations. Triggers on: \"Azure\", \"AKS\", \"ACI\", \"App Service\", \"Azure Functions\", \"Blob Storage\", \"VNet\", \"App Gateway\", \"Front Door\", \"EntraID\", \"Managed Identity\", \"ARM template\", \"Bicep\", \"Azure DevOps\", \"ACR\", \"Service Bus\", \"Logic Apps\", \"Cosmos DB\". Uses opus — Azure spans identity, networking, and multi-subscription governance; deep reasoning reduces costly misconfigurations.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "azure"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["azure"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -143,16 +101,9 @@
       "name": "azure-specialist",
       "description": "Deep-dive Azure architecture review, debugging, and service design. Use for structured investigations of Azure-specific issues, identity or cost audits, and multi-service design reviews. Triggers on: \"Azure audit\", \"Azure design review\", \"EntraID review\", \"Managed Identity debug\", \"review my Azure\", \"Azure troubleshooting\", \"AKS deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "azure"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["azure"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -165,16 +116,9 @@
       "name": "backend-developer",
       "description": "Use when building or modifying server-side code: APIs, services, data models, background jobs, or infrastructure logic. Triggers on: \"build API\", \"add endpoint\", \"database schema\", \"backend service\", \"server-side\", \"REST\", \"GraphQL\", \"background job\", \"migration\". Uses sonnet — everyday backend implementation benefits from balanced capability and throughput.\n",
       "facets": {
-        "domain": [
-          "backend"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "scaffolding",
-          "debugging"
-        ],
+        "domain": ["backend"],
+        "platform": ["none"],
+        "task": ["scaffolding", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -187,15 +131,9 @@
       "name": "changelog",
       "description": "Generate a changelog entry from git history. Defaults to commits since the last tag or the last 20 commits.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -208,16 +146,9 @@
       "name": "changelog-assistant",
       "description": "Use when generating changelog entries, drafting release notes, or summarizing git history for a release. Triggers on: \"generate changelog\", \"release notes\", \"what changed\", \"CHANGELOG\", \"summarize commits\", \"release summary\", \"version bump notes\". Uses haiku — changelog generation from git history is formulaic and lightweight; fast output benefits release flow.\n",
       "facets": {
-        "domain": [
-          "writing",
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["writing", "devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -230,16 +161,9 @@
       "name": "compliance-auditor",
       "description": "Use when auditing data quality gates, config-driven checks, or invariant enforcement. Cross-references declaration files against runtime enforcement code to find declared-not-enforced and enforced-not-declared gaps. Read-only — produces a coverage matrix, never modifies code or config. Triggers on: \"gate coverage\", \"quality check audit\", \"data invariants\", \"declared vs enforced\", \"config vs code gaps\", \"quality gate completeness\".\n",
       "facets": {
-        "domain": [
-          "security"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "diagnostics"
-        ],
+        "domain": ["security"],
+        "platform": ["none"],
+        "task": ["review", "diagnostics"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -252,16 +176,9 @@
       "name": "container-engineer",
       "description": "Use when authoring, optimizing, or reviewing container images and build pipelines. Triggers on: \"Dockerfile\", \"container image\", \"multi-stage build\", \"image size\", \"OCI\", \"Docker Compose\", \"container registry\", \"base image\", \"layer cache\". Uses sonnet — container image optimization is structured and pattern-driven; sonnet provides the right depth without excess cost.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "docker"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["docker"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -274,16 +191,9 @@
       "name": "create-assessment",
       "description": "Create a structured assessment document grading a target on a 0-10 scale with a weighted rubric, saved to docs/assessments/. Use for numeric grades; use /create-audit for issue-triage.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -296,16 +206,9 @@
       "name": "create-audit",
       "description": "Create an evidence-based audit document and save it to docs/audits/. Trigger: user asks for an audit, review, or assessment of any system, feature, or component.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -318,16 +221,9 @@
       "name": "create-experiment",
       "description": "Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /spec (which is heavier and design-oriented).\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -340,16 +236,9 @@
       "name": "create-inspection",
       "description": "Investigate a specific problem and surface viable fix paths with trade-offs, saved to docs/inspections/. Use when the user needs to understand *how* to fix something before committing to an approach. Sits between /create-audit (find problems) and /fix-with-evidence (implement the fix).\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -362,16 +251,9 @@
       "name": "crossplane-engineer",
       "description": "Use when designing, debugging, or reviewing Crossplane configurations and Kubernetes-native IaC. Triggers on: \"Crossplane\", \"XRD\", \"Composition\", \"CompositeResource\", \"Claim\", \"managed resource\", \"provider config\", \"ProviderConfig\", \"composite resource definition\", \"Crossplane package\". Uses sonnet — Crossplane Composition authoring is well-specified; sonnet covers the depth needed.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "kubernetes",
-          "crossplane"
-        ],
-        "task": [
-          "provisioning"
-        ],
+        "domain": ["infra"],
+        "platform": ["kubernetes", "crossplane"],
+        "task": ["provisioning"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -384,17 +266,9 @@
       "name": "crossplane-specialist",
       "description": "Deep-dive Crossplane platform review: XRD design, Composition correctness, provider config audit, managed resource health, and GitOps integration. Use for structured investigations of stuck Claims, composition pipeline bugs, and credential injection patterns. Triggers on: \"Crossplane audit\", \"XRD review\", \"Composition debug\", \"stuck Claim\", \"managed resource stuck\", \"provider config review\", \"Crossplane GitOps\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "crossplane",
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["crossplane", "kubernetes"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -407,16 +281,9 @@
       "name": "data-scientist",
       "description": "Use when validating statistical models, scoring formulas, or config-driven math. Audits formula correctness, boundary conditions, config-vs-code drift, and output scale changes. Read-only — surfaces findings, never modifies code. Triggers on: \"validate scoring math\", \"check formula\", \"config drift\", \"boundary conditions\", \"statistical model audit\", \"rating algorithm review\".\n",
       "facets": {
-        "domain": [
-          "data"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "diagnostics"
-        ],
+        "domain": ["data"],
+        "platform": ["none"],
+        "task": ["review", "diagnostics"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -429,16 +296,9 @@
       "name": "dependabot-sweep",
       "description": "Batch-triage all open Dependabot PRs in the current repo using parallel subagents. Produces a risk-annotated table and merges only safe bumps.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "security"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex", "security"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -451,16 +311,9 @@
       "name": "deployment-engineer",
       "description": "Use when planning or executing deployment strategies, release coordination, traffic shifting, or rollback procedures. Triggers on: \"deployment strategy\", \"blue/green\", \"canary release\", \"rolling update\", \"traffic shifting\", \"rollback\", \"release coordination\", \"feature flag\", \"progressive delivery\", \"deploy to production\". Uses sonnet — deployment strategy execution is structured; sonnet handles the reasoning without over-provisioning cost.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "infra"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "runtime-ops"
-        ],
+        "domain": ["devex", "infra"],
+        "platform": ["none"],
+        "task": ["runtime-ops"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -473,16 +326,9 @@
       "name": "detect-flaky",
       "description": "Detect, diagnose, and fix flaky tests in Python, Go, or JavaScript/TypeScript codebases by repeated execution + root-cause analysis.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "testing",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["testing", "debugging"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -495,16 +341,9 @@
       "name": "devops-engineer",
       "description": "Use when building or improving CI/CD pipelines, release workflows, build automation, or developer tooling. Triggers on: \"CI pipeline\", \"CD workflow\", \"GitHub Actions\", \"build automation\", \"artifact\", \"release workflow\", \"environment promotion\", \"pipeline stage\", \"deploy pipeline\", \"lint CI\". Uses sonnet — CI/CD pipeline work is structured and iterative; sonnet matches the workload.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "scaffolding",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["scaffolding", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -517,16 +356,9 @@
       "name": "docker-engineer",
       "description": "Use when designing, operating, or debugging Docker Compose stacks and running containers. Triggers on: \"docker compose up\", \"docker compose exec\", \"docker compose ps\", \"docker compose down\", \"docker compose restart\", \"compose stack\", \"multi-service compose\", \"service dependencies\", \"docker exec\", \"inspect container\", \"container logs\", \"docker logs\", \"container networking\", \"docker network\", \"running container\", \"container debug\", \"docker stats\", \"docker scout\". Uses sonnet — Compose design and runtime ops are structured; sonnet provides the right depth.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "docker"
-        ],
-        "task": [
-          "debugging",
-          "runtime-ops"
-        ],
+        "domain": ["infra"],
+        "platform": ["docker"],
+        "task": ["debugging", "runtime-ops"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -539,16 +371,9 @@
       "name": "documentation-writer",
       "description": "Use when writing or updating documentation: user guides, READMEs, API references, onboarding materials, docstrings, or inline docs. Triggers on: \"write docs\", \"update README\", \"API documentation\", \"document this\", \"user guide\", \"onboarding guide\", \"add examples\", \"explain how\". Uses haiku — documentation writing is templated and fast-turnaround; throughput matters more than deep reasoning.\n",
       "facets": {
-        "domain": [
-          "writing",
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["writing", "devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -561,16 +386,9 @@
       "name": "fix-with-evidence",
       "description": "Fix a bug using a strict Reproduce -> Fix -> Verify -> PR loop where each phase gates on the previous. Trigger: any bug-fix request.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -583,16 +401,9 @@
       "name": "frontend-developer",
       "description": "Use when building or modifying client-side code: UI components, pages, forms, state management, or client-side data fetching. Triggers on: \"build UI\", \"React component\", \"frontend\", \"CSS\", \"accessibility\", \"form validation\", \"client-side\", \"Next.js page\", \"Tailwind\". Uses sonnet — everyday frontend implementation benefits from balanced capability and response speed.\n",
       "facets": {
-        "domain": [
-          "frontend"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "scaffolding",
-          "debugging"
-        ],
+        "domain": ["frontend"],
+        "platform": ["none"],
+        "task": ["scaffolding", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -605,16 +416,9 @@
       "name": "gcp-engineer",
       "description": "Use when designing, debugging, or reviewing Google Cloud workloads and service integrations. Triggers on: \"GCP\", \"Google Cloud\", \"GKE\", \"Cloud Run\", \"GCE\", \"Cloud Functions\", \"Pub/Sub\", \"GCS\", \"BigQuery\", \"Cloud Build\", \"Workload Identity\", \"Service Account\", \"VPC\", \"Cloud Armor\", \"Cloud CDN\", \"Deployment Manager\", \"Config Connector\". Uses opus — GCP architecture across Workload Identity, VPC networks, and IAM hierarchies requires deep reasoning to avoid security gaps.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "gcp"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["gcp"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -627,16 +431,9 @@
       "name": "gcp-specialist",
       "description": "Deep-dive Google Cloud architecture review, debugging, and service design. Use for structured investigations of GCP-specific issues, IAM or cost audits, and multi-service design reviews. Triggers on: \"GCP audit\", \"GCP design review\", \"Workload Identity debug\", \"IAM review GCP\", \"review my GKE\", \"GCP troubleshooting\", \"Cloud Run deep-dive\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "gcp"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["gcp"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -649,15 +446,9 @@
       "name": "git",
       "description": "Project-aware git workflow: conventional commits, PR creation, safe pushes, PR merges, and branch naming suggestions.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -670,16 +461,9 @@
       "name": "ground-first",
       "description": "Produce a code-grounded analysis before any edit is proposed. Use when the user asks for a fix/change/investigation and has not yet confirmed you understand current behavior.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -692,16 +476,9 @@
       "name": "handoff",
       "description": "Transfer conversation context between agentic CLIs (Claude Code, GitHub Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a source session transcript by UUID and produces either an inline summary, a paste-ready handoff digest, a written markdown file, or a branch in a user-owned private git repo that another machine can fetch. Use when switching agents mid-task, recovering context, or moving between Windows/Linux/macOS setups. Triggers on: \"handoff\", \"transfer context\", \"continue in codex\", \"continue in claude\", \"continue in copilot\", \"switch to codex\", \"switch to claude\", \"what was that session about\", \"claude --resume\", \"copilot --resume\", \"codex resume\", \"find the session where\", \"search sessions\", \"which session did I\", \"push handoff\", \"fetch handoff\", \"handoff to other machine\", \"resume on my other laptop\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation", "debugging"],
         "maturity": "draft"
       },
       "version": "1.2.0",
@@ -714,18 +491,9 @@
       "name": "iac-engineer",
       "description": "Use when writing, reviewing, or refactoring infrastructure-as-code modules, managing state, or handling drift detection. Triggers on: \"Terraform\", \"Pulumi\", \"OpenTofu\", \"infrastructure as code\", \"IaC module\", \"state file\", \"drift detection\", \"resource graph\", \"provider\", \"workspace\", \"remote state\". Uses sonnet — IaC authoring is structured and pattern-driven; sonnet covers the depth needed without excess cost.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform",
-          "terragrunt",
-          "pulumi"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform", "terragrunt", "pulumi"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -738,24 +506,14 @@
       "name": "kubernetes-specialist",
       "description": "Use when designing, debugging, or reviewing Kubernetes workloads and cluster configuration. Triggers on: \"kubernetes\", \"k8s\", \"pod\", \"deployment\", \"cluster\", \"kubectl\", \"namespace\", \"ingress\", \"helm chart\", \"workload\", \"node not ready\". Uses opus — Kubernetes troubleshooting spans scheduler decisions, network policy semantics, and control-plane interactions; deep reasoning prevents misdiagnosis.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "diagnostics",
-          "runtime-ops"
-        ],
+        "domain": ["infra"],
+        "platform": ["kubernetes"],
+        "task": ["debugging", "diagnostics", "runtime-ops"],
         "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha",
-      "related": [
-        "kubernetes-specialist"
-      ]
+      "related": ["kubernetes-specialist"]
     },
     {
       "id": "kubernetes-specialist",
@@ -764,16 +522,9 @@
       "name": "kubernetes-specialist",
       "description": "Deep-dive Kubernetes troubleshooting, workload design, and cluster health review. Use when you need a structured investigation of a cluster issue, a design review of Kubernetes manifests, or a health audit of a namespace or workload. Triggers on: \"debug kubernetes\", \"why is my pod\", \"review my manifests\", \"cluster health\", \"kubernetes design review\", \"k8s audit\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "kubernetes"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["kubernetes"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -786,16 +537,9 @@
       "name": "markdown",
       "description": "Fix markdown formatting and structure across a file or directory. Normalizes headings, tables, code blocks, link references.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "writing"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex", "writing"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -808,16 +552,9 @@
       "name": "merge-pr",
       "description": "Merge a pull request only after full local verification, with an optional data-regression gate for paths configured in docs/repo-facts.json.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -830,17 +567,9 @@
       "name": "platform-engineer",
       "description": "Use when designing or improving internal developer platforms, golden paths, self-service tooling, or environment parity. Triggers on: \"developer platform\", \"internal tooling\", \"golden path\", \"paved road\", \"developer experience\", \"self-service\", \"environment parity\", \"platform team\", \"scaffolding\", \"service catalog\". Uses opus — platform design decisions compound over time; deep reasoning prevents golden-path choices that become maintenance burdens.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "infra"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "scaffolding",
-          "provisioning"
-        ],
+        "domain": ["devex", "infra"],
+        "platform": ["none"],
+        "task": ["scaffolding", "provisioning"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -853,16 +582,9 @@
       "name": "pre-pr",
       "description": "Pre-PR quality gate: simplify changed code, security-review the diff, run the full test suite, and surface a go/no-go summary before opening a pull request.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -875,16 +597,9 @@
       "name": "pulumi-engineer",
       "description": "Use when working with Pulumi stacks, component resources, or the Automation API. Triggers on: \"Pulumi\", \"pulumi up\", \"pulumi stack\", \"ComponentResource\", \"Pulumi ESC\", \"Automation API\", \"pulumi.Config\", \"pulumi new\", \"stack reference\", \"StackReference\". Uses sonnet — Pulumi stack work is code-first and structured; sonnet matches the task depth.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "pulumi"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["pulumi"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -897,16 +612,9 @@
       "name": "pulumi-specialist",
       "description": "Deep-dive Pulumi stack review, component design, Automation API audit, and secrets management. Use for structured investigations of Pulumi stack drift, ComponentResource coupling, ESC configuration, and Automation API workflows. Triggers on: \"Pulumi audit\", \"stack review\", \"Automation API review\", \"ComponentResource design\", \"ESC audit\", \"Pulumi secrets\", \"Pulumi testing\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "pulumi"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["pulumi"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -919,15 +627,9 @@
       "name": "review-pr",
       "description": "Review a pull request: fetch comments, validate, apply fixes, resolve conflicts, and close out all threads.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -940,15 +642,9 @@
       "name": "review-prs",
       "description": "Batch-review multiple PRs in parallel: dispatch one sub-agent per PR in an isolated worktree, aggregate results into a summary table.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "github-actions"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review"],
         "maturity": "draft"
       },
       "version": "1.0.1",
@@ -961,16 +657,9 @@
       "name": "security-auditor",
       "description": "Use when conducting security audits, reviewing code for vulnerabilities, assessing secrets exposure, or evaluating compliance posture. Triggers on: \"audit security\", \"find vulnerabilities\", \"check secrets\", \"OWASP review\", \"security scan\", \"CVE\", \"threat model\". Uses opus — security analysis requires thorough reasoning; false negatives have high downstream cost.\n",
       "facets": {
-        "domain": [
-          "security"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "diagnostics"
-        ],
+        "domain": ["security"],
+        "platform": ["none"],
+        "task": ["review", "diagnostics"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -983,17 +672,9 @@
       "name": "security-engineer",
       "description": "Use when hardening infrastructure security posture, reviewing network policies, managing secrets, or assessing supply-chain risks. Triggers on: \"infrastructure hardening\", \"network policy\", \"secrets management\", \"RBAC\", \"admission controller\", \"mTLS\", \"supply chain\", \"image signing\", \"privilege escalation\", \"security posture\". Uses opus — infrastructure hardening and privilege analysis require deep reasoning; a missed vector has high downstream cost.\n",
       "facets": {
-        "domain": [
-          "security",
-          "infra"
-        ],
-        "platform": [
-          "kubernetes"
-        ],
-        "task": [
-          "review",
-          "provisioning"
-        ],
+        "domain": ["security", "infra"],
+        "platform": ["kubernetes"],
+        "task": ["review", "provisioning"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -1006,16 +687,9 @@
       "name": "security-review",
       "description": "Analyze a diff or changed files for common security vulnerabilities (injection, XSS, SSRF, secrets). Defaults to staged changes.\n",
       "facets": {
-        "domain": [
-          "devex",
-          "security"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review"
-        ],
+        "domain": ["devex", "security"],
+        "platform": ["none"],
+        "task": ["review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1028,15 +702,9 @@
       "name": "spec",
       "description": "Create structured engineering specs through interactive pairing. Use when the user wants to create a spec, design doc, technical specification, architecture document, RFC, or engineering plan. Triggers on \"let's spec this out\", \"create a spec\", \"design doc\", \"write a technical plan\", \"plan the architecture\". Works for greenfield and brownfield projects. Outputs to docs/specs/.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "documentation"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["documentation"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1049,16 +717,9 @@
       "name": "terraform-specialist",
       "description": "Deep-dive Terraform architecture review, module design, state management, and migration. Use for structured investigations of Terraform workspaces, provider configuration, module coupling, import workflows, and test coverage. Triggers on: \"Terraform audit\", \"module review\", \"state management\", \"Terraform import\", \"workspace design\", \"provider config review\", \"Terraform testing\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1071,17 +732,9 @@
       "name": "terragrunt-engineer",
       "description": "Use when working with Terragrunt configurations, DRY Terraform patterns, or multi-environment root-module hierarchies. Triggers on: \"Terragrunt\", \"terragrunt.hcl\", \"run-all\", \"DRY Terraform\", \"dependency block\", \"env hierarchy\", \"root module\", \"terragrunt hooks\", \"generate block\". Uses sonnet — Terragrunt DRY patterns are well-specified; sonnet handles the reasoning without over-provisioning cost.\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terragrunt",
-          "terraform"
-        ],
-        "task": [
-          "provisioning",
-          "debugging"
-        ],
+        "domain": ["infra"],
+        "platform": ["terragrunt", "terraform"],
+        "task": ["provisioning", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -1094,17 +747,9 @@
       "name": "terragrunt-specialist",
       "description": "Deep-dive Terragrunt hierarchy review, DRY pattern audits, and run-all orchestration analysis. Use for structured investigations of multi-environment Terragrunt layouts, dependency graphs, remote state config, and hook correctness. Triggers on: \"Terragrunt audit\", \"run-all review\", \"dependency block\", \"DRY pattern review\", \"env hierarchy audit\", \"mock_outputs\", \"terragrunt hooks\".\n",
       "facets": {
-        "domain": [
-          "infra"
-        ],
-        "platform": [
-          "terraform",
-          "terragrunt"
-        ],
-        "task": [
-          "debugging",
-          "review"
-        ],
+        "domain": ["infra"],
+        "platform": ["terraform", "terragrunt"],
+        "task": ["debugging", "review"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1117,17 +762,9 @@
       "name": "test-engineer",
       "description": "Use when writing tests, auditing test coverage, fixing flaky tests, or setting up test infrastructure. Triggers on: \"write tests\", \"add test coverage\", \"fix flaky test\", \"integration test\", \"test suite\", \"coverage report\", \"missing tests\", \"test CI\". Uses sonnet — test design benefits from reasoning about edge cases and failure modes; sonnet balances depth and speed.\n",
       "facets": {
-        "domain": [
-          "backend",
-          "frontend"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "testing",
-          "debugging"
-        ],
+        "domain": ["backend", "frontend"],
+        "platform": ["none"],
+        "task": ["testing", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -1140,16 +777,9 @@
       "name": "validate-spec",
       "description": "Audit an already-implemented spec against the codebase. Walks each constraint (ARCH-N, PERF-N, KD-N, etc.) and acceptance criterion, grounds findings in file:line evidence, runs the spec.json acceptance_commands, and writes a single audit doc to docs/audits/. Use whenever the user asks to \"validate a spec\", \"audit a spec\", \"check if spec is implemented\", \"verify the spec is done\", \"is this spec really done\", or otherwise wants closure on spec-driven work. Read-only against the spec — produces an audit, never modifies the spec itself.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "validated"
       },
       "version": "1.0.0",
@@ -1162,16 +792,9 @@
       "name": "veracity-audit",
       "description": "Audit a data pipeline for Veracity and Value. Dispatches data-scientist, compliance-auditor, and data-engineer agents with project context injected at dispatch time. All source paths are supplied via flags — no defaults, no project assumptions. Subcommands: audit (full pipeline walk), score-check (scoring math only), gate-check (gate coverage only), source-trace <label> (single source end-to-end). Invoke when: \"audit pipeline\", \"veracity check\", \"scoring math correct?\", \"check gates\", \"trace source\", \"verify quality gates\", \"formula correct?\".\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "review",
-          "testing"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["review", "testing"],
         "maturity": "draft"
       },
       "version": "1.0.0",
@@ -1184,16 +807,9 @@
       "name": "workflow-orchestrator",
       "description": "Use when coordinating multi-step tasks that require multiple agents, managing parallel workstreams, or planning and delegating complex implementation efforts. Triggers on: \"orchestrate\", \"coordinate agents\", \"parallel tasks\", \"multi-step plan\", \"delegate work\", \"break down\", \"dispatch subagents\". Uses opus — orchestration quality compounds across delegated agents; poor decomposition cascades into downstream failures.\n",
       "facets": {
-        "domain": [
-          "devex"
-        ],
-        "platform": [
-          "none"
-        ],
-        "task": [
-          "scaffolding",
-          "debugging"
-        ],
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["scaffolding", "debugging"],
         "maturity": "draft"
       },
       "version": "1.0.0",

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -8,6 +8,7 @@
       "changelog-assistant",
       "create-assessment",
       "create-audit",
+      "create-experiment",
       "create-inspection",
       "dependabot-sweep",
       "deployment-engineer",
@@ -53,8 +54,15 @@
       "terragrunt-engineer",
       "terragrunt-specialist"
     ],
-    "backend": ["backend-developer", "test-engineer"],
-    "writing": ["changelog-assistant", "documentation-writer", "markdown"],
+    "backend": [
+      "backend-developer",
+      "test-engineer"
+    ],
+    "writing": [
+      "changelog-assistant",
+      "documentation-writer",
+      "markdown"
+    ],
     "security": [
       "compliance-auditor",
       "dependabot-sweep",
@@ -62,8 +70,13 @@
       "security-engineer",
       "security-review"
     ],
-    "data": ["data-scientist"],
-    "frontend": ["frontend-developer", "test-engineer"]
+    "data": [
+      "data-scientist"
+    ],
+    "frontend": [
+      "frontend-developer",
+      "test-engineer"
+    ]
   },
   "platform": {
     "none": [
@@ -76,6 +89,7 @@
       "compliance-auditor",
       "create-assessment",
       "create-audit",
+      "create-experiment",
       "create-inspection",
       "data-scientist",
       "deployment-engineer",
@@ -97,9 +111,18 @@
       "veracity-audit",
       "workflow-orchestrator"
     ],
-    "aws": ["aws-engineer", "aws-specialist"],
-    "azure": ["azure-engineer", "azure-specialist"],
-    "docker": ["container-engineer", "docker-engineer"],
+    "aws": [
+      "aws-engineer",
+      "aws-specialist"
+    ],
+    "azure": [
+      "azure-engineer",
+      "azure-specialist"
+    ],
+    "docker": [
+      "container-engineer",
+      "docker-engineer"
+    ],
     "kubernetes": [
       "crossplane-engineer",
       "crossplane-specialist",
@@ -107,7 +130,10 @@
       "kubernetes-specialist",
       "security-engineer"
     ],
-    "crossplane": ["crossplane-engineer", "crossplane-specialist"],
+    "crossplane": [
+      "crossplane-engineer",
+      "crossplane-specialist"
+    ],
     "github-actions": [
       "dependabot-sweep",
       "devops-engineer",
@@ -115,15 +141,26 @@
       "review-pr",
       "review-prs"
     ],
-    "gcp": ["gcp-engineer", "gcp-specialist"],
+    "gcp": [
+      "gcp-engineer",
+      "gcp-specialist"
+    ],
     "terraform": [
       "iac-engineer",
       "terraform-specialist",
       "terragrunt-engineer",
       "terragrunt-specialist"
     ],
-    "terragrunt": ["iac-engineer", "terragrunt-engineer", "terragrunt-specialist"],
-    "pulumi": ["iac-engineer", "pulumi-engineer", "pulumi-specialist"]
+    "terragrunt": [
+      "iac-engineer",
+      "terragrunt-engineer",
+      "terragrunt-specialist"
+    ],
+    "pulumi": [
+      "iac-engineer",
+      "pulumi-engineer",
+      "pulumi-specialist"
+    ]
   },
   "task": {
     "debugging": [
@@ -165,6 +202,7 @@
       "compliance-auditor",
       "create-assessment",
       "create-audit",
+      "create-experiment",
       "crossplane-specialist",
       "data-scientist",
       "dependabot-sweep",
@@ -209,6 +247,7 @@
       "changelog-assistant",
       "create-assessment",
       "create-audit",
+      "create-experiment",
       "create-inspection",
       "documentation-writer",
       "handoff",
@@ -221,7 +260,11 @@
       "kubernetes-specialist",
       "security-auditor"
     ],
-    "runtime-ops": ["deployment-engineer", "docker-engineer", "kubernetes-specialist"],
+    "runtime-ops": [
+      "deployment-engineer",
+      "docker-engineer",
+      "kubernetes-specialist"
+    ],
     "testing": [
       "detect-flaky",
       "fix-with-evidence",
@@ -241,6 +284,7 @@
       "changelog",
       "create-assessment",
       "create-audit",
+      "create-experiment",
       "create-inspection",
       "crossplane-specialist",
       "dependabot-sweep",

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -54,15 +54,8 @@
       "terragrunt-engineer",
       "terragrunt-specialist"
     ],
-    "backend": [
-      "backend-developer",
-      "test-engineer"
-    ],
-    "writing": [
-      "changelog-assistant",
-      "documentation-writer",
-      "markdown"
-    ],
+    "backend": ["backend-developer", "test-engineer"],
+    "writing": ["changelog-assistant", "documentation-writer", "markdown"],
     "security": [
       "compliance-auditor",
       "dependabot-sweep",
@@ -70,13 +63,8 @@
       "security-engineer",
       "security-review"
     ],
-    "data": [
-      "data-scientist"
-    ],
-    "frontend": [
-      "frontend-developer",
-      "test-engineer"
-    ]
+    "data": ["data-scientist"],
+    "frontend": ["frontend-developer", "test-engineer"]
   },
   "platform": {
     "none": [
@@ -111,18 +99,9 @@
       "veracity-audit",
       "workflow-orchestrator"
     ],
-    "aws": [
-      "aws-engineer",
-      "aws-specialist"
-    ],
-    "azure": [
-      "azure-engineer",
-      "azure-specialist"
-    ],
-    "docker": [
-      "container-engineer",
-      "docker-engineer"
-    ],
+    "aws": ["aws-engineer", "aws-specialist"],
+    "azure": ["azure-engineer", "azure-specialist"],
+    "docker": ["container-engineer", "docker-engineer"],
     "kubernetes": [
       "crossplane-engineer",
       "crossplane-specialist",
@@ -130,10 +109,7 @@
       "kubernetes-specialist",
       "security-engineer"
     ],
-    "crossplane": [
-      "crossplane-engineer",
-      "crossplane-specialist"
-    ],
+    "crossplane": ["crossplane-engineer", "crossplane-specialist"],
     "github-actions": [
       "dependabot-sweep",
       "devops-engineer",
@@ -141,26 +117,15 @@
       "review-pr",
       "review-prs"
     ],
-    "gcp": [
-      "gcp-engineer",
-      "gcp-specialist"
-    ],
+    "gcp": ["gcp-engineer", "gcp-specialist"],
     "terraform": [
       "iac-engineer",
       "terraform-specialist",
       "terragrunt-engineer",
       "terragrunt-specialist"
     ],
-    "terragrunt": [
-      "iac-engineer",
-      "terragrunt-engineer",
-      "terragrunt-specialist"
-    ],
-    "pulumi": [
-      "iac-engineer",
-      "pulumi-engineer",
-      "pulumi-specialist"
-    ]
+    "terragrunt": ["iac-engineer", "terragrunt-engineer", "terragrunt-specialist"],
+    "pulumi": ["iac-engineer", "pulumi-engineer", "pulumi-specialist"]
   },
   "task": {
     "debugging": [
@@ -260,11 +225,7 @@
       "kubernetes-specialist",
       "security-auditor"
     ],
-    "runtime-ops": [
-      "deployment-engineer",
-      "docker-engineer",
-      "kubernetes-specialist"
-    ],
+    "runtime-ops": ["deployment-engineer", "docker-engineer", "kubernetes-specialist"],
     "testing": [
       "detect-flaky",
       "fix-with-evidence",

--- a/index/by-type.json
+++ b/index/by-type.json
@@ -45,6 +45,7 @@
     "changelog",
     "create-assessment",
     "create-audit",
+    "create-experiment",
     "create-inspection",
     "dependabot-sweep",
     "detect-flaky",

--- a/plugins/dotclaude/templates/claude/commands/create-experiment.md
+++ b/plugins/dotclaude/templates/claude/commands/create-experiment.md
@@ -5,20 +5,17 @@ type: command
 version: 1.0.0
 domain: [devex]
 platform: [none]
-task: [exploration, prototyping, documentation]
+task: [review, documentation]
 maturity: validated
-owner: "@kaiohenricunha"
-created: 2026-04-29
-updated: 2026-04-30
 description: >
-  Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /create-spec (which is heavier and design-oriented).
+  Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /spec (which is heavier and design-oriented).
 argument-hint: "[topic or hypothesis]"
 model: sonnet
 ---
 
 Run a scoped, local-only experiment and produce a structured report saved to the project's `docs/experiments/` directory.
 
-Trigger: when the user asks "let's try X", "I want to compare A vs B", "can we prototype Y", "explore Z before we commit", or invokes `/create-experiment` directly. Use this skill **before** `/create-spec` (which is for design docs, not exploratory probes) and **after** plain shell tinkering becomes too messy to track.
+Trigger: when the user asks "let's try X", "I want to compare A vs B", "can we prototype Y", "explore Z before we commit", or invokes `/create-experiment` directly. Use this skill **before** `/spec` (which is for design docs, not exploratory probes) and **after** plain shell tinkering becomes too messy to track.
 
 Arguments: `$ARGUMENTS` — a topic or hypothesis (e.g. "ripgrep vs grep on this repo", "switch from pnpm to bun", "does Postgres LISTEN/NOTIFY scale to N clients"). Required — if empty, ask the user what they want to explore.
 
@@ -54,7 +51,7 @@ Echo the refined goal back as a paragraph + bulleted success criteria. **Wait fo
 
 ### Step 2 — Set up the environment
 
-Execute setup commands in the sandbox. **Capture every command and its full output** — this is the reproducibility ledger and goes verbatim into the report. Examples:
+Execute setup commands in the sandbox. **Capture every command and its output** as the reproducibility ledger — redact any tokens or credentials before including output in the report. Examples:
 
 - `git worktree add .claude/worktrees/experiment-<slug> -b experiment/<slug> origin/main`
 - `npm i <pkg>` / `pnpm add <pkg>` / `bun add <pkg>`
@@ -83,7 +80,7 @@ Build a comparison table that maps each approach against the agreed success crit
 
 Generate a filename: `<topic-slug>-<YYYY-MM-DD>.md` in lowercase kebab-case (e.g. `ripgrep-vs-grep-2026-04-29.md`). Create `docs/experiments/` if it doesn't exist. Use this structure:
 
-```markdown
+````markdown
 # Experiment: <Topic> — <YYYY-MM-DD>
 
 <One-sentence hypothesis.>
@@ -114,9 +111,11 @@ Sandbox: `<absolute path chosen in Step 1>`
 - **Idea:** <one line>
 - **Code/config:** `<path-in-sandbox>`
 - **Commands:**
+
   ```bash
   <commands>
   ```
+
 - **Result:** PASS | PARTIAL | FAIL — <observed signal vs criterion>
 - **Notes:** <gotchas, surprises, dead-ends>
 
@@ -137,7 +136,7 @@ assumptions or unresolved questions.>
 
 ## Next Step
 
-- Promote to `/create-spec <topic>` to formalize the chosen approach, OR
+- Promote to `/spec <topic>` to formalize the chosen approach, OR
 - Run `/fix-with-evidence <topic>` to implement directly, OR
 - Re-run `/create-experiment` with a refined hypothesis, OR
 - Drop it — this document is the negative-result record.
@@ -148,7 +147,7 @@ assumptions or unresolved questions.>
 git worktree remove .claude/worktrees/experiment-<slug>   # or
 rm -rf ~/experiments/<slug>
 ```
-```
+````
 
 ### Step 6 — Report back
 

--- a/plugins/dotclaude/templates/claude/commands/create-experiment.md
+++ b/plugins/dotclaude/templates/claude/commands/create-experiment.md
@@ -9,7 +9,7 @@ task: [exploration, prototyping, documentation]
 maturity: validated
 owner: "@kaiohenricunha"
 created: 2026-04-29
-updated: 2026-04-29
+updated: 2026-04-30
 description: >
   Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /create-spec (which is heavier and design-oriented).
 argument-hint: "[topic or hypothesis]"
@@ -28,30 +28,31 @@ Arguments: `$ARGUMENTS` — a topic or hypothesis (e.g. "ripgrep vs grep on this
 
 The output is a dated markdown file under `docs/experiments/` plus a sandbox directory containing the runnable artifacts. Both are left untracked for the user to review.
 
-## Phases
+## Steps
 
-### Phase 0 — Refine the goal (interactive, blocking)
+### Step 0 — Refine the goal (interactive, blocking)
 
-Before running anything, ask the user up to 5 short questions. Skip any already answered in `$ARGUMENTS` or recent context. Do not infer answers — ask.
+If `$ARGUMENTS` already covers hypothesis + observable success signal, echo the refined goal back as a paragraph + bulleted success criteria and **wait for user sign-off** before proceeding. Skip questions already answered in `$ARGUMENTS` or recent context.
+
+Otherwise, ask up to 4 short questions:
 
 1. **What are you trying to learn?** — one-sentence hypothesis.
 2. **What does "it worked" look like?** — concrete, observable signal (a benchmark number, a working prototype, a config that boots, a passing test).
 3. **What's out of scope?** — what should NOT be touched.
 4. **Time-box** — sketch (≤30 min), half-day (≤4 hr), or full-day (≤8 hr).
-5. **Environment** — repo / language / runtime, plus any external services that need stubbing or mocking.
 
-Echo the refined goal back as a paragraph + bulleted success criteria. **Wait for explicit user sign-off before continuing.** Do not proceed to Phase 1 until the user confirms.
+Echo the refined goal back as a paragraph + bulleted success criteria. **Wait for explicit user sign-off before continuing.** Do not proceed to Step 1 until the user confirms.
 
-### Phase 1 — Plan the experiment
+### Step 1 — Plan the experiment
 
 - Propose 1–3 approaches to try. Each is a distinct path to the same hypothesis.
 - For each approach, sketch: what gets installed, what runs, what's measured.
 - Pick the sandbox target:
-  - **Default:** a fresh git worktree at `.claude/worktrees/experiment-<slug>/` branched from the latest `origin/main` (per the dotclaude *Worktree discipline* rule). Run `git fetch origin main` first.
+  - **Default:** a fresh git worktree at `.claude/worktrees/experiment-<slug>/` branched from the latest `origin/main`. Run `git fetch origin main` first.
   - **Fallback:** `~/experiments/<slug>/` if there is no enclosing git repo.
 - Show this plan to the user and get a final go-ahead before touching the system.
 
-### Phase 2 — Set up the environment
+### Step 2 — Set up the environment
 
 Execute setup commands in the sandbox. **Capture every command and its full output** — this is the reproducibility ledger and goes verbatim into the report. Examples:
 
@@ -63,20 +64,22 @@ Execute setup commands in the sandbox. **Capture every command and its full outp
 
 If a setup step fails, document the failure, attempt **one** recovery (e.g. install a missing system dep), and proceed only if it succeeds. Do not silently swallow errors.
 
-### Phase 3 — Execute the approaches
+### Step 3 — Execute the approaches
+
+Approaches are independent by default — execute concurrently when possible (parallel tool calls or background jobs with per-approach log files). Fall back to serial execution only when one approach depends on another's artifact.
 
 For each approach:
 
 - Save code/config under `experiments/<slug>/<approach>/` inside the sandbox.
-- Run the approach. Capture stdout/stderr — keep at least the **last 10 lines** of every non-trivial command (per the dotclaude *Test Plan Verification* rule).
-- Evaluate against the success criteria from Phase 0. Record the result as **PASS**, **PARTIAL**, or **FAIL**.
+- Run the approach. For measurement commands and any failing command, capture full output — at minimum the last 10 lines.
+- Evaluate against the success criteria from Step 0. Record the result as **PASS**, **PARTIAL**, or **FAIL**.
 - If an approach surfaces a blocker that invalidates the hypothesis itself, stop and surface that to the user before continuing — they may want to refine the goal.
 
-### Phase 4 — Compare & recommend
+### Step 4 — Compare & recommend
 
 Build a comparison table that maps each approach against the agreed success criteria. Pick a recommendation, **or** explicitly say "none of these — here's why and what to try next." A clean negative result is a complete experiment.
 
-### Phase 5 — Write the report
+### Step 5 — Write the report
 
 Generate a filename: `<topic-slug>-<YYYY-MM-DD>.md` in lowercase kebab-case (e.g. `ripgrep-vs-grep-2026-04-29.md`). Create `docs/experiments/` if it doesn't exist. Use this structure:
 
@@ -96,13 +99,13 @@ Generate a filename: `<topic-slug>-<YYYY-MM-DD>.md` in lowercase kebab-case (e.g
 
 ## Environment Setup
 
-Sandbox: `<absolute path to worktree or ~/experiments/<slug>/>`
+Sandbox: `<absolute path chosen in Step 1>`
 
 ```bash
 <exact commands run, in order>
 ```
 
-<key output snippets — last 10 lines per command if non-trivial>
+<output snippets for any measurement or failing command — last 10 lines minimum>
 
 ## Approaches Tried
 
@@ -117,13 +120,13 @@ Sandbox: `<absolute path to worktree or ~/experiments/<slug>/>`
 - **Result:** PASS | PARTIAL | FAIL — <observed signal vs criterion>
 - **Notes:** <gotchas, surprises, dead-ends>
 
-### Approach 2: …
+<!-- Add sections for each approach tried; omit if only one approach was attempted -->
 
 ## Comparison
 
-| Approach | Result | Effort | Risk | Criterion 1 | Criterion 2 |
-| -------- | ------ | ------ | ---- | ----------- | ----------- |
-| ...      | ...    | ...    | ...  | ...         | ...         |
+| Approach | Result | <Criterion 1> | <Criterion 2> | Effort |
+| -------- | ------ | ------------- | ------------- | ------ |
+| ...      | ...    | ...           | ...           | ...    |
 
 ## Recommendation
 
@@ -147,19 +150,16 @@ rm -rf ~/experiments/<slug>
 ```
 ```
 
-### Phase 6 — Report back
+### Step 6 — Report back
 
-Show the user: the doc path, the recommendation in one sentence, and the sandbox path so they can re-enter it. **Do not dump the full document into chat.**
+Reply with: doc path, one-sentence recommendation, and sandbox path. **Do not paste the full document into chat.**
 
 ## Rules
 
-- Refine the goal **before** running anything. No code executes until success criteria are agreed and the user signs off.
 - All work runs **locally**. No production endpoints, no cloud writes, no real auth tokens, no shared infrastructure. If the experiment needs an external service, mock it or use a disposable test account.
 - Environment setup is part of the experiment — every install/config/boot command must appear in the report. Reproducibility is the bar.
 - Capture failed approaches too. Negative results are valuable signal and **must** be in the report.
-- Cite `file:line` for any code referenced. Paste the last 10 lines of any command output claimed.
-- Default sandbox is a git worktree at `.claude/worktrees/experiment-<slug>/`. Fall back to `~/experiments/<slug>/` only when there is no enclosing git repo.
 - Do not commit the experiment doc or the sandbox. Leave both untracked for the user.
-- Do not install global tools (`apt`, `brew`, `npm i -g`) without explicit user approval during Phase 1.
+- Do not install global tools (`apt`, `brew`, `npm i -g`) without explicit user approval during Step 1.
 - Tables and code blocks over prose. No filler.
 - An experiment is **done when success criteria are evaluated** — not when "everything works." A clean failure is a finished experiment.

--- a/plugins/dotclaude/templates/claude/commands/create-experiment.md
+++ b/plugins/dotclaude/templates/claude/commands/create-experiment.md
@@ -1,0 +1,165 @@
+---
+id: create-experiment
+name: create-experiment
+type: command
+version: 1.0.0
+domain: [devex]
+platform: [none]
+task: [exploration, prototyping, documentation]
+maturity: validated
+owner: "@kaiohenricunha"
+created: 2026-04-29
+updated: 2026-04-29
+description: >
+  Run a scoped, local-only experiment to try things out before committing to a spec or roadmap, and save the report to docs/experiments/. Use when the user is exploring options, comparing libraries, validating assumptions, or prototyping an approach. Sits before /create-spec (which is heavier and design-oriented).
+argument-hint: "[topic or hypothesis]"
+model: sonnet
+---
+
+Run a scoped, local-only experiment and produce a structured report saved to the project's `docs/experiments/` directory.
+
+Trigger: when the user asks "let's try X", "I want to compare A vs B", "can we prototype Y", "explore Z before we commit", or invokes `/create-experiment` directly. Use this skill **before** `/create-spec` (which is for design docs, not exploratory probes) and **after** plain shell tinkering becomes too messy to track.
+
+Arguments: `$ARGUMENTS` — a topic or hypothesis (e.g. "ripgrep vs grep on this repo", "switch from pnpm to bun", "does Postgres LISTEN/NOTIFY scale to N clients"). Required — if empty, ask the user what they want to explore.
+
+## Purpose
+
+`/create-experiment` is **not** a spec (no formal design), **not** an audit (it doesn't enumerate issues), **not** a fix (it doesn't ship anything). It is a **decision-grade probe**: refine a hypothesis, run it locally, capture results — including negative ones — and recommend a next move.
+
+The output is a dated markdown file under `docs/experiments/` plus a sandbox directory containing the runnable artifacts. Both are left untracked for the user to review.
+
+## Phases
+
+### Phase 0 — Refine the goal (interactive, blocking)
+
+Before running anything, ask the user up to 5 short questions. Skip any already answered in `$ARGUMENTS` or recent context. Do not infer answers — ask.
+
+1. **What are you trying to learn?** — one-sentence hypothesis.
+2. **What does "it worked" look like?** — concrete, observable signal (a benchmark number, a working prototype, a config that boots, a passing test).
+3. **What's out of scope?** — what should NOT be touched.
+4. **Time-box** — sketch (≤30 min), half-day (≤4 hr), or full-day (≤8 hr).
+5. **Environment** — repo / language / runtime, plus any external services that need stubbing or mocking.
+
+Echo the refined goal back as a paragraph + bulleted success criteria. **Wait for explicit user sign-off before continuing.** Do not proceed to Phase 1 until the user confirms.
+
+### Phase 1 — Plan the experiment
+
+- Propose 1–3 approaches to try. Each is a distinct path to the same hypothesis.
+- For each approach, sketch: what gets installed, what runs, what's measured.
+- Pick the sandbox target:
+  - **Default:** a fresh git worktree at `.claude/worktrees/experiment-<slug>/` branched from the latest `origin/main` (per the dotclaude *Worktree discipline* rule). Run `git fetch origin main` first.
+  - **Fallback:** `~/experiments/<slug>/` if there is no enclosing git repo.
+- Show this plan to the user and get a final go-ahead before touching the system.
+
+### Phase 2 — Set up the environment
+
+Execute setup commands in the sandbox. **Capture every command and its full output** — this is the reproducibility ledger and goes verbatim into the report. Examples:
+
+- `git worktree add .claude/worktrees/experiment-<slug> -b experiment/<slug> origin/main`
+- `npm i <pkg>` / `pnpm add <pkg>` / `bun add <pkg>`
+- `python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`
+- `docker compose up -d`
+- `cargo new <name> && cd <name>`
+
+If a setup step fails, document the failure, attempt **one** recovery (e.g. install a missing system dep), and proceed only if it succeeds. Do not silently swallow errors.
+
+### Phase 3 — Execute the approaches
+
+For each approach:
+
+- Save code/config under `experiments/<slug>/<approach>/` inside the sandbox.
+- Run the approach. Capture stdout/stderr — keep at least the **last 10 lines** of every non-trivial command (per the dotclaude *Test Plan Verification* rule).
+- Evaluate against the success criteria from Phase 0. Record the result as **PASS**, **PARTIAL**, or **FAIL**.
+- If an approach surfaces a blocker that invalidates the hypothesis itself, stop and surface that to the user before continuing — they may want to refine the goal.
+
+### Phase 4 — Compare & recommend
+
+Build a comparison table that maps each approach against the agreed success criteria. Pick a recommendation, **or** explicitly say "none of these — here's why and what to try next." A clean negative result is a complete experiment.
+
+### Phase 5 — Write the report
+
+Generate a filename: `<topic-slug>-<YYYY-MM-DD>.md` in lowercase kebab-case (e.g. `ripgrep-vs-grep-2026-04-29.md`). Create `docs/experiments/` if it doesn't exist. Use this structure:
+
+```markdown
+# Experiment: <Topic> — <YYYY-MM-DD>
+
+<One-sentence hypothesis.>
+
+## Goal
+
+<2–3 sentences. What we're learning and why this experiment was run now.>
+
+## Success Criteria
+
+- <observable signal 1>
+- <observable signal 2>
+
+## Environment Setup
+
+Sandbox: `<absolute path to worktree or ~/experiments/<slug>/>`
+
+```bash
+<exact commands run, in order>
+```
+
+<key output snippets — last 10 lines per command if non-trivial>
+
+## Approaches Tried
+
+### Approach 1: <Name>
+
+- **Idea:** <one line>
+- **Code/config:** `<path-in-sandbox>`
+- **Commands:**
+  ```bash
+  <commands>
+  ```
+- **Result:** PASS | PARTIAL | FAIL — <observed signal vs criterion>
+- **Notes:** <gotchas, surprises, dead-ends>
+
+### Approach 2: …
+
+## Comparison
+
+| Approach | Result | Effort | Risk | Criterion 1 | Criterion 2 |
+| -------- | ------ | ------ | ---- | ----------- | ----------- |
+| ...      | ...    | ...    | ...  | ...         | ...         |
+
+## Recommendation
+
+**<Adopt Approach N | Iterate further | Abandon>**
+
+<2–3 sentences. Why this conclusion best matches the success criteria. Call out
+assumptions or unresolved questions.>
+
+## Next Step
+
+- Promote to `/create-spec <topic>` to formalize the chosen approach, OR
+- Run `/fix-with-evidence <topic>` to implement directly, OR
+- Re-run `/create-experiment` with a refined hypothesis, OR
+- Drop it — this document is the negative-result record.
+
+## Sandbox Cleanup
+
+```bash
+git worktree remove .claude/worktrees/experiment-<slug>   # or
+rm -rf ~/experiments/<slug>
+```
+```
+
+### Phase 6 — Report back
+
+Show the user: the doc path, the recommendation in one sentence, and the sandbox path so they can re-enter it. **Do not dump the full document into chat.**
+
+## Rules
+
+- Refine the goal **before** running anything. No code executes until success criteria are agreed and the user signs off.
+- All work runs **locally**. No production endpoints, no cloud writes, no real auth tokens, no shared infrastructure. If the experiment needs an external service, mock it or use a disposable test account.
+- Environment setup is part of the experiment — every install/config/boot command must appear in the report. Reproducibility is the bar.
+- Capture failed approaches too. Negative results are valuable signal and **must** be in the report.
+- Cite `file:line` for any code referenced. Paste the last 10 lines of any command output claimed.
+- Default sandbox is a git worktree at `.claude/worktrees/experiment-<slug>/`. Fall back to `~/experiments/<slug>/` only when there is no enclosing git repo.
+- Do not commit the experiment doc or the sandbox. Leave both untracked for the user.
+- Do not install global tools (`apt`, `brew`, `npm i -g`) without explicit user approval during Phase 1.
+- Tables and code blocks over prose. No filler.
+- An experiment is **done when success criteria are evaluated** — not when "everything works." A clean failure is a finished experiment.

--- a/plugins/dotclaude/templates/claude/skills-manifest.json
+++ b/plugins/dotclaude/templates/claude/skills-manifest.json
@@ -52,6 +52,13 @@
       "lastValidated": null
     },
     {
+      "name": "create-experiment",
+      "path": ".claude/commands/create-experiment.md",
+      "checksum": "",
+      "dependencies": [],
+      "lastValidated": null
+    },
+    {
       "name": "create-inspection",
       "path": ".claude/commands/create-inspection.md",
       "checksum": "",


### PR DESCRIPTION
## Summary

- Adds `/create-experiment` command: a local sandboxed exploration skill for trying out approaches, comparing libraries, validating assumptions, or prototyping before committing to a spec or roadmap
- Ships the command file (`commands/create-experiment.md`), the npm package template (`plugins/dotclaude/templates/claude/commands/create-experiment.md`), manifest entry with checksum, and the `CLAUDE.md` reference table entry

## Test plan

- [ ] Invoke `/create-experiment ripgrep vs grep` in a project — verify Phase 0 interactive refinement runs before any code executes
- [ ] Confirm report is written to `docs/experiments/<slug>-<date>.md` and sandbox created at `.claude/worktrees/experiment-<slug>/`
- [ ] Confirm `dotclaude bootstrap` picks up the new command after npm publish
- [ ] Verify `skills-manifest.json` checksum matches the committed file: `sha256sum commands/create-experiment.md`

## No-spec rationale

Greenfield command addition with no API contract or multi-system coordination — spec overhead not warranted.