### PR TITLE
fix(handoff): seed main as transport repo default during bootstrap

### DIFF
--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -477,6 +477,79 @@ export async function promptLine(message) {
 }
 
 /**
+ * Ensure the transport repo has `main` as its default branch so the first
+ * handoff push doesn't get pinned as HEAD (issue #180). Idempotent: safe
+ * to run on a fresh repo, an already-seeded repo, or a buggy repo whose
+ * current default is a `handoff/*` ref.
+ *
+ * Steps:
+ *   1. Probe `git ls-remote --heads <url> refs/heads/main`. If absent,
+ *      build an inert `main` in a tmp repo (init -b main, README, commit,
+ *      push) so the next step has a valid target.
+ *   2. PATCH the GitHub repo's default_branch to `main` unconditionally.
+ *      The PATCH is the remediation hook for already-bootstrapped buggy
+ *      repos that already have `main` but still default to a handoff ref.
+ *
+ * The PATCH is non-fatal: a failed flip leaves the repo functional but
+ * still bug-prone, so we surface a one-line warning and let the caller
+ * print remediation steps. Push failure is fatal — without `main` the
+ * default-branch flip would silently target a missing ref.
+ *
+ * @param {string} login    GitHub username from `gh api user`
+ * @param {string} name     repo name (e.g. "dotclaude-handoff-store")
+ * @param {string} repoUrl  ssh URL from `gh repo view`
+ * @returns {{ seeded: boolean, defaultBranchPatched: boolean, warning?: string }}
+ */
+export function seedTransportDefaultBranch(login, name, repoUrl) {
+  let seeded = false;
+  const probe = runGit(["ls-remote", "--heads", repoUrl, "refs/heads/main"], process.cwd());
+  if (probe.status !== 0 || !probe.stdout.trim()) {
+    const tmp = mkdtempSync(join(tmpdir(), "handoff-bootstrap-seed-"));
+    try {
+      runGitOrThrow(["init", "-q", "-b", "main"], tmp);
+      writeFileSync(
+        join(tmp, "README.md"),
+        "# dotclaude handoff transport store\n\nManaged by `dotclaude handoff`. Do not edit by hand.\n",
+      );
+      runGitOrThrow(["add", "README.md"], tmp);
+      runGitOrThrow(
+        [
+          "-c",
+          "user.email=dotclaude@local",
+          "-c",
+          "user.name=dotclaude",
+          "commit",
+          "-m",
+          "chore: seed default branch",
+          "-q",
+        ],
+        tmp,
+      );
+      runGitOrThrow(["push", "-q", repoUrl, "main"], tmp);
+      seeded = true;
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+  const patch = spawnSync(
+    "gh",
+    ["api", "-X", "PATCH", `repos/${login}/${name}`, "-f", "default_branch=main"],
+    { encoding: "utf8" },
+  );
+  if (patch.status !== 0) {
+    const detail =
+      (patch.stderr || patch.stdout || "").trim().split("\n")[0] ||
+      `gh exited ${patch.status ?? "?"}`;
+    return {
+      seeded,
+      defaultBranchPatched: false,
+      warning: `could not set default branch to main (${detail}); run \`gh api -X PATCH repos/${login}/${name} -f default_branch=main\` to remediate`,
+    };
+  }
+  return { seeded, defaultBranchPatched: true };
+}
+
+/**
  * Interactively create a private GitHub repo for handoff storage via `gh`.
  * Writes the URL to the persisted env file and sets DOTCLAUDE_HANDOFF_REPO.
  * Exits 2 with a manual-setup block when non-TTY, gh missing, or user aborts.
@@ -565,6 +638,20 @@ export async function bootstrapTransportRepo() {
     view.status === 0 && view.stdout.trim()
       ? view.stdout.trim()
       : `git@github.com:${login}/${name}.git`;
+
+  // Seed `main` as the default branch BEFORE any handoff push lands, so
+  // GitHub doesn't pin the first handoff ref as HEAD (issue #180).
+  // Idempotent — re-running bootstrap on a buggy already-bootstrapped
+  // repo also remediates it.
+  const seed = seedTransportDefaultBranch(login, name, url);
+  if (seed.seeded) {
+    process.stderr.write("  ✓ seeded `main` as default branch\n");
+  } else {
+    process.stderr.write("  ✓ default branch already initialized\n");
+  }
+  if (seed.warning) {
+    process.stderr.write(`  ⚠ ${seed.warning}\n`);
+  }
 
   mkdirSync(currentConfigDir(), { recursive: true, mode: 0o700 });
   writeFileSync(

--- a/plugins/dotclaude/src/lib/handoff-remote.mjs
+++ b/plugins/dotclaude/src/lib/handoff-remote.mjs
@@ -518,6 +518,8 @@ export function seedTransportDefaultBranch(login, name, repoUrl) {
           "user.email=dotclaude@local",
           "-c",
           "user.name=dotclaude",
+          "-c",
+          "commit.gpgsign=false",
           "commit",
           "-m",
           "chore: seed default branch",

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -1511,6 +1511,98 @@ describe("parsePushDeleteStderr", () => {
   });
 });
 
+// ---- seedTransportDefaultBranch ---------------------------------------
+
+describe("seedTransportDefaultBranch", () => {
+  beforeEach(() => {
+    spawnSync.mockReset();
+    mkdtempSync.mockReset().mockReturnValue("/tmp/mock-seed");
+  });
+
+  it("no-ops the seed when main already exists on the remote and PATCHes default to main", () => {
+    // ls-remote: main exists.
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "abcdef0123456789abcdef0123456789abcdef01\trefs/heads/main\n",
+      stderr: "",
+    });
+    // gh api PATCH: success.
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    const r = lib.seedTransportDefaultBranch("alice", "store", "git@github.com:alice/store.git");
+    expect(r).toEqual({ seeded: false, defaultBranchPatched: true });
+    // Two spawns total (no init/add/commit/push).
+    expect(spawnSync).toHaveBeenCalledTimes(2);
+    const cmds = spawnSync.mock.calls.map((c) => `${c[0]} ${c[1].slice(0, 2).join(" ")}`);
+    expect(cmds[0]).toMatch(/^git ls-remote/);
+    expect(cmds[1]).toMatch(/^gh api/);
+  });
+
+  it("seeds main via init/add/commit/push when ls-remote returns no refs, then PATCHes default", () => {
+    // ls-remote: empty stdout.
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    // git init -b main
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    // git add README.md
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    // git commit
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    // git push
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    // gh api PATCH
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    const r = lib.seedTransportDefaultBranch("alice", "store", "git@github.com:alice/store.git");
+    expect(r).toEqual({ seeded: true, defaultBranchPatched: true });
+    const initCall = spawnSync.mock.calls.find(
+      (c) => c[0] === "git" && Array.isArray(c[1]) && c[1].includes("init"),
+    );
+    expect(initCall[1]).toContain("-b");
+    expect(initCall[1]).toContain("main");
+    const pushCall = spawnSync.mock.calls.find(
+      (c) => c[0] === "git" && Array.isArray(c[1]) && c[1][0] === "push",
+    );
+    expect(pushCall[1]).toContain("git@github.com:alice/store.git");
+    expect(pushCall[1]).toContain("main");
+    const patchCall = spawnSync.mock.calls.find(
+      (c) => c[0] === "gh" && Array.isArray(c[1]) && c[1].includes("PATCH"),
+    );
+    expect(patchCall[1]).toContain("repos/alice/store");
+    expect(patchCall[1]).toContain("default_branch=main");
+  });
+
+  it("returns a warning instead of throwing when the gh PATCH fails", () => {
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "abcdef0123456789abcdef0123456789abcdef01\trefs/heads/main\n",
+      stderr: "",
+    });
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout: "",
+      stderr: "HTTP 403: Resource not accessible by integration",
+    });
+    const r = lib.seedTransportDefaultBranch("alice", "store", "git@github.com:alice/store.git");
+    expect(r.seeded).toBe(false);
+    expect(r.defaultBranchPatched).toBe(false);
+    expect(r.warning).toMatch(/could not set default branch to main/);
+    expect(r.warning).toMatch(/repos\/alice\/store/);
+  });
+
+  it("throws when push of seeded main fails (cannot establish main on remote)", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // ls-remote empty
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // git init
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // git add
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // git commit
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout: "",
+      stderr: "fatal: unable to access remote",
+    });
+    expect(() =>
+      lib.seedTransportDefaultBranch("alice", "store", "git@github.com:alice/store.git"),
+    ).toThrow(/git push.*main.*failed/);
+  });
+});
+
 // ---- probeCollision ----------------------------------------------------
 
 describe("probeCollision", () => {

--- a/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-coverage.test.mjs
@@ -1601,6 +1601,45 @@ describe("seedTransportDefaultBranch", () => {
       lib.seedTransportDefaultBranch("alice", "store", "git@github.com:alice/store.git"),
     ).toThrow(/git push.*main.*failed/);
   });
+
+  it("treats ls-remote non-zero exit as 'no main' and seeds (covers probe.status !== 0 branch)", () => {
+    // ls-remote: failed (e.g. transient transport error before HEAD probe).
+    spawnSync.mockReturnValueOnce({ status: 128, stdout: "", stderr: "remote helper hiccup" });
+    // Full seed sequence then PATCH success.
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // git init
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // git add
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // git commit
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // git push
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" }); // gh PATCH
+    const r = lib.seedTransportDefaultBranch("alice", "store", "git@github.com:alice/store.git");
+    expect(r).toEqual({ seeded: true, defaultBranchPatched: true });
+  });
+
+  it("falls back to stdout then to 'gh exited <status>' when PATCH stderr is empty", () => {
+    // Case A: stderr empty, stdout has the message.
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "abcdef0123456789abcdef0123456789abcdef01\trefs/heads/main\n",
+      stderr: "",
+    });
+    spawnSync.mockReturnValueOnce({
+      status: 1,
+      stdout: "could not change repo settings\n",
+      stderr: "",
+    });
+    const a = lib.seedTransportDefaultBranch("alice", "store", "git@github.com:alice/store.git");
+    expect(a.warning).toMatch(/could not change repo settings/);
+
+    // Case B: both empty — falls through to "gh exited <status>".
+    spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: "abcdef0123456789abcdef0123456789abcdef01\trefs/heads/main\n",
+      stderr: "",
+    });
+    spawnSync.mockReturnValueOnce({ status: 7, stdout: "", stderr: "" });
+    const b = lib.seedTransportDefaultBranch("alice", "store", "git@github.com:alice/store.git");
+    expect(b.warning).toMatch(/gh exited 7/);
+  });
 });
 
 // ---- probeCollision ----------------------------------------------------

--- a/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotclaude/tests/handoff-remote-lib.test.mjs
@@ -56,6 +56,7 @@ describe("export shape", () => {
     "runGit",
     "runGitOrThrow",
     "runScript",
+    "seedTransportDefaultBranch",
     "slugify",
     "slugifyRepoName",
     "tagsFromMeta",


### PR DESCRIPTION
## Summary

- Add `seedTransportDefaultBranch(login, name, repoUrl)` that ensures the transport repo has `main` as its default branch before any handoff push lands.
- Call it from `bootstrapTransportRepo` after the create-or-reuse branch. Idempotent on every invocation, so re-running bootstrap also remediates already-bootstrapped buggy repos.
- PATCH failure is non-fatal (returns a warning + remediation command); push failure is fatal so we never flip the default to a missing ref.

Closes #180.

## Test plan

- [x] `npx vitest run plugins/dotclaude/tests/handoff-remote-coverage.test.mjs plugins/dotclaude/tests/handoff-remote-lib.test.mjs` — 183 tests pass, including 4 new cases for the seed helper (probe-found-main no-op, full seed sequence, PATCH-failure warning, push-failure throws).
- [x] `npm test` — 574 / 574 across 38 files.
- [x] `npm run lint` — prettier + markdownlint + jsdoc-coverage all clean.
- [x] `npx prettier@3 --check` on modified files — clean.
- [ ] End-to-end smoke: unset DOTCLAUDE_HANDOFF_REPO, run `dotclaude handoff push --from claude` to trigger interactive bootstrap, then `gh repo view <login>/<name> --json defaultBranchRef -q .defaultBranchRef.name` reports `main` and a subsequent `prune --older-than 0d --yes` of the just-pushed branch deletes cleanly. Manual; deferred to merge time.

## No-spec rationale

Bug fix in an existing skill (`handoff`) — no architectural change, no public API change beyond an internal helper export. The fix is local to `bootstrapTransportRepo`; existing tests carry the contract for the rest of the file.