### PR TITLE
fix(handoff): v1.0.2 patch bundle — input validation, output contract, validation coverage, docs (#147 #148 #149 #152)

### DIFF
--- a/docs/specs/handoff-skill/spec/4-data-flow-components.md
+++ b/docs/specs/handoff-skill/spec/4-data-flow-components.md
@@ -84,6 +84,33 @@ OUTPUT: <handoff>...</handoff> on stdout.
 No transport, no scrubbing, no remote calls. `pull` is local-only by
 definition.
 
+#### 4.1.1 Session-validity rules
+
+The resolver in step 2 only treats a session as discoverable when its
+per-CLI **marker file** is present. Directories without the marker are
+invisible to `pull`: `latest` skips them, and a UUID prefix that points
+at one returns exit 2 ("no session matches"). This is by design — a
+session without its event log has no replayable content.
+
+| CLI     | Root                            | Required marker file                     |
+| ------- | ------------------------------- | ---------------------------------------- |
+| claude  | `~/.claude/projects/<slug>/`    | any `*.jsonl` (typically `<uuid>.jsonl`) |
+| copilot | `~/.copilot/session-state/`     | `<uuid>/events.jsonl`                    |
+| codex   | `~/.codex/sessions/YYYY/MM/DD/` | `rollout-<ts>-<uuid>.jsonl`              |
+
+Implications:
+
+- An incomplete copilot directory (`workspace.yaml`, `checkpoints/`,
+  `files/`, `research/`, but no `events.jsonl`) is treated as if the
+  directory did not exist. `pull <its-prefix>` returns exit 2.
+- `pull latest` falls through to the next-newest session whose marker
+  exists; the incomplete dir's mtime does not advance the candidate set.
+- If every session in a root is incomplete, `pull latest --from <cli>`
+  returns exit 2 with `no <cli> session matches: latest` per §5.3.2.
+- If every session across every root is incomplete or absent,
+  `pull latest` (no `--from`) returns exit 2 with
+  `no session matches: latest`.
+
 ### 4.2 `push [<query>] [--tag <label>...] [--from <cli>]` — upload to remote
 
 ```

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   dotclaude handoff                              print usage and exit 0 (#86)
- *   dotclaude handoff pull [<id>] [--summary] [-o <path|auto|->] [--from <cli>]
+ *   dotclaude handoff pull <query> [--summary] [-o <path|auto|->] [--from <cli>]
  *                                                  render a local session: <handoff> block (default),
  *                                                  --summary for inline markdown, -o to write to disk.
  *   dotclaude handoff fetch [<query>] [--from <cli>] [--verify]
@@ -946,7 +946,8 @@ async function main() {
     // runs the local resolver — never forwards to remote. When local misses
     // and DOTCLAUDE_HANDOFF_REPO is set, resolveLocalForPull appends a
     // single stderr hint pointing at `fetch` (#87).
-    const id = second ?? "latest";
+    if (second === undefined) fail(EXIT_CODES.USAGE, "pull requires a <query>");
+    const id = second;
     const summaryMode = Boolean(argv.flags.summary);
     const out = argv.flags.output != null ? String(argv.flags.output) : undefined;
     let hit;

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -355,12 +355,12 @@ function writeOutput(body, out, meta, { kind, prompts, sourcePath, toCli }) {
       `- Prompts: ${(prompts ?? []).length} (verbatim); assistant turns summarized above.`,
     ].join("\n");
     writeFileSync(outPath, envelope + "\n");
-    process.stdout.write(`${outPath}\n`);
+    process.stderr.write(`${outPath}\n`);
     return;
   }
   const outPath = resolvePath(out.toString());
   writeFileSync(outPath, body.endsWith("\n") ? body : body + "\n");
-  process.stdout.write(`${outPath}\n`);
+  process.stderr.write(`${outPath}\n`);
 }
 
 function renderDescribeMarkdown(meta, prompts) {

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -667,7 +667,7 @@ if (!/^\d+$/.test(limit.toString()))
 const detectedHost = detectHost();
 const toCli = detectedHost === "unknown" ? "claude" : detectedHost;
 
-const fromCli = argv.flags.from ? String(argv.flags.from) : null;
+const fromCli = argv.flags.from !== undefined ? String(argv.flags.from).trim() : null;
 if (fromCli !== null && !CLIS.has(fromCli)) {
   fail(EXIT_CODES.USAGE, `--from must be one of: ${[...CLIS].join(", ")}`);
 }

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -303,8 +303,9 @@ teardown() {
 }
 
 @test "pull --from codex narrows to local codex session" {
-  # `pull --from codex` resolves locally; bbbb2222 is the only codex session.
-  run node "$BIN" pull --from codex
+  # `pull latest --from codex` resolves locally; bbbb2222 is the only codex session.
+  # Explicit `latest` is required per §5.2.1 (<query> mandatory always).
+  run node "$BIN" pull latest --from codex
   [ "$status" -eq 0 ]
   [[ "$output" == *"bbbb2222"* ]]
   [[ "$output" != *"aaaa1111"* ]]
@@ -372,12 +373,13 @@ teardown() {
   [[ "$output" == *"Continue from"* ]]
 }
 
-@test "pull zero-arg under CODEX_HOME narrows to codex root" {
+@test "pull latest under CODEX_HOME narrows to codex root" {
   # CODEX_HOME triggers the CODEX_* env-var probe, returning "codex" from
   # detectHost(). Host-scoped `latest` then narrows to the codex root.
   # bbbb2222 is the newest codex session (seeded last in setup).
+  # Explicit `latest` is required per §5.2.1 (<query> mandatory always).
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CODEX_HOME="/any/path" \
-    node "$BIN" pull
+    node "$BIN" pull latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"bbbb2222"* ]]
   [[ "$output" != *"aaaa1111"* ]]

--- a/plugins/dotclaude/tests/bats/handoff-pull-edges.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-edges.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+# Lock §5.5.1 output-path edge cases for pull (issue #152 sweep).
+#
+# Covered:
+#   12a/12b  --summary: stdout is markdown, no <handoff> block
+#   19b      --summary 2>/dev/null: summary still lands on stdout (OPS-2)
+#   29       -o nonexistent-dir/file.md: exits 2 on ENOENT
+#   30       -o /etc/file.md: exits 2 on EACCES (permission denied)
+#   32b      -o existing-file (second write): exits 0, file present (silent overwrite)
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  export XDG_CONFIG_HOME="$TEST_HOME"
+  export DOTCLAUDE_HANDOFF_REPO="/nonexistent/pull-edges-$$"
+  export DOTCLAUDE_QUIET=1
+
+  CLAUDE_UUID="dddd1111-2222-2222-2222-222222222222"
+  make_claude_session_tree "$TEST_HOME" "$CLAUDE_UUID"
+  CLAUDE_SHORT="${CLAUDE_UUID:0:8}"
+  export CLAUDE_UUID CLAUDE_SHORT
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# --- cells 12a/12b: --summary mode -------------------------------------------
+
+@test "pull --summary: stdout has no <handoff> tag (§5.5.1, cell 12a)" {
+  run node "$BIN" pull "$CLAUDE_SHORT" --summary
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"<handoff "* ]]
+}
+
+@test "pull --summary: stdout contains markdown summary header (§5.5.1, cell 12a)" {
+  run node "$BIN" pull "$CLAUDE_SHORT" --summary
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**claude**"* ]]
+}
+
+@test "pull UUID --summary: stdout has no <handoff> tag (cell 12b)" {
+  run node "$BIN" pull "$CLAUDE_UUID" --summary
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"<handoff "* ]]
+}
+
+# --- cell 19b: --summary with stderr redirected (OPS-2 stream isolation) -----
+
+@test "pull --summary 2>/dev/null: summary content still on stdout (cell 19b)" {
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' --summary 2>/dev/null"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  [[ "$output" != *"<handoff "* ]]
+}
+
+# --- cell 29: -o into nonexistent directory ----------------------------------
+
+@test "pull -o nonexistent-dir/file.md: exits 2 (ENOENT, cell 29)" {
+  run node "$BIN" pull "$CLAUDE_SHORT" -o "$TEST_HOME/no-such-dir-$$/file.md"
+  [ "$status" -eq 2 ]
+}
+
+# --- cell 30: -o into read-only location -------------------------------------
+
+@test "pull -o /etc/file.md: exits 2 (EACCES, cell 30)" {
+  run node "$BIN" pull "$CLAUDE_SHORT" -o "/etc/pull-edges-test-$$.md"
+  [ "$status" -eq 2 ]
+}
+
+# --- cell 32b: silent overwrite ----------------------------------------------
+
+@test "pull -o existing-file (second write): exits 0 and file still present (cell 32b)" {
+  local out="$TEST_HOME/overwrite-test.md"
+  run node "$BIN" pull "$CLAUDE_SHORT" -o "$out"
+  [ "$status" -eq 0 ]
+  [ -f "$out" ]
+  run node "$BIN" pull "$CLAUDE_SHORT" -o "$out"
+  [ "$status" -eq 0 ]
+  [ -f "$out" ]
+}

--- a/plugins/dotclaude/tests/bats/handoff-pull-from-validation.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-from-validation.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# Lock §5.3.2 rejection of empty/whitespace --from values (issue #147).
+#
+# Before this fix, `--from ""` was silently accepted because the truthiness
+# guard (`argv.flags.from ? ...`) coerced "" to null, bypassing the CLIS
+# membership check entirely. The fix uses `!== undefined` + `.trim()` so
+# all three forms — empty string, whitespace-only, equals-empty — hit the
+# same `fail(EXIT_CODES.USAGE, "--from must be one of: ...")` path as
+# an already-rejected unknown value like `--from foo`.
+#
+# Cases:
+#   1. --from ""       → exit 64 (was: silently accepted as no-from)
+#   2. --from "   "    → exit 64 (whitespace-only, trimmed to "")
+#   3. --from=         → exit 64 (equals-empty form; parseArgs yields "")
+#   4. --from foo      → exit 64 (existing baseline, must not regress)
+#   5. --from claude   → exit 0  (positive control)
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  export XDG_CONFIG_HOME="$TEST_HOME"
+  export DOTCLAUDE_HANDOFF_REPO="/nonexistent/from-validation-$$"
+  export DOTCLAUDE_QUIET=1
+
+  CLAUDE_UUID="cccc4444-5555-5555-5555-555555555555"
+  make_claude_session_tree "$TEST_HOME" "$CLAUDE_UUID"
+  CLAUDE_SHORT="${CLAUDE_UUID:0:8}"
+  export CLAUDE_UUID CLAUDE_SHORT
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+@test "--from \"\": exit 64 (empty string must be rejected)" {
+  run node "$BIN" pull latest --from ""
+  [ "$status" -eq 64 ]
+}
+
+@test "--from \"\": error message names valid CLIs" {
+  run node "$BIN" pull latest --from ""
+  [[ "$output" == *"--from must be one of:"* ]]
+}
+
+@test "--from \"   \" (whitespace-only): exit 64" {
+  run node "$BIN" pull latest --from "   "
+  [ "$status" -eq 64 ]
+}
+
+@test "--from= (equals-empty): exit 64" {
+  run node "$BIN" pull latest --from=
+  [ "$status" -eq 64 ]
+}
+
+@test "--from foo (unknown CLI): exit 64 (existing baseline must not regress)" {
+  run node "$BIN" pull latest --from foo
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"--from must be one of:"* ]]
+}
+
+@test "--from claude (valid CLI): exits 0 (positive control)" {
+  run node "$BIN" pull "$CLAUDE_SHORT" --from claude
+  [ "$status" -eq 0 ]
+}

--- a/plugins/dotclaude/tests/bats/handoff-pull-incomplete-session.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-incomplete-session.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Lock §4.1.1 session-validity rules: per-CLI marker-file requirement.
+# Issue #149.
+#
+# A copilot directory without events.jsonl is invisible to the resolver:
+#   case 1: cross-root resolver behavior (no --from)
+#     pull <incomplete-prefix>: exit 2 (UUID lookup fails)
+#   cases 2/3: narrowed --from copilot behavior
+#     pull latest --from copilot: skips incomplete dir, picks valid one
+#       even when the incomplete dir has the newer mtime
+#     pull latest --from copilot: exit 2 + "no copilot session matches:
+#       latest" when every dir is incomplete (§5.3.2 template)
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+# Lay down a copilot dir with the structural files copilot writes around
+# the event log (workspace config, checkpoints/, files/, research/) but
+# missing the only marker the resolver looks for: events.jsonl.
+seed_incomplete_copilot() {
+  local home="$1" uuid="$2"
+  local dir="$home/.copilot/session-state/$uuid"
+  mkdir -p "$dir/checkpoints" "$dir/files" "$dir/research"
+  printf 'workspace: incomplete\n' > "$dir/workspace.yaml"
+}
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  export XDG_CONFIG_HOME="$TEST_HOME"
+  export DOTCLAUDE_HANDOFF_REPO="/nonexistent/incomplete-session-$$"
+  export DOTCLAUDE_QUIET=1
+
+  INCOMPLETE_UUID="aaaaaaaa-1111-1111-1111-111111111111"
+  VALID_UUID="bbbbbbbb-2222-2222-2222-222222222222"
+  INCOMPLETE_SHORT="${INCOMPLETE_UUID:0:8}"
+  VALID_SHORT="${VALID_UUID:0:8}"
+  export INCOMPLETE_UUID VALID_UUID INCOMPLETE_SHORT VALID_SHORT
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# --- case 1: UUID lookup misses an incomplete dir (cross-root, no --from) ---
+
+@test "pull <incomplete-prefix>: exits 2 — copilot dir without events.jsonl is invisible (§4.1.1)" {
+  seed_incomplete_copilot "$TEST_HOME" "$INCOMPLETE_UUID"
+  run node "$BIN" pull "$INCOMPLETE_SHORT"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no session matches: $INCOMPLETE_SHORT"* ]]
+}
+
+# --- case 2: pull latest skips incomplete, picks valid (--from copilot) -----
+
+@test "pull latest --from copilot: incomplete dir invisible to resolver regardless of dir/file mtimes (§4.1.1)" {
+  # Seed both. Make the incomplete dir's marker mtime NEWER than the valid
+  # dir's events.jsonl. If the resolver were tolerant of incomplete dirs
+  # (e.g., taking newest dir mtime regardless of marker), it would pick
+  # the incomplete one. The assertion proves marker presence is required;
+  # mtime ordering is irrelevant when the marker is absent.
+  seed_incomplete_copilot "$TEST_HOME" "$INCOMPLETE_UUID"
+  make_copilot_session_tree "$TEST_HOME" "$VALID_UUID"
+  touch -d '2026-01-01 00:00' "$TEST_HOME/.copilot/session-state/$VALID_UUID/events.jsonl"
+  touch -d '2026-12-31 23:59' "$TEST_HOME/.copilot/session-state/$INCOMPLETE_UUID/workspace.yaml"
+
+  run node "$BIN" pull latest --from copilot
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"session=\"$VALID_SHORT\""* ]]
+  [[ "$output" != *"session=\"$INCOMPLETE_SHORT\""* ]]
+}
+
+# --- case 3: all sessions incomplete → clean exit 2 + §5.3.2 template -------
+
+@test "pull latest --from copilot: exits 2 with §5.3.2 template when all dirs incomplete" {
+  seed_incomplete_copilot "$TEST_HOME" "$INCOMPLETE_UUID"
+  seed_incomplete_copilot "$TEST_HOME" "$VALID_UUID"
+
+  run node "$BIN" pull latest --from copilot
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no copilot session matches: latest"* ]]
+}

--- a/plugins/dotclaude/tests/bats/handoff-pull-input-validation.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-input-validation.bats
@@ -98,8 +98,8 @@ teardown() {
 
 # --- cell 27: two positionals — first-arg wins -------------------------------
 
-@test "pull latest uuid2 (two positionals): exits 0, first arg resolves (cell 27)" {
-  run node "$BIN" pull latest "$CLAUDE_SHORT"
+@test "pull latest invalid-query (two positionals): exits 0, first arg resolves (cell 27)" {
+  run node "$BIN" pull latest "not-a-real-session"
   [ "$status" -eq 0 ]
   [[ "$output" == *"session=\"$CLAUDE_SHORT\""* ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-pull-input-validation.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-input-validation.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# Lock input-validation and injection-safety contracts for pull (issue #152 sweep).
+#
+# Covered:
+#   22    pull "": exit 2 (resolver "no session matches")
+#   23    pull "   ": whitespace-only, exit 2
+#   24a   pull "abc": 3-char prefix, exit 2
+#   24b   pull "a": single char, exit 2
+#   25a   pull "abc;touch /tmp/...": semicolon injection — exit 2, sentinel absent
+#   25a+  pull "$(touch /tmp/...)": command-substitution injection — exit 2, sentinel absent
+#   25b   pull "abc def": embedded space, exit 2
+#   26    pull (no positional): exit 64 per §5.3.2, error names the missing arg
+#   27    pull latest uuid2 (two positionals): first-arg wins — exit 0 + session attr
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  export XDG_CONFIG_HOME="$TEST_HOME"
+  export DOTCLAUDE_HANDOFF_REPO="/nonexistent/pull-input-val-$$"
+  export DOTCLAUDE_QUIET=1
+
+  CLAUDE_UUID="eeee1111-2222-2222-2222-222222222222"
+  make_claude_session_tree "$TEST_HOME" "$CLAUDE_UUID"
+  CLAUDE_SHORT="${CLAUDE_UUID:0:8}"
+  export CLAUDE_UUID CLAUDE_SHORT
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# --- cells 22-24: degenerate positionals (all exit 2) ------------------------
+
+@test 'pull "": exits 2 — resolver no-match (cell 22)' {
+  run node "$BIN" pull ""
+  [ "$status" -eq 2 ]
+}
+
+@test 'pull "   ": exits 2 — whitespace-only query (cell 23)' {
+  run node "$BIN" pull "   "
+  [ "$status" -eq 2 ]
+}
+
+@test 'pull "abc": exits 2 — 3-char prefix does not match 8-hex (cell 24a)' {
+  run node "$BIN" pull "abc"
+  [ "$status" -eq 2 ]
+}
+
+@test 'pull "a": exits 2 — single char (cell 24b)' {
+  run node "$BIN" pull "a"
+  [ "$status" -eq 2 ]
+}
+
+# --- cell 25a: shell injection — semicolon form ------------------------------
+
+@test 'pull "abc;touch /tmp/...": exits 2, semicolon injection not executed (cell 25a)' {
+  local sentinel="/tmp/sentinel-pull-semi-$$"
+  rm -f "$sentinel"
+  run node "$BIN" pull "abc;touch $sentinel"
+  [ "$status" -eq 2 ]
+  [ ! -e "$sentinel" ]
+}
+
+# --- cell 25a+: shell injection — command-substitution form ------------------
+
+@test 'pull "$(touch /tmp/...)": exits 2, subshell injection not executed (cell 25a+)' {
+  local sentinel="/tmp/sentinel-pull-csub-$$"
+  rm -f "$sentinel"
+  local payload="\$(touch $sentinel)"
+  run node "$BIN" pull "$payload"
+  [ "$status" -eq 2 ]
+  [ ! -e "$sentinel" ]
+}
+
+# --- cell 25b: embedded space ------------------------------------------------
+
+@test 'pull "abc def": exits 2 — space in query (cell 25b)' {
+  run node "$BIN" pull "abc def"
+  [ "$status" -eq 2 ]
+}
+
+# --- cell 26: missing positional (§5.3.2) ------------------------------------
+
+@test "pull (no positional): exits 64 per §5.3.2 (cell 26)" {
+  run node "$BIN" pull
+  [ "$status" -eq 64 ]
+}
+
+@test "pull (no positional): error names the missing argument (cell 26)" {
+  run node "$BIN" pull
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"pull requires a <query>"* ]]
+}
+
+# --- cell 27: two positionals — first-arg wins -------------------------------
+
+@test "pull latest uuid2 (two positionals): exits 0, first arg resolves (cell 27)" {
+  run node "$BIN" pull latest "$CLAUDE_SHORT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"session=\"$CLAUDE_SHORT\""* ]]
+}

--- a/plugins/dotclaude/tests/bats/handoff-pull-output-flag.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-output-flag.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# Lock the §5.5.1 OPS-2 output-flag contract for `pull -o <path>`.
+#
+# §5.5.1 OPS-2 states: when -o is set, stdout MUST be empty; the destination
+# path is written to stderr only. The file at the path contains the <handoff>
+# block (or summary markdown) verbatim with mode 0644.
+#
+# Previously the binary wrote the path to stdout (process.stdout.write).
+# This file pins the corrected behavior so no future refactor regresses it.
+#
+# Covered cases:
+#   1. pull -o <path>         — stdout empty, stderr has path, file is <handoff>
+#   2. pull --summary -o <p> — stdout empty, stderr has path, file is markdown
+#   3. pull -o /dev/null      — stdout empty, exit 0 (null sink)
+#   4. pull -o auto           — stdout empty, stderr has auto-placed path
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotclaude/bin/dotclaude-handoff.mjs"
+
+setup() {
+  TEST_HOME=$(mktemp -d)
+  export HOME="$TEST_HOME"
+  export XDG_CONFIG_HOME="$TEST_HOME"
+  export DOTCLAUDE_HANDOFF_REPO="/nonexistent/pull-output-flag-$$"
+  export DOTCLAUDE_QUIET=1
+
+  CLAUDE_UUID="bbbb2222-3333-3333-3333-333333333333"
+  make_claude_session_tree "$TEST_HOME" "$CLAUDE_UUID"
+  CLAUDE_SHORT="${CLAUDE_UUID:0:8}"
+  export CLAUDE_UUID CLAUDE_SHORT
+
+  STDERR_FILE="$TEST_HOME/stderr.txt"
+  export STDERR_FILE
+}
+
+teardown() {
+  rm -rf "$TEST_HOME"
+}
+
+# --- case 1: explicit path ---------------------------------------------------
+
+@test "pull -o <path>: stdout is empty (§5.5.1 OPS-2)" {
+  local out="$TEST_HOME/handoff-out.md"
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' -o '$out' 2>'$STDERR_FILE'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "pull -o <path>: stderr contains the destination path" {
+  local out="$TEST_HOME/handoff-out.md"
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' -o '$out' 2>'$STDERR_FILE'"
+  [ "$status" -eq 0 ]
+  grep -qF "$out" "$STDERR_FILE"
+}
+
+@test "pull -o <path>: file contains <handoff> block" {
+  local out="$TEST_HOME/handoff-out.md"
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' -o '$out' 2>'$STDERR_FILE'"
+  [ "$status" -eq 0 ]
+  [ -f "$out" ]
+  head -1 "$out" | grep -q "^<handoff "
+}
+
+@test "pull -o <path>: file mode is 0644" {
+  local out="$TEST_HOME/handoff-out.md"
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' -o '$out' 2>'$STDERR_FILE'"
+  [ "$status" -eq 0 ]
+  [ "$(stat -c '%a' "$out")" = "644" ]
+}
+
+# --- case 2: --summary -o <path> ---------------------------------------------
+
+@test "pull --summary -o <path>: stdout is empty" {
+  local out="$TEST_HOME/summary-out.md"
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' --summary -o '$out' 2>'$STDERR_FILE'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "pull --summary -o <path>: stderr contains the destination path" {
+  local out="$TEST_HOME/summary-out.md"
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' --summary -o '$out' 2>'$STDERR_FILE'"
+  [ "$status" -eq 0 ]
+  grep -qF "$out" "$STDERR_FILE"
+}
+
+@test "pull --summary -o <path>: file contains markdown (not bare <handoff> block)" {
+  local out="$TEST_HOME/summary-out.md"
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' --summary -o '$out' 2>'$STDERR_FILE'"
+  [ "$status" -eq 0 ]
+  [ -f "$out" ]
+  grep -q "^\*\*claude\*\*" "$out"
+}
+
+# --- case 3: /dev/null sink ---------------------------------------------------
+
+@test "pull -o /dev/null: stdout is empty and exits 0" {
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' -o /dev/null 2>'$STDERR_FILE'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "pull -o /dev/null: stderr still emits the path" {
+  run bash -c "node '$BIN' pull '$CLAUDE_SHORT' -o /dev/null 2>'$STDERR_FILE'"
+  [ "$status" -eq 0 ]
+  grep -q "/dev/null" "$STDERR_FILE"
+}
+
+# --- case 4: auto path -------------------------------------------------------
+
+@test "pull -o auto: stdout is empty" {
+  # Use a hermetic temp git repo so the auto-path writes to its docs/handoffs/
+  # rather than polluting the real repo checkout.
+  local tmp_repo; tmp_repo=$(make_tmp_git_repo)
+  run bash -c "cd '$tmp_repo' && HOME='$TEST_HOME' DOTCLAUDE_QUIET=1 \
+    DOTCLAUDE_HANDOFF_REPO='/nonexistent' \
+    node '$BIN' pull '$CLAUDE_SHORT' -o auto 2>'$STDERR_FILE'"
+  rm -rf "$tmp_repo" "${tmp_repo}-bare.git"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "pull -o auto: stderr contains the auto-placed path" {
+  local tmp_repo; tmp_repo=$(make_tmp_git_repo)
+  run bash -c "cd '$tmp_repo' && HOME='$TEST_HOME' DOTCLAUDE_QUIET=1 \
+    DOTCLAUDE_HANDOFF_REPO='/nonexistent' \
+    node '$BIN' pull '$CLAUDE_SHORT' -o auto 2>'$STDERR_FILE'"
+  rm -rf "$tmp_repo" "${tmp_repo}-bare.git"
+  [ "$status" -eq 0 ]
+  grep -q "\.md$" "$STDERR_FILE"
+}


### PR DESCRIPTION
## Summary

- **Commit 1 (#148):** `pull -o <path>` redirects destination-path message from stdout to stderr, satisfying §5.5.1 OPS-2. New bats fixture `handoff-pull-output-flag.bats` pins the corrected contract (11 cases).
- **Commit 2 (#147):** _(pending CI green on commit 1)_ Reject empty/whitespace `--from` value, exit 64.
- **Commit 3 (#152):** _(pending)_ Close validation-script coverage gap via bats fixtures from commit 1.
- **Commit 4 (#149):** _(pending)_ Document resolver session-validity rules and fall-through in spec §4.1.

## Test plan

- [x] `pull -o <path>` stdout is empty, path on stderr, file contains `<handoff>` block (bats: handoff-pull-output-flag.bats, 11 cases)
- [x] `pull --from ""` exits 64 (bats: handoff-pull-from-validation.bats)
- [ ] Manual: cells 8b, 13a, 14, 33 from `/tmp/handoff-pull-validation-v1.0.1.md` show fixed behavior
- [x] Full vitest + bats suite green
- [x] `npm test` 549/549 locally (verified on commit 1)

## Spec ID

dotclaude-core
handoff-skill


## Release notes

When release-please opens the v1.0.2 chore PR, expand the auto-generated `### Fixed` entry for #152 (which will land as a subject-only line) into the prose block below before merging. The body paragraph from commit `c8702cc` does not flow through release-please by default (verified against v1.0.1's #142 entry: three-paragraph commit body → subject-only changelog line). The richer v1.0.0 entries were hand-curated since v1.0.0 was cut outside release-please's normal flow.

Suggested CHANGELOG expansion for v1.0.2:

```markdown
- **handoff #152 — `pull` requires an explicit `<query>` per spec §5.2.1.**
  Previous versions silently defaulted to `latest` when the positional was
  omitted, which contradicted the spec. The fix removes the implicit
  default; users who relied on bare `dotclaude handoff pull` as shorthand
  must now type `dotclaude handoff pull latest`. Narrowing behavior of
  `pull latest` (host detection via env vars + `--from`) is unchanged.
  Fixed in #154.
```