### PR TITLE
fix(readme): align lead description with model-agnostic positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 
 > Maintained by [@kaiohenricunha](https://github.com/kaiohenricunha) · [Changelog](./CHANGELOG.md) · [Security](./SECURITY.md)
 
-An opinionated Claude Code toolkit. Ships a curated library of skills,
-slash commands, and cloud/IaC specialists plus a global rule floor that
-hardens every Claude Code session — and an optional spec-driven-development
+An opinionated, model-agnostic governance toolkit for Claude Code, Codex,
+Gemini CLI, Copilot CLI, and other agentic CLIs. Ships a curated library of
+skills, slash commands, and cloud/IaC specialists plus a global rule floor
+that hardens every agent session — and an optional spec-driven-development
 governance CLI on top, for repos that want PR-time gates.
 
 **Who is this for?**


### PR DESCRIPTION
## Summary

- The README's lead paragraph still described dotbabel as "An opinionated Claude Code toolkit" — drift from the model-agnostic positioning that motivated the 2.0.0 rename
- `package.json` description was updated correctly during the rename ("model-agnostic governance toolkit for Claude Code, Codex, Gemini, and other agentic CLIs"); the README's lead missed it
- Updated to match. Phrasing kept close to `package.json` so the two stay in sync going forward
- Generalized "Claude Code session" → "agent session" since the global rule floor (CLAUDE.md, hooks, etc.) applies to any agentic CLI

## Diff

Before:
```
An opinionated Claude Code toolkit. Ships a curated library of skills,
slash commands, and cloud/IaC specialists plus a global rule floor that
hardens every Claude Code session — and an optional spec-driven-development
governance CLI on top, for repos that want PR-time gates.
```

After:
```
An opinionated, model-agnostic governance toolkit for Claude Code, Codex,
Gemini CLI, Copilot CLI, and other agentic CLIs. Ships a curated library of
skills, slash commands, and cloud/IaC specialists plus a global rule floor
that hardens every agent session — and an optional spec-driven-development
governance CLI on top, for repos that want PR-time gates.
```

## Test plan

- [x] No code changes — README only; lint/tests unaffected
- [x] `package.json` description and README lead now align
- [ ] On merge: release-please picks up the `fix:` commit, queues a 2.0.1 release PR. Merging that release PR triggers `release.yml` which validates the new Trusted Publishing / OIDC flow on a real release (first OIDC-driven publish since the auth path changed in PR #190)

## Why this also serves as the OIDC verification

The 2.0.0 publish was done manually from a logged-in terminal because the original CI run was blocked by the auth gymnastics. PR #190 switched CI to OIDC but no release tag has fired through that path yet. This `fix:` is a legitimate scope-correcting change AND happens to be the smallest reasonable trigger for a 2.0.1 release that proves the OIDC flow works end-to-end.

## Spec ID

dotbabel-core
