### PR TITLE
fix/docs: v1.2.1 bundle — cell-27 tighten, merge convention, host-scoping docs

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -187,7 +187,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:b83b55dadf14eeac53eb1e1e8f2ea3659b77344358288c5f03c8f9ba960e9df4",
+      "checksum": "sha256:a2cc3765c4de9d12909fd4a19e646975fba305be21ce48694d09e47b020f0157",
       "dependencies": [],
       "lastValidated": "2026-05-01"
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,13 @@ npx dotclaude-doctor         # self-diagnostic
   `chore(scope): summary`, …
 - **PR body** must contain `## Summary` + `## Test plan` sections. Use
   `gh pr create --body-file` to avoid heredoc quoting pitfalls.
+- **Merge strategy**: `feat:` and `fix:` PRs → **squash-merge** (one commit
+  on `main` = one CHANGELOG entry). `chore:` PRs — specifically
+  release-please's own `chore(main): release X.Y.Z` — → **merge-commit**;
+  release-please expects that shape. Using merge-commit on `feat:`/`fix:` PRs
+  causes release-please to emit duplicate CHANGELOG entries: one from the
+  merge SHA's PR reference and one from the individual conventional-commit SHA.
+  PR #163 triggered this in v1.2.0 and required a manual splice.
 - **Never** force-push someone else's branch, `--amend` a published commit,
   or pass `--no-verify` / `--no-gpg-sign`.
 - Open commits are preferred over `--amend` once a PR is in review.

--- a/docs/specs/handoff-skill/spec/5-interfaces-apis.md
+++ b/docs/specs/handoff-skill/spec/5-interfaces-apis.md
@@ -340,6 +340,8 @@ Frozen across `pull`, `push`, `fetch`, `describe`:
 | Branch suffix (fetch only) | partial branch path                                            | trailing-`/<short>` match against ls-remote |
 | Commit prefix (fetch only) | `[0-9a-f]{4,40}`                                               | matches commit hash prefix in ls-remote     |
 
+**`latest` resolution precedence** (`--from` > detected host > cross-root union): when `--from` is omitted, the binary checks environment signals (`CLAUDECODE=1`, any `COPILOT_*`, `CODEX`) to detect the host CLI and narrows to that root. When the host is undetectable, it falls back to cross-root union — the newest session by mtime across all three roots.
+
 Copilot has **no** alias support; UUID / short / `latest` only (per
 `handoff-resolve.sh:151`). Claude does; Codex does.
 

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -83,6 +83,7 @@ distinguish a hand-rolled block from a real one.
 Brief reference. `dotclaude handoff --help` is authoritative.
 
 - `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`, `pull`; filters `list`, `search`, and `prune`.
+  For `pull latest`, omitting `--from` triggers host auto-detection: `CLAUDECODE=1` / `COPILOT_*` / `CODEX` env signals → narrowed to that CLI's root; host undetectable → cross-root union (newest mtime across all three roots).
 - `--summary` (on `pull`) emits a prose summary instead of the full `<handoff>` block.
 - `-o <path>` (on `pull`) controls output: `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`; any other string is a literal path.
 - `--since <ISO>` cuts off `list` and `search` (default 30 days for `search`).

