### PR TITLE
fix(handoff): partition push --delete stderr for accurate prune reporting

### DIFF
--- a/plugins/dotclaude/bin/dotclaude-handoff.mjs
+++ b/plugins/dotclaude/bin/dotclaude-handoff.mjs
@@ -680,7 +680,13 @@ function renderPruneResult({ deleted, failures }) {
   if (deleted.length) lines.push(`deleted ${deleted.length} branch(es).`);
   if (failures.length) {
     lines.push(`failed: ${failures.length}`);
-    for (const f of failures) lines.push(`  ${f.branch}: ${f.reason}`);
+    for (const f of failures) {
+      const reason =
+        String(f.reason ?? "")
+          .split("\n")[0]
+          .trim() || "unknown error";
+      lines.push(`  ${f.branch}: ${reason}`);
+    }
   }
   lines.push("");
   return lines.join("\n");

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -1175,13 +1175,71 @@ export function listPruneCandidates({ olderThanMs, fromCli = null, repoUrl }) {
 }
 
 /**
+ * Escape a branch name for embedding in a RegExp. Branch names contain `/`
+ * and digits; `.` and `+` are theoretically possible.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Parse `git push --delete` stderr into per-ref outcomes for the input
+ * branches. Recognized line shapes (modern git):
+ *
+ *   - [deleted]         <ref>
+ *   ! [remote rejected] <ref> (<reason>)
+ *   ! [rejected]        <ref> (<reason>)
+ *   ! [error]           <ref> (<reason>)
+ *
+ * `<ref>` may appear with or without the `refs/heads/` prefix. A branch
+ * matched by no line is returned in `unclassified` so the caller can
+ * fall back to a per-ref retry.
+ *
+ * @param {string} stderr
+ * @param {string[]} branches
+ * @returns {{ deleted: string[], failures: Array<{branch: string, reason: string}>, unclassified: string[] }}
+ */
+export function parsePushDeleteStderr(stderr, branches) {
+  const text = stderr || "";
+  const deleted = [];
+  const failures = [];
+  const unclassified = [];
+  for (const branch of branches) {
+    const refPattern = `(?:refs/heads/)?${escapeRegExp(branch)}`;
+    const deletedRe = new RegExp(`^\\s*-\\s*\\[deleted\\]\\s+${refPattern}\\s*$`, "m");
+    const rejectedRe = new RegExp(
+      `^\\s*!\\s*\\[(?:remote rejected|rejected|error)\\]\\s+${refPattern}\\s+\\((.*)\\)\\s*$`,
+      "m",
+    );
+    if (deletedRe.test(text)) {
+      deleted.push(branch);
+      continue;
+    }
+    const m = text.match(rejectedRe);
+    if (m) {
+      const reason = redactUrlSecrets((m[1] || "").trim()) || "rejected";
+      failures.push({ branch, reason });
+      continue;
+    }
+    unclassified.push(branch);
+  }
+  return { deleted, failures, unclassified };
+}
+
+/**
  * Delete N remote branches in one `git push --delete` call. Works from a
  * throwaway tmp git repo — no working tree, no commits required.
  *
- * Returns per-branch results: branches absent from the failures array
- * succeeded. The git protocol surfaces per-ref status, but parsing it
- * portably is brittle; on a non-zero overall exit we treat the whole batch
- * as failed and surface the raw stderr for the bin's error formatter.
+ * On non-zero overall exit, parse `git push --delete` per-ref status from
+ * stderr to partition the input into deleted vs. rejected. Branches the
+ * parser cannot classify are retried one by one (bounded), so a corrupt
+ * or unfamiliar stderr never causes us to lose a per-ref outcome silently.
+ * If the parser produces no signal at all, fall back to the legacy
+ * "all-failed with raw stderr" behavior so the operator still sees the
+ * underlying error.
  *
  * @param {string} repoUrl
  * @param {string[]} branches
@@ -1200,11 +1258,30 @@ export function deleteRemoteBranches(repoUrl, branches) {
     if (r.status === 0) {
       return { deleted: branches.slice(), failures: [] };
     }
-    const reason = redactUrlSecrets((r.stderr || r.stdout).trim()) || "unknown error";
-    return {
-      deleted: [],
-      failures: branches.map((branch) => ({ branch, reason })),
-    };
+    const stderr = r.stderr || r.stdout || "";
+    const parsed = parsePushDeleteStderr(stderr, branches);
+    const deleted = parsed.deleted.slice();
+    const failures = parsed.failures.slice();
+    for (const branch of parsed.unclassified) {
+      const rr = runGit(["push", "-q", repoUrl, "--delete", `refs/heads/${branch}`], tmp);
+      if (rr.status === 0) {
+        deleted.push(branch);
+        continue;
+      }
+      const rrText = (rr.stderr || rr.stdout || "").trim();
+      const retryParsed = parsePushDeleteStderr(rrText, [branch]);
+      if (retryParsed.failures.length === 1) {
+        failures.push(retryParsed.failures[0]);
+        continue;
+      }
+      const firstLine = redactUrlSecrets(rrText).split("\n")[0].trim();
+      failures.push({ branch, reason: firstLine || "unknown error" });
+    }
+    if (deleted.length === 0 && failures.length === 0) {
+      const reason = redactUrlSecrets(stderr.trim()) || "unknown error";
+      return { deleted: [], failures: branches.map((branch) => ({ branch, reason })) };
+    }
+    return { deleted, failures };
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -1186,17 +1186,66 @@ function escapeRegExp(s) {
 }
 
 /**
+ * Parse `git push --porcelain --delete` stdout into per-ref outcomes for
+ * the input branches. Each status line is tab-delimited:
+ *
+ *   <flag>\t<from>:<to>\t<summary>[ (<reason>)]
+ *
+ * For deletes, `<from>:<to>` is `:refs/heads/<branch>`. Recognized
+ * combinations:
+ *
+ *   -\t:<ref>\t[deleted]
+ *   !\t:<ref>\t[remote rejected] (<reason>)
+ *   !\t:<ref>\t[rejected] (<reason>)
+ *   !\t:<ref>\t[error] (<reason>)
+ *
+ * Porcelain is the preferred classification path because the format is
+ * stable across git versions and machine-readable. A branch matched by
+ * no line is returned in `unclassified` so the caller can fall back to
+ * stderr parsing or a per-ref retry.
+ *
+ * @param {string} stdout
+ * @param {string[]} branches
+ * @returns {{ deleted: string[], failures: Array<{branch: string, reason: string}>, unclassified: string[] }}
+ */
+export function parsePushDeletePorcelain(stdout, branches) {
+  const text = stdout || "";
+  const deleted = [];
+  const failures = [];
+  const unclassified = [];
+  for (const branch of branches) {
+    const refPattern = `(?:refs/heads/)?${escapeRegExp(branch)}`;
+    const deletedRe = new RegExp(`^-\\t:${refPattern}\\t\\[deleted\\]`, "m");
+    const rejectedRe = new RegExp(
+      `^!\\t:${refPattern}\\t\\[(?:remote rejected|rejected|error)\\](?:\\s+\\((.*)\\))?`,
+      "m",
+    );
+    if (deletedRe.test(text)) {
+      deleted.push(branch);
+      continue;
+    }
+    const m = text.match(rejectedRe);
+    if (m) {
+      const reason = redactUrlSecrets((m[1] || "").trim()) || "rejected";
+      failures.push({ branch, reason });
+      continue;
+    }
+    unclassified.push(branch);
+  }
+  return { deleted, failures, unclassified };
+}
+
+/**
  * Parse `git push --delete` stderr into per-ref outcomes for the input
- * branches. Recognized line shapes (modern git):
+ * branches. Recognized line shapes (modern git, human format):
  *
  *   - [deleted]         <ref>
  *   ! [remote rejected] <ref> (<reason>)
  *   ! [rejected]        <ref> (<reason>)
  *   ! [error]           <ref> (<reason>)
  *
- * `<ref>` may appear with or without the `refs/heads/` prefix. A branch
- * matched by no line is returned in `unclassified` so the caller can
- * fall back to a per-ref retry.
+ * Used as a fallback when `--porcelain` stdout is missing/incomplete.
+ * `<ref>` may appear with or without the `refs/heads/` prefix.
  *
  * @param {string} stderr
  * @param {string[]} branches
@@ -1254,31 +1303,43 @@ export function deleteRemoteBranches(repoUrl, branches) {
       throw new Error(`git init failed: ${init.stderr.trim()}`);
     }
     const refs = branches.map((b) => `refs/heads/${b}`);
-    const r = runGit(["push", "-q", repoUrl, "--delete", ...refs], tmp);
+    const r = runGit(["push", "--porcelain", repoUrl, "--delete", ...refs], tmp);
     if (r.status === 0) {
       return { deleted: branches.slice(), failures: [] };
     }
-    const stderr = r.stderr || r.stdout || "";
-    const parsed = parsePushDeleteStderr(stderr, branches);
-    const deleted = parsed.deleted.slice();
-    const failures = parsed.failures.slice();
-    for (const branch of parsed.unclassified) {
-      const rr = runGit(["push", "-q", repoUrl, "--delete", `refs/heads/${branch}`], tmp);
+    const stdout = r.stdout || "";
+    const stderr = r.stderr || "";
+    const fromPorcelain = parsePushDeletePorcelain(stdout, branches);
+    const fromStderr = parsePushDeleteStderr(stderr, fromPorcelain.unclassified);
+    const deleted = [...fromPorcelain.deleted, ...fromStderr.deleted];
+    const failures = [...fromPorcelain.failures, ...fromStderr.failures];
+    for (const branch of fromStderr.unclassified) {
+      const rr = runGit(["push", "--porcelain", repoUrl, "--delete", `refs/heads/${branch}`], tmp);
       if (rr.status === 0) {
         deleted.push(branch);
         continue;
       }
+      const rrPorcelain = parsePushDeletePorcelain(rr.stdout || "", [branch]);
+      if (rrPorcelain.deleted.length === 1) {
+        deleted.push(branch);
+        continue;
+      }
+      if (rrPorcelain.failures.length === 1) {
+        failures.push(rrPorcelain.failures[0]);
+        continue;
+      }
       const rrText = (rr.stderr || rr.stdout || "").trim();
-      const retryParsed = parsePushDeleteStderr(rrText, [branch]);
-      if (retryParsed.failures.length === 1) {
-        failures.push(retryParsed.failures[0]);
+      const rrStderr = parsePushDeleteStderr(rrText, [branch]);
+      if (rrStderr.failures.length === 1) {
+        failures.push(rrStderr.failures[0]);
         continue;
       }
       const firstLine = redactUrlSecrets(rrText).split("\n")[0].trim();
       failures.push({ branch, reason: firstLine || "unknown error" });
     }
     if (deleted.length === 0 && failures.length === 0) {
-      const reason = redactUrlSecrets(stderr.trim()) || "unknown error";
+      const raw = stderr.trim() || stdout.trim();
+      const reason = redactUrlSecrets(raw) || "unknown error";
       return { deleted: [], failures: branches.map((branch) => ({ branch, reason })) };
     }
     return { deleted, failures };

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -1290,7 +1290,7 @@ describe("deleteRemoteBranches", () => {
     expect(spawnSync).not.toHaveBeenCalled();
   });
 
-  it("issues a single batched push --delete and reports all branches deleted on success", () => {
+  it("issues a single batched push --porcelain --delete and reports all branches deleted on success", () => {
     spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
     spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // push --delete
     const r = lib.deleteRemoteBranches("https://x.test/repo.git", [
@@ -1302,18 +1302,19 @@ describe("deleteRemoteBranches", () => {
       "handoff/p/claude/2026-01/bbbbbbbb",
     ]);
     expect(r.failures).toEqual([]);
-    // The single push call carried both refs.
+    // The single push call carried both refs and used --porcelain.
     const pushCall = spawnSync.mock.calls.find(
       (c) => c[0] === "git" && Array.isArray(c[1]) && c[1].includes("--delete"),
     );
+    expect(pushCall[1]).toContain("--porcelain");
     expect(pushCall[1]).toContain("refs/heads/handoff/p/claude/2026-01/aaaaaaaa");
     expect(pushCall[1]).toContain("refs/heads/handoff/p/claude/2026-01/bbbbbbbb");
   });
 
-  it("falls back to legacy all-failed report with redacted URLs when stderr matches no per-ref status (and parser-driven retry also fails)", () => {
+  it("falls back to legacy all-failed report with redacted URLs when neither porcelain stdout nor stderr classify any ref (and parser-driven retry also fails)", () => {
     // git init
     spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
-    // batched push --delete: total auth failure, no per-ref status lines.
+    // batched push --delete: total auth failure, no per-ref status lines on stdout or stderr.
     spawnSync.mockReturnValueOnce({
       status: 1,
       stdout: "",
@@ -1335,17 +1336,21 @@ describe("deleteRemoteBranches", () => {
     expect(r.failures[0].reason).toMatch(/\*\*\*@/);
   });
 
-  it("partitions partial-success stderr into deleted + rejected (issue #179 reproduction)", () => {
+  it("partitions partial-success porcelain stdout into deleted + rejected (issue #179 reproduction)", () => {
     spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
-    const stderr = [
+    const stdout = [
       "To github.com:owner/repo.git",
-      " - [deleted]         handoff/dotclaude/claude/2026-04/98d26b79",
-      " - [deleted]         handoff/dotclaude/claude/2026-05/00837a18",
-      " - [deleted]         handoff/squadranks/claude/2026-05/d6243fc6",
-      " ! [remote rejected] handoff/dotclaude/claude/2026-04/3668f1d7 (refusing to delete the current branch: refs/heads/handoff/dotclaude/claude/2026-04/3668f1d7)",
-      "error: failed to push some refs to 'github.com:owner/repo.git'",
+      "-\t:refs/heads/handoff/dotclaude/claude/2026-04/98d26b79\t[deleted]",
+      "-\t:refs/heads/handoff/dotclaude/claude/2026-05/00837a18\t[deleted]",
+      "-\t:refs/heads/handoff/squadranks/claude/2026-05/d6243fc6\t[deleted]",
+      "!\t:refs/heads/handoff/dotclaude/claude/2026-04/3668f1d7\t[remote rejected] (refusing to delete the current branch: refs/heads/handoff/dotclaude/claude/2026-04/3668f1d7)",
+      "Done",
     ].join("\n");
-    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr });
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout,
+      stderr: "error: failed to push some refs to 'github.com:owner/repo.git'",
+    });
     const r = lib.deleteRemoteBranches("https://x.test/repo.git", [
       "handoff/dotclaude/claude/2026-04/3668f1d7",
       "handoff/dotclaude/claude/2026-04/98d26b79",
@@ -1362,14 +1367,37 @@ describe("deleteRemoteBranches", () => {
     expect(r.failures[0].reason).toMatch(/refusing to delete the current branch/);
   });
 
-  it("retries unparsed branches per-ref and merges the retry outcome", () => {
-    // git init
-    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
-    // batched push: A is classified as deleted, B is missing from stderr.
+  it("falls back to stderr parsing when porcelain stdout is missing (older git)", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
+    // No porcelain output (older git that ignores --porcelain), human stderr present.
     spawnSync.mockReturnValueOnce({
       status: 1,
       stdout: "",
-      stderr: " - [deleted]         handoff/p/claude/2026-01/aaaaaaaa\n",
+      stderr: [
+        "To github.com:owner/repo.git",
+        " - [deleted]         handoff/p/claude/2026-01/aaaaaaaa",
+        " ! [remote rejected] handoff/p/claude/2026-01/bbbbbbbb (refusing to delete the current branch)",
+        "error: failed to push some refs",
+      ].join("\n"),
+    });
+    const r = lib.deleteRemoteBranches("https://x.test/repo.git", [
+      "handoff/p/claude/2026-01/aaaaaaaa",
+      "handoff/p/claude/2026-01/bbbbbbbb",
+    ]);
+    expect(r.deleted).toEqual(["handoff/p/claude/2026-01/aaaaaaaa"]);
+    expect(r.failures).toHaveLength(1);
+    expect(r.failures[0].branch).toBe("handoff/p/claude/2026-01/bbbbbbbb");
+    expect(r.failures[0].reason).toMatch(/refusing to delete the current branch/);
+  });
+
+  it("retries unparsed branches per-ref and merges the retry outcome", () => {
+    // git init
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    // batched push: A classified as deleted via porcelain, B missing entirely.
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout: "-\t:refs/heads/handoff/p/claude/2026-01/aaaaaaaa\t[deleted]\n",
+      stderr: "",
     });
     // per-ref retry for B succeeds.
     spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
@@ -1388,14 +1416,15 @@ describe("deleteRemoteBranches", () => {
     spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
     spawnSync.mockReturnValueOnce({
       status: 1,
-      stdout: "",
-      stderr: " - [deleted]         handoff/p/claude/2026-01/aaaaaaaa\n",
+      stdout: "-\t:refs/heads/handoff/p/claude/2026-01/aaaaaaaa\t[deleted]\n",
+      stderr: "",
     });
+    // Per-ref retry for B fails with a porcelain-shaped rejection.
     spawnSync.mockReturnValueOnce({
       status: 1,
-      stdout: "",
-      stderr:
-        "remote: pre-receive hook declined\nTo github.com:owner/repo.git\n ! [remote rejected] handoff/p/claude/2026-01/bbbbbbbb (pre-receive hook declined)\nerror: failed to push some refs",
+      stdout:
+        "!\t:refs/heads/handoff/p/claude/2026-01/bbbbbbbb\t[remote rejected] (pre-receive hook declined)\n",
+      stderr: "error: failed to push some refs",
     });
     const r = lib.deleteRemoteBranches("https://x.test/repo.git", [
       "handoff/p/claude/2026-01/aaaaaaaa",
@@ -1412,6 +1441,40 @@ describe("deleteRemoteBranches", () => {
   it("throws when git init fails", () => {
     spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "disk full" });
     expect(() => lib.deleteRemoteBranches("url", ["handoff/x"])).toThrow(/git init failed/);
+  });
+});
+
+describe("parsePushDeletePorcelain", () => {
+  it("classifies tab-delimited per-ref status lines", () => {
+    const stdout = [
+      "To github.com:owner/repo.git",
+      "-\t:refs/heads/handoff/x/claude/2026-01/aaaaaaaa\t[deleted]",
+      "!\t:refs/heads/handoff/x/claude/2026-01/bbbbbbbb\t[remote rejected] (default branch protected)",
+      "!\t:refs/heads/handoff/x/claude/2026-01/cccccccc\t[rejected] (non-fast-forward)",
+      "!\t:refs/heads/handoff/x/claude/2026-01/dddddddd\t[error] (hook declined)",
+      "Done",
+    ].join("\n");
+    const r = lib.parsePushDeletePorcelain(stdout, [
+      "handoff/x/claude/2026-01/aaaaaaaa",
+      "handoff/x/claude/2026-01/bbbbbbbb",
+      "handoff/x/claude/2026-01/cccccccc",
+      "handoff/x/claude/2026-01/dddddddd",
+      "handoff/x/claude/2026-01/eeeeeeee",
+    ]);
+    expect(r.deleted).toEqual(["handoff/x/claude/2026-01/aaaaaaaa"]);
+    expect(r.failures.map((f) => [f.branch, f.reason])).toEqual([
+      ["handoff/x/claude/2026-01/bbbbbbbb", "default branch protected"],
+      ["handoff/x/claude/2026-01/cccccccc", "non-fast-forward"],
+      ["handoff/x/claude/2026-01/dddddddd", "hook declined"],
+    ]);
+    expect(r.unclassified).toEqual(["handoff/x/claude/2026-01/eeeeeeee"]);
+  });
+
+  it("returns all branches as unclassified for empty stdout", () => {
+    const r = lib.parsePushDeletePorcelain("", ["handoff/x/claude/2026-01/aaaaaaaa"]);
+    expect(r.deleted).toEqual([]);
+    expect(r.failures).toEqual([]);
+    expect(r.unclassified).toEqual(["handoff/x/claude/2026-01/aaaaaaaa"]);
   });
 });
 

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -1310,8 +1310,16 @@ describe("deleteRemoteBranches", () => {
     expect(pushCall[1]).toContain("refs/heads/handoff/p/claude/2026-01/bbbbbbbb");
   });
 
-  it("reports per-branch failures with redacted URLs on push error", () => {
+  it("falls back to legacy all-failed report with redacted URLs when stderr matches no per-ref status (and parser-driven retry also fails)", () => {
+    // git init
     spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    // batched push --delete: total auth failure, no per-ref status lines.
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout: "",
+      stderr: "fatal: unable to access 'https://user:tok@x.test/repo.git/': denied",
+    });
+    // per-ref retry: same auth error.
     spawnSync.mockReturnValueOnce({
       status: 1,
       stdout: "",
@@ -1327,9 +1335,116 @@ describe("deleteRemoteBranches", () => {
     expect(r.failures[0].reason).toMatch(/\*\*\*@/);
   });
 
+  it("partitions partial-success stderr into deleted + rejected (issue #179 reproduction)", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
+    const stderr = [
+      "To github.com:owner/repo.git",
+      " - [deleted]         handoff/dotclaude/claude/2026-04/98d26b79",
+      " - [deleted]         handoff/dotclaude/claude/2026-05/00837a18",
+      " - [deleted]         handoff/squadranks/claude/2026-05/d6243fc6",
+      " ! [remote rejected] handoff/dotclaude/claude/2026-04/3668f1d7 (refusing to delete the current branch: refs/heads/handoff/dotclaude/claude/2026-04/3668f1d7)",
+      "error: failed to push some refs to 'github.com:owner/repo.git'",
+    ].join("\n");
+    spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr });
+    const r = lib.deleteRemoteBranches("https://x.test/repo.git", [
+      "handoff/dotclaude/claude/2026-04/3668f1d7",
+      "handoff/dotclaude/claude/2026-04/98d26b79",
+      "handoff/dotclaude/claude/2026-05/00837a18",
+      "handoff/squadranks/claude/2026-05/d6243fc6",
+    ]);
+    expect(r.deleted.sort()).toEqual([
+      "handoff/dotclaude/claude/2026-04/98d26b79",
+      "handoff/dotclaude/claude/2026-05/00837a18",
+      "handoff/squadranks/claude/2026-05/d6243fc6",
+    ]);
+    expect(r.failures).toHaveLength(1);
+    expect(r.failures[0].branch).toBe("handoff/dotclaude/claude/2026-04/3668f1d7");
+    expect(r.failures[0].reason).toMatch(/refusing to delete the current branch/);
+  });
+
+  it("retries unparsed branches per-ref and merges the retry outcome", () => {
+    // git init
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    // batched push: A is classified as deleted, B is missing from stderr.
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout: "",
+      stderr: " - [deleted]         handoff/p/claude/2026-01/aaaaaaaa\n",
+    });
+    // per-ref retry for B succeeds.
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    const r = lib.deleteRemoteBranches("https://x.test/repo.git", [
+      "handoff/p/claude/2026-01/aaaaaaaa",
+      "handoff/p/claude/2026-01/bbbbbbbb",
+    ]);
+    expect(r.deleted.sort()).toEqual([
+      "handoff/p/claude/2026-01/aaaaaaaa",
+      "handoff/p/claude/2026-01/bbbbbbbb",
+    ]);
+    expect(r.failures).toEqual([]);
+  });
+
+  it("retries unparsed branches per-ref and reports a single-line reason on retry failure", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // init
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout: "",
+      stderr: " - [deleted]         handoff/p/claude/2026-01/aaaaaaaa\n",
+    });
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout: "",
+      stderr:
+        "remote: pre-receive hook declined\nTo github.com:owner/repo.git\n ! [remote rejected] handoff/p/claude/2026-01/bbbbbbbb (pre-receive hook declined)\nerror: failed to push some refs",
+    });
+    const r = lib.deleteRemoteBranches("https://x.test/repo.git", [
+      "handoff/p/claude/2026-01/aaaaaaaa",
+      "handoff/p/claude/2026-01/bbbbbbbb",
+    ]);
+    expect(r.deleted).toEqual(["handoff/p/claude/2026-01/aaaaaaaa"]);
+    expect(r.failures).toHaveLength(1);
+    expect(r.failures[0].branch).toBe("handoff/p/claude/2026-01/bbbbbbbb");
+    expect(r.failures[0].reason).toBe("pre-receive hook declined");
+    // Reason must be single-line so the renderer cannot duplicate a multi-line block.
+    expect(r.failures[0].reason).not.toMatch(/\n/);
+  });
+
   it("throws when git init fails", () => {
     spawnSync.mockReturnValueOnce({ status: 1, stdout: "", stderr: "disk full" });
     expect(() => lib.deleteRemoteBranches("url", ["handoff/x"])).toThrow(/git init failed/);
+  });
+});
+
+describe("parsePushDeleteStderr", () => {
+  it("classifies each line shape and reports unmatched branches as unclassified", () => {
+    const stderr = [
+      "To github.com:owner/repo.git",
+      " - [deleted]         handoff/x/claude/2026-01/aaaaaaaa",
+      " ! [remote rejected] handoff/x/claude/2026-01/bbbbbbbb (default branch protected)",
+      " ! [rejected]        handoff/x/claude/2026-01/cccccccc (non-fast-forward)",
+      " ! [error]           handoff/x/claude/2026-01/dddddddd (hook declined)",
+    ].join("\n");
+    const r = lib.parsePushDeleteStderr(stderr, [
+      "handoff/x/claude/2026-01/aaaaaaaa",
+      "handoff/x/claude/2026-01/bbbbbbbb",
+      "handoff/x/claude/2026-01/cccccccc",
+      "handoff/x/claude/2026-01/dddddddd",
+      "handoff/x/claude/2026-01/eeeeeeee",
+    ]);
+    expect(r.deleted).toEqual(["handoff/x/claude/2026-01/aaaaaaaa"]);
+    expect(r.failures.map((f) => [f.branch, f.reason])).toEqual([
+      ["handoff/x/claude/2026-01/bbbbbbbb", "default branch protected"],
+      ["handoff/x/claude/2026-01/cccccccc", "non-fast-forward"],
+      ["handoff/x/claude/2026-01/dddddddd", "hook declined"],
+    ]);
+    expect(r.unclassified).toEqual(["handoff/x/claude/2026-01/eeeeeeee"]);
+  });
+
+  it("returns all branches as unclassified for empty stderr", () => {
+    const r = lib.parsePushDeleteStderr("", ["handoff/x/claude/2026-01/aaaaaaaa"]);
+    expect(r.deleted).toEqual([]);
+    expect(r.failures).toEqual([]);
+    expect(r.unclassified).toEqual(["handoff/x/claude/2026-01/aaaaaaaa"]);
   });
 });
 

--- a/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
@@ -41,6 +41,7 @@ describe("export shape", () => {
     "PRUNE_SKIP_BUCKETS",
     "parseDuration",
     "parseHandoffBranch",
+    "parsePushDeleteStderr",
     "parseTagsFromDescription",
     "printManualSetupBlock",
     "probeCollision",

--- a/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
@@ -41,6 +41,7 @@ describe("export shape", () => {
     "PRUNE_SKIP_BUCKETS",
     "parseDuration",
     "parseHandoffBranch",
+    "parsePushDeletePorcelain",
     "parsePushDeleteStderr",
     "parseTagsFromDescription",
     "printManualSetupBlock",


### PR DESCRIPTION
## Summary

- Add `parsePushDeleteStderr(stderr, branches)` that partitions a `git push --delete` stderr into per-ref outcomes (`[deleted]`, `[remote rejected]`, `[rejected]`, `[error]`). Branches matched by no line are returned as `unclassified` for retry.
- `deleteRemoteBranches` now calls the parser on non-zero exit, runs a bounded per-ref retry for unclassified branches, and only falls back to the legacy "all-failed with raw stderr" report when the parser produces no signal at all.
- `renderPruneResult` single-lines each `f.reason` defensively so a multi-line reason can never re-introduce the duplicated-block symptom.

Closes #179.

## Test plan

- [x] `npx vitest run plugins/dotclaude/tests/handoff-remote-coverage.test.mjs` — 125 tests pass, including 4 new cases (partial-success repro of #179, per-ref retry success, per-ref retry failure with single-line reason, empty-partition fallback) plus a `parsePushDeleteStderr` unit test.
- [x] `npm test` — 567 / 567 pass across 38 files.
- [x] `npm run lint` — prettier + markdownlint + jsdoc-coverage all clean.
- [x] `npx prettier@3 --check` on modified files — clean.
- [ ] End-to-end smoke against a transport repo with one undeletable default ref (manual verification, requires write to a real handoff store; deferred to merge time).

## No-spec rationale

Bug fix in an existing skill (`handoff`) — no architectural change, no public API change. The fix is local to `deleteRemoteBranches` plus a defensive renderer clamp; existing tests carry the contract.
