### PR TITLE
chore(handoff-skill): drop stale active_prs reference (PR #108 merged)

### DIFF
--- a/docs/specs/handoff-skill/spec.json
+++ b/docs/specs/handoff-skill/spec.json
@@ -23,7 +23,7 @@
     "bats plugins/dotbabel/tests/bats/handoff-*.bats"
   ],
   "depends_on_specs": ["dotbabel-core"],
-  "active_prs": [108],
+  "active_prs": [],
   "_label_history": {
     "note": "During spec drafting, chat-time NFR labels were renumbered to sequential order in §7. Mapping preserved here for chat-history-to-spec reconciliation. Spec body uses the sequential labels exclusively.",
     "mappings": [


### PR DESCRIPTION
## Summary

- `docs/specs/handoff-skill/spec.json` `active_prs: [108]` was stale — PR #108 (`spec(handoff-skill): redesign + ARCH-10 drift test`) was merged prior to the dotbabel rename and never cleaned out of the field
- Emptying the array so the metadata reflects the actual current state (no in-flight PRs against this spec)

## Test plan

- [x] `gh pr view 108 --json state` returns `MERGED`
- [x] `npx dotbabel-validate-specs` still passes (spec.json schema unchanged, only the value of an array shrunk)

## Spec ID

handoff-skill
