### PR TITLE
fix: v1.x patch bundle — placeholder wording, post-bump regen prettier, codex format-drift coverage (#159 #156 #160)

### DIFF
--- a/.github/workflows/release-please-post-bump.yml
+++ b/.github/workflows/release-please-post-bump.yml
@@ -45,6 +45,9 @@ jobs:
       - name: regen index
         run: node plugins/dotclaude/bin/dotclaude-index.mjs
 
+      - name: format regen output
+        run: npx prettier --write index/artifacts.json index/by-type.json index/by-facet.json
+
       - name: stamp doc versions
         run: node scripts/stamp-doc-versions.mjs
 

--- a/.github/workflows/release-please-post-bump.yml
+++ b/.github/workflows/release-please-post-bump.yml
@@ -46,7 +46,7 @@ jobs:
         run: node plugins/dotclaude/bin/dotclaude-index.mjs
 
       - name: format regen output
-        run: npx prettier --write index/artifacts.json index/by-type.json index/by-facet.json
+        run: npx --yes prettier@3 --write index/artifacts.json index/by-type.json index/by-facet.json --ignore-unknown
 
       - name: stamp doc versions
         run: node scripts/stamp-doc-versions.mjs

--- a/docs/audits/codex-extraction-investigation-2026-04-30.md
+++ b/docs/audits/codex-extraction-investigation-2026-04-30.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-30
 **Trigger:** `dotclaude handoff pull 019ddf95 --from codex` returned `_(no assistant output captured)_`. Question: substrate bug, upstream format limitation, or something between?
-**Scope:** `plugins/dotclaude/scripts/handoff-extract.sh` codex case (`turns_codex`, lines 279–291) and the wrapper render path it feeds.
+**Scope:** `plugins/dotclaude/scripts/handoff-extract.sh` codex case (`turns_codex`) and the wrapper render path it feeds.
 **Verdict:** No bug. The original output was a true negative.
 
 ---
@@ -69,7 +69,7 @@ For the richest session (`019d9dbf`), `.payload.content[*].type` flattened acros
 
 ### Phase 3 — Extractor filter
 
-`turns_codex`, `plugins/dotclaude/scripts/handoff-extract.sh:279-291`:
+`turns_codex` in `plugins/dotclaude/scripts/handoff-extract.sh`:
 
 ```bash
 turns_codex() {
@@ -122,7 +122,7 @@ For each session, two layers were tested independently:
 
 The original observation that triggered this investigation (`019ddf95` returning the empty-assistant placeholder) was a true negative. Phase 2 confirmed that session genuinely has zero `response_item.role=="assistant"` and zero `event_msg.agent_message` records. The user typed shell commands without engaging the AI in that session. The placeholder rendered correctly.
 
-The filter at `handoff-extract.sh:279-291` correctly:
+The `turns_codex` filter in `handoff-extract.sh` correctly:
 
 - Identifies assistant `response_item` records (3/5 sessions had them)
 - Extracts `.payload.content[0].text` (safe — single-block invariant confirmed)
@@ -153,7 +153,7 @@ The filter at `handoff-extract.sh:279-291` correctly:
 
 The filter reads `response_item` only and ignores the `event_msg.agent_message` mirror. Phase 2 showed 1:1 correspondence in every tested session, so this is fine today. But if Codex ever desyncs them — streaming interruption, partial session writes, future schema change that drops one form — content would silently disappear from handoffs.
 
-- **Recommendation**: Add a source comment at `handoff-extract.sh:284` documenting the chosen path and the mirror's existence. Optionally, hardening for v1.x: fallback chain `(response_item assistant turns) ?? (event_msg agent_message events)`.
+- **Recommendation**: Add a source comment above `turns_codex` in `handoff-extract.sh` documenting the chosen path and the mirror's existence. Optionally, hardening for v1.x: fallback chain `(response_item assistant turns) ?? (event_msg agent_message events)`.
 - **Severity**: P4 (speculative; no observed divergence).
 - **Why bank**: cheap to document; expensive to debug if it ever fires.
 

--- a/docs/audits/codex-extraction-investigation-2026-04-30.md
+++ b/docs/audits/codex-extraction-investigation-2026-04-30.md
@@ -1,0 +1,188 @@
+# Codex Session Extraction Investigation
+
+**Date:** 2026-04-30
+**Trigger:** `dotclaude handoff pull 019ddf95 --from codex` returned `_(no assistant output captured)_`. Question: substrate bug, upstream format limitation, or something between?
+**Scope:** `plugins/dotclaude/scripts/handoff-extract.sh` codex case (`turns_codex`, lines 279–291) and the wrapper render path it feeds.
+**Verdict:** No bug. The original output was a true negative.
+
+---
+
+## 1. Investigation Question
+
+### Original observation
+
+Pulling Codex session `019ddf95` produced a `<handoff>` block whose assistant-turns section was the literal placeholder `_(no assistant output captured)_`. The session had non-zero `response_item` records, so on its face the placeholder looked suspicious.
+
+### Three hypotheses tested
+
+- **(a) Substrate bug** in `handoff-extract.sh`'s codex jq filter — wrong field, wrong path, missing branch.
+- **(b) Upstream format limitation** — Codex's `rollout-*.jsonl` genuinely doesn't carry assistant text the way Claude/Copilot sessions do.
+- **(c) Something between** — assistant content present in the rollout but in a structure the filter doesn't recognize.
+
+### Verdict
+
+**None of the above.** The codex extractor is structurally correct; assistant content extraction works on every session that contains assistant content. The original observation reflected the truth: `019ddf95` was a shell-only session with zero AI turns. The placeholder rendered correctly.
+
+---
+
+## 2. Evidence Summary
+
+### Phase 1 — Inventory
+
+5 Codex rollouts on disk, spanning 13 days (Apr 17 → Apr 30 2026). All surfaced by `dotclaude handoff list --from codex`; no hidden older sessions. Diversity matrix:
+
+| Short UUID | Date | Lines | Size | Profile |
+|------------|------|-------|------|---------|
+| `019d9dbf` | 2026-04-17 (oldest) | 76 | 191 KB | Rich agent session (Copilot session-finding work) |
+| `019dda3a` | 2026-04-29 | 19 | 63 KB | Short interactive (binary testing) |
+| `019ddea6` | 2026-04-30 10:49 | 63 | 244 KB | Rich agent session, MCP-rich |
+| `019ddf94` | 2026-04-30 15:09 | 5 | 23 KB | Genuinely shell-only |
+| `019ddf95` | 2026-04-30 15:10 (newest) | 17 | 40 KB | Genuinely shell-only (the trigger) |
+
+### Phase 2 — Raw rollout structure
+
+Format is **stable across all 5 sessions**. Top-level shape: `{payload, timestamp, type}`. `.type ∈ {session_meta, turn_context, response_item, event_msg}`. Session 019ddea6 additionally contains `mcp_tool_call_end` event_msgs (additive, not structural). No format drift across the 13-day span.
+
+Assistant content lives in **two redundant locations**:
+
+1. **`response_item` records** with `.payload.role == "assistant"`, content array `.payload.content[].text` where each block is `.type == "output_text"`.
+2. **`event_msg` records** with `.payload.type == "agent_message"`, text directly at `.payload.message`.
+
+User content mirrors:
+- `response_item.payload.role == "user"` with `.payload.content[].text` (block type `input_text`)
+- `event_msg.payload.type == "user_message"` with `.payload.message`
+
+#### Per-session assistant census
+
+| Short UUID | response_item assistant | event_msg agent_message | Profile |
+|------------|------------------------|------------------------|---------|
+| `019d9dbf` | 7 | 7 | Rich agent session |
+| `019dda3a` | 2 | 2 | Short interactive |
+| `019ddea6` | 6 | 6 | MCP-rich |
+| `019ddf94` | 0 | 0 | Genuinely shell-only |
+| `019ddf95` | 0 | 0 | Genuinely shell-only |
+
+`response_item` and `event_msg` mirrors are 1:1 in every session tested.
+
+For the richest session (`019d9dbf`), `.payload.content[*].type` flattened across all 7 assistant records yielded `7 output_text` — i.e. each assistant turn has exactly one content block. `[0]`-only access is safe.
+
+### Phase 3 — Extractor filter
+
+`turns_codex`, `plugins/dotclaude/scripts/handoff-extract.sh:279-291`:
+
+```bash
+turns_codex() {
+  local file="$1"
+  local limit="${2:-20}"
+  local tail_arg="$limit"
+  [[ "$limit" == "0" ]] && tail_arg="+1"
+  jq -c '
+    select(.type == "response_item"
+           and .payload.type == "message"
+           and .payload.role == "assistant")
+    | .payload.content[0].text // ""
+    | select(length > 0)
+  ' "$file" 2>/dev/null | tail -n "$tail_arg"
+}
+```
+
+The filter reads exactly the path Phase 2 confirmed valid:
+
+| Predicate | Phase 2 evidence | Match |
+|-----------|------------------|-------|
+| `.type == "response_item"` | Present in all 5 sessions (40/8/35/1/4 records) | ✓ |
+| `.payload.type == "message"` | Subset within response_item where role applies | ✓ |
+| `.payload.role == "assistant"` | 7/2/6/0/0 records across the 5 sessions | ✓ |
+| `.payload.content[0].text` | Sample showed `{"type":"output_text","text":"…"}` at `content[0]` | ✓ |
+| `select(length > 0)` | Empty-string guard | ✓ |
+
+### Phase 4 — Layer comparison
+
+For each session, two layers were tested independently:
+
+- **Layer 1**: `bash handoff-extract.sh turns codex <rollout> 0` (extractor function direct, via the script's `main` dispatch)
+- **Layer 2**: `dotclaude handoff pull <short> --from codex` (full extractor + render pipeline)
+
+| Session | Phase 2 expected | Layer 1 lines | Layer 2 rendered | Diagnosis |
+|---------|------------------|---------------|------------------|-----------|
+| `019d9dbf` | 7 | 7 | 7 quoted assistant blocks | Works |
+| `019dda3a` | 2 | 2 | 2 quoted assistant blocks | Works |
+| `019ddea6` | 6 | 6 | 6 quoted assistant blocks (incl. MCP-rich) | Works |
+| `019ddf94` | 0 | 0 | `_(no assistant output captured)_` | Correct (true negative) |
+| `019ddf95` | 0 | 0 | `_(no assistant output captured)_` | Correct (true negative) |
+
+**Layer 1 == Layer 2 == Phase 2 expected count, across every session.** No discrepancy at any layer.
+
+---
+
+## 3. Verdict
+
+**Codex extractor is healthy.** No substrate bug, no upstream format limitation, no downstream pipeline drop.
+
+The original observation that triggered this investigation (`019ddf95` returning the empty-assistant placeholder) was a true negative. Phase 2 confirmed that session genuinely has zero `response_item.role=="assistant"` and zero `event_msg.agent_message` records. The user typed shell commands without engaging the AI in that session. The placeholder rendered correctly.
+
+The filter at `handoff-extract.sh:279-291` correctly:
+- Identifies assistant `response_item` records (3/5 sessions had them)
+- Extracts `.payload.content[0].text` (safe — single-block invariant confirmed)
+- Returns empty for sessions with no assistant content
+- Surfaces both states accurately into the `<handoff>` block
+
+---
+
+## 4. Side Findings (separate from the verdict — none are bugs, each is worth banking)
+
+### (a) Placeholder wording is ambiguous — P3
+
+`_(no assistant output captured)_` reads as if extraction failed, when in fact it means "the session had no AI turns." Suggested clearer wording: `_(session contained no assistant turns)_` or similar.
+
+- **Scope**: Single-line change in whichever wrapper renders the placeholder (likely a `handoff-render` or pull-formatter script — not in `handoff-extract.sh` itself).
+- **Severity**: P3 (clarity; not behaviorally wrong).
+- **Why bank, not silently fix**: Wording changes affect snapshot-style bats fixtures; should be explicit.
+
+### (b) Format-drift coverage gap — P3
+
+`plugins/dotclaude/tests/bats/handoff-extract.bats` does not assert against a Codex rollout fixture. If Codex evolves its rollout schema (e.g. renames `response_item` → `response_message`, restructures `payload.content`), the extractor fails silently across **all** sessions and the bats suite passes.
+
+- **Recommendation**: Add a synthetic `rollout-*.jsonl` fixture (a few records: `session_meta`, one `response_item` user turn, one `response_item` assistant turn with `output_text` block, one `event_msg` agent_message). Assert `turns_codex` returns expected count and content; assert `prompts_codex` filters `<environment_context>`; assert `meta_codex` parses session id and cwd.
+- **Severity**: P3 (preventative; format hasn't drifted as of Phase 2 evidence).
+- **Why bank**: this is a real coverage hole, just not currently exploited.
+
+### (c) Single-source extraction fragility — P4 (speculative)
+
+The filter reads `response_item` only and ignores the `event_msg.agent_message` mirror. Phase 2 showed 1:1 correspondence in every tested session, so this is fine today. But if Codex ever desyncs them — streaming interruption, partial session writes, future schema change that drops one form — content would silently disappear from handoffs.
+
+- **Recommendation**: Add a source comment at `handoff-extract.sh:284` documenting the chosen path and the mirror's existence. Optionally, hardening for v1.x: fallback chain `(response_item assistant turns) ?? (event_msg agent_message events)`.
+- **Severity**: P4 (speculative; no observed divergence).
+- **Why bank**: cheap to document; expensive to debug if it ever fires.
+
+### (d) MCP tool calls not surfaced — bank for v2.x
+
+Session `019ddea6` contained `mcp_tool_call_end` events the extractor doesn't read. Spec §4.1 defines handoff content as prompts + turns, not tool traces, so this is spec-compliant — but for MCP-rich Codex sessions, the handoff carries less context than for AI-turn-rich sessions.
+
+- **Open design question (not a bug)**: should handoff blocks include tool-call summaries for richer cross-CLI context? Touches §4.1 definition.
+- **Out of scope for v1.x.** Bank for v2.x design discussion.
+
+---
+
+## 5. Recommendations
+
+1. **Close the original concern** — no fix is needed for the codex extractor.
+2. **Side findings (a) and (b)** — file as small follow-up issues, bundle as v1.x docs/test improvements.
+3. **Side findings (c) and (d)** — bank as design notes; don't file until they become actionable.
+
+---
+
+## 6. Validation Pattern (banked methodology)
+
+Phase 1 → Phase 2 → Phase 3 → Phase 4 is a reusable debugging recipe for any future "extractor returned X, did it actually work?" question:
+
+| Phase | Question | Output |
+|-------|----------|--------|
+| 1 | What's available? | Diverse-sample inventory across the input space |
+| 2 | What's the raw shape? | Top-level keys, payload paths, distinct discriminator values, content-block census |
+| 3 | What does the extractor expect? | Verbatim filter + path-by-path comparison vs. Phase 2 evidence |
+| 4 | Does the pipeline produce the right thing? | Layer 1 (filter direct) vs. Layer 2 (full pipeline) vs. Phase 2 expectation |
+
+The key discipline: **separate "is the data there" from "does the filter find it" from "does the pipeline render it."** Conflating them produces shallow diagnoses.
+
+Worth referencing in audit methodology docs (e.g., a future entry in `docs/audits/` or `skills/handoff/references/`) when similar extraction questions arise for Claude or Copilot sessions.

--- a/docs/audits/codex-extraction-investigation-2026-04-30.md
+++ b/docs/audits/codex-extraction-investigation-2026-04-30.md
@@ -31,13 +31,13 @@ Pulling Codex session `019ddf95` produced a `<handoff>` block whose assistant-tu
 
 5 Codex rollouts on disk, spanning 13 days (Apr 17 → Apr 30 2026). All surfaced by `dotclaude handoff list --from codex`; no hidden older sessions. Diversity matrix:
 
-| Short UUID | Date | Lines | Size | Profile |
-|------------|------|-------|------|---------|
-| `019d9dbf` | 2026-04-17 (oldest) | 76 | 191 KB | Rich agent session (Copilot session-finding work) |
-| `019dda3a` | 2026-04-29 | 19 | 63 KB | Short interactive (binary testing) |
-| `019ddea6` | 2026-04-30 10:49 | 63 | 244 KB | Rich agent session, MCP-rich |
-| `019ddf94` | 2026-04-30 15:09 | 5 | 23 KB | Genuinely shell-only |
-| `019ddf95` | 2026-04-30 15:10 (newest) | 17 | 40 KB | Genuinely shell-only (the trigger) |
+| Short UUID | Date                      | Lines | Size   | Profile                                           |
+| ---------- | ------------------------- | ----- | ------ | ------------------------------------------------- |
+| `019d9dbf` | 2026-04-17 (oldest)       | 76    | 191 KB | Rich agent session (Copilot session-finding work) |
+| `019dda3a` | 2026-04-29                | 19    | 63 KB  | Short interactive (binary testing)                |
+| `019ddea6` | 2026-04-30 10:49          | 63    | 244 KB | Rich agent session, MCP-rich                      |
+| `019ddf94` | 2026-04-30 15:09          | 5     | 23 KB  | Genuinely shell-only                              |
+| `019ddf95` | 2026-04-30 15:10 (newest) | 17    | 40 KB  | Genuinely shell-only (the trigger)                |
 
 ### Phase 2 — Raw rollout structure
 
@@ -49,18 +49,19 @@ Assistant content lives in **two redundant locations**:
 2. **`event_msg` records** with `.payload.type == "agent_message"`, text directly at `.payload.message`.
 
 User content mirrors:
+
 - `response_item.payload.role == "user"` with `.payload.content[].text` (block type `input_text`)
 - `event_msg.payload.type == "user_message"` with `.payload.message`
 
 #### Per-session assistant census
 
-| Short UUID | response_item assistant | event_msg agent_message | Profile |
-|------------|------------------------|------------------------|---------|
-| `019d9dbf` | 7 | 7 | Rich agent session |
-| `019dda3a` | 2 | 2 | Short interactive |
-| `019ddea6` | 6 | 6 | MCP-rich |
-| `019ddf94` | 0 | 0 | Genuinely shell-only |
-| `019ddf95` | 0 | 0 | Genuinely shell-only |
+| Short UUID | response_item assistant | event_msg agent_message | Profile              |
+| ---------- | ----------------------- | ----------------------- | -------------------- |
+| `019d9dbf` | 7                       | 7                       | Rich agent session   |
+| `019dda3a` | 2                       | 2                       | Short interactive    |
+| `019ddea6` | 6                       | 6                       | MCP-rich             |
+| `019ddf94` | 0                       | 0                       | Genuinely shell-only |
+| `019ddf95` | 0                       | 0                       | Genuinely shell-only |
 
 `response_item` and `event_msg` mirrors are 1:1 in every session tested.
 
@@ -88,13 +89,13 @@ turns_codex() {
 
 The filter reads exactly the path Phase 2 confirmed valid:
 
-| Predicate | Phase 2 evidence | Match |
-|-----------|------------------|-------|
-| `.type == "response_item"` | Present in all 5 sessions (40/8/35/1/4 records) | ✓ |
-| `.payload.type == "message"` | Subset within response_item where role applies | ✓ |
-| `.payload.role == "assistant"` | 7/2/6/0/0 records across the 5 sessions | ✓ |
-| `.payload.content[0].text` | Sample showed `{"type":"output_text","text":"…"}` at `content[0]` | ✓ |
-| `select(length > 0)` | Empty-string guard | ✓ |
+| Predicate                      | Phase 2 evidence                                                  | Match |
+| ------------------------------ | ----------------------------------------------------------------- | ----- |
+| `.type == "response_item"`     | Present in all 5 sessions (40/8/35/1/4 records)                   | ✓     |
+| `.payload.type == "message"`   | Subset within response_item where role applies                    | ✓     |
+| `.payload.role == "assistant"` | 7/2/6/0/0 records across the 5 sessions                           | ✓     |
+| `.payload.content[0].text`     | Sample showed `{"type":"output_text","text":"…"}` at `content[0]` | ✓     |
+| `select(length > 0)`           | Empty-string guard                                                | ✓     |
 
 ### Phase 4 — Layer comparison
 
@@ -103,13 +104,13 @@ For each session, two layers were tested independently:
 - **Layer 1**: `bash handoff-extract.sh turns codex <rollout> 0` (extractor function direct, via the script's `main` dispatch)
 - **Layer 2**: `dotclaude handoff pull <short> --from codex` (full extractor + render pipeline)
 
-| Session | Phase 2 expected | Layer 1 lines | Layer 2 rendered | Diagnosis |
-|---------|------------------|---------------|------------------|-----------|
-| `019d9dbf` | 7 | 7 | 7 quoted assistant blocks | Works |
-| `019dda3a` | 2 | 2 | 2 quoted assistant blocks | Works |
-| `019ddea6` | 6 | 6 | 6 quoted assistant blocks (incl. MCP-rich) | Works |
-| `019ddf94` | 0 | 0 | `_(no assistant output captured)_` | Correct (true negative) |
-| `019ddf95` | 0 | 0 | `_(no assistant output captured)_` | Correct (true negative) |
+| Session    | Phase 2 expected | Layer 1 lines | Layer 2 rendered                           | Diagnosis               |
+| ---------- | ---------------- | ------------- | ------------------------------------------ | ----------------------- |
+| `019d9dbf` | 7                | 7             | 7 quoted assistant blocks                  | Works                   |
+| `019dda3a` | 2                | 2             | 2 quoted assistant blocks                  | Works                   |
+| `019ddea6` | 6                | 6             | 6 quoted assistant blocks (incl. MCP-rich) | Works                   |
+| `019ddf94` | 0                | 0             | `_(no assistant output captured)_`         | Correct (true negative) |
+| `019ddf95` | 0                | 0             | `_(no assistant output captured)_`         | Correct (true negative) |
 
 **Layer 1 == Layer 2 == Phase 2 expected count, across every session.** No discrepancy at any layer.
 
@@ -122,6 +123,7 @@ For each session, two layers were tested independently:
 The original observation that triggered this investigation (`019ddf95` returning the empty-assistant placeholder) was a true negative. Phase 2 confirmed that session genuinely has zero `response_item.role=="assistant"` and zero `event_msg.agent_message` records. The user typed shell commands without engaging the AI in that session. The placeholder rendered correctly.
 
 The filter at `handoff-extract.sh:279-291` correctly:
+
 - Identifies assistant `response_item` records (3/5 sessions had them)
 - Extracts `.payload.content[0].text` (safe — single-block invariant confirmed)
 - Returns empty for sessions with no assistant content
@@ -176,12 +178,12 @@ Session `019ddea6` contained `mcp_tool_call_end` events the extractor doesn't re
 
 Phase 1 → Phase 2 → Phase 3 → Phase 4 is a reusable debugging recipe for any future "extractor returned X, did it actually work?" question:
 
-| Phase | Question | Output |
-|-------|----------|--------|
-| 1 | What's available? | Diverse-sample inventory across the input space |
-| 2 | What's the raw shape? | Top-level keys, payload paths, distinct discriminator values, content-block census |
-| 3 | What does the extractor expect? | Verbatim filter + path-by-path comparison vs. Phase 2 evidence |
-| 4 | Does the pipeline produce the right thing? | Layer 1 (filter direct) vs. Layer 2 (full pipeline) vs. Phase 2 expectation |
+| Phase | Question                                   | Output                                                                             |
+| ----- | ------------------------------------------ | ---------------------------------------------------------------------------------- |
+| 1     | What's available?                          | Diverse-sample inventory across the input space                                    |
+| 2     | What's the raw shape?                      | Top-level keys, payload paths, distinct discriminator values, content-block census |
+| 3     | What does the extractor expect?            | Verbatim filter + path-by-path comparison vs. Phase 2 evidence                     |
+| 4     | Does the pipeline produce the right thing? | Layer 1 (filter direct) vs. Layer 2 (full pipeline) vs. Phase 2 expectation        |
 
 The key discipline: **separate "is the data there" from "does the filter find it" from "does the pipeline render it."** Conflating them produces shallow diagnoses.
 

--- a/docs/specs/handoff-skill/spec/5-interfaces-apis.md
+++ b/docs/specs/handoff-skill/spec/5-interfaces-apis.md
@@ -170,8 +170,8 @@ is removed (target is implicit per ARCH-2).
 
 **Empty-content fallbacks (frozen):**
 
-- No prompts: `1. (no user prompts captured)`.
-- No turns: `_(no assistant output captured)_` in place of the quote block.
+- No prompts: `1. (session contained no user prompts)`.
+- No turns: `_(session contained no assistant turns)_` in place of the quote block.
 
 **Generic Next-step line (frozen text):**
 

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -372,7 +372,7 @@ function renderDescribeMarkdown(meta, prompts) {
   lines.push("**User prompts:**");
   lines.push("");
   const toShow = prompts.slice(0, 10);
-  if (toShow.length === 0) lines.push("- (no user prompts captured)");
+  if (toShow.length === 0) lines.push("- (session contained no user prompts)");
   else for (const p of toShow) lines.push(`- ${p.length > 200 ? `${p.slice(0, 200).trim()}…` : p}`);
   if (prompts.length > 10) lines.push(`- …and ${prompts.length - 10} more (truncated)`);
   lines.push("");

--- a/plugins/dotclaude/scripts/handoff-extract.sh
+++ b/plugins/dotclaude/scripts/handoff-extract.sh
@@ -266,6 +266,8 @@ prompts_codex() {
   # The first user message in every Codex session is an <environment_context>
   # block. Filter it out; every other user turn stays.
   # Output: one JSON-encoded string per line so multi-line prompts stay atomic.
+  # Reads response_item only; see turns_codex below for the response_item-vs-
+  # event_msg single-source note.
   jq -c '
     select(.type == "response_item"
            and .payload.type == "message"
@@ -276,6 +278,12 @@ prompts_codex() {
   ' "$file" 2>/dev/null
 }
 
+# Reads response_item records only. Codex also emits event_msg agent_message
+# records that mirror assistant turns 1:1 in every session tested per
+# docs/audits/codex-extraction-investigation-2026-04-30.md Phase 2. If those
+# mirrors ever desync from response_item (streaming interruption, partial
+# writes, schema change), assistant content would silently drop here.
+# Potential v1.x hardening: fallback chain to event_msg.agent_message.
 turns_codex() {
   local file="$1"
   local limit="${2:-20}"

--- a/plugins/dotclaude/scripts/handoff-extract.sh
+++ b/plugins/dotclaude/scripts/handoff-extract.sh
@@ -266,8 +266,6 @@ prompts_codex() {
   # The first user message in every Codex session is an <environment_context>
   # block. Filter it out; every other user turn stays.
   # Output: one JSON-encoded string per line so multi-line prompts stay atomic.
-  # Reads response_item only; see turns_codex below for the response_item-vs-
-  # event_msg single-source note.
   jq -c '
     select(.type == "response_item"
            and .payload.type == "message"

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -166,8 +166,8 @@ export function nextStepFor(toCli) {
 
 /** Produce a one-sentence summary: first prompt + last assistant turn (clipped). */
 export function mechanicalSummary(prompts, turns) {
-  const first = prompts[0] ?? "(no user prompts captured)";
-  const last = turns[turns.length - 1] ?? "(no assistant turns captured)";
+  const first = prompts[0] ?? "(session contained no user prompts)";
+  const last = turns[turns.length - 1] ?? "(session contained no assistant turns)";
   const clip = (s, n) => (s.length > n ? `${s.slice(0, n).trim()}…` : s);
   return `Session opened with: "${clip(first, 160)}". Last assistant output (truncated): "${clip(last, 160)}". Full prompt log and assistant tail follow for context.`;
 }
@@ -187,7 +187,7 @@ export function renderHandoffBlock(meta, prompts, turns, toCli) {
   lines.push("");
   lines.push("**User prompts (last 10, in order).**");
   lines.push("");
-  if (promptsCapped.length === 0) lines.push("1. (no user prompts captured)");
+  if (promptsCapped.length === 0) lines.push("1. (session contained no user prompts)");
   else
     promptsCapped.forEach((p, i) => {
       const trimmed = p.length > 300 ? `${p.slice(0, 300).trim()}…` : p;
@@ -196,7 +196,7 @@ export function renderHandoffBlock(meta, prompts, turns, toCli) {
   lines.push("");
   lines.push("**Last assistant turns (tail).**");
   lines.push("");
-  if (turnsTail.length === 0) lines.push("_(no assistant output captured)_");
+  if (turnsTail.length === 0) lines.push("_(session contained no assistant turns)_");
   else
     for (const t of turnsTail) {
       const trimmed = t.length > 400 ? `${t.slice(0, 400).trim()}…` : t;

--- a/plugins/dotclaude/tests/bats/handoff-extract.bats
+++ b/plugins/dotclaude/tests/bats/handoff-extract.bats
@@ -53,19 +53,38 @@ model: gpt-5
 summary: Test session
 EOF
 
-  # --- Codex fixture: session_meta + env-context first user turn + real prompts ---
+  # --- Codex fixture: session_meta + turn_context + response_items + event_msg mirrors.
+  # Schema mirror per docs/audits/codex-extraction-investigation-2026-04-30.md Phase 2:
+  # top-level types {session_meta, turn_context, response_item, event_msg}; response_item
+  # content blocks use input_text (user) / output_text (assistant).
   CODEX_FILE="$TEST_DIR/codex.jsonl"
   cat > "$CODEX_FILE" <<'EOF'
 {"type":"session_meta","payload":{"id":"eeee5555-5555-5555-5555-555555555555","cwd":"/work/demo","cli_version":"0.121.0","timestamp":"2026-04-18T20:38:53Z","model_provider":"openai"}}
-{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"<environment_context>shell: zsh\ncwd: /work/demo</environment_context>"}]}}
-{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"Improve documentation in @README.md"}]}}
-{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"I'll read README.md first."}]}}
-{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"Go ahead"}]}}
-{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"Refactor this:\n- step one\n- step two"}]}}
-{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"text","text":"Done."}]}}
+{"type":"turn_context","payload":{"cwd":"/work/demo","sandbox_policy":{"mode":"workspace-write"}}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>shell: zsh\ncwd: /work/demo</environment_context>"}]}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Improve documentation in @README.md"}]}}
+{"type":"event_msg","payload":{"type":"user_message","message":"Improve documentation in @README.md"}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I'll read README.md first."}]}}
+{"type":"event_msg","payload":{"type":"agent_message","message":"I'll read README.md first.","phase":"commentary"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Go ahead"}]}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Refactor this:\n- step one\n- step two"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}}
+{"type":"event_msg","payload":{"type":"agent_message","message":"Done.","phase":"final"}}
 EOF
 
-  export CLAUDE_FILE COPILOT_FILE COPILOT_DIR CODEX_FILE TEST_DIR
+  # --- Codex empty-case fixture: shell-only session with no assistant turns.
+  # Mirrors the 019ddf95 profile from the investigation — turns_codex must
+  # return empty (not crash) and prompts_codex must filter the env_context
+  # record cleanly to also return empty.
+  CODEX_EMPTY_FILE="$TEST_DIR/codex-empty.jsonl"
+  cat > "$CODEX_EMPTY_FILE" <<'EOF'
+{"type":"session_meta","payload":{"id":"ffff6666-6666-6666-6666-666666666666","cwd":"/work/empty","cli_version":"0.121.0","timestamp":"2026-04-30T15:10:00Z","model_provider":"openai"}}
+{"type":"turn_context","payload":{"cwd":"/work/empty","sandbox_policy":{"mode":"workspace-write"}}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>shell: bash\ncwd: /work/empty</environment_context>"}]}}
+{"type":"event_msg","payload":{"type":"exec_command_end","exit_code":0,"stdout":"ok"}}
+EOF
+
+  export CLAUDE_FILE COPILOT_FILE COPILOT_DIR CODEX_FILE CODEX_EMPTY_FILE TEST_DIR
 }
 
 teardown() {
@@ -200,6 +219,25 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"I'll read README.md first."* ]]
   [[ "$output" == *"Done."* ]]
+}
+
+@test "turns codex returns empty for shell-only session" {
+  run "$EX" turns codex "$CODEX_EMPTY_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "prompts codex returns empty when only environment_context user record exists" {
+  run "$EX" prompts codex "$CODEX_EMPTY_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "meta codex still parses session_meta on shell-only session" {
+  run "$EX" meta codex "$CODEX_EMPTY_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"session_id":"ffff6666-6666-6666-6666-666666666666"'* ]]
+  [[ "$output" == *'"cwd":"/work/empty"'* ]]
 }
 
 # -- usage / errors -------------------------------------------------------

--- a/plugins/dotclaude/tests/fixtures/cross-cli-invocation-baseline.txt
+++ b/plugins/dotclaude/tests/fixtures/cross-cli-invocation-baseline.txt
@@ -1,15 +1,15 @@
 === claude-pull ===
 <handoff origin="claude" session="aaaa1111" cwd="/seed/claude" target="claude">
 
-**Summary.** Session opened with: "(no user prompts captured)". Last assistant output (truncated): "(no assistant turns captured)". Full prompt log and assistant tail follow for context.
+**Summary.** Session opened with: "(session contained no user prompts)". Last assistant output (truncated): "(session contained no assistant turns)". Full prompt log and assistant tail follow for context.
 
 **User prompts (last 10, in order).**
 
-1. (no user prompts captured)
+1. (session contained no user prompts)
 
 **Last assistant turns (tail).**
 
-_(no assistant output captured)_
+_(session contained no assistant turns)_
 **Next step.** Continue from the last assistant turn using the same file scope and goals summarized above.
 
 </handoff>
@@ -17,15 +17,15 @@ _(no assistant output captured)_
 === copilot-pull ===
 <handoff origin="copilot" session="bbbb1111" cwd="/seed/copilot" target="claude">
 
-**Summary.** Session opened with: "(no user prompts captured)". Last assistant output (truncated): "(no assistant turns captured)". Full prompt log and assistant tail follow for context.
+**Summary.** Session opened with: "(session contained no user prompts)". Last assistant output (truncated): "(session contained no assistant turns)". Full prompt log and assistant tail follow for context.
 
 **User prompts (last 10, in order).**
 
-1. (no user prompts captured)
+1. (session contained no user prompts)
 
 **Last assistant turns (tail).**
 
-_(no assistant output captured)_
+_(session contained no assistant turns)_
 **Next step.** Continue from the last assistant turn using the same file scope and goals summarized above.
 
 </handoff>
@@ -35,22 +35,22 @@ _(no assistant output captured)_
 
 **User prompts:**
 
-- (no user prompts captured)
+- (session contained no user prompts)
 
 **Prompt count:** 0
 === /copilot-pull-summary ===
 === codex-pull ===
 <handoff origin="codex" session="cccc1111" cwd="/seed/codex" target="claude">
 
-**Summary.** Session opened with: "(no user prompts captured)". Last assistant output (truncated): "(no assistant turns captured)". Full prompt log and assistant tail follow for context.
+**Summary.** Session opened with: "(session contained no user prompts)". Last assistant output (truncated): "(session contained no assistant turns)". Full prompt log and assistant tail follow for context.
 
 **User prompts (last 10, in order).**
 
-1. (no user prompts captured)
+1. (session contained no user prompts)
 
 **Last assistant turns (tail).**
 
-_(no assistant output captured)_
+_(session contained no assistant turns)_
 **Next step.** Continue from the last assistant turn using the same file scope and goals summarized above.
 
 </handoff>

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -204,8 +204,8 @@ describe("nextStepFor", () => {
 describe("mechanicalSummary", () => {
   it("uses placeholder text when arrays are empty", () => {
     const s = lib.mechanicalSummary([], []);
-    expect(s).toContain("(no user prompts captured)");
-    expect(s).toContain("(no assistant turns captured)");
+    expect(s).toContain("(session contained no user prompts)");
+    expect(s).toContain("(session contained no assistant turns)");
   });
 
   it("clips prompt and turn to 160 chars with ellipsis", () => {
@@ -240,8 +240,8 @@ describe("renderHandoffBlock", () => {
 
   it("handles empty prompts with fallback text", () => {
     const block = lib.renderHandoffBlock(meta, [], [], "claude");
-    expect(block).toContain("(no user prompts captured)");
-    expect(block).toContain("_(no assistant output captured)_");
+    expect(block).toContain("(session contained no user prompts)");
+    expect(block).toContain("_(session contained no assistant turns)_");
   });
 
   it("caps prompts at last 10", () => {

--- a/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
@@ -248,8 +248,8 @@ describe("nextStepFor", () => {
 describe("mechanicalSummary", () => {
   it("uses placeholder text when both arrays are empty", () => {
     const s = lib.mechanicalSummary([], []);
-    expect(s).toContain("(no user prompts captured)");
-    expect(s).toContain("(no assistant turns captured)");
+    expect(s).toContain("(session contained no user prompts)");
+    expect(s).toContain("(session contained no assistant turns)");
   });
 
   it("uses first prompt and last turn when both arrays are non-empty", () => {
@@ -289,12 +289,12 @@ describe("renderHandoffBlock", () => {
 
   it("renders the fallback when prompts are empty", () => {
     const block = lib.renderHandoffBlock(meta, [], [], "claude");
-    expect(block).toContain("(no user prompts captured)");
+    expect(block).toContain("(session contained no user prompts)");
   });
 
   it("renders the fallback when turns are empty", () => {
     const block = lib.renderHandoffBlock(meta, [], [], "claude");
-    expect(block).toContain("_(no assistant output captured)_");
+    expect(block).toContain("_(session contained no assistant turns)_");
   });
 
   it("renders prompts and turns when present", () => {

--- a/plugins/dotclaude/tests/handoff-unit.test.mjs
+++ b/plugins/dotclaude/tests/handoff-unit.test.mjs
@@ -142,8 +142,8 @@ describe("nextStepFor", () => {
 describe("mechanicalSummary", () => {
   it("handles empty prompts and turns", () => {
     const s = mechanicalSummary([], []);
-    expect(s).toContain("(no user prompts captured)");
-    expect(s).toContain("(no assistant turns captured)");
+    expect(s).toContain("(session contained no user prompts)");
+    expect(s).toContain("(session contained no assistant turns)");
   });
 
   it("quotes the first prompt and the last turn", () => {


### PR DESCRIPTION
v1.x patch bundle. Four commits land on this branch (3 issue commits + 1 lint cleanup). PR moves out of draft once all four are green.

## Summary

- **Commit 1 (#159)** ✅ — harmonize empty-state placeholder wording across all four fallbacks to one voice (`session contained no <X>`). Touches the spec's frozen-contract entries in `§5 interfaces-apis.md`, the renderer in `handoff-remote.mjs`, the describe shim in `dotclaude-handoff.mjs`, the cross-CLI baseline fixture, and three test files.
- **Commit 2 (#156)** ✅ — make `release-please-post-bump` regen output prettier-compliant by inserting a `format regen output` step that runs `npx prettier --write` on the three index files between regen and stamp. Removes the manual splice required during the v1.1.0 release (PR #151 commit `050665b`).
- **Commit 3 (#160)** ✅ — enrich the codex inline fixture in `handoff-extract.bats` to mirror the real `rollout-*.jsonl` schema (turn_context + event_msg mirror records + realistic content-block types). Add a shell-only-session fixture and three empty-case tests. Add source comments documenting the response_item-only filter. Relocate the codex extraction investigation from `/tmp` to `docs/audits/codex-extraction-investigation-2026-04-30.md`.
- **Commit 4 (style fix)** — apply prettier + markdownlint to the relocated audit doc. Lint pipeline caught the unlinted doc on commit 3's first push; this is the cleanup. Pure formatting, no content changes.

## Test plan

### Commit 1 (done)

- [x] Full vitest suite: 549/549 passing across 37 files
- [x] `grep -rn` confirms zero orphan instances of the old wording
- [x] Manual smoke: `dotclaude handoff pull 019ddf95 --from codex` (shell-only) → renders `_(session contained no assistant turns)_` with underscores intact
- [x] Manual smoke: `dotclaude handoff pull 019d9dbf --from codex` (assistant-rich) → quoted content unaffected
- [x] CI green on commit 1 (SHA `03992ca`)

### Commit 2 (done)

- [x] Workflow YAML is itself prettier-compliant after the edit
- [x] Local regen reproduces the bug as expected (the YAML fix only fires in CI, not locally)
- [x] Only `.github/workflows/release-please-post-bump.yml` modified in the commit
- [x] vitest 549/549 still green
- [x] CI green on commit 2 (SHA `45164ae`)
- [ ] **Post-merge verification (must do)**: when the next release-please PR fires after this bundle merges, watch `release-please-post-bump.yml` on its branch and confirm the regenerated `index/artifacts.json` and `index/by-facet.json` are prettier-compliant out of the box — no manual splice required.

### Commit 3 (done — but lint failure on first push, fixed in commit 4)

- [x] `handoff-extract.bats` runs clean: 22/22 (19 existing + 3 new empty-case tests)
- [x] Full bats suite: 360/360 passing
- [x] vitest still 549/549
- [x] Diff scope: exactly 3 files (1 new audit doc, 2 modified)
- [x] CI on commit 3 (SHA `7aebcef`): tests + bats green; prettier + markdownlint failed on the relocated audit doc — addressed in commit 4

### Commit 4 (lint cleanup)

- [x] `npx prettier --check docs/audits/codex-extraction-investigation-2026-04-30.md` passes
- [x] `npx markdownlint-cli2 docs/audits/codex-extraction-investigation-2026-04-30.md` passes
- [x] Diff scope: exactly the audit doc (formatting only — 36 insertions, 34 deletions, no content changes)
- [ ] CI green on commit 4 (SHA `0c16abd`)

## Background

`docs/audits/codex-extraction-investigation-2026-04-30.md` (relocated from /tmp into the repo as part of commit 3) documents the investigation that surfaced #159 and #160 (the empty-state ambiguity and the format-drift coverage gap, respectively). The source comment in `handoff-extract.sh` references this document for the response_item-vs-event_msg single-source rationale.

## Spec ID

dotclaude-core, handoff-skill
