### PR TITLE
feat(handoff): forbid fabrication when binary execution fails (#157)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -187,9 +187,9 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:66129dd0c5c49af5e047570b9c9f2c2046f2c6e2b0c8f64a972f658f9896131c",
+      "checksum": "sha256:b83b55dadf14eeac53eb1e1e8f2ea3659b77344358288c5f03c8f9ba960e9df4",
       "dependencies": [],
-      "lastValidated": "2026-04-30"
+      "lastValidated": "2026-05-01"
     },
     {
       "name": "review-prs",

--- a/docs/specs/handoff-skill/spec/4-data-flow-components.md
+++ b/docs/specs/handoff-skill/spec/4-data-flow-components.md
@@ -430,3 +430,25 @@ contract single-pathed.
 the source pinned" and "user shouldn't have to type ceremony." The
 host LLM is the right place to fill the flag because it's the only
 component that always knows the answer with certainty.
+
+### KD-7 — SKILL.md auto-trigger contract forbids fabrication when the binary cannot run
+
+The skill markdown explicitly instructs host LLMs (Claude / Copilot /
+Codex) that when the `dotclaude handoff` binary cannot be executed —
+for any reason: permission denied, sandbox restriction, binary
+missing, network failure — they MUST NOT reconstruct a `<handoff>`
+block from raw session JSONL files. The required behavior is a
+three-step protocol: report the tool-execution error verbatim,
+instruct the user to run the command manually, and stop. ARCH-10's
+drift test asserts the rule stays present in `skills/handoff/SKILL.md`
+across edits, the same way the symbol-list intersection guards the
+`--from` rule from KD-6.
+
+**Reasoning**: the binary is the authoritative producer of `<handoff>`
+blocks — it owns the scrub passes, the extraction shape, and the
+metadata schema the transport depends on. Fabricated blocks may be
+schema-valid but bypass scrubbing entirely, exposing secrets if
+pushed; they also synthesize content from raw transcripts without
+the per-CLI extraction normalization §4.1 step 4 specifies. The host
+LLM is the only component that observes the failed invocation, so it
+is the right place to enforce the rule.

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -57,6 +57,27 @@ is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
 `codex` for Codex). The flag is required in that mode; the binary exits
 64 without it.
 