--- a/plugins/dotclaude/tests/bats/handoff-pull-input-validation.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-input-validation.bats
@@ -23,10 +23,12 @@ setup() {
   export DOTCLAUDE_HANDOFF_REPO="/nonexistent/pull-input-val-$$"
   export DOTCLAUDE_QUIET=1
 
+  CLAUDE_UUID2="ffff2222-3333-3333-3333-333333333333"
   CLAUDE_UUID="eeee1111-2222-2222-2222-222222222222"
-  make_claude_session_tree "$TEST_HOME" "$CLAUDE_UUID"
+  make_claude_session_tree "$TEST_HOME" "$CLAUDE_UUID2" "$CLAUDE_UUID"
   CLAUDE_SHORT="${CLAUDE_UUID:0:8}"
-  export CLAUDE_UUID CLAUDE_SHORT
+  CLAUDE_SHORT2="${CLAUDE_UUID2:0:8}"
+  export CLAUDE_UUID CLAUDE_SHORT CLAUDE_UUID2 CLAUDE_SHORT2
 }
 
 teardown() {
@@ -98,8 +100,9 @@ teardown() {
 
 # --- cell 27: two positionals — first-arg wins -------------------------------
 
-@test "pull latest invalid-query (two positionals): exits 0, first arg resolves (cell 27)" {
-  run node "$BIN" pull latest "not-a-real-session"
+@test "pull latest <uuid2> (two positionals): exits 0, first arg (latest) wins, second ignored (cell 27)" {
+  run node "$BIN" pull latest "$CLAUDE_SHORT2"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"session=\"$CLAUDE_SHORT\""* ]]
+  [[ "$output" == *"session=\"$CLAUDE_SHORT\""* ]]   # latest = uuid, resolves
+  [[ "$output" != *"session=\"$CLAUDE_SHORT2\""* ]]  # uuid2 (second arg) ignored
 }

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -86,6 +86,7 @@ distinguish a hand-rolled block from a real one.
 Brief reference. `dotclaude handoff --help` is authoritative.
 
 - `--from <cli>` narrows source-CLI auto-detection on `push`, `fetch`, `pull`; filters `list`, `search`, and `prune`.
+  For `pull latest`, omitting `--from` triggers host auto-detection: `CLAUDECODE=1` / `COPILOT_*` / `CODEX` env signals → narrowed to that CLI's root; host undetectable → cross-root union (newest mtime across all three roots).
 - `--summary` (on `pull`) emits a prose summary instead of the full `<handoff>` block.
 - `-o <path>` (on `pull`) controls output: `-` forces stdout; `auto` writes to `<repo>/docs/handoffs/<date>-<cli>-<short>.md`; any other string is a literal path.
 - `--since <ISO>` cuts off `list` and `search` (default 30 days for `search`).


### PR DESCRIPTION
## Summary

- **fix(handoff) #155** — tighten cell-27 bats test to use a valid second-positional UUID with a negative assertion, strictly proving first-arg-wins rather than relying on second-arg failure
- **docs(contributing) #165** — add "Merge strategy" bullet to `CONTRIBUTING.md` establishing squash-merge for `feat:`/`fix:` PRs and merge-commit for `chore:` (release-please) PRs; documents the duplication mechanism and cites PR #163/v1.2.0 as evidence
- **docs(handoff)** — document `pull latest` three-tier host-scoping precedence (`--from` > detected host > cross-root union) that shipped via #85 but was absent from spec §5.4 and `SKILL.md`; no binary change; TWO-pin updates (manifest checksum + plugin template regen) bundled per banked discipline

## Test plan

- [x] `bats plugins/dotclaude/tests/bats/` — 360/360 (all cells 22–27 pass, including tightened cell-27)
- [x] `npm test` — 550/550 (drift test KD-7 still asserts; no regressions)
- [x] `node scripts/build-plugin.mjs --check` — plugin templates fresh (116 files)
- [x] `sha256sum skills/handoff/SKILL.md` — matches `.claude/skills-manifest.json` checksum pin
- [x] `npx prettier@3 --check CONTRIBUTING.md` — passes
- [x] markdownlint violations pre-existing (lines 24, 28, 34, 46, 61 — unchanged by this PR)
- [x] `git diff --stat HEAD~3` — exactly 6 files: bats file, CONTRIBUTING.md, spec, SKILL.md, manifest, plugin template

## Merge note

This PR should be **squash-merged** — per the very discipline commit 2 documents. One commit on `main` = one `fix:` CHANGELOG entry (the `docs:` commits are hidden by release-please config).

Expected semver bump: **v1.2.1** (one `fix:` commit closes #155; `docs:` commits are changelog-hidden per `release-please-config.json`).

## No-spec rationale

Commit 3 (`docs(handoff)`) amends spec §5.4 under the existing `dotclaude-core` / `handoff-skill` spec umbrella — covered by the `Spec ID: dotclaude-core, handoff-skill` footer in its commit body. Commits 1 and 2 are test and workflow discipline respectively; no new protected-path spec required.

## Spec ID

dotclaude-core, handoff-skill
