### PR TITLE
ci(release): switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,9 @@ jobs:
       - run: npm test
       - run: bash plugins/dotbabel/tests/test_validate_settings.sh
 
-      - name: Publish to npm with provenance
+      # Trusted Publishing: npm CLI auto-detects the GitHub Actions OIDC env
+      # and exchanges it for a short-lived publish token. No NPM_TOKEN secret
+      # is required as long as the @dotbabel org (or this package) has a
+      # Trusted Publisher configured for kaiohenricunha/dotbabel + release.yml.
+      - name: Publish to npm with provenance (Trusted Publishing / OIDC)
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Drops `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from `release.yml` and switches the publish step to Trusted Publishing (npm OIDC)
- Same workflow already has `id-token: write` permission (for provenance), so no permissions change needed
- After merge, future releases publish via short-lived OIDC tokens — no static secret required

## Context

`@dotbabel/dotbabel@2.0.0` was published manually from the maintainer's terminal (the original CI publish failed with `EOTP` because granular tokens can't bypass 2FA on first-publish for a new scope, even with "Authorization only" mode, when a security key is registered). This PR wires up the proper modern path so future releases go through CI cleanly.

## Required operator action BEFORE merging

On https://www.npmjs.com/package/@dotbabel/dotbabel/access (or the equivalent org-level Trusted Publishers page):

1. Find **Trusted Publishers** section
2. **Add publisher**:
   - **Provider**: GitHub Actions
   - **Repository owner**: `kaiohenricunha`
   - **Repository name**: `dotbabel`
   - **Workflow filename**: `release.yml`
   - **Environment**: leave blank
3. Save

If that's not configured, the next release tag's CI run fails on auth. Easy to roll back (revert this PR + restore NPM_TOKEN flow) if needed.

## After merge (cleanup)

- Delete the `NPM_TOKEN` repository secret (no longer used)
- Revoke the granular token `dotbabel-ci-publish` on npm (it leaked in a screenshot during the manual-publish dance)

## Test plan

- [x] No code changes — workflow file only; `npm test` / `npm run lint` etc. all unaffected
- [ ] Manual verification on next release: tag `v2.0.x` is created → `release.yml` job succeeds and publishes via OIDC

## Spec ID

dotbabel-core