+## Tool execution failures
+
+When the `dotclaude` binary cannot be executed for any reason —
+permission denied, binary not found, network failure, sandbox
+restriction — do NOT fabricate, reconstruct, or synthesize a
+`<handoff>` block from raw session JSONL files. Report the
+tool-execution error verbatim and stop; instruct the user to run
+the command manually in a shell where `dotclaude` is available.
+
+Specifically:
+
+1. Quote the exact command attempted and the failure message.
+2. Tell the user to run it themselves and paste the output back.
+3. Do not infer, summarize, or proceed as if the call had succeeded.
+
+Why: the binary is the authoritative producer of `<handoff>` blocks
+— it owns the scrub passes (`push` redaction) and the extraction
+logic §4 data flow depends on. Fabricated output may pass shape
+validation but bypasses scrubbing entirely; the consumer cannot
+distinguish a hand-rolled block from a real one.
+
 ## Cross-cutting flags
 
 Brief reference. `dotclaude handoff --help` is authoritative.

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -322,7 +322,7 @@ export function extractFabricationRule(text) {
     const mentionsRequired =
       /\bverbatim\b/.test(lower) ||
       /\b(?:stop|halt)\b/.test(lower) ||
-      /\breport[^a-z]*(?:error|failure)\b/.test(lower);
+      /\breport\b(?:[\s-]+[a-z]+){0,4}[\s-]+(?:error|failure)\b/.test(lower);
     if (mentionsFailure && mentionsBinary && mentionsForbidden && mentionsRequired) {
       return { present: true };
     }

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -285,6 +285,52 @@ export function extractFromRule(text) {
 }
 
 /**
+ * Structural search for the fabrication-forbidden rule paragraph (KD-7).
+ * SKILL.md-only: --help and the user-facing guide don't need to discuss
+ * what consumers should do on a failed invocation, so this is asymmetric
+ * to extractFromRule (which checks all 3 sources).
+ *
+ * Heuristic: a paragraph that mentions all four clauses simultaneously,
+ * the same approach as extractFromRule. Loose enough to survive wording
+ * changes per spec §5.0; strict enough that incidental mentions of
+ * "fabricate" or "dotclaude" alone don't false-positive.
+ *
+ * @param {string} text
+ * @returns {{ present: boolean }}
+ */
+export function extractFabricationRule(text) {
+  // Cheap absence check: if no forbidden-behavior verb appears at all,
+  // no paragraph could match the four-clause conjunction below.
+  if (!/\b(fabricat|reconstruct|synthesi[sz]e)/i.test(text)) {
+    return { present: false };
+  }
+
+  const paragraphs = text.split(/\n\s*\n/);
+  for (const p of paragraphs) {
+    const lower = p.toLowerCase();
+    const mentionsFailure =
+      /\bpermission\s+denied\b/.test(lower) ||
+      /\btool[\s-]execution\b/.test(lower) ||
+      /\bcannot\s+(?:be\s+)?(?:execute|run|invoke)/.test(lower) ||
+      /\bsandbox\b/.test(lower) ||
+      /\bbinary\s+(?:not\s+found|missing)\b/.test(lower);
+    const mentionsBinary = /\bdotclaude\b/.test(lower);
+    const mentionsForbidden =
+      /\bfabricat/.test(lower) ||
+      /\breconstruct/.test(lower) ||
+      /\bsynthesi[sz]e/.test(lower);
+    const mentionsRequired =
+      /\bverbatim\b/.test(lower) ||
+      /\b(?:stop|halt)\b/.test(lower) ||
+      /\breport[^a-z]*(?:error|failure)\b/.test(lower);
+    if (mentionsFailure && mentionsBinary && mentionsForbidden && mentionsRequired) {
+      return { present: true };
+    }
+  }
+  return { present: false };
+}
+
+/**
  * Parse `docs/handoff-guide.md`.
  *
  * Sub-commands come from the `## When to use it` table's second column —
@@ -444,5 +490,10 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
     expect(skillSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
     expect(helpSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
     expect(guideSurface.from_rule).toEqual(PHASE_1_BASELINE_FROM_RULE);
+  });
+
+  it("SKILL.md contains the fabrication-forbidden rule (KD-7)", () => {
+    const text = readFileSync(SKILL_MD_PATH, "utf8");
+    expect(extractFabricationRule(text)).toEqual({ present: true });
   });
 });

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -60,6 +60,27 @@ is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
 `codex` for Codex). The flag is required in that mode; the binary exits
 64 without it.
 
+## Tool execution failures
+
+When the `dotclaude` binary cannot be executed for any reason —
+permission denied, binary not found, network failure, sandbox
+restriction — do NOT fabricate, reconstruct, or synthesize a
+`<handoff>` block from raw session JSONL files. Report the
+tool-execution error verbatim and stop; instruct the user to run
+the command manually in a shell where `dotclaude` is available.
+
+Specifically:
+
+1. Quote the exact command attempted and the failure message.
+2. Tell the user to run it themselves and paste the output back.
+3. Do not infer, summarize, or proceed as if the call had succeeded.
+
+Why: the binary is the authoritative producer of `<handoff>` blocks
+— it owns the scrub passes (`push` redaction) and the extraction
+logic §4 data flow depends on. Fabricated output may pass shape
+validation but bypasses scrubbing entirely; the consumer cannot
+distinguish a hand-rolled block from a real one.
+
 ## Cross-cutting flags
 
 Brief reference. `dotclaude handoff --help` is authoritative.


### PR DESCRIPTION
Closes #157.

## Summary

Three-layer fix for the SKILL.md fabrication finding:

- **Spec §4 KD-7** — new key-decision establishing the consumer-side contract. Mirrors KD-6's structure (success-path SKILL.md contract → `--from` pre-fill); KD-7 adds the failure-path contract (don't fabricate).
- **`skills/handoff/SKILL.md`** — new `## Tool execution failures` section with explicit three-step protocol (report verbatim, instruct manual run, stop) plus a "Why" paragraph anchoring the rule to scrub-pass safety and §4 extraction normalization.
- **ARCH-10 drift test** — new `extractFabricationRule()` helper + new `it()` block. Uses the same 4-clause conjunction heuristic as `extractFromRule`: failure context AND `dotclaude` AND fabricate/reconstruct/synthesize AND verbatim/stop/report. Fails loud if a future SKILL.md edit silently removes the contract.

## Discovery context

Real cross-CLI handoff use on 2026-04-30: a user typed `/handoff pull <id> --from claude` in a Copilot CLI session. Copilot's tool-execution layer denied the shell call to the dotclaude binary. The consuming LLM fell back to reading session JSONL files directly and synthesized a schema-valid but semantically hollow `<handoff>` block — bypassing scrub passes (which protect against secrets exposure on `push`) and the per-CLI extraction normalization the spec depends on. Distinct failure mode from R-1 (doc/binary symbol drift) and R-1b (intra-LLM misinterpretation) in the audit risk catalog.

## Test plan

- [x] Full vitest suite: 550/550 passing across 37 files (was 549; +1 for the new KD-7 drift test)
- [x] Drift test in isolation: 5/5 passing (was 4; +1 KD-7 test)
- [x] Diff scope: exactly 5 files, +117 / -2 (3 content files in commit 1; manifest + template fixups in commits 2-3)
- [x] Heuristic self-test: paragraph 1 of the new SKILL.md section contains all four clauses (`permission denied`, `dotclaude`, `fabricate`, `verbatim`) — drift assertion passes against the same text it guards
- [x] CI green on the draft (5 workflow groups: lint, release-gate, cross-cli-invocation, test, dogfood)

## Release-please impact

This is a `feat(handoff):` commit, which under release-please's conventional-commit policy triggers a **minor bump (v1.1.1 → v1.2.0)**, not a patch. Acknowledged: the new contract is a non-breaking surface addition that meaningfully expands the consumer-side guarantees, so a minor bump is the correct semver shape. Future-you reviewing the v1.2.0 chore PR should not be surprised by the version jump.

## Spec ID

dotclaude-core, handoff-skill