### PR TITLE
chore(pages): add CNAME for dotbabel.dev (schema hosting)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+dotbabel.dev


### PR DESCRIPTION
## Summary

- Adds `CNAME` at repo root with content `dotbabel.dev` so GitHub Pages will serve the repo on the custom domain
- After merge, enable Pages in repo Settings → Pages: Source = "Deploy from a branch", Branch = `main`, Folder = `/` (root)
- After Cloudflare DNS records are pointed at GitHub Pages anycast IPs, schema `$id` URLs declared in `schemas/*.schema.json` and `plugins/dotbabel/src/build-index.mjs` will resolve

## Why root, not `/schemas`

GitHub Pages only supports `/` or `/docs` as the publish source path. Putting CNAME in `/schemas` doesn't work. Source = `/` serves the entire public repo, including the README as the landing page (Jekyll-rendered) and the schemas under `/schemas/`. The repo is public anyway, so no information disclosure concern.

## URL contract after deploy

| Request | Resolves to |
|---|---|
| `https://dotbabel.dev/schemas/skill.schema.json` | `schemas/skill.schema.json` JSON content |
| `https://dotbabel.dev/schemas/<n>.schema.json` (other 8) | corresponding schema file |
| `https://dotbabel.dev/` | README rendered as HTML (free landing page) |

## Test plan

- [x] No code paths changed — CNAME-only commit; tests/lint unaffected
- [ ] Manual after merge: enable Pages + configure DNS, then `curl -I https://dotbabel.dev/schemas/skill.schema.json` returns HTTP/2 200 with `content-type: application/json`

## Spec ID

dotbabel-core
