### PR TITLE
feat(handoff): support deliberate-label aliases in pull/fetch resolution (#158)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -187,9 +187,9 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:a2cc3765c4de9d12909fd4a19e646975fba305be21ce48694d09e47b020f0157",
+      "checksum": "sha256:d419b1ff5cf039a971ac790915d57eb25f8bfafab71679d9d0a7d2bd0e840c26",
       "dependencies": [],
-      "lastValidated": "2026-05-01"
+      "lastValidated": "2026-05-04"
     },
     {
       "name": "review-prs",

--- a/docs/handoff-guide.md
+++ b/docs/handoff-guide.md
@@ -137,7 +137,10 @@ wins.
 Sub-commands that render content accept `--summary` (terse inline) and `-o <path|auto|->` (write to file).
 
 Every `<query>` can be a full UUID, short UUID (first 8 hex), `latest`,
-a Claude `customTitle`, or a Codex `thread_name`.
+or a deliberate-label alias: Claude `customTitle`/`aiTitle`, Codex
+`thread_name`, or Copilot `workspace.yaml:name`. Aliases match
+case-insensitively. Resolution precedence: UUID > short-UUID > `latest` >
+alias (no fall-through on miss).
 
 ---
 
@@ -161,6 +164,14 @@ a Claude `customTitle`, or a Codex `thread_name`.
 
 ```
 /handoff search "auth middleware" --from claude --fixed
+```
+
+**Resolve by deliberate label (case-insensitive):**
+
+```
+/handoff pull "refactor extract pipeline"   # matches Claude aiTitle "Refactor Extract Pipeline" (case-folded)
+/handoff pull "pull latest changes"         # matches Copilot workspace.yaml:name "Pull Latest Changes"
+/handoff pull "my-feature"                  # matches Codex thread_name "my-feature"
 ```
 
 **Scripting with structured output:**

--- a/docs/specs/handoff-skill/spec/5-interfaces-apis.md
+++ b/docs/specs/handoff-skill/spec/5-interfaces-apis.md
@@ -186,11 +186,11 @@ per-target variants exist.
 
 ### 5.2.1 `pull <query> [flags]`
 
-| Flag           | Type       | Default | Mandatory when | Notes                                                                  |
-| -------------- | ---------- | ------- | -------------- | ---------------------------------------------------------------------- |
-| `<query>`      | positional | n/a     | always         | UUID / 8-hex short / `latest` / Claude customTitle / Codex thread_name |
-| `--from <cli>` | string     | (none)  | optional       | narrow to one root; values: `claude` \| `copilot` \| `codex`           |
-| `--limit <N>`  | integer    | 20      | optional       | turns extraction tail length                                           |
+| Flag           | Type       | Default | Mandatory when | Notes                                                                                                  |
+| -------------- | ---------- | ------- | -------------- | ------------------------------------------------------------------------------------------------------ |
+| `<query>`      | positional | n/a     | always         | UUID / 8-hex short / `latest` / Claude customTitle / Claude aiTitle / Codex thread_name / Copilot name |
+| `--from <cli>` | string     | (none)  | optional       | narrow to one root; values: `claude` \| `copilot` \| `codex`                                           |
+| `--limit <N>`  | integer    | 20      | optional       | turns extraction tail length                                                                           |
 
 No `--to`. No `--json`. No `--out-dir`. No environment-variable detection.
 
@@ -275,13 +275,13 @@ command and locks the **prefix** of the stderr template.
 
 ### 5.3.2 `pull`-specific exits
 
-| Code | Condition                                | Stderr template                                                                    |
-| ---- | ---------------------------------------- | ---------------------------------------------------------------------------------- |
-| 2    | no session matches (no `--from`)         | `dotclaude-handoff: no session matches: <query>`                                   |
-| 2    | no session matches (with `--from <cli>`) | `dotclaude-handoff: no <cli> session matches: <query>`                             |
-| 2    | multiple sessions match (non-TTY)        | header `dotclaude-handoff: multiple sessions match "<query>":` + TSV lines (5.3.5) |
-| 64   | unknown flag                             | `dotclaude-handoff: unknown flag: <flag>` + usage                                  |
-| 64   | missing `<query>`                        | `dotclaude-handoff: pull requires a <query>` + usage                               |
+| Code | Condition                                | Stderr template                                                                                                                                                             |
+| ---- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2    | no session matches (no `--from`)         | `dotclaude-handoff: no session matches: <query>`                                                                                                                            |
+| 2    | no session matches (with `--from <cli>`) | `dotclaude-handoff: no <cli> session matches: <query>`                                                                                                                      |
+| 2    | multiple sessions match (non-TTY)        | header `dotclaude-handoff: multiple sessions match "<query>":` + TSV lines (5.3.5) + trailing hint line `hint: pass --from <cli> to narrow, or use UUID/short-UUID prefix.` |
+| 64   | unknown flag                             | `dotclaude-handoff: unknown flag: <flag>` + usage                                                                                                                           |
+| 64   | missing `<query>`                        | `dotclaude-handoff: pull requires a <query>` + usage                                                                                                                        |
 
 When `--from <cli>` is set the no-match message is narrowed to the requested
 CLI ("no `<cli>` session matches"), giving a clearer diagnostic when the user
@@ -315,35 +315,37 @@ lookups (no `--from`). Both forms are stable public output (#136).
 Both `pull` and `fetch` emit candidate lines on multi-match (non-TTY).
 Column order is fixed; tools parsing this format can rely on field positions.
 
-| Command | Columns (tab-separated, in order)                     |
-| ------- | ----------------------------------------------------- |
-| `pull`  | `<cli>`, `<session_id>`, `<absolute-path>`, `<query>` |
-| `fetch` | `<branch>`, `<commit>`, `<description>`, `<query>`    |
+| Command | Columns (tab-separated, in order)                                              |
+| ------- | ------------------------------------------------------------------------------ |
+| `pull`  | `<cli>`, `<short-id>`, `<absolute-path>`, `<matched-value>`, `<matched-field>` |
+| `fetch` | `<branch>`, `<commit>`, `<description>`, `<query>`                             |
 
 One candidate per line. No header row in the TSV (the human-readable
 header line above the TSV is plain prose, ignored by parsers). Fields
 are guaranteed not to contain literal tabs (resolver / git outputs are
-controlled).
+controlled). Alias-form `<matched-value>` is sanitized at emit
+(tabs/newlines collapsed to single space) — see §5.4 alias rows.
 
 ## 5.4 `<query>` valid forms (cross-cutting)
 
 Frozen across `pull`, `push`, `fetch`, `describe`:
 
-| Form                       | Lexical                                                        | Notes                                       |
-| -------------------------- | -------------------------------------------------------------- | ------------------------------------------- |
-| Full UUID                  | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | exact match on session id                   |
-| Short UUID                 | `[0-9a-f]{8}`                                                  | first 8 hex of session id                   |
-| Literal `latest`           | exactly the string `latest`                                    | newest by mtime in target root(s)           |
-| Claude `customTitle` alias | non-hex string ≤ 256 chars                                     | scanned via `customTitle` JSONL records     |
-| Codex `thread_name` alias  | non-hex string ≤ 256 chars                                     | scanned via `event_msg.thread_name` records |
-| Tag (fetch only)           | `[a-z0-9-]{1,40}`                                              | matches description tag segment             |
-| Branch suffix (fetch only) | partial branch path                                            | trailing-`/<short>` match against ls-remote |
-| Commit prefix (fetch only) | `[0-9a-f]{4,40}`                                               | matches commit hash prefix in ls-remote     |
+| Form                       | Lexical                                                        | Notes                                                                                              |
+| -------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Full UUID                  | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | exact match on session id                                                                          |
+| Short UUID                 | `[0-9a-f]{8}`                                                  | first 8 hex of session id                                                                          |
+| Literal `latest`           | exactly the string `latest`, case-insensitive                  | newest by mtime in target root(s); `latest`/`Latest`/`LATEST` all match                            |
+| Claude `customTitle` alias | non-hex string ≤ 256 chars                                     | scanned via `customTitle` JSONL records (case-insensitive exact match; collisions → 5-col TSV)     |
+| Claude `aiTitle` alias     | non-hex string ≤ 256 chars                                     | scanned via `ai-title` JSONL records (case-insensitive exact match; collisions → 5-col TSV)        |
+| Codex `thread_name` alias  | non-hex string ≤ 256 chars                                     | scanned via `event_msg.thread_name` records (case-insensitive exact match; collisions → 5-col TSV) |
+| Copilot `name` alias       | non-hex string ≤ 256 chars                                     | scanned via `workspace.yaml:name` key (case-insensitive exact match; collisions → 5-col TSV)       |
+| Tag (fetch only)           | `[a-z0-9-]{1,40}`                                              | matches description tag segment                                                                    |
+| Branch suffix (fetch only) | partial branch path                                            | trailing-`/<short>` match against ls-remote                                                        |
+| Commit prefix (fetch only) | `[0-9a-f]{4,40}`                                               | matches commit hash prefix in ls-remote                                                            |
+
+**Resolution precedence** (input-shape-driven): when a query lexically matches multiple forms, precedence is UUID > short-UUID > `latest` > alias. UUID-shaped queries are not consulted as aliases (no fall-through on miss). The `latest` keyword check is case-insensitive (`latest`/`Latest`/`LATEST` all preempt alias matching); a session whose alias case-folds to `latest` remains reachable via UUID or short-UUID.
 
 **`latest` resolution precedence** (`--from` > detected host > cross-root union): when `--from` is omitted, the binary checks environment signals (`CLAUDECODE=1`, any `COPILOT_*`, `CODEX`) to detect the host CLI and narrows to that root. When the host is undetectable, it falls back to cross-root union — the newest session by mtime across all three roots.
-
-Copilot has **no** alias support; UUID / short / `latest` only (per
-`handoff-resolve.sh:151`). Claude does; Codex does.
 
 ## 5.5 SKILL.md auto-trigger contract (testable)
 

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotclaude.dev/schemas/index.schema.json",
-  "generatedAt": "2026-05-01T21:55:15.253Z",
+  "generatedAt": "2026-05-04T15:40:36.658Z",
   "version": "1.2.1",
   "artifacts": [
     {
@@ -481,7 +481,7 @@
         "task": ["documentation", "debugging"],
         "maturity": "draft"
       },
-      "version": "1.2.0",
+      "version": "1.3.0",
       "owner": "@kaiohenricunha"
     },
     {

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -18,7 +18,9 @@
  *
  * `<id>` / `<query>` resolves across all three CLIs (claude, copilot, codex):
  * full UUID, short UUID (first 8 hex), `latest`, or a named alias
- * (Claude customTitle, Codex thread_name). `latest` is host-scoped (#85).
+ * (Claude customTitle/aiTitle, Codex thread_name, Copilot workspace.yaml:name).
+ * Aliases use case-insensitive exact match. `latest` is host-scoped (#85).
+ * Resolution precedence: UUID > short-UUID > latest > alias (no fall-through).
  *
  * Exits: 0 ok, 2 not-found / runtime error, 64 usage error.
  */
@@ -101,7 +103,7 @@ const META = {
   synopsis:
     "dotclaude handoff [pull|fetch|list|search|push|prune|doctor] [args...] [--from <cli>] [--summary] [-o <path>] [--tag <label>...] [--tags] [--since <ISO>] [--limit <N>] [--verify] [--dry-run] [--older-than <30d|6m|1y|YYYY-MM-DD>] [--yes]",
   description:
-    "Cross-agent and cross-machine session handoff. `pull <id>` renders a local session as <handoff> block (or --summary / -o <path>). push/fetch handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO). push/fetch auto-run a preflight check (cached 5 min); --verify forces re-run.\n\nFor push without a query, --from <cli> is required. Omitting --from exits 64 with a usage hint.",
+    "Cross-agent and cross-machine session handoff. `pull <id>` renders a local session as <handoff> block (or --summary / -o <path>). push/fetch handle the remote transport (a user-owned private git repo named by DOTCLAUDE_HANDOFF_REPO). push/fetch auto-run a preflight check (cached 5 min); --verify forces re-run.\n\nFor push without a query, --from <cli> is required. Omitting --from exits 64 with a usage hint.\n\nA `<query>` resolves by full UUID, short UUID (first 8 hex), `latest`, or a deliberate-label alias: claude `customTitle`/`aiTitle`, codex `thread_name`, or copilot `workspace.yaml:name`. Aliases match case-insensitively. Resolution precedence: UUID > short-UUID > `latest` > alias (no fall-through on miss).",
   flags: {
     // #91 Gap 7: tag is multi-valued for push (--tag foo --tag bar) and a
     // single-value filter on `list --remote --tag <name>`. argv.mjs always
@@ -153,10 +155,6 @@ function parseSinceOrFail(raw, { defaultDays = null } = {}) {
 // ---- resolver / extractor bridge ---------------------------------------
 
 /**
- * @typedef {{cli: string, sessionId: string, path: string, query: string}} Candidate
- */
-
-/**
  * Strip the resolver-script's `handoff-resolve:` prefix from captured stderr
  * so the binary's own `dotclaude-handoff:` prefix doesn't double up (#135).
  * Returns the trimmed remainder.
@@ -166,6 +164,47 @@ function parseSinceOrFail(raw, { defaultDays = null } = {}) {
  */
 function stripResolverPrefix(raw) {
   return raw.trim().replace(/^handoff-resolve:\s*/, "");
+}
+
+/**
+ * Parse a 5-column TSV candidate list from a captured `handoff-resolve.sh` stderr
+ * (collision case) and dispatch to TTY prompt or non-TTY stderr passthrough per
+ * ARCH-3. Used by `resolveAny`, `resolveNarrowed`, and `resolveLocalForPull` —
+ * single source of truth for the §5.3.5 5-column contract.
+ *
+ * Each candidate row has 5 tab-separated fields per §5.3.5:
+ *   <cli> <short-id> <absolute-path> <matched-value> <matched-field>
+ *
+ * Edge case: if stderr contains the "multiple sessions match" header but no
+ * lines parse as 5-tab-field rows (corrupted resolver output), fall through
+ * to the non-TTY passthrough path — better to surface the raw stderr than to
+ * prompt with an empty candidate list.
+ *
+ * @param {string} stderr  captured stderr from the resolver
+ * @param {string} query   original user query (for the TTY prompt header)
+ * @returns {Promise<{cli: string, path: string}>}  resolved on TTY pick
+ */
+async function parseCollisionAndDispatch(stderr, query) {
+  const candidates = [];
+  for (const line of stderr.split("\n")) {
+    const parts = line.split("\t");
+    if (parts.length === 5) {
+      candidates.push({
+        cli: parts[0],
+        shortId: parts[1],
+        path: parts[2],
+        matchedValue: parts[3],
+        matchedField: parts[4],
+      });
+    }
+  }
+  if (process.stdin.isTTY && candidates.length > 0) {
+    return await promptCollisionChoice(query, candidates);
+  }
+  // Non-TTY OR corrupted stderr (header without parseable rows):
+  // surface the raw resolver stderr verbatim and exit 2.
+  process.stderr.write(stderr);
+  process.exit(2);
 }
 
 /**
@@ -186,7 +225,8 @@ async function resolveAny(query) {
     return { cli, path };
   }
   // status != 0. If stderr begins with "multiple sessions match", it is a
-  // collision. Otherwise it's "no session matches" or an env error.
+  // collision (intra-CLI alias collision passed through, OR cross-CLI union of
+  // alias hits). Otherwise it's "no session matches" or an env error.
   const stderr = r.stderr;
   if (!stderr.includes("multiple sessions match")) {
     fail(
@@ -194,49 +234,44 @@ async function resolveAny(query) {
       stripResolverPrefix(stderr) || `no session matches: ${query}`,
     );
   }
-  // Parse candidate TSV lines (4 fields: cli\tsid\tpath\tquery).
-  const candidates = [];
-  for (const line of stderr.split("\n")) {
-    const parts = line.split("\t");
-    if (parts.length === 4) {
-      candidates.push({ cli: parts[0], sessionId: parts[1], path: parts[2], query: parts[3] });
-    }
-  }
-  if (process.stdin.isTTY) {
-    return await promptCollisionChoice(query, candidates);
-  }
-  // Non-TTY: pass through the script's stderr and exit 2.
-  process.stderr.write(stderr);
-  process.exit(2);
+  return await parseCollisionAndDispatch(stderr, query);
 }
 
 /**
- * Resolve `<id>` against a single CLI's root. Thin wrapper over the
- * per-CLI entry point of handoff-resolve.sh — no collision handling
- * because the per-CLI resolvers return at most one hit.
+ * Resolve `<id>` against a single CLI's root. Thin wrapper over the per-CLI
+ * entry point of handoff-resolve.sh. Collisions can occur on alias scans
+ * (claude customTitle/aiTitle, codex thread_name, copilot name) when multiple
+ * sessions share the same alias value within one CLI's root — handled via
+ * parseCollisionAndDispatch (TTY prompt or non-TTY stderr passthrough).
  *
  * @param {string} cli    one of CLIS
  * @param {string} id     uuid | short-uuid | "latest" | alias
- * @returns {{cli: string, path: string}}
+ * @returns {Promise<{cli: string, path: string}>}
  */
-function resolveNarrowed(cli, id) {
+async function resolveNarrowed(cli, id) {
   const r = runScript(RESOLVE_SH, [cli, id]);
-  if (r.status !== 0) {
-    fail(
-      r.status === 64 ? EXIT_CODES.USAGE : 2,
-      stripResolverPrefix(r.stderr) || `no ${cli} session matches: ${id}`,
-    );
+  if (r.status === 0) {
+    return { cli, path: r.stdout.trim() };
   }
-  return { cli, path: r.stdout.trim() };
+  // status != 0. Same dispatch as resolveAny: collision if "multiple sessions
+  // match" prefix; otherwise a "not found"/env error.
+  const stderr = r.stderr;
+  if (stderr.includes("multiple sessions match")) {
+    return await parseCollisionAndDispatch(stderr, id);
+  }
+  fail(
+    r.status === 64 ? EXIT_CODES.USAGE : 2,
+    stripResolverPrefix(stderr) || `no ${cli} session matches: ${id}`,
+  );
 }
 
 /**
  * Local resolver variant for the `pull` verb. Mirrors resolveAny /
- * resolveNarrowed but intercepts the no-match path so the binary can
- * append a single stderr hint (`for remote handoffs use fetch <id>`)
- * when a remote transport is configured — without auto-forwarding.
- * Collisions in the union path still route through resolveAny's TTY
- * prompt / non-TTY candidate dump.
+ * resolveNarrowed but intercepts the no-match path so the binary can append a
+ * single stderr hint (`for remote handoffs use fetch <id>`) when a remote
+ * transport is configured — without auto-forwarding. Collisions are dispatched
+ * via parseCollisionAndDispatch in both narrowTo-given (per-CLI alias) and
+ * null (cross-CLI union / per-CLI passed through resolve_any) paths.
  *
  * @param {string} id
  * @param {string|null} narrowTo   one of CLIS, or null for union lookup.
@@ -251,9 +286,12 @@ async function resolveLocalForPull(id, narrowTo) {
     return { cli, path };
   }
   const stderr = r.stderr;
-  if (!narrowTo && stderr.includes("multiple sessions match")) {
-    return await resolveAny(id);
+  if (stderr.includes("multiple sessions match")) {
+    // Collision in either narrowTo-given (per-CLI alias collision) or null
+    // (cross-CLI union or per-CLI alias collision aggregated by resolve_any).
+    return await parseCollisionAndDispatch(stderr, id);
   }
+  // No-match path: emit "not found" with optional remote-handoff hint.
   const msg =
     stripResolverPrefix(stderr) ||
     (narrowTo ? `no ${narrowTo} session matches: ${id}` : `no session matches: ${id}`);
@@ -264,10 +302,27 @@ async function resolveLocalForPull(id, narrowTo) {
   process.exit(r.status === 64 ? EXIT_CODES.USAGE : 2);
 }
 
+/**
+ * Render the collision candidate menu and prompt the user to pick one.
+ * Each candidate is rendered on a single line with the (cli/matched-field)
+ * disambiguation tag, the matched value (case as stored by the resolver,
+ * soft-truncated at 80 chars for pathological lengths), and the short-id in
+ * brackets for traceability. The path is omitted from the rendered line —
+ * users pick by N, and short-id provides the unique identifier.
+ *
+ * @param {string} query  the original user query (header line)
+ * @param {Array<{cli: string, shortId: string, path: string, matchedValue: string, matchedField: string}>} candidates
+ * @returns {Promise<{cli: string, path: string}>}
+ */
 async function promptCollisionChoice(query, candidates) {
   process.stderr.write(`dotclaude-handoff: multiple sessions match "${query}":\n`);
   candidates.forEach((c, i) => {
-    process.stderr.write(`  [${i + 1}] ${c.cli.padEnd(8)} ${c.sessionId}  ${c.path}\n`);
+    const tag = `(${c.cli}/${c.matchedField})`;
+    const displayValue =
+      c.matchedValue.length > 80 ? c.matchedValue.slice(0, 77) + "..." : c.matchedValue;
+    process.stderr.write(
+      `  [${i + 1}] ${tag.padEnd(22)} ${displayValue.padEnd(50)} [${c.shortId}]\n`,
+    );
   });
   const rl = createInterface({ input: process.stdin, output: process.stderr });
   const ans = await new Promise((resolve) => {
@@ -685,7 +740,7 @@ function shortIdFromPath(path) {
 async function resolveLatestWithHostScope({ fromCli, detectedHost }) {
   const narrowTo = fromCli ?? (detectedHost !== "unknown" ? detectedHost : null);
   if (narrowTo) {
-    const hit = resolveNarrowed(narrowTo, "latest");
+    const hit = await resolveNarrowed(narrowTo, "latest");
     const shortId = shortIdFromPath(hit.path);
     const prefix = fromCli ? `using --from ${narrowTo} override, ` : "";
     return { hit, note: `${prefix}latest ${narrowTo} session: ${shortId}` };
@@ -888,7 +943,7 @@ async function main() {
       // explicit query — it would silently mis-route a user who
       // typed `push <codex-alias>` from inside a Claude Code session.
       sessionHit = fromCli
-        ? resolveNarrowed(fromCli, explicitQuery)
+        ? await resolveNarrowed(fromCli, explicitQuery)
         : await resolveAny(explicitQuery);
     } else {
       // §5.5.2: --from is required when push has no <query>.

--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -1006,8 +1006,11 @@ async function main() {
     const summaryMode = Boolean(argv.flags.summary);
     const out = argv.flags.output != null ? String(argv.flags.output) : undefined;
     let hit;
-    if (id === "latest") {
+    if (id.toLowerCase() === "latest") {
       // Host-scope the `latest` shortcut per #85: --from > detected host > union.
+      // Case-fold matches the resolver's case-glob (Decision 2) so mixed-case
+      // `Latest`/`LATEST` enter the host-scoped path here instead of falling
+      // through to `any` resolution.
       const { hit: latestHit, note } = await resolveLatestWithHostScope({ fromCli, detectedHost });
       if (note) process.stderr.write(note + "\n");
       hit = latestHit;

--- a/plugins/dotclaude/scripts/handoff-resolve.sh
+++ b/plugins/dotclaude/scripts/handoff-resolve.sh
@@ -4,14 +4,25 @@
 # Usage:
 #   handoff-resolve.sh <cli> <identifier>
 #
-# cli:          claude | copilot | codex
+# cli:          claude | copilot | codex | any
 # identifier:   full UUID (36 chars), short UUID (first 8 hex),
-#               the literal word `latest`, or, for codex only,
-#               a thread_name alias (e.g. `my-feature`).
+#               the literal word `latest` (case-insensitive), or an alias:
+#                 - claude:  customTitle (`claude --resume "<name>"`) or aiTitle
+#                            (auto-generated TUI summary)
+#                 - codex:   thread_name (user-set, `event_msg.thread_name`)
+#                 - copilot: workspace.yaml:name (auto-generated session label)
+#               Aliases: case-insensitive exact match. Decision 4 precedence:
+#               UUID > short-UUID > latest > alias (no fall-through on miss).
+#
+# Stdout (success):  absolute path to the resolved JSONL
+# Stderr (success):  matched-field=<uuid|short-uuid|latest|customTitle|aiTitle|thread_name|name>
+#                    matched-value=<sanitized matched value>
+# Stderr (collision, alias-form): handoff-resolve: multiple sessions match "<id>":
+#                    + 5-column TSV rows + hint line (see §5.3.5 / §5.3.2)
 #
 # Exits:
-#   0  prints absolute path to the resolved JSONL on stdout
-#   2  "not found" or other runtime error, with structured message on stderr
+#   0  success — single path resolved
+#   2  "not found", "no session matches", or "multiple sessions match" (collision)
 #   64 usage error
 
 set -euo pipefail
@@ -31,6 +42,58 @@ EOF
   exit 64
 }
 
+# Helpers for 5-column TSV emit on alias collisions and matched-value sanitization.
+# See docs/specs/handoff-skill/spec/5-interfaces-apis.md §5.3.5 for the column contract.
+
+# Collapse tabs/newlines in a matched-value to single spaces, preserving field width.
+# §5.3.5 invariant: alias-form <matched-value> is sanitized at emit so TSV rows
+# never contain literal tabs/newlines that would corrupt column boundaries.
+sanitize_for_tsv() {
+  local v="$1"
+  v="${v//$'\t'/ }"
+  v="${v//$'\n'/ }"
+  printf '%s' "$v"
+}
+
+# First 8 hex of a session id, for the <short-id> TSV column.
+short_id_from_session() {
+  local sid="$1"
+  printf '%s' "${sid:0:8}"
+}
+
+# Emit a 5-column collision TSV to stderr and exit 2. Caller passes the input
+# query followed by pre-formatted 5-col rows (already sanitized) as positional
+# args. Header + rows + trailing hint per §5.3.2.
+emit_collision_tsv() {
+  local query="$1"
+  shift
+  {
+    printf 'handoff-resolve: multiple sessions match "%s":\n' "$query"
+    local row
+    for row in "$@"; do
+      printf '%s\n' "$row"
+    done
+    printf 'hint: pass --from <cli> to narrow, or use UUID/short-UUID prefix.\n'
+  } >&2
+  exit 2
+}
+
+# Infer matched-field tag from input shape — fallback for cases where a per-CLI
+# resolver's single-hit branch returned a path on stdout but did NOT emit the
+# matched-field=/matched-value= stderr metadata that (d).7 standardized. As of
+# v1.3.0 (#158) all per-CLI single-hit branches emit explicit tags; reaching
+# this fallback indicates a per-CLI contract drift worth investigating, not a
+# normal code path. The four shape categories below mirror Decision 4's
+# precedence order so debugging signal is unambiguous.
+infer_field_from_id() {
+  local id="$1"
+  if [[ "$id" =~ $UUID_RE ]]; then printf '%s' "uuid"
+  elif [[ "$id" =~ $SHORT_UUID_RE ]]; then printf '%s' "short-uuid"
+  elif [[ "$id" == [Ll][Aa][Tt][Ee][Ss][Tt] ]]; then printf '%s' "latest"
+  else printf '%s' "alias"
+  fi
+}
+
 UUID_RE='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 SHORT_UUID_RE='^[0-9a-f]{8}$'
 
@@ -46,6 +109,11 @@ fi
 
 # Pick newest by mtime from a newline-separated list on stdin. Prints path only.
 # Pure-bash loop: no word-splitting on paths with spaces, no subshell per file.
+# Returns 0 on both empty and populated input. Empty input → empty stdout, exit 0
+# (NOT exit 1 — callers compose this in pipefail-sensitive substitutions like
+# `hit="$(find ... | pick_newest)"` and rely on `[[ -z "$hit" ]]` for the no-match
+# branch; an exit-1 from the helper would propagate via pipefail and errexit-kill
+# the calling script before the no-match branch could dispatch).
 pick_newest() {
   local best_ms=0 best_path="" file frac secs frac_part frac_ms
   while IFS= read -r file; do
@@ -67,7 +135,10 @@ pick_newest() {
       best_path="$file"
     fi
   done
-  [[ -n "$best_path" ]] && printf '%s\n' "$best_path"
+  if [[ -n "$best_path" ]]; then
+    printf '%s\n' "$best_path"
+  fi
+  return 0
 }
 
 resolve_claude() {
@@ -75,11 +146,13 @@ resolve_claude() {
   local root="${HOME}/.claude/projects"
   [[ -d "$root" ]] || die_runtime "claude session root not found: $root"
 
-  if [[ "$id" == "latest" ]]; then
+  if [[ "$id" == [Ll][Aa][Tt][Ee][Ss][Tt] ]]; then
     local hit
     hit="$(find "$root" -maxdepth 2 -type f -name '*.jsonl' 2>/dev/null | pick_newest)"
     [[ -n "$hit" ]] || die_runtime "no claude sessions found under $root"
     printf '%s\n' "$hit"
+    printf 'matched-field=latest\n' >&2
+    printf 'matched-value=latest\n' >&2
     return 0
   fi
 
@@ -89,38 +162,133 @@ resolve_claude() {
     hit="$(find "$root" -maxdepth 2 -type f -name "${id}.jsonl" 2>/dev/null | head -1)"
     [[ -n "$hit" ]] || die_runtime "claude session not found for uuid: $id"
     printf '%s\n' "$hit"
+    printf 'matched-field=uuid\n' >&2
+    printf 'matched-value=%s\n' "$(sanitize_for_tsv "$id")" >&2
     return 0
   fi
 
   # Short UUID (first 8 hex) — pick newest by mtime; deterministic across prefix collisions.
+  # Strict precedence per Decision 4: short-UUID-shaped queries are not consulted
+  # as aliases on miss (no fall-through to customTitle/aiTitle scans).
   if [[ "$id" =~ $SHORT_UUID_RE ]]; then
     local hit
     hit="$(find "$root" -maxdepth 2 -type f -name "${id}*.jsonl" 2>/dev/null | pick_newest)"
     if [[ -n "$hit" ]]; then
       printf '%s\n' "$hit"
+      printf 'matched-field=short-uuid\n' >&2
+      printf 'matched-value=%s\n' "$(sanitize_for_tsv "$id")" >&2
       return 0
     fi
-    # Fall through to customTitle scan if short-UUID lookup missed.
+    die_runtime "claude session not found for short-uuid: $id"
   fi
 
   # Claude `custom-title` alias scan: `claude --resume "<name>"` stores
   # the alias as a JSONL record `{"type":"custom-title","customTitle":"<name>","sessionId":"<uuid>"}`.
-  # Prefilter with grep so we only jq-verify files that contain the alias.
+  # Case-insensitive exact match via jq ascii_downcase (Decision 1/2). Collect-all
+  # per ARCH-3: collisions emit 5-col TSV via emit_collision_tsv; single hit emits
+  # matched-field/matched-value to stderr alongside path on stdout.
+  # Prefilter with grep -iF so case-folded inputs pass the gate.
   if command -v jq >/dev/null 2>&1; then
-    local f session_id
+    local f session_id matched_value
+    local -a custom_rows=()
+    local custom_hit_path="" custom_hit_value=""
+    local seen_sids=""
     while IFS= read -r f; do
-      session_id=$(jq -r --arg name "$id" '
-        select(.type == "custom-title" and .customTitle == $name)
-        | .sessionId' "$f" 2>/dev/null | head -1)
-      if [[ -n "$session_id" ]]; then
+      while IFS=$'\t' read -r session_id matched_value; do
+        [[ -n "$session_id" ]] || continue
+        # Intra-file dedup-by-sessionId: a single conversation file can hold
+        # 100+ identical custom-title records (Claude rewrites the record on
+        # every save). Skip if we've already collected this sessionId.
+        # NOT to be confused with cross-file collision detection — different
+        # sessionIds with the same alias are real collisions, handled by the
+        # outer loop's accumulation into custom_rows + emit_collision_tsv.
+        case " $seen_sids " in
+          *" $session_id "*) continue ;;
+        esac
+        seen_sids="$seen_sids $session_id"
         local hit
         hit="$(find "$root" -maxdepth 2 -type f -name "${session_id}.jsonl" 2>/dev/null | head -1)"
-        if [[ -n "$hit" ]]; then
-          printf '%s\n' "$hit"
-          return 0
-        fi
-      fi
-    done < <(grep -rl --include='*.jsonl' -F "\"customTitle\":\"${id}\"" "$root" 2>/dev/null)
+        [[ -n "$hit" ]] || continue
+        custom_hit_path="$hit"
+        custom_hit_value="$matched_value"
+        custom_rows+=("$(printf '%s\t%s\t%s\t%s\t%s' \
+          "claude" \
+          "$(short_id_from_session "$session_id")" \
+          "$hit" \
+          "$(sanitize_for_tsv "$matched_value")" \
+          "customTitle")")
+      done < <(jq -r --arg name "$id" '
+        select(.type == "custom-title"
+               and (.customTitle | ascii_downcase) == ($name | ascii_downcase))
+        | "\(.sessionId)\t\(.customTitle | gsub("[\t\n]"; " "))"' "$f" 2>/dev/null)
+    done < <(grep -rl --include='*.jsonl' -iF "\"customTitle\":\"${id}\"" "$root" 2>/dev/null)
+
+    case ${#custom_rows[@]} in
+      0) ;;  # no customTitle match; fall through to die_runtime at function bottom
+      1)
+        printf '%s\n' "$custom_hit_path"
+        printf 'matched-field=customTitle\n' >&2
+        printf 'matched-value=%s\n' "$(sanitize_for_tsv "$custom_hit_value")" >&2
+        return 0
+        ;;
+      *)
+        emit_collision_tsv "$id" "${custom_rows[@]}"
+        ;;
+    esac
+  fi
+
+  # Claude `ai-title` alias scan: Claude Code auto-generates a short summary
+  # for sessions that accumulate enough conversation, persisted as JSONL records
+  # `{"type":"ai-title","aiTitle":"<text>","sessionId":"<uuid>"}`. This is the
+  # primary TUI title source — what `claude --resume`'s picker displays for
+  # sessions that have an ai-title (4/24 in dotclaude project per Phase 1).
+  # Same shape as the customTitle scan above: case-insensitive via jq
+  # ascii_downcase, intra-file dedup-by-sessionId, single-hit metadata to
+  # stderr, collisions via emit_collision_tsv. Files can hold many ai-title
+  # records (Claude rewrites the summary as conversation grows; one observed
+  # file has 3 distinct historical aiTitles for one session — historical
+  # values still resolve to the same session via dedup-by-sessionId).
+  if command -v jq >/dev/null 2>&1; then
+    local f session_id matched_value
+    local -a aititle_rows=()
+    local aititle_hit_path="" aititle_hit_value=""
+    local seen_sids_aititle=""
+    while IFS= read -r f; do
+      while IFS=$'\t' read -r session_id matched_value; do
+        [[ -n "$session_id" ]] || continue
+        case " $seen_sids_aititle " in
+          *" $session_id "*) continue ;;
+        esac
+        seen_sids_aititle="$seen_sids_aititle $session_id"
+        local hit
+        hit="$(find "$root" -maxdepth 2 -type f -name "${session_id}.jsonl" 2>/dev/null | head -1)"
+        [[ -n "$hit" ]] || continue
+        aititle_hit_path="$hit"
+        aititle_hit_value="$matched_value"
+        aititle_rows+=("$(printf '%s\t%s\t%s\t%s\t%s' \
+          "claude" \
+          "$(short_id_from_session "$session_id")" \
+          "$hit" \
+          "$(sanitize_for_tsv "$matched_value")" \
+          "aiTitle")")
+      done < <(jq -r --arg name "$id" '
+        select(.type == "ai-title"
+               and (.aiTitle | ascii_downcase) == ($name | ascii_downcase))
+        | "\(.sessionId)\t\(.aiTitle | gsub("[\t\n]"; " "))"' "$f" 2>/dev/null)
+    done < <(grep -rl --include='*.jsonl' -iF "\"aiTitle\":\"${id}\"" "$root" 2>/dev/null)
+
+    case ${#aititle_rows[@]} in
+      0) ;;  # no aiTitle match; fall through to die_runtime at function bottom
+      1)
+        printf '%s\n' "$aititle_hit_path"
+        printf 'matched-field=aiTitle\n' >&2
+        printf 'matched-value=%s\n' "$(sanitize_for_tsv "$aititle_hit_value")" >&2
+        return 0
+        ;;
+      *)
+        emit_collision_tsv "$id" "${aititle_rows[@]}"
+        ;;
+    esac
   fi
 
   die_runtime "claude session not found for identifier: $id"
@@ -131,11 +299,13 @@ resolve_copilot() {
   local root="${HOME}/.copilot/session-state"
   [[ -d "$root" ]] || die_runtime "copilot session root not found: $root"
 
-  if [[ "$id" == "latest" ]]; then
+  if [[ "$id" == [Ll][Aa][Tt][Ee][Ss][Tt] ]]; then
     local hit
     hit="$(find "$root" -maxdepth 2 -type f -name 'events.jsonl' 2>/dev/null | pick_newest)"
     [[ -n "$hit" ]] || die_runtime "no copilot sessions found under $root"
     printf '%s\n' "$hit"
+    printf 'matched-field=latest\n' >&2
+    printf 'matched-value=latest\n' >&2
     return 0
   fi
 
@@ -144,6 +314,8 @@ resolve_copilot() {
     local candidate="${root}/${id}/events.jsonl"
     [[ -f "$candidate" ]] || die_runtime "copilot session not found for uuid: $id"
     printf '%s\n' "$candidate"
+    printf 'matched-field=uuid\n' >&2
+    printf 'matched-value=%s\n' "$(sanitize_for_tsv "$id")" >&2
     return 0
   fi
 
@@ -154,10 +326,62 @@ resolve_copilot() {
     [[ -n "$hit" ]] \
       || die_runtime "copilot session not found for short-uuid: $id"
     printf '%s\n' "$hit"
+    printf 'matched-field=short-uuid\n' >&2
+    printf 'matched-value=%s\n' "$(sanitize_for_tsv "$id")" >&2
     return 0
   fi
 
-  die_runtime "copilot identifier must be full UUID, short-UUID (8 hex), or 'latest': $id"
+  # Copilot `workspace.yaml:name` alias scan: copilot persists an LLM-generated
+  # session name at session-start time as a top-level YAML key in
+  # `~/.copilot/session-state/<uuid>/workspace.yaml`. The `name` field is what
+  # `copilot --resume`'s picker displays. Distinct from `summary` (decorative
+  # companion key, often identical but not the resolution target per Decision 4).
+  # Case-insensitive exact match via LC_ALL=C tr (matching the bash 3.2 floor
+  # established at handoff-description.sh:34). One workspace.yaml per session
+  # directory, so no intra-resource dedup needed (structural invariant: one
+  # name per UUID directory). Cross-directory matches are real collisions —
+  # accumulate into name_rows + emit_collision_tsv.
+  local id_lower
+  id_lower="$(printf '%s' "$id" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
+  local d workspace_yaml name_value name_lower sid
+  local -a name_rows=()
+  local name_hit_path="" name_hit_value=""
+  while IFS= read -r d; do
+    workspace_yaml="${d}/workspace.yaml"
+    [[ -f "$workspace_yaml" ]] || continue
+    name_value=$(sed -n 's/^name: *//p' "$workspace_yaml" 2>/dev/null | head -1)
+    name_value="${name_value#\"}"
+    name_value="${name_value%\"}"
+    [[ -n "$name_value" ]] || continue
+    name_lower="$(printf '%s' "$name_value" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
+    [[ "$name_lower" == "$id_lower" ]] || continue
+    local hit="${d}/events.jsonl"
+    [[ -f "$hit" ]] || continue
+    sid=$(basename "$d")
+    name_hit_path="$hit"
+    name_hit_value="$name_value"
+    name_rows+=("$(printf '%s\t%s\t%s\t%s\t%s' \
+      "copilot" \
+      "$(short_id_from_session "$sid")" \
+      "$hit" \
+      "$(sanitize_for_tsv "$name_value")" \
+      "name")")
+  done < <(find "$root" -maxdepth 1 -mindepth 1 -type d 2>/dev/null)
+
+  case ${#name_rows[@]} in
+    0) ;;  # no name match; fall through to die_runtime below
+    1)
+      printf '%s\n' "$name_hit_path"
+      printf 'matched-field=name\n' >&2
+      printf 'matched-value=%s\n' "$(sanitize_for_tsv "$name_hit_value")" >&2
+      return 0
+      ;;
+    *)
+      emit_collision_tsv "$id" "${name_rows[@]}"
+      ;;
+  esac
+
+  die_runtime "copilot session not found for identifier: $id"
 }
 
 resolve_codex() {
@@ -165,53 +389,115 @@ resolve_codex() {
   local root="${HOME}/.codex/sessions"
   [[ -d "$root" ]] || die_runtime "codex session root not found: $root"
 
-  if [[ "$id" == "latest" ]]; then
+  if [[ "$id" == [Ll][Aa][Tt][Ee][Ss][Tt] ]]; then
     local hit
     hit="$(find "$root" -type f -name 'rollout-*.jsonl' 2>/dev/null | pick_newest)"
     [[ -n "$hit" ]] || die_runtime "no codex sessions found under $root"
     printf '%s\n' "$hit"
+    printf 'matched-field=latest\n' >&2
+    printf 'matched-value=latest\n' >&2
     return 0
   fi
 
   # Full UUID.
+  # Strict precedence per Decision 4: UUID-shaped queries are not consulted as
+  # aliases on miss (no fall-through to thread_name scan). Removes the
+  # previously-codex-only "very unlikely, but cheap" fall-through that diverged
+  # from claude/copilot's strict-precedence shape.
   if [[ "$id" =~ $UUID_RE ]]; then
     local hit
     hit="$(find "$root" -type f -name "rollout-*-${id}.jsonl" 2>/dev/null | head -1)"
     if [[ -n "$hit" ]]; then
       printf '%s\n' "$hit"
+      printf 'matched-field=uuid\n' >&2
+      printf 'matched-value=%s\n' "$(sanitize_for_tsv "$id")" >&2
       return 0
     fi
-    # UUID-shaped but not on disk: fall through to alias scan in case someone
-    # named a thread with UUID-like shape. Very unlikely, but cheap.
+    die_runtime "codex session not found for uuid: $id"
   fi
 
   # Short UUID — pick newest by mtime; deterministic across prefix collisions.
+  # Strict precedence per Decision 4: short-UUID-shaped queries are not consulted
+  # as aliases on miss (no fall-through to thread_name scan).
   if [[ "$id" =~ $SHORT_UUID_RE ]]; then
     local hit
     hit="$(find "$root" -type f -name "rollout-*-${id}-*.jsonl" 2>/dev/null | pick_newest)"
     if [[ -n "$hit" ]]; then
       printf '%s\n' "$hit"
+      printf 'matched-field=short-uuid\n' >&2
+      printf 'matched-value=%s\n' "$(sanitize_for_tsv "$id")" >&2
       return 0
     fi
-    # Fall through to alias scan.
+    die_runtime "codex session not found for short-uuid: $id"
   fi
 
-  # Alias scan: look for event_msg records with thread_name == "$id".
-  # Prefilter with grep — rollout dirs can hold hundreds of files, jq-parsing
-  # each one is quadratic. Then jq-verify only candidates if jq is present.
-  local f
-  while IFS= read -r f; do
-    if command -v jq >/dev/null 2>&1; then
-      local match
-      match=$(jq -r --arg name "$id" '
+  # Codex `thread_name` user-set alias scan: stored as
+  # `{"type":"event_msg","payload":{"thread_name":"<name>", ...}}` in rollout JSONL.
+  # Structural note: codex sessionId is encoded in the rollout filename (not a JSON
+  # field), so jq emits input_filename instead of looking up by sessionId. Bash
+  # extracts short-id via session_id_from_path "codex" "$path".
+  # Case-insensitive exact match via jq ascii_downcase (Decision 1/2). Null guard
+  # because ascii_downcase errors on null and most event_msg records lack
+  # .payload.thread_name. Collect-all per ARCH-3: collisions emit 5-col TSV via
+  # emit_collision_tsv; single hit emits matched-field/matched-value to stderr
+  # alongside path on stdout.
+  # Prefilter with grep -iF so case-folded inputs pass the gate.
+  #
+  # Implicit invariant: only event_msg records carrying a thread_name have
+  # .payload.thread_name; the null guard filters safely without a .payload.type
+  # discriminator. Empirical verification 2026-05-03: 0 thread_name records
+  # across 5 local rollouts (Phase 1 finding). The .payload.type discriminator
+  # is unverified on real thread_name data — revisit when production data is
+  # available; tightening to .payload.type == "thread_name" would be a strict
+  # invariant upgrade if confirmed.
+  if command -v jq >/dev/null 2>&1; then
+    local f path matched_value
+    local -a thread_rows=()
+    local thread_hit_path="" thread_hit_value=""
+    local seen_paths=""
+    while IFS= read -r f; do
+      while IFS=$'\t' read -r path matched_value; do
+        [[ -n "$path" ]] || continue
+        [[ -f "$path" ]] || continue
+        # Intra-file dedup-by-path: codex sessionId is encoded in the rollout
+        # filename, so same path === same session. Multiple thread_name records
+        # within one rollout (if any — Phase 1 found 0 records on local data)
+        # would dedupe to one row. NOT to be confused with cross-file collision
+        # detection — different paths with the same alias are real collisions,
+        # handled by accumulation into thread_rows + emit_collision_tsv.
+        case " $seen_paths " in
+          *" $path "*) continue ;;
+        esac
+        seen_paths="$seen_paths $path"
+        local sid; sid=$(session_id_from_path "codex" "$path")
+        thread_hit_path="$path"
+        thread_hit_value="$matched_value"
+        thread_rows+=("$(printf '%s\t%s\t%s\t%s\t%s' \
+          "codex" \
+          "$(short_id_from_session "$sid")" \
+          "$path" \
+          "$(sanitize_for_tsv "$matched_value")" \
+          "thread_name")")
+      done < <(jq -r --arg name "$id" '
         select(.type == "event_msg"
-               and .payload.thread_name == $name)
-        | input_filename' "$f" 2>/dev/null | head -1)
-      [[ -n "$match" ]] || continue
-    fi
-    printf '%s\n' "$f"
-    return 0
-  done < <(grep -rl --include='rollout-*.jsonl' -F "\"thread_name\":\"${id}\"" "$root" 2>/dev/null)
+               and .payload.thread_name != null
+               and (.payload.thread_name | ascii_downcase) == ($name | ascii_downcase))
+        | "\(input_filename)\t\(.payload.thread_name | gsub("[\t\n]"; " "))"' "$f" 2>/dev/null)
+    done < <(grep -rl --include='rollout-*.jsonl' -iF "\"thread_name\":\"${id}\"" "$root" 2>/dev/null)
+
+    case ${#thread_rows[@]} in
+      0) ;;  # no thread_name match; fall through to die_runtime at function bottom
+      1)
+        printf '%s\n' "$thread_hit_path"
+        printf 'matched-field=thread_name\n' >&2
+        printf 'matched-value=%s\n' "$(sanitize_for_tsv "$thread_hit_value")" >&2
+        return 0
+        ;;
+      *)
+        emit_collision_tsv "$id" "${thread_rows[@]}"
+        ;;
+    esac
+  fi
 
   die_runtime "codex session not found for identifier: $id"
 }
@@ -235,13 +521,23 @@ session_id_from_path() {
   esac
 }
 
-# `any` mode: probe all three CLIs. Emit single path on exactly-one match;
-# TSV candidate list on stderr + exit 2 on collision; exit 2 on no match.
+# `any` mode: probe all three CLIs. On exactly-one match emit single path on stdout
+# plus matched-field=/matched-value= metadata on stderr (mirroring per-CLI single-hit
+# contract). On multi-match (intra-CLI alias collision passed through, OR cross-CLI
+# union of single hits with the same alias), emit 5-column TSV via emit_collision_tsv.
+# On no match across all CLIs, exit 2 with "no session matches: <id>".
+#
+# Per-CLI stderr is captured per-iteration to a tmpfile so resolve_any can:
+#   (a) parse matched-field=/matched-value= metadata from per-CLI single-hit branches
+#   (b) detect per-CLI alias-collision via "handoff-resolve: multiple sessions match"
+#       header and aggregate the 5-tab-field rows into resolve_any's own row array
+#   (c) discard "not found" stderr from CLIs that miss (skip silently)
+# Cleanup: per-iteration rm -f for happy path, RETURN trap for abnormal exits.
 resolve_any() {
   local id="$1"
 
   # Special case: `any latest` picks the newest jsonl across all three roots.
-  if [[ "$id" == "latest" ]]; then
+  if [[ "$id" == [Ll][Aa][Tt][Ee][Ss][Tt] ]]; then
     local roots=()
     [[ -d "${HOME}/.claude/projects" ]]       && roots+=("${HOME}/.claude/projects")
     [[ -d "${HOME}/.copilot/session-state" ]] && roots+=("${HOME}/.copilot/session-state")
@@ -251,21 +547,61 @@ resolve_any() {
     hit="$(find "${roots[@]}" -type f -name '*.jsonl' 2>/dev/null | pick_newest)"
     [[ -n "$hit" ]] || die_runtime "no sessions found across any root"
     printf '%s\n' "$hit"
+    printf 'matched-field=latest\n' >&2
+    printf 'matched-value=latest\n' >&2
     return 0
   fi
 
-  # Collect hits from each per-CLI resolver (each may die_runtime on miss;
-  # subshell captures the non-zero exit and we skip).
+  # Probe each per-CLI resolver. Capture stderr per-iteration so we can:
+  #   - parse matched-field/matched-value metadata on single-hit success
+  #   - aggregate 5-column collision rows on per-CLI alias collision (exit 2 +
+  #     "multiple sessions match" header from emit_collision_tsv)
+  #   - skip silently on per-CLI miss (any other exit + stderr we don't recognize)
   local hits=()
   local tsv=()
-  local cli path sid
+  local cli path sid matched_field matched_value first_field row_path row err_tmp
   for cli in claude copilot codex; do
-    if path=$("resolve_$cli" "$id" 2>/dev/null); then
-      [[ -n "$path" ]] || continue
+    err_tmp=$(mktemp) || die_runtime "mktemp failed"
+    if path=$("resolve_$cli" "$id" 2>"$err_tmp"); then
+      # Single-hit case: extract metadata, build 5-column row.
+      if [[ -z "$path" ]]; then
+        rm -f "$err_tmp"
+        continue
+      fi
+      matched_field=$(awk -F= '/^matched-field=/{sub(/^matched-field=/,""); print; exit}' "$err_tmp")
+      matched_value=$(awk '/^matched-value=/{sub(/^matched-value=/,""); print; exit}' "$err_tmp")
+      [[ -n "$matched_field" ]] || matched_field=$(infer_field_from_id "$id")
+      [[ -n "$matched_value" ]] || matched_value="$id"
       sid=$(session_id_from_path "$cli" "$path")
       hits+=("$path")
-      tsv+=("$(printf '%s\t%s\t%s\t%s' "$cli" "$sid" "$path" "$id")")
+      tsv+=("$(printf '%s\t%s\t%s\t%s\t%s' \
+        "$cli" \
+        "$(short_id_from_session "$sid")" \
+        "$path" \
+        "$(sanitize_for_tsv "$matched_value")" \
+        "$matched_field")")
+    elif grep -q '^handoff-resolve: multiple sessions match' "$err_tmp"; then
+      # Per-CLI alias collision: aggregate the 5-tab-field rows into resolve_any's
+      # tsv array (skipping the per-CLI emit_collision_tsv header and trailing hint).
+      # Each row's first field is the cli name (claude|copilot|codex), and the row
+      # already carries the per-CLI's matched-field/matched-value — no
+      # re-construction needed.
+      while IFS= read -r row; do
+        [[ "$row" == *$'\t'* ]] || continue
+        first_field="${row%%$'\t'*}"
+        case "$first_field" in
+          claude|copilot|codex)
+            tsv+=("$row")
+            row_path=$(printf '%s' "$row" | cut -f3)
+            hits+=("$row_path")
+            ;;
+        esac
+      done < "$err_tmp"
     fi
+    # Other exits (per-CLI miss with "not found" stderr, env error, etc.): skip
+    # silently — same behavior as the pre-(d).9 2>/dev/null discard, just with the
+    # tmpfile capture made explicit instead of dropping unconditionally.
+    rm -f "$err_tmp"
   done
 
   case ${#hits[@]} in
@@ -274,17 +610,18 @@ resolve_any() {
       ;;
     1)
       printf '%s\n' "${hits[0]}"
+      # Surface the metadata from the single matched row (5 tab fields:
+      # cli, short-id, path, matched-value, matched-field).
+      matched_value=$(printf '%s' "${tsv[0]}" | cut -f4)
+      matched_field=$(printf '%s' "${tsv[0]}" | cut -f5)
+      printf 'matched-field=%s\n' "$matched_field" >&2
+      printf 'matched-value=%s\n' "$matched_value" >&2
       return 0
       ;;
     *)
-      {
-        printf 'handoff-resolve: multiple sessions match "%s":\n' "$id"
-        local line
-        for line in "${tsv[@]}"; do
-          printf '%s\n' "$line"
-        done
-      } >&2
-      exit 2
+      # Multi-hit: cross-CLI union OR per-CLI alias collision passthrough.
+      # emit_collision_tsv handles header + rows + hint per §5.3.2 stderr template.
+      emit_collision_tsv "$id" "${tsv[@]}"
       ;;
   esac
 }

--- a/plugins/dotclaude/scripts/handoff-resolve.sh
+++ b/plugins/dotclaude/scripts/handoff-resolve.sh
@@ -182,26 +182,31 @@ resolve_claude() {
     die_runtime "claude session not found for short-uuid: $id"
   fi
 
-  # Claude `custom-title` alias scan: `claude --resume "<name>"` stores
-  # the alias as a JSONL record `{"type":"custom-title","customTitle":"<name>","sessionId":"<uuid>"}`.
-  # Case-insensitive exact match via jq ascii_downcase (Decision 1/2). Collect-all
-  # per ARCH-3: collisions emit 5-col TSV via emit_collision_tsv; single hit emits
-  # matched-field/matched-value to stderr alongside path on stdout.
-  # Prefilter with grep -iF so case-folded inputs pass the gate.
+  # Claude alias scans — `customTitle` (user-set via `claude --resume "<name>"`)
+  # and `aiTitle` (auto-generated TUI summary). Per ARCH-3, both fields are
+  # equally-weighted alias surfaces for the same CLI; the two mechanisms are
+  # SCANNED INDEPENDENTLY but their hits ACCUMULATE into a single Claude alias
+  # candidate set with shared dedup-by-sessionId. Only after BOTH scans complete
+  # do we decide single-hit vs collision — otherwise a cross-mechanism match
+  # (e.g. customTitle="x" in session A and aiTitle="x" in session B) would
+  # silently exit on the first scan, missing the collision.
+  #
+  # Both scans use:
+  #   - jq ascii_downcase for case-insensitive exact match (Decisions 1/2)
+  #   - grep -iF prefilter so case-folded inputs pass the gate
+  #   - intra-file dedup-by-sessionId (claude rewrites these records on every
+  #     save, producing 100+ identical records per file — Phase 1 cardinality
+  #     survey: 73-366 records per file)
   if command -v jq >/dev/null 2>&1; then
     local f session_id matched_value
-    local -a custom_rows=()
-    local custom_hit_path="" custom_hit_value=""
+    local -a claude_rows=()
+    local claude_hit_path="" claude_hit_value="" claude_hit_field=""
     local seen_sids=""
+
+    # customTitle scan
     while IFS= read -r f; do
       while IFS=$'\t' read -r session_id matched_value; do
         [[ -n "$session_id" ]] || continue
-        # Intra-file dedup-by-sessionId: a single conversation file can hold
-        # 100+ identical custom-title records (Claude rewrites the record on
-        # every save). Skip if we've already collected this sessionId.
-        # NOT to be confused with cross-file collision detection — different
-        # sessionIds with the same alias are real collisions, handled by the
-        # outer loop's accumulation into custom_rows + emit_collision_tsv.
         case " $seen_sids " in
           *" $session_id "*) continue ;;
         esac
@@ -209,9 +214,12 @@ resolve_claude() {
         local hit
         hit="$(find "$root" -maxdepth 2 -type f -name "${session_id}.jsonl" 2>/dev/null | head -1)"
         [[ -n "$hit" ]] || continue
-        custom_hit_path="$hit"
-        custom_hit_value="$matched_value"
-        custom_rows+=("$(printf '%s\t%s\t%s\t%s\t%s' \
+        if [[ -z "$claude_hit_path" ]]; then
+          claude_hit_path="$hit"
+          claude_hit_value="$matched_value"
+          claude_hit_field="customTitle"
+        fi
+        claude_rows+=("$(printf '%s\t%s\t%s\t%s\t%s' \
           "claude" \
           "$(short_id_from_session "$session_id")" \
           "$hit" \
@@ -223,49 +231,26 @@ resolve_claude() {
         | "\(.sessionId)\t\(.customTitle | gsub("[\t\n]"; " "))"' "$f" 2>/dev/null)
     done < <(grep -rl --include='*.jsonl' -iF "\"customTitle\":\"${id}\"" "$root" 2>/dev/null)
 
-    case ${#custom_rows[@]} in
-      0) ;;  # no customTitle match; fall through to die_runtime at function bottom
-      1)
-        printf '%s\n' "$custom_hit_path"
-        printf 'matched-field=customTitle\n' >&2
-        printf 'matched-value=%s\n' "$(sanitize_for_tsv "$custom_hit_value")" >&2
-        return 0
-        ;;
-      *)
-        emit_collision_tsv "$id" "${custom_rows[@]}"
-        ;;
-    esac
-  fi
-
-  # Claude `ai-title` alias scan: Claude Code auto-generates a short summary
-  # for sessions that accumulate enough conversation, persisted as JSONL records
-  # `{"type":"ai-title","aiTitle":"<text>","sessionId":"<uuid>"}`. This is the
-  # primary TUI title source — what `claude --resume`'s picker displays for
-  # sessions that have an ai-title (4/24 in dotclaude project per Phase 1).
-  # Same shape as the customTitle scan above: case-insensitive via jq
-  # ascii_downcase, intra-file dedup-by-sessionId, single-hit metadata to
-  # stderr, collisions via emit_collision_tsv. Files can hold many ai-title
-  # records (Claude rewrites the summary as conversation grows; one observed
-  # file has 3 distinct historical aiTitles for one session — historical
-  # values still resolve to the same session via dedup-by-sessionId).
-  if command -v jq >/dev/null 2>&1; then
-    local f session_id matched_value
-    local -a aititle_rows=()
-    local aititle_hit_path="" aititle_hit_value=""
-    local seen_sids_aititle=""
+    # aiTitle scan — shares seen_sids with customTitle so a session matched by
+    # both mechanisms collapses to one row (whichever scan saw it first wins
+    # the matched-field tag). Different sessions matched by different mechanisms
+    # remain distinct rows in claude_rows for collision dispatch below.
     while IFS= read -r f; do
       while IFS=$'\t' read -r session_id matched_value; do
         [[ -n "$session_id" ]] || continue
-        case " $seen_sids_aititle " in
+        case " $seen_sids " in
           *" $session_id "*) continue ;;
         esac
-        seen_sids_aititle="$seen_sids_aititle $session_id"
+        seen_sids="$seen_sids $session_id"
         local hit
         hit="$(find "$root" -maxdepth 2 -type f -name "${session_id}.jsonl" 2>/dev/null | head -1)"
         [[ -n "$hit" ]] || continue
-        aititle_hit_path="$hit"
-        aititle_hit_value="$matched_value"
-        aititle_rows+=("$(printf '%s\t%s\t%s\t%s\t%s' \
+        if [[ -z "$claude_hit_path" ]]; then
+          claude_hit_path="$hit"
+          claude_hit_value="$matched_value"
+          claude_hit_field="aiTitle"
+        fi
+        claude_rows+=("$(printf '%s\t%s\t%s\t%s\t%s' \
           "claude" \
           "$(short_id_from_session "$session_id")" \
           "$hit" \
@@ -277,16 +262,17 @@ resolve_claude() {
         | "\(.sessionId)\t\(.aiTitle | gsub("[\t\n]"; " "))"' "$f" 2>/dev/null)
     done < <(grep -rl --include='*.jsonl' -iF "\"aiTitle\":\"${id}\"" "$root" 2>/dev/null)
 
-    case ${#aititle_rows[@]} in
-      0) ;;  # no aiTitle match; fall through to die_runtime at function bottom
+    # Unified dispatch over the union of customTitle + aiTitle hits.
+    case ${#claude_rows[@]} in
+      0) ;;  # no alias match in either mechanism; fall through to die_runtime
       1)
-        printf '%s\n' "$aititle_hit_path"
-        printf 'matched-field=aiTitle\n' >&2
-        printf 'matched-value=%s\n' "$(sanitize_for_tsv "$aititle_hit_value")" >&2
+        printf '%s\n' "$claude_hit_path"
+        printf 'matched-field=%s\n' "$claude_hit_field" >&2
+        printf 'matched-value=%s\n' "$(sanitize_for_tsv "$claude_hit_value")" >&2
         return 0
         ;;
       *)
-        emit_collision_tsv "$id" "${aititle_rows[@]}"
+        emit_collision_tsv "$id" "${claude_rows[@]}"
         ;;
     esac
   fi

--- a/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotclaude/templates/claude/skills/handoff/SKILL.md
@@ -2,7 +2,7 @@
 id: handoff
 name: handoff
 type: skill
-version: 1.2.0
+version: 1.3.0
 domain: [devex]
 platform: [none]
 task: [documentation, debugging]
@@ -44,10 +44,12 @@ the right invocation.
 | `push handoff` / `send to other machine` / `save this`                 | `dotclaude handoff push --from <host-cli> [--tag …]` |
 | `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch [<query>]`                  |
 
-Extract `<id>` from the user message (UUID, short UUID, or named alias).
+Extract `<id>` from the user message (UUID, short UUID, or a deliberate-label
+alias: claude `customTitle`/`aiTitle`, codex `thread_name`, or copilot
+`workspace.yaml:name`). Aliases match case-insensitively. Resolution
+precedence: UUID > short-UUID > `latest` > alias (no fall-through on miss).
 The resolver probes Claude / Copilot / Codex roots automatically. If the
-query is missing or ambiguous, ask one clarifying question before
-proceeding.
+query is missing or ambiguous, ask one clarifying question before proceeding.
 
 ## The `--from` filling rule
 

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -127,6 +127,20 @@ teardown() {
   [[ "$stderr" == *"aaaa1111"* ]]
 }
 
+@test "pull Latest (mixed case) under CLAUDECODE=1 narrows to claude root" {
+  # The resolver case-folds the `latest` keyword (Decision 2). The wrapper's
+  # host-scope dispatch must do the same — otherwise mixed-case `Latest`
+  # bypasses resolveLatestWithHostScope and falls through to `any Latest`,
+  # which case-folds at the resolver layer and returns the cross-root newest
+  # (codex here, not the host-scoped claude).
+  run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \
+    node "$BIN" pull Latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"aaaa1111"* ]]
+  [[ "$output" != *"bbbb2222"* ]]
+  [[ "$stderr" == *"latest claude session"* ]]
+}
+
 @test "pull latest --from codex overrides host detection" {
   # --from must outrank detectedHost, mirroring push's precedence.
   run --separate-stderr env -i HOME="$TEST_HOME" PATH="$PATH" CLAUDECODE=1 \

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -164,6 +164,90 @@ teardown() {
   [[ "$output" == *"codex"* ]]
 }
 
+@test "pull (no --from): wrapper passes through intra-CLI claude customTitle collision verbatim" {
+  # 2 distinct claude sessions sharing customTitle. Wrapper path:
+  # resolveLocalForPull(narrowTo=null) → resolveAny → parseCollisionAndDispatch
+  # → non-TTY stderr passthrough. Verifies the resolveAny aggregation wires
+  # correctly from per-CLI single-hit emits into a 2-row collision TSV.
+  local uuid1="aaaa4444-4444-4444-4444-444444444444"
+  local uuid2="aaaa5555-5555-5555-5555-555555555555"
+  local dir1="$TEST_HOME/.claude/projects/-home-u-collide1"
+  local dir2="$TEST_HOME/.claude/projects/-home-u-collide2"
+  mkdir -p "$dir1" "$dir2"
+  local path1="$dir1/$uuid1.jsonl"
+  local path2="$dir2/$uuid2.jsonl"
+  printf '{"type":"user","cwd":"/c1","sessionId":"%s","version":"2.1","message":{"content":"hi"}}\n' "$uuid1" > "$path1"
+  printf '{"type":"custom-title","customTitle":"shared-title","sessionId":"%s"}\n' "$uuid1" >> "$path1"
+  printf '{"type":"user","cwd":"/c2","sessionId":"%s","version":"2.1","message":{"content":"hi"}}\n' "$uuid2" > "$path2"
+  printf '{"type":"custom-title","customTitle":"shared-title","sessionId":"%s"}\n' "$uuid2" >> "$path2"
+
+  run --separate-stderr node "$BIN" pull "shared-title" </dev/null
+  [ "$status" -eq 2 ]
+  [ -z "$output" ]
+  [[ "$stderr" == *"multiple sessions match"* ]]
+  [[ "$stderr" == *"$path1"* ]]
+  [[ "$stderr" == *"$path2"* ]]
+  local row_count
+  row_count=$(echo "$stderr" | grep -c $'\t'"customTitle"$)
+  [ "$row_count" -eq 2 ]
+}
+
+@test "pull --from copilot: wrapper passes through intra-CLI copilot name collision verbatim" {
+  # 2 distinct copilot sessions sharing workspace.yaml:name. Wrapper path:
+  # resolveLocalForPull(narrowTo="copilot") → resolveNarrowed → per-CLI
+  # emit_collision_tsv → parseCollisionAndDispatch → stderr passthrough.
+  # Verifies resolveNarrowed's collision-aware extension from Step 3 (3).
+  local uuid1="cccc4444-4444-4444-4444-444444444444"
+  local uuid2="cccc5555-5555-5555-5555-555555555555"
+  make_copilot_session_tree "$TEST_HOME" "$uuid1"
+  make_copilot_session_tree "$TEST_HOME" "$uuid2"
+  set_copilot_workspace_name "$TEST_HOME" "$uuid1" "shared-name"
+  set_copilot_workspace_name "$TEST_HOME" "$uuid2" "shared-name"
+  local path1="$TEST_HOME/.copilot/session-state/$uuid1/events.jsonl"
+  local path2="$TEST_HOME/.copilot/session-state/$uuid2/events.jsonl"
+
+  run --separate-stderr node "$BIN" pull "shared-name" --from copilot </dev/null
+  [ "$status" -eq 2 ]
+  [ -z "$output" ]
+  [[ "$stderr" == *"multiple sessions match"* ]]
+  [[ "$stderr" == *"$path1"* ]]
+  [[ "$stderr" == *"$path2"* ]]
+  local row_count
+  row_count=$(echo "$stderr" | grep -c $'\t'"name"$)
+  [ "$row_count" -eq 2 ]
+}
+
+@test "pull (no --from): wrapper passes through cross-CLI claude+copilot collision verbatim" {
+  # 1 claude + 1 copilot sharing alias value across distinct alias mechanisms.
+  # Wrapper path: resolveLocalForPull(narrowTo=null) → resolveAny → cross-CLI
+  # aggregation → 5-col TSV with mixed matched-field rows. Each row carries
+  # the per-CLI matched-field tag — disambiguation preserved end-to-end.
+  local claude_uuid="aaaa6666-6666-6666-6666-666666666666"
+  local copilot_uuid="cccc6666-6666-6666-6666-666666666666"
+  local claude_dir="$TEST_HOME/.claude/projects/-home-u-cross"
+  mkdir -p "$claude_dir"
+  local claude_path="$claude_dir/$claude_uuid.jsonl"
+  printf '{"type":"user","cwd":"/cross","sessionId":"%s","version":"2.1","message":{"content":"hi"}}\n' "$claude_uuid" > "$claude_path"
+  printf '{"type":"custom-title","customTitle":"shared-cross-cli","sessionId":"%s"}\n' "$claude_uuid" >> "$claude_path"
+
+  make_copilot_session_tree "$TEST_HOME" "$copilot_uuid"
+  set_copilot_workspace_name "$TEST_HOME" "$copilot_uuid" "shared-cross-cli"
+  local copilot_path="$TEST_HOME/.copilot/session-state/$copilot_uuid/events.jsonl"
+
+  run --separate-stderr node "$BIN" pull "shared-cross-cli" </dev/null
+  [ "$status" -eq 2 ]
+  [ -z "$output" ]
+  [[ "$stderr" == *"multiple sessions match"* ]]
+  [[ "$stderr" == *"$claude_path"* ]]
+  [[ "$stderr" == *"$copilot_path"* ]]
+  local claude_rows
+  claude_rows=$(echo "$stderr" | grep -c $'\t'"customTitle"$)
+  [ "$claude_rows" -eq 1 ]
+  local copilot_rows
+  copilot_rows=$(echo "$stderr" | grep -c $'\t'"name"$)
+  [ "$copilot_rows" -eq 1 ]
+}
+
 # -- pull: no-match hint for remote handoffs (#87) ------------------------
 
 @test "pull <unmatched> with DOTCLAUDE_HANDOFF_REPO set appends fetch hint" {

--- a/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
+++ b/plugins/dotclaude/tests/bats/dotclaude-handoff-five-form.bats
@@ -177,9 +177,9 @@ teardown() {
   local path1="$dir1/$uuid1.jsonl"
   local path2="$dir2/$uuid2.jsonl"
   printf '{"type":"user","cwd":"/c1","sessionId":"%s","version":"2.1","message":{"content":"hi"}}\n' "$uuid1" > "$path1"
-  printf '{"type":"custom-title","customTitle":"shared-title","sessionId":"%s"}\n' "$uuid1" >> "$path1"
+  set_claude_custom_title "$path1" "$uuid1" "shared-title"
   printf '{"type":"user","cwd":"/c2","sessionId":"%s","version":"2.1","message":{"content":"hi"}}\n' "$uuid2" > "$path2"
-  printf '{"type":"custom-title","customTitle":"shared-title","sessionId":"%s"}\n' "$uuid2" >> "$path2"
+  set_claude_custom_title "$path2" "$uuid2" "shared-title"
 
   run --separate-stderr node "$BIN" pull "shared-title" </dev/null
   [ "$status" -eq 2 ]
@@ -228,7 +228,7 @@ teardown() {
   mkdir -p "$claude_dir"
   local claude_path="$claude_dir/$claude_uuid.jsonl"
   printf '{"type":"user","cwd":"/cross","sessionId":"%s","version":"2.1","message":{"content":"hi"}}\n' "$claude_uuid" > "$claude_path"
-  printf '{"type":"custom-title","customTitle":"shared-cross-cli","sessionId":"%s"}\n' "$claude_uuid" >> "$claude_path"
+  set_claude_custom_title "$claude_path" "$claude_uuid" "shared-cross-cli"
 
   make_copilot_session_tree "$TEST_HOME" "$copilot_uuid"
   set_copilot_workspace_name "$TEST_HOME" "$copilot_uuid" "shared-cross-cli"

--- a/plugins/dotclaude/tests/bats/handoff-boundary.bats
+++ b/plugins/dotclaude/tests/bats/handoff-boundary.bats
@@ -3,6 +3,8 @@
 # Degenerate inputs: empty files, unicode, CRLF, whitespace in paths,
 # prefix collisions, and negative/zero --limit values.
 
+bats_require_minimum_version 1.5.0
+
 load helpers
 
 RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
@@ -82,7 +84,7 @@ teardown() {
   mkdir -p "$dir"
   printf '{"cwd":"/x","sessionId":"%s"}\n{"type":"custom-title","customTitle":"🚀 launch","sessionId":"%s"}\n' \
     "$uuid" "$uuid" > "$dir/$uuid.jsonl"
-  run "$RESOLVE" claude "🚀 launch"
+  run --separate-stderr "$RESOLVE" claude "🚀 launch"
   [ "$status" -eq 0 ]
   [[ "$output" == *"$uuid.jsonl" ]]
 }
@@ -95,7 +97,7 @@ teardown() {
   export HOME="$TEST_HOME/home with spaces"
   mkdir -p "$HOME"
   make_claude_session_tree "$HOME" "dddd4444-4444-4444-4444-444444444444"
-  run "$RESOLVE" claude dddd4444
+  run --separate-stderr "$RESOLVE" claude dddd4444
   [ "$status" -eq 0 ]
   [[ "$output" == *"dddd4444-4444-4444-4444-444444444444.jsonl" ]]
 }
@@ -117,7 +119,7 @@ teardown() {
   fi
   touch -d '2026-01-01 00:00:00.500000000' "$mid"
   touch -d '2026-01-01 00:00:00.900000000' "$newer"
-  run "$RESOLVE" claude abcd1234
+  run --separate-stderr "$RESOLVE" claude abcd1234
   [ "$status" -eq 0 ]
   [[ "$output" == *"000000000003.jsonl" ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-integration.bats
+++ b/plugins/dotclaude/tests/bats/handoff-integration.bats
@@ -62,7 +62,7 @@ teardown() {
   # Chain the scripts by hand: resolve emits a path, extract reads it.
   # This catches any disagreement between the two on what a session file
   # looks like (e.g., if resolve accepts a path extract can't parse).
-  run "$RESOLVE" claude aaaa1111
+  run --separate-stderr "$RESOLVE" claude aaaa1111
   [ "$status" -eq 0 ]
   local path="$output"
   [ -n "$path" ]
@@ -86,7 +86,7 @@ teardown() {
   # Codex alias path runs through a separate grep-prefilter branch in
   # resolve; the happy-path existence is covered elsewhere, but the
   # resolve→extract chain across the codex layout is worth pinning.
-  run "$RESOLVE" codex codex-thread
+  run --separate-stderr "$RESOLVE" codex codex-thread
   [ "$status" -eq 0 ]
   local path="$output"
   run "$EXTRACT" prompts codex "$path"

--- a/plugins/dotclaude/tests/bats/handoff-portability.bats
+++ b/plugins/dotclaude/tests/bats/handoff-portability.bats
@@ -4,6 +4,8 @@
 # runtime fallback chain; busybox substrate coverage lives in
 # handoff-resolve-busybox.bats.
 
+bats_require_minimum_version 1.5.0
+
 load helpers
 
 RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
@@ -45,7 +47,7 @@ seed_fractional_pair() {
   local older="aaaa1111-1111-1111-1111-111111111111"
   local newer="bbbb2222-2222-2222-2222-222222222222"
   seed_fractional_pair "$older" "$newer"
-  run "$RESOLVE" claude latest
+  run --separate-stderr "$RESOLVE" claude latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"$newer.jsonl" ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-pull-incomplete-session.bats
+++ b/plugins/dotclaude/tests/bats/handoff-pull-incomplete-session.bats
@@ -74,10 +74,16 @@ teardown() {
 # --- case 3: all sessions incomplete → clean exit 2 + §5.3.2 template -------
 
 @test "pull latest --from copilot: exits 2 with §5.3.2 template when all dirs incomplete" {
+  # Pre-(d).9 helper-fix, this test passed because pick_newest exited 1 on
+  # empty input which (via pipefail) silenced the resolver's structured
+  # die_runtime — wrapper fallback "no copilot session matches: latest" then
+  # fired. Post-fix, the resolver correctly emits "no copilot sessions found
+  # under <root>" and the wrapper passes that through; the fallback path no
+  # longer runs. The test now asserts on the canonical resolver message.
   seed_incomplete_copilot "$TEST_HOME" "$INCOMPLETE_UUID"
   seed_incomplete_copilot "$TEST_HOME" "$VALID_UUID"
 
   run node "$BIN" pull latest --from copilot
   [ "$status" -eq 2 ]
-  [[ "$output" == *"no copilot session matches: latest"* ]]
+  [[ "$output" == *"no copilot sessions found under"* ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-regression.bats
+++ b/plugins/dotclaude/tests/bats/handoff-regression.bats
@@ -2,6 +2,8 @@
 # Regression seeds: each test locks in a bug previously fixed in the
 # handoff scripts. Failing any of these means a fix has been lost.
 
+bats_require_minimum_version 1.5.0
+
 load helpers
 
 RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
@@ -73,7 +75,7 @@ teardown() {
   export HOME="$TEST_HOME/home with spaces"
   mkdir -p "$HOME"
   make_claude_session_tree "$HOME" "dddd4444-4444-4444-4444-444444444444"
-  run "$RESOLVE" claude dddd4444
+  run --separate-stderr "$RESOLVE" claude dddd4444
   [ "$status" -eq 0 ]
   [[ "$output" == *"dddd4444-4444-4444-4444-444444444444.jsonl" ]]
 }
@@ -109,7 +111,7 @@ teardown() {
   mkdir -p "$(dirname "$path")"
   printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"regression-target","type":"thread_renamed"}}\n' \
     "$uuid" "$uuid" > "$path"
-  run "$RESOLVE" codex "regression-target"
+  run --separate-stderr "$RESOLVE" codex "regression-target"
   [ "$status" -eq 0 ]
   [ "$output" = "$path" ]
 }

--- a/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
@@ -147,7 +147,7 @@ teardown() {
   # Add claude session with customTitle "shared-cross-cli"
   local claude_path="$TEST_HOME/.claude/projects/-home-u-demo/$claude_uuid.jsonl"
   printf '{"cwd":"/home/u/demo","sessionId":"%s","version":"2.1"}\n' "$claude_uuid" > "$claude_path"
-  printf '{"type":"custom-title","customTitle":"shared-cross-cli","sessionId":"%s"}\n' "$claude_uuid" >> "$claude_path"
+  set_claude_custom_title "$claude_path" "$claude_uuid" "shared-cross-cli"
 
   # Add copilot session with workspace.yaml:name "shared-cross-cli"
   make_copilot_session_tree "$TEST_HOME" "$copilot_uuid"

--- a/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve-any.bats
@@ -3,11 +3,14 @@
 #
 # The `any` mode probes all three session roots (claude, copilot, codex)
 # and:
-#   - returns the single matching path when exactly one root resolves
-#   - on collision (two or more roots match), exits 2 with a TSV
-#     candidate list on stderr. One line per candidate:
-#       <cli>\t<session-id>\t<path>\t<label>
+#   - returns the single matching path on stdout plus matched-field=/
+#     matched-value= metadata on stderr when exactly one root resolves
+#   - on collision (two or more roots match), exits 2 with a 5-column TSV
+#     candidate list on stderr per §5.3.5:
+#       <cli>\t<short-id>\t<path>\t<matched-value>\t<matched-field>
 #   - on no match, exits 2 with a "no session matches" message
+
+bats_require_minimum_version 1.5.0
 
 load helpers
 
@@ -61,13 +64,13 @@ teardown() {
 }
 
 @test "any: resolves claude full UUID" {
-  run "$RESOLVE" any aaaa2222-2222-2222-2222-222222222222
+  run --separate-stderr "$RESOLVE" any aaaa2222-2222-2222-2222-222222222222
   [ "$status" -eq 0 ]
   [ "$output" = "$CLAUDE_PLAIN_FILE" ]
 }
 
 @test "any: resolves claude short UUID" {
-  run "$RESOLVE" any aaaa2222
+  run --separate-stderr "$RESOLVE" any aaaa2222
   [ "$status" -eq 0 ]
   [ "$output" = "$CLAUDE_PLAIN_FILE" ]
 }
@@ -76,7 +79,7 @@ teardown() {
   # Temporarily break the codex collision fixture to ensure customTitle
   # scan still works. Rename just the codex alias record away.
   sed -i 's/refactor/refactor-codex/' "$CODEX_ALIAS_FILE"
-  run "$RESOLVE" any refactor
+  run --separate-stderr "$RESOLVE" any refactor
   [ "$status" -eq 0 ]
   [ "$output" = "$CLAUDE_ALIAS_FILE" ]
 }
@@ -84,27 +87,32 @@ teardown() {
 @test "any: resolves codex thread_name alias when unique" {
   # Temporarily break the claude collision fixture.
   sed -i 's/refactor/refactor-claude/' "$CLAUDE_ALIAS_FILE"
-  run "$RESOLVE" any refactor
+  run --separate-stderr "$RESOLVE" any refactor
   [ "$status" -eq 0 ]
   [ "$output" = "$CODEX_ALIAS_FILE" ]
 }
 
 @test "any: resolves codex full UUID" {
-  run "$RESOLVE" any eeee5555-5555-5555-5555-555555555555
+  run --separate-stderr "$RESOLVE" any eeee5555-5555-5555-5555-555555555555
   [ "$status" -eq 0 ]
   [ "$output" = "$CODEX_ALIAS_FILE" ]
 }
 
 @test "any: resolves copilot full UUID" {
-  run "$RESOLVE" any dddd3333-3333-3333-3333-333333333333
+  run --separate-stderr "$RESOLVE" any dddd3333-3333-3333-3333-333333333333
   [ "$status" -eq 0 ]
   [ "$output" = "$COPILOT_FILE" ]
 }
 
-@test "any: latest picks newest across all three roots" {
-  run "$RESOLVE" any latest
+@test "any: latest picks newest across all three roots and emits matched-field=latest metadata" {
+  # Verifies (d).9 closure of the (d).7 gap: the `any latest` early-return
+  # block in resolve_any now emits matched-field=/matched-value= stderr
+  # metadata mirroring the per-CLI single-hit contract.
+  run --separate-stderr "$RESOLVE" any latest
   [ "$status" -eq 0 ]
   [ "$output" = "$CODEX_NEWEST_FILE" ]
+  [[ "$stderr" == *"matched-field=latest"* ]]
+  [[ "$stderr" == *"matched-value=latest"* ]]
 }
 
 @test "any: unknown identifier exits 2 with structured error" {
@@ -118,13 +126,47 @@ teardown() {
   # default fixture.
   run "$RESOLVE" any refactor
   [ "$status" -eq 2 ]
-  # Expect at least two candidate lines, each with 4 TSV fields.
-  # Candidate line shape: <cli>\t<session-id>\t<path>\t<label>
+  # Expect at least two candidate lines, each with 5 TSV fields per §5.3.5:
+  # <cli>\t<short-id>\t<path>\t<matched-value>\t<matched-field>
   # bats' $output includes both stdout and stderr.
   [[ "$output" == *"claude"* ]]
   [[ "$output" == *"codex"* ]]
   [[ "$output" == *"cccc1111"* ]]
   [[ "$output" == *"eeee5555"* ]]
+}
+
+@test "any: cross-CLI collision claude customTitle + copilot name emits 5-col TSV" {
+  # Two distinct CLIs, different alias mechanisms (claude customTitle vs copilot
+  # workspace.yaml:name), same matched value. Verifies (d).9 cross-CLI
+  # aggregation: per-CLI single hits aggregate into resolve_any's tsv array,
+  # multi-hit dispatch fires emit_collision_tsv. Each row carries the per-CLI
+  # matched-field tag — disambiguation is preserved across CLIs.
+  local claude_uuid="bbbb7777-7777-7777-7777-777777777777"
+  local copilot_uuid="bbbb8888-8888-8888-8888-888888888888"
+
+  # Add claude session with customTitle "shared-cross-cli"
+  local claude_path="$TEST_HOME/.claude/projects/-home-u-demo/$claude_uuid.jsonl"
+  printf '{"cwd":"/home/u/demo","sessionId":"%s","version":"2.1"}\n' "$claude_uuid" > "$claude_path"
+  printf '{"type":"custom-title","customTitle":"shared-cross-cli","sessionId":"%s"}\n' "$claude_uuid" >> "$claude_path"
+
+  # Add copilot session with workspace.yaml:name "shared-cross-cli"
+  make_copilot_session_tree "$TEST_HOME" "$copilot_uuid"
+  set_copilot_workspace_name "$TEST_HOME" "$copilot_uuid" "shared-cross-cli"
+  local copilot_path="$TEST_HOME/.copilot/session-state/$copilot_uuid/events.jsonl"
+
+  run --separate-stderr "$RESOLVE" any "shared-cross-cli"
+  [ "$status" -eq 2 ]
+  [ -z "$output" ]
+  [[ "$stderr" == *"multiple sessions match"* ]]
+  [[ "$stderr" == *"$claude_path"* ]]
+  [[ "$stderr" == *"$copilot_path"* ]]
+  # Cross-CLI: each row has a different matched-field; verify exactly 1 of each.
+  local claude_rows
+  claude_rows=$(echo "$stderr" | grep -c $'\t'"customTitle"$)
+  [ "$claude_rows" -eq 1 ]
+  local copilot_rows
+  copilot_rows=$(echo "$stderr" | grep -c $'\t'"name"$)
+  [ "$copilot_rows" -eq 1 ]
 }
 
 @test "any: missing identifier exits 64" {
@@ -135,7 +177,7 @@ teardown() {
 @test "any: graceful degrade when only one root exists" {
   # Remove copilot and codex fixtures; any <claude-uuid> should still work.
   rm -rf "$TEST_HOME/.copilot" "$TEST_HOME/.codex"
-  run "$RESOLVE" any aaaa2222
+  run --separate-stderr "$RESOLVE" any aaaa2222
   [ "$status" -eq 0 ]
   [ "$output" = "$CLAUDE_PLAIN_FILE" ]
 }

--- a/plugins/dotclaude/tests/bats/handoff-resolve-busybox.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve-busybox.bats
@@ -5,6 +5,8 @@
 # cannot detect the failure). The stat probe at init detects this case
 # and sets _STAT_FLAVOR=posix, causing pick_newest to use `stat -c %Y`.
 
+bats_require_minimum_version 1.5.0
+
 load helpers
 
 RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
@@ -60,7 +62,7 @@ teardown() {
   shim=$(with_fake_tool_bin stat "$BUSYBOX_STAT_BODY")
   SHIM_DIRS+=("$shim")
 
-  run "$RESOLVE" claude latest
+  run --separate-stderr "$RESOLVE" claude latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"$newer.jsonl" ]]
 }
@@ -77,7 +79,7 @@ teardown() {
   shim=$(with_fake_tool_bin stat "$BUSYBOX_STAT_BODY")
   SHIM_DIRS+=("$shim")
 
-  run "$RESOLVE" claude latest
+  run --separate-stderr "$RESOLVE" claude latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"$uuid.jsonl" ]]
 }
@@ -102,7 +104,7 @@ esac
 ')
   SHIM_DIRS+=("$shim")
 
-  run "$RESOLVE" claude latest
+  run --separate-stderr "$RESOLVE" claude latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"$uuid.jsonl" ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-resolve.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve.bats
@@ -1,8 +1,11 @@
 #!/usr/bin/env bats
 # Behavior tests for plugins/dotclaude/scripts/handoff-resolve.sh.
 # Resolves <cli> <identifier> to an absolute JSONL file path.
-# Supports: claude (uuid|latest), copilot (uuid|latest),
-#           codex (uuid|alias|latest).
+# Supports: claude (uuid|short-uuid|latest|customTitle|aiTitle),
+#           copilot (uuid|short-uuid|latest|workspace.yaml:name),
+#           codex (uuid|short-uuid|latest|thread_name).
+
+bats_require_minimum_version 1.5.0
 
 load helpers
 
@@ -63,22 +66,28 @@ teardown() {
 # -- claude ---------------------------------------------------------------
 
 @test "resolve claude by full UUID" {
-  run "$RESOLVE" claude aaaa1111-1111-1111-1111-111111111111
+  run --separate-stderr "$RESOLVE" claude aaaa1111-1111-1111-1111-111111111111
   [ "$status" -eq 0 ]
   [ "$output" = "$TEST_HOME/.claude/projects/-home-user-projects-demo/aaaa1111-1111-1111-1111-111111111111.jsonl" ]
+  [[ "$stderr" == *"matched-field=uuid"* ]]
+  [[ "$stderr" == *"matched-value=aaaa1111-1111-1111-1111-111111111111"* ]]
 }
 
 @test "resolve claude by short UUID (first 8 hex)" {
-  run "$RESOLVE" claude aaaa1111
+  run --separate-stderr "$RESOLVE" claude aaaa1111
   [ "$status" -eq 0 ]
   [ "$output" = "$TEST_HOME/.claude/projects/-home-user-projects-demo/aaaa1111-1111-1111-1111-111111111111.jsonl" ]
+  [[ "$stderr" == *"matched-field=short-uuid"* ]]
+  [[ "$stderr" == *"matched-value=aaaa1111"* ]]
 }
 
 @test "resolve claude latest picks newest mtime" {
-  run "$RESOLVE" claude latest
+  run --separate-stderr "$RESOLVE" claude latest
   [ "$status" -eq 0 ]
   # cccc1111 is created last (sleep 0.01 after bbbb2222) so it is the newest.
   [[ "$output" == *"cccc1111-1111-1111-1111-111111111111.jsonl" ]]
+  [[ "$stderr" == *"matched-field=latest"* ]]
+  [[ "$stderr" == *"matched-value=latest"* ]]
 }
 
 @test "resolve claude miss exits 2 with structured error" {
@@ -89,9 +98,11 @@ teardown() {
 }
 
 @test "resolve claude by customTitle alias" {
-  run "$RESOLVE" claude my-feature
+  run --separate-stderr "$RESOLVE" claude my-feature
   [ "$status" -eq 0 ]
   [ "$output" = "$CLAUDE_ALIAS_FILE" ]
+  [[ "$stderr" == *"matched-field=customTitle"* ]]
+  [[ "$stderr" == *"matched-value=my-feature"* ]]
 }
 
 @test "resolve claude unknown customTitle exits 2" {
@@ -100,22 +111,93 @@ teardown() {
   [[ "$output" == *"not found"* ]]
 }
 
+@test "intra-file dedup: 100 identical customTitle records resolve to one row" {
+  # Verifies the (d).3 dedup-by-sessionId retrofit. Claude Code rewrites the
+  # custom-title record on every save, producing 100+ identical records per
+  # file in the wild (Phase 1 cardinality survey: 73-366 records per file).
+  # Without dedup, naive collect-all would emit a 100-row collision TSV from
+  # a single-session match. With dedup, the 100 records collapse to one row.
+  local uuid="dddd3333-3333-3333-3333-333333333333"
+  local dir="$TEST_HOME/.claude/projects/-home-user-projects-dedup"
+  mkdir -p "$dir"
+  local path="$dir/$uuid.jsonl"
+  printf '{"cwd":"/home/user/projects/dedup","sessionId":"%s","version":"2.1"}\n' "$uuid" > "$path"
+
+  # Append 100 identical custom-title records (simulates rewrite-on-every-save).
+  local i=0
+  while (( i < 100 )); do
+    printf '{"type":"custom-title","customTitle":"force-push-collision-guard","sessionId":"%s"}\n' "$uuid" >> "$path"
+    i=$((i + 1))
+  done
+
+  run --separate-stderr "$RESOLVE" claude "force-push-collision-guard"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$path" ]
+  [[ "$stderr" == *"matched-field=customTitle"* ]]
+  [[ "$stderr" == *"matched-value=force-push-collision-guard"* ]]
+}
+
+@test "intra-CLI collision: claude customTitle shared by 2 sessions emits 5-col TSV" {
+  # Two distinct claude sessions (different UUIDs) with the same customTitle.
+  # Without dedup-by-sessionId would dedupe; with dedup-by-sessionId these
+  # remain distinct rows since their sessionIds differ. Real ARCH-3 collision.
+  local uuid1="aaaa2222-2222-2222-2222-222222222222"
+  local uuid2="aaaa3333-3333-3333-3333-333333333333"
+  local dir1="$TEST_HOME/.claude/projects/-home-user-projects-collide1"
+  local dir2="$TEST_HOME/.claude/projects/-home-user-projects-collide2"
+  mkdir -p "$dir1" "$dir2"
+  local path1="$dir1/$uuid1.jsonl"
+  local path2="$dir2/$uuid2.jsonl"
+  printf '{"cwd":"/home/user/projects/c1","sessionId":"%s","version":"2.1"}\n' "$uuid1" > "$path1"
+  printf '{"type":"custom-title","customTitle":"shared-title","sessionId":"%s"}\n' "$uuid1" >> "$path1"
+  printf '{"cwd":"/home/user/projects/c2","sessionId":"%s","version":"2.1"}\n' "$uuid2" > "$path2"
+  printf '{"type":"custom-title","customTitle":"shared-title","sessionId":"%s"}\n' "$uuid2" >> "$path2"
+
+  run --separate-stderr "$RESOLVE" claude "shared-title"
+  [ "$status" -eq 2 ]
+  [ -z "$output" ]
+  [[ "$stderr" == *"multiple sessions match"* ]]
+  [[ "$stderr" == *"$path1"* ]]
+  [[ "$stderr" == *"$path2"* ]]
+  local row_count
+  row_count=$(echo "$stderr" | grep -c $'\t'"customTitle"$)
+  [ "$row_count" -eq 2 ]
+}
+
+@test "resolve claude by aiTitle alias" {
+  # Seed an extra claude session with an ai-title record. Claude Code emits
+  # ai-title as the auto-generated TUI summary (4/24 sessions in the dotclaude
+  # project per Phase 1) — distinct from user-set customTitle.
+  local uuid="dddd2222-2222-2222-2222-222222222222"
+  local dir="$TEST_HOME/.claude/projects/-home-user-projects-aititle"
+  mkdir -p "$dir"
+  local path="$dir/$uuid.jsonl"
+  printf '{"cwd":"/home/user/projects/aititle","sessionId":"%s","version":"2.1"}\n' "$uuid" > "$path"
+  printf '{"type":"ai-title","aiTitle":"Refactor extract pipeline","sessionId":"%s"}\n' "$uuid" >> "$path"
+
+  run --separate-stderr "$RESOLVE" claude "Refactor extract pipeline"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$path" ]
+  [[ "$stderr" == *"matched-field=aiTitle"* ]]
+  [[ "$stderr" == *"matched-value=Refactor extract pipeline"* ]]
+}
+
 # -- copilot --------------------------------------------------------------
 
 @test "resolve copilot by full UUID" {
-  run "$RESOLVE" copilot cccc3333-3333-3333-3333-333333333333
+  run --separate-stderr "$RESOLVE" copilot cccc3333-3333-3333-3333-333333333333
   [ "$status" -eq 0 ]
   [ "$output" = "$TEST_HOME/.copilot/session-state/cccc3333-3333-3333-3333-333333333333/events.jsonl" ]
 }
 
 @test "resolve copilot by short UUID" {
-  run "$RESOLVE" copilot cccc3333
+  run --separate-stderr "$RESOLVE" copilot cccc3333
   [ "$status" -eq 0 ]
   [[ "$output" == *"cccc3333-3333-3333-3333-333333333333/events.jsonl" ]]
 }
 
 @test "resolve copilot latest picks newest mtime" {
-  run "$RESOLVE" copilot latest
+  run --separate-stderr "$RESOLVE" copilot latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"dddd4444-4444-4444-4444-444444444444/events.jsonl" ]]
 }
@@ -126,30 +208,97 @@ teardown() {
   [[ "$output" == *"not found"* ]]
 }
 
+@test "resolve copilot by name alias" {
+  # Seed an extra copilot session with workspace.yaml:name set. The `name`
+  # field is what `copilot --resume`'s picker displays — distinct from
+  # short-UUID resolution and from events.jsonl content.
+  local uuid="eeee2222-2222-2222-2222-222222222222"
+  make_copilot_session_tree "$TEST_HOME" "$uuid"
+  set_copilot_workspace_name "$TEST_HOME" "$uuid" "Validate Cross-Root Pull Behavior"
+
+  run --separate-stderr "$RESOLVE" copilot "Validate Cross-Root Pull Behavior"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TEST_HOME/.copilot/session-state/$uuid/events.jsonl" ]
+  [[ "$stderr" == *"matched-field=name"* ]]
+  [[ "$stderr" == *"matched-value=Validate Cross-Root Pull Behavior"* ]]
+}
+
+@test "intra-CLI collision: copilot name shared by 2 sessions emits 5-col TSV" {
+  # Two distinct copilot sessions (different UUID dirs) with workspace.yaml:name
+  # set to the same value. Copilot dedup is by directory; different dirs with
+  # same name are real collisions.
+  local uuid1="ffff3333-3333-3333-3333-333333333333"
+  local uuid2="ffff4444-4444-4444-4444-444444444444"
+  make_copilot_session_tree "$TEST_HOME" "$uuid1"
+  make_copilot_session_tree "$TEST_HOME" "$uuid2"
+  set_copilot_workspace_name "$TEST_HOME" "$uuid1" "Shared Workspace Name"
+  set_copilot_workspace_name "$TEST_HOME" "$uuid2" "Shared Workspace Name"
+
+  local path1="$TEST_HOME/.copilot/session-state/$uuid1/events.jsonl"
+  local path2="$TEST_HOME/.copilot/session-state/$uuid2/events.jsonl"
+
+  run --separate-stderr "$RESOLVE" copilot "Shared Workspace Name"
+  [ "$status" -eq 2 ]
+  [ -z "$output" ]
+  [[ "$stderr" == *"multiple sessions match"* ]]
+  [[ "$stderr" == *"$path1"* ]]
+  [[ "$stderr" == *"$path2"* ]]
+  local row_count
+  row_count=$(echo "$stderr" | grep -c $'\t'"name"$)
+  [ "$row_count" -eq 2 ]
+}
+
 # -- codex ----------------------------------------------------------------
 
 @test "resolve codex by full UUID" {
-  run "$RESOLVE" codex eeee5555-5555-5555-5555-555555555555
+  run --separate-stderr "$RESOLVE" codex eeee5555-5555-5555-5555-555555555555
   [ "$status" -eq 0 ]
   [ "$output" = "$CODEX_ONE" ]
 }
 
 @test "resolve codex by short UUID" {
-  run "$RESOLVE" codex eeee5555
+  run --separate-stderr "$RESOLVE" codex eeee5555
   [ "$status" -eq 0 ]
   [ "$output" = "$CODEX_ONE" ]
 }
 
 @test "resolve codex latest picks newest mtime" {
-  run "$RESOLVE" codex latest
+  run --separate-stderr "$RESOLVE" codex latest
   [ "$status" -eq 0 ]
   [ "$output" = "$CODEX_TWO" ]
 }
 
 @test "resolve codex by alias (thread_name scan)" {
-  run "$RESOLVE" codex my-feature
+  run --separate-stderr "$RESOLVE" codex my-feature
   [ "$status" -eq 0 ]
   [ "$output" = "$CODEX_ONE" ]
+  [[ "$stderr" == *"matched-field=thread_name"* ]]
+  [[ "$stderr" == *"matched-value=my-feature"* ]]
+}
+
+@test "intra-CLI collision: codex thread_name shared by 2 sessions emits 5-col TSV" {
+  # Two distinct codex rollouts with the same thread_name. Codex's dedup is
+  # by-path; different paths with same thread_name are real collisions.
+  local uuid1="eeee3333-3333-3333-3333-333333333333"
+  local uuid2="eeee4444-4444-4444-4444-444444444444"
+  local dir="$TEST_HOME/.codex/sessions/2026/04/19"
+  mkdir -p "$dir"
+  local path1="$dir/rollout-2026-04-19T10-00-00-${uuid1}.jsonl"
+  local path2="$dir/rollout-2026-04-19T11-00-00-${uuid2}.jsonl"
+  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"shared-thread","type":"thread_renamed"}}\n' \
+    "$uuid1" "$uuid1" > "$path1"
+  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"shared-thread","type":"thread_renamed"}}\n' \
+    "$uuid2" "$uuid2" > "$path2"
+
+  run --separate-stderr "$RESOLVE" codex "shared-thread"
+  [ "$status" -eq 2 ]
+  [ -z "$output" ]
+  [[ "$stderr" == *"multiple sessions match"* ]]
+  [[ "$stderr" == *"$path1"* ]]
+  [[ "$stderr" == *"$path2"* ]]
+  local row_count
+  row_count=$(echo "$stderr" | grep -c $'\t'"thread_name"$)
+  [ "$row_count" -eq 2 ]
 }
 
 @test "resolve codex alias miss exits 2" {
@@ -158,8 +307,10 @@ teardown() {
   [[ "$output" == *"not found"* ]]
 }
 
-@test "resolve codex UUID-shaped miss falls through to alias scan and exits 2" {
-  # A UUID-shaped string that does not match any file or alias.
+@test "exits 2 with not-found error on codex UUID-shaped miss" {
+  # Decision 4 strict-precedence: UUID-shaped queries are not consulted as
+  # aliases on miss (no fall-through to thread_name scan). Verifies the
+  # harmonized "<cli> session not found for uuid: <id>" message.
   run "$RESOLVE" codex 99999999-9999-9999-9999-999999999999
   [ "$status" -eq 2 ]
   [[ "$output" == *"not found"* ]]
@@ -183,4 +334,66 @@ teardown() {
   run "$RESOLVE" claude
   [ "$status" -eq 64 ]
   [[ "$output" == *"usage:"* ]]
+}
+
+# -- case-insensitive alias matching (Decision 1/2) ------------------------
+
+@test "case-insensitive: claude customTitle resolves on lowercase query" {
+  local uuid="aaaa7777-7777-7777-7777-777777777777"
+  local dir="$TEST_HOME/.claude/projects/-home-user-projects-case1"
+  mkdir -p "$dir"
+  local path="$dir/$uuid.jsonl"
+  printf '{"cwd":"/home/user/projects/case1","sessionId":"%s","version":"2.1"}\n' "$uuid" > "$path"
+  printf '{"type":"custom-title","customTitle":"Refactor Pipeline","sessionId":"%s"}\n' "$uuid" >> "$path"
+
+  # Query with all-lowercase variant; jq's ascii_downcase on both sides matches.
+  run --separate-stderr "$RESOLVE" claude "refactor pipeline"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$path" ]
+  [[ "$stderr" == *"matched-field=customTitle"* ]]
+  # matched-value preserves case-as-stored per Decision 3.
+  [[ "$stderr" == *"matched-value=Refactor Pipeline"* ]]
+}
+
+@test "case-insensitive: claude aiTitle resolves on uppercase query" {
+  local uuid="aaaa8888-8888-8888-8888-888888888888"
+  local dir="$TEST_HOME/.claude/projects/-home-user-projects-case2"
+  mkdir -p "$dir"
+  local path="$dir/$uuid.jsonl"
+  printf '{"cwd":"/home/user/projects/case2","sessionId":"%s","version":"2.1"}\n' "$uuid" > "$path"
+  printf '{"type":"ai-title","aiTitle":"Extract Pipeline","sessionId":"%s"}\n' "$uuid" >> "$path"
+
+  run --separate-stderr "$RESOLVE" claude "EXTRACT PIPELINE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$path" ]
+  [[ "$stderr" == *"matched-field=aiTitle"* ]]
+  [[ "$stderr" == *"matched-value=Extract Pipeline"* ]]
+}
+
+@test "case-insensitive: codex thread_name resolves on mixed-case query" {
+  local uuid="ffff7777-7777-7777-7777-777777777777"
+  local dir="$TEST_HOME/.codex/sessions/2026/04/19"
+  mkdir -p "$dir"
+  local path="$dir/rollout-2026-04-19T14-00-00-${uuid}.jsonl"
+  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"my-thread","type":"thread_renamed"}}\n' \
+    "$uuid" "$uuid" > "$path"
+
+  run --separate-stderr "$RESOLVE" codex "MY-Thread"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$path" ]
+  [[ "$stderr" == *"matched-field=thread_name"* ]]
+  [[ "$stderr" == *"matched-value=my-thread"* ]]
+}
+
+@test "case-insensitive: copilot name resolves on lowercase query" {
+  local uuid="ffff8888-8888-8888-8888-888888888888"
+  make_copilot_session_tree "$TEST_HOME" "$uuid"
+  set_copilot_workspace_name "$TEST_HOME" "$uuid" "Pull Latest Changes"
+
+  # Copilot uses bash-side LC_ALL=C tr for case-folding (no jq dependency).
+  run --separate-stderr "$RESOLVE" copilot "pull latest changes"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TEST_HOME/.copilot/session-state/$uuid/events.jsonl" ]
+  [[ "$stderr" == *"matched-field=name"* ]]
+  [[ "$stderr" == *"matched-value=Pull Latest Changes"* ]]
 }

--- a/plugins/dotclaude/tests/bats/handoff-resolve.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve.bats
@@ -137,6 +137,40 @@ teardown() {
   [[ "$stderr" == *"matched-value=force-push-collision-guard"* ]]
 }
 
+@test "intra-CLI collision: claude customTitle + aiTitle cross-mechanism emits 5-col TSV" {
+  # Claude has TWO alias mechanisms — customTitle (user-set) and aiTitle
+  # (auto-generated). Per ARCH-3, both are equally-weighted alias surfaces
+  # for the same CLI; a query that matches one mechanism in session A and
+  # the other mechanism in session B is a real cross-mechanism collision,
+  # not a single-hit. The resolver must collect rows from BOTH scans into
+  # one Claude alias candidate set before deciding single-hit vs collision.
+  local uuid_custom="aaaa9999-9999-9999-9999-999999999999"
+  local uuid_ai="bbbb5555-5555-5555-5555-555555555555"
+  local dir_custom="$TEST_HOME/.claude/projects/-home-user-projects-cross-mech1"
+  local dir_ai="$TEST_HOME/.claude/projects/-home-user-projects-cross-mech2"
+  mkdir -p "$dir_custom" "$dir_ai"
+  local path_custom="$dir_custom/$uuid_custom.jsonl"
+  local path_ai="$dir_ai/$uuid_ai.jsonl"
+  printf '{"cwd":"/home/user/projects/cm1","sessionId":"%s","version":"2.1"}\n' "$uuid_custom" > "$path_custom"
+  set_claude_custom_title "$path_custom" "$uuid_custom" "shared-cross-mech"
+  printf '{"cwd":"/home/user/projects/cm2","sessionId":"%s","version":"2.1"}\n' "$uuid_ai" > "$path_ai"
+  set_claude_ai_title "$path_ai" "$uuid_ai" "shared-cross-mech"
+
+  run --separate-stderr "$RESOLVE" claude "shared-cross-mech"
+  [ "$status" -eq 2 ]
+  [ -z "$output" ]
+  [[ "$stderr" == *"multiple sessions match"* ]]
+  [[ "$stderr" == *"$path_custom"* ]]
+  [[ "$stderr" == *"$path_ai"* ]]
+  # Each row carries its own matched-field tag.
+  local custom_rows
+  custom_rows=$(echo "$stderr" | grep -c $'\t'"customTitle"$)
+  [ "$custom_rows" -eq 1 ]
+  local ai_rows
+  ai_rows=$(echo "$stderr" | grep -c $'\t'"aiTitle"$)
+  [ "$ai_rows" -eq 1 ]
+}
+
 @test "intra-CLI collision: claude customTitle shared by 2 sessions emits 5-col TSV" {
   # Two distinct claude sessions (different UUIDs) with the same customTitle.
   # Without dedup-by-sessionId would dedupe; with dedup-by-sessionId these

--- a/plugins/dotclaude/tests/bats/handoff-resolve.bats
+++ b/plugins/dotclaude/tests/bats/handoff-resolve.bats
@@ -126,7 +126,7 @@ teardown() {
   # Append 100 identical custom-title records (simulates rewrite-on-every-save).
   local i=0
   while (( i < 100 )); do
-    printf '{"type":"custom-title","customTitle":"force-push-collision-guard","sessionId":"%s"}\n' "$uuid" >> "$path"
+    set_claude_custom_title "$path" "$uuid" "force-push-collision-guard"
     i=$((i + 1))
   done
 
@@ -149,9 +149,9 @@ teardown() {
   local path1="$dir1/$uuid1.jsonl"
   local path2="$dir2/$uuid2.jsonl"
   printf '{"cwd":"/home/user/projects/c1","sessionId":"%s","version":"2.1"}\n' "$uuid1" > "$path1"
-  printf '{"type":"custom-title","customTitle":"shared-title","sessionId":"%s"}\n' "$uuid1" >> "$path1"
+  set_claude_custom_title "$path1" "$uuid1" "shared-title"
   printf '{"cwd":"/home/user/projects/c2","sessionId":"%s","version":"2.1"}\n' "$uuid2" > "$path2"
-  printf '{"type":"custom-title","customTitle":"shared-title","sessionId":"%s"}\n' "$uuid2" >> "$path2"
+  set_claude_custom_title "$path2" "$uuid2" "shared-title"
 
   run --separate-stderr "$RESOLVE" claude "shared-title"
   [ "$status" -eq 2 ]
@@ -173,7 +173,7 @@ teardown() {
   mkdir -p "$dir"
   local path="$dir/$uuid.jsonl"
   printf '{"cwd":"/home/user/projects/aititle","sessionId":"%s","version":"2.1"}\n' "$uuid" > "$path"
-  printf '{"type":"ai-title","aiTitle":"Refactor extract pipeline","sessionId":"%s"}\n' "$uuid" >> "$path"
+  set_claude_ai_title "$path" "$uuid" "Refactor extract pipeline"
 
   run --separate-stderr "$RESOLVE" claude "Refactor extract pipeline"
   [ "$status" -eq 0 ]
@@ -285,10 +285,10 @@ teardown() {
   mkdir -p "$dir"
   local path1="$dir/rollout-2026-04-19T10-00-00-${uuid1}.jsonl"
   local path2="$dir/rollout-2026-04-19T11-00-00-${uuid2}.jsonl"
-  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"shared-thread","type":"thread_renamed"}}\n' \
-    "$uuid1" "$uuid1" > "$path1"
-  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"shared-thread","type":"thread_renamed"}}\n' \
-    "$uuid2" "$uuid2" > "$path2"
+  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n' "$uuid1" > "$path1"
+  set_codex_thread_name "$path1" "$uuid1" "shared-thread"
+  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n' "$uuid2" > "$path2"
+  set_codex_thread_name "$path2" "$uuid2" "shared-thread"
 
   run --separate-stderr "$RESOLVE" codex "shared-thread"
   [ "$status" -eq 2 ]
@@ -344,7 +344,7 @@ teardown() {
   mkdir -p "$dir"
   local path="$dir/$uuid.jsonl"
   printf '{"cwd":"/home/user/projects/case1","sessionId":"%s","version":"2.1"}\n' "$uuid" > "$path"
-  printf '{"type":"custom-title","customTitle":"Refactor Pipeline","sessionId":"%s"}\n' "$uuid" >> "$path"
+  set_claude_custom_title "$path" "$uuid" "Refactor Pipeline"
 
   # Query with all-lowercase variant; jq's ascii_downcase on both sides matches.
   run --separate-stderr "$RESOLVE" claude "refactor pipeline"
@@ -361,7 +361,7 @@ teardown() {
   mkdir -p "$dir"
   local path="$dir/$uuid.jsonl"
   printf '{"cwd":"/home/user/projects/case2","sessionId":"%s","version":"2.1"}\n' "$uuid" > "$path"
-  printf '{"type":"ai-title","aiTitle":"Extract Pipeline","sessionId":"%s"}\n' "$uuid" >> "$path"
+  set_claude_ai_title "$path" "$uuid" "Extract Pipeline"
 
   run --separate-stderr "$RESOLVE" claude "EXTRACT PIPELINE"
   [ "$status" -eq 0 ]
@@ -375,8 +375,8 @@ teardown() {
   local dir="$TEST_HOME/.codex/sessions/2026/04/19"
   mkdir -p "$dir"
   local path="$dir/rollout-2026-04-19T14-00-00-${uuid}.jsonl"
-  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"my-thread","type":"thread_renamed"}}\n' \
-    "$uuid" "$uuid" > "$path"
+  printf '{"type":"session_meta","payload":{"id":"%s","cwd":"/work"}}\n' "$uuid" > "$path"
+  set_codex_thread_name "$path" "$uuid" "my-thread"
 
   run --separate-stderr "$RESOLVE" codex "MY-Thread"
   [ "$status" -eq 0 ]

--- a/plugins/dotclaude/tests/bats/handoff-security.bats
+++ b/plugins/dotclaude/tests/bats/handoff-security.bats
@@ -3,6 +3,8 @@
 # Each test asserts that a hostile input is neutralised (regex gate rejects,
 # jq --arg literalises, grep -F disables regex, symlinks don't escape, etc.).
 
+bats_require_minimum_version 1.5.0
+
 load helpers
 
 RESOLVE="$REPO_ROOT/plugins/dotclaude/scripts/handoff-resolve.sh"
@@ -60,7 +62,7 @@ teardown() {
   printf '{"cwd":"/x","sessionId":"%s","version":"2.1"}\n{"type":"custom-title","customTitle":"; rm -rf /","sessionId":"%s"}\n' \
     "$uuid" "$uuid" > "$dir/$uuid.jsonl"
   # The alias scan must find it by literal-match; grep -F + jq --arg keep it safe.
-  run "$RESOLVE" claude "; rm -rf /"
+  run --separate-stderr "$RESOLVE" claude "; rm -rf /"
   [ "$status" -eq 0 ]
   [[ "$output" == *"$uuid.jsonl" ]]
 }
@@ -103,7 +105,7 @@ teardown() {
   # resolver only calls find under the session root; -name filters exclude
   # /etc/passwd regardless, so the symlink must not surface it.
   ln -s /etc "$TEST_HOME/.claude/projects/escape"
-  run "$RESOLVE" claude latest
+  run --separate-stderr "$RESOLVE" claude latest
   [ "$status" -eq 0 ]
   [[ "$output" != *"/etc/passwd"* ]]
   [[ "$output" == *".jsonl" ]]

--- a/plugins/dotclaude/tests/bats/helpers.bash
+++ b/plugins/dotclaude/tests/bats/helpers.bash
@@ -141,6 +141,18 @@ make_codex_session_tree() {
   export CODEX_SESSION_UUIDS
 }
 
+# set_copilot_workspace_name <home> <uuid> <name>
+# Set the top-level `name:` field in a copilot session's workspace.yaml — the
+# alias surface for `copilot --resume`'s picker. Use AFTER make_copilot_session_tree
+# (which only seeds events.jsonl). Decorative `summary:` companion is set to
+# the same value to mirror copilot's actual on-disk format.
+set_copilot_workspace_name() {
+  local home="$1" uuid="$2" name="$3"
+  local dir="$home/.copilot/session-state/$uuid"
+  mkdir -p "$dir"
+  printf 'id: %s\nname: %s\nsummary: %s\n' "$uuid" "$name" "$name" > "$dir/workspace.yaml"
+}
+
 # make_many_codex_sessions <home> <count>
 # Bulk-seed <count> codex sessions under ~/.codex/sessions/2026/04/18/.
 # Avoids the per-iteration `sleep 0.01` of `make_codex_session_tree` so 10k

--- a/plugins/dotclaude/tests/bats/helpers.bash
+++ b/plugins/dotclaude/tests/bats/helpers.bash
@@ -153,6 +153,33 @@ set_copilot_workspace_name() {
   printf 'id: %s\nname: %s\nsummary: %s\n' "$uuid" "$name" "$name" > "$dir/workspace.yaml"
 }
 
+# set_claude_custom_title <session-jsonl-path> <uuid> <title>
+# Append a `custom-title` JSONL record (the user-set alias `claude --resume "<name>"`
+# stores) to an existing claude session file. Caller is responsible for creating
+# the file with its `cwd`/`sessionId` header record first.
+set_claude_custom_title() {
+  local path="$1" uuid="$2" title="$3"
+  printf '{"type":"custom-title","customTitle":"%s","sessionId":"%s"}\n' "$title" "$uuid" >> "$path"
+}
+
+# set_claude_ai_title <session-jsonl-path> <uuid> <title>
+# Append an `ai-title` JSONL record (the auto-generated TUI summary Claude Code
+# emits) to an existing claude session file. Caller is responsible for creating
+# the file with its `cwd`/`sessionId` header record first.
+set_claude_ai_title() {
+  local path="$1" uuid="$2" title="$3"
+  printf '{"type":"ai-title","aiTitle":"%s","sessionId":"%s"}\n' "$title" "$uuid" >> "$path"
+}
+
+# set_codex_thread_name <rollout-jsonl-path> <uuid> <name>
+# Append an `event_msg` thread-rename record (the user-set `codex thread rename`
+# alias surface) to an existing codex rollout file. Caller is responsible for
+# creating the file with its `session_meta` header record first.
+set_codex_thread_name() {
+  local path="$1" uuid="$2" name="$3"
+  printf '{"type":"event_msg","payload":{"thread_id":"%s","thread_name":"%s","type":"thread_renamed"}}\n' "$uuid" "$name" >> "$path"
+}
+
 # make_many_codex_sessions <home> <count>
 # Bulk-seed <count> codex sessions under ~/.codex/sessions/2026/04/18/.
 # Avoids the per-iteration `sleep 0.01` of `make_codex_session_tree` so 10k

--- a/plugins/dotclaude/tests/handoff-drift.test.mjs
+++ b/plugins/dotclaude/tests/handoff-drift.test.mjs
@@ -76,6 +76,7 @@ const GUIDE_MD_PATH = resolve(repoRoot, "docs/handoff-guide.md");
  * @property {string[]} commands  — sorted, lowercase sub-command names (e.g. `["doctor", "fetch", ...]`)
  * @property {Record<string, string[]>} flags_by_command  — `"*"` → sorted global flag tokens (each `--name` or `-x`)
  * @property {FromRule} from_rule
+ * @property {string[]} alias_mechanisms  — sorted unique alias-resolution mechanism names found in source
  */
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,14 @@ const PHASE_1_BASELINE_FROM_RULE = Object.freeze({
   applies_to: ["push"],
   mandatory_when: "no <query>",
 });
+
+/**
+ * Cross-source intersection of alias-resolution mechanisms (#158).
+ * All 4 forms must appear in --help, SKILL.md, AND handoff-guide.md
+ * (Steps 5+6 of the v1.3.0 alias-resolver work updated each source
+ * to enumerate the 4 mechanisms by canonical name).
+ */
+const PHASE_2_BASELINE_ALIAS_MECHANISMS = ["aiTitle", "customTitle", "name", "thread_name"];
 
 // ---------------------------------------------------------------------------
 // Extractors
@@ -172,6 +181,7 @@ export function extractFromSkillMd(text) {
     commands,
     flags_by_command: { "*": [...flagTokens].sort() },
     from_rule: extractFromRule(text),
+    alias_mechanisms: extractAliasMechanisms(text),
   };
 }
 
@@ -221,6 +231,7 @@ export function extractFromHelp(text) {
     commands,
     flags_by_command: { "*": [...flagTokens].sort() },
     from_rule: extractFromRule(text),
+    alias_mechanisms: extractAliasMechanisms(text),
   };
 }
 
@@ -343,6 +354,36 @@ export function extractFabricationRule(text) {
  * @param {string} text
  * @returns {HandoffSurface}
  */
+
+/**
+ * Scan a source for canonical alias-mechanism names. The handoff resolver
+ * dispatches alias queries through 4 mechanisms — claude `customTitle`,
+ * claude `aiTitle`, codex `thread_name`, copilot `workspace.yaml:name` —
+ * and ARCH-10 asserts that all 4 are documented across the cross-source
+ * triangle (--help / SKILL.md / handoff-guide.md). When any source
+ * documents fewer than 4, the alias surface has drifted out of sync with
+ * the resolver implementation; the test fails to surface that.
+ *
+ * The mechanism names map to canonical strings the sources MUST mention:
+ * `customTitle`, `aiTitle`, `thread_name`, and `workspace.yaml:name` (the
+ * copilot mechanism uses the full `workspace.yaml:name` form to disambiguate
+ * from incidental `--name` flags or generic "name" prose). If a future
+ * source documents copilot's alias mechanism without using the canonical
+ * form, that's drift worth surfacing — the test should fail, not be
+ * patched to pass via fallback regexes.
+ *
+ * @param {string} text
+ * @returns {string[]}  sorted unique mechanism names found
+ */
+export function extractAliasMechanisms(text) {
+  const found = new Set();
+  if (/\bcustomTitle\b/.test(text)) found.add("customTitle");
+  if (/\baiTitle\b/.test(text)) found.add("aiTitle");
+  if (/\bthread_name\b/.test(text)) found.add("thread_name");
+  if (/workspace\.yaml:name\b/.test(text)) found.add("name");
+  return [...found].sort();
+}
+
 export function extractFromGuide(text) {
   // Commands: parse second column of "When to use it" table.
   // Safety: terminate only on `\n## ` (next H2) or EOF, not `\n# `.
@@ -392,6 +433,7 @@ export function extractFromGuide(text) {
     commands,
     flags_by_command: { "*": [...flagTokens].sort() },
     from_rule: extractFromRule(text),
+    alias_mechanisms: extractAliasMechanisms(text),
   };
 }
 
@@ -443,6 +485,7 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
             present: expect.any(Boolean),
             applies_to: expect.any(Array),
           }),
+          alias_mechanisms: expect.any(Array),
         }),
       );
       // Element-type checks.
@@ -457,6 +500,10 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
         `${name} flags_by_command values`,
       ).toBe(true);
       expect(surface.from_rule.applies_to.every((c) => typeof c === "string")).toBe(true);
+      expect(
+        surface.alias_mechanisms.every((m) => typeof m === "string"),
+        `${name} alias_mechanisms`,
+      ).toBe(true);
       expect(
         surface.from_rule.mandatory_when === null ||
           typeof surface.from_rule.mandatory_when === "string",
@@ -484,6 +531,15 @@ describe("handoff drift (ARCH-10) — Phase 1", () => {
       .filter((f) => skillFlags.has(f) && guideFlags.has(f))
       .sort();
     expect(intersection).toEqual(PHASE_1_BASELINE_FLAGS_INTERSECTION);
+  });
+
+  it("alias mechanisms intersection across sources matches Phase 2 baseline (#158)", () => {
+    const skillSet = new Set(skillSurface.alias_mechanisms);
+    const guideSet = new Set(guideSurface.alias_mechanisms);
+    const intersection = helpSurface.alias_mechanisms
+      .filter((m) => skillSet.has(m) && guideSet.has(m))
+      .sort();
+    expect(intersection).toEqual(PHASE_2_BASELINE_ALIAS_MECHANISMS);
   });
 
   it("from_rule baseline matches in all sources", () => {

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -2,14 +2,14 @@
 id: handoff
 name: handoff
 type: skill
-version: 1.2.0
+version: 1.3.0
 domain: [devex]
 platform: [none]
 task: [documentation, debugging]
 maturity: draft
 owner: "@kaiohenricunha"
 created: 2026-04-17
-updated: 2026-04-28
+updated: 2026-05-04
 description: >
   Transfer conversation context between agentic CLIs (Claude Code, GitHub
   Copilot CLI, OpenAI Codex CLI) locally and across machines. Reads a
@@ -47,10 +47,12 @@ the right invocation.
 | `push handoff` / `send to other machine` / `save this`                 | `dotclaude handoff push --from <host-cli> [--tag …]` |
 | `pull handoff` / `fetch handoff` / `continue from yesterday's machine` | `dotclaude handoff fetch [<query>]`                  |
 
-Extract `<id>` from the user message (UUID, short UUID, or named alias).
+Extract `<id>` from the user message (UUID, short UUID, or a deliberate-label
+alias: claude `customTitle`/`aiTitle`, codex `thread_name`, or copilot
+`workspace.yaml:name`). Aliases match case-insensitively. Resolution
+precedence: UUID > short-UUID > `latest` > alias (no fall-through on miss).
 The resolver probes Claude / Copilot / Codex roots automatically. If the
-query is missing or ambiguous, ask one clarifying question before
-proceeding.
+query is missing or ambiguous, ask one clarifying question before proceeding.
 
 ## The `--from` filling rule
 


### PR DESCRIPTION
## Summary

Extends `dotclaude handoff` resolution to four deliberate-label alias forms across three CLIs, harmonizes resolution precedence per Decision 4, and corrects two pre-existing bugs that surfaced during the work.

**New alias surfaces (v1.3.0):**

- Claude `aiTitle` (the auto-generated TUI summary)
- Copilot `workspace.yaml:name` (the LLM-generated session name)

**Existing alias forms preserved:**

- Claude `customTitle`, Codex `thread_name`

All four match case-insensitively. Resolution precedence is now uniform across all three CLIs: UUID > short-UUID > `latest` > alias (no fall-through on miss).

## Changes

- **Resolver** (`plugins/dotclaude/scripts/handoff-resolve.sh`): 5-column TSV emit, case-insensitive jq filters, intra-resource dedup-by-canonical-key, strict-precedence harmonization, single-hit metadata stderr emit
- **Wrapper** (`plugins/dotclaude/bin/dotclaude-handoff.mjs`): shared `parseCollisionAndDispatch` helper, collision-aware extensions in `resolveNarrowed` (now async) and `resolveLocalForPull`, `promptCollisionChoice` render with `(cli/matched-field)` tag and 80-char soft-truncate, `META.description` extended for runtime `--help`
- **Spec** (`docs/specs/handoff-skill/spec/5-interfaces-apis.md`): §5.2.1, §5.3.2, §5.3.5, §5.4 amendments
- **Documentation**: `skills/handoff/SKILL.md` (v1.2.0 → v1.3.0) + `docs/handoff-guide.md` updated to enumerate all 4 alias mechanisms with case-insensitive note and precedence statement
- **Drift test**: ARCH-10 extended with `alias_mechanisms` field on `HandoffSurface` + cross-source intersection assertion (`PHASE_2_BASELINE_ALIAS_MECHANISMS`)

## Spec section references

- §5.2.1 — `pull <query>` Notes cell extended
- §5.3.2 — multi-match stderr template extended with hint line
- §5.3.5 — pull TSV column-order amended (`<session_id>` → `<short-id>`; +`<matched-value>`, +`<matched-field>`; tab-sanitization sentence)
- §5.4 — grammar table 8→10 rows; Resolution precedence prose paragraph; deleted obsolete "Copilot has no alias support" paragraph

## Test plan

- [x] `npm test` — 551 vitest tests passing (drift test 5 → 6)
- [x] `npx bats plugins/dotclaude/tests/bats/` — 376 bats tests passing (was 360; +2 TDD regressions added during review)
- [x] `npm run lint` — clean (only pre-existing CHANGELOG.md warning, unrelated)
- [x] `node scripts/build-plugin.mjs --check` — TWO-pin sync verified
- [x] Live-data smoke tests passed — UUID/short-UUID/latest, alias (customTitle/aiTitle/copilot name), strict-precedence "not found", cross-CLI single-hit resolution, all metadata flows verified end-to-end
- [x] Wrapper-level CLI smokes via `node plugins/dotclaude/bin/dotclaude-handoff.mjs pull ...` — all expected paths exercised

## How to test

```bash
# Existing flows (regression):
dotclaude handoff pull <short-uuid>              # UUID resolution unchanged
dotclaude handoff pull latest                    # cross-root newest, with metadata
dotclaude handoff pull --from claude latest      # host-scoped latest

# New alias flows (case-insensitive):
dotclaude handoff pull "extract pipeline"        # matches Claude aiTitle (case-folded)
dotclaude handoff pull "Pull Latest Changes"     # matches Copilot workspace.yaml:name
dotclaude handoff pull --from copilot "..."      # narrowed alias resolution

# Miss paths:
dotclaude handoff pull "no-such-thing"           # exit 2 + "no session matches"
dotclaude handoff pull --from copilot deadbeef   # exit 2 + "copilot session not found for short-uuid"
```

## Fix (prerequisite for Decision 4 verification)

`pick_newest` helper no longer triggers `errexit` on empty input (was: silent exit 1; now: exit 0 + empty stdout). Affected all three CLIs' short-UUID branches. Without this fix, Step 4 bats fixtures could not empirically verify strict-precedence "exit 2 + not-found on short-UUID miss" because runtime was "exit 1 silent." Subsumed Issue #171 which was originally filed for copilot only.

## Closes

- Closes #158
- Closes #171

## Spec ID

handoff-skill