### PR TITLE
ci(release): use npm 11 for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, for example v2.1.0"
+        required: true
+        type: string
 
 # npm provenance requires the id-token permission. GitHub Release creation is
 # handled by release-please; contents: read is sufficient here.
@@ -16,18 +22,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref_name }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Use npm 11 for Trusted Publishing
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
+
       - run: npm ci
       - name: Verify tag matches package.json version
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           PKG=$(node -p "require('./package.json').version")
-          TAG="${GITHUB_REF_NAME#v}"
+          TAG="${RELEASE_TAG#v}"
           if [ "$PKG" != "$TAG" ]; then
             echo "::error::tag $TAG does not match package.json version $PKG"
             exit 1
@@ -35,9 +50,9 @@ jobs:
       - run: npm test
       - run: bash plugins/dotbabel/tests/test_validate_settings.sh
 
-      # Trusted Publishing: npm CLI auto-detects the GitHub Actions OIDC env
-      # and exchanges it for a short-lived publish token. No NPM_TOKEN secret
-      # is required as long as the @dotbabel org (or this package) has a
+      # Trusted Publishing: npm CLI 11.5.1+ auto-detects the GitHub Actions
+      # OIDC env and exchanges it for a short-lived publish token. No NPM_TOKEN
+      # secret is required as long as the @dotbabel org (or this package) has a
       # Trusted Publisher configured for kaiohenricunha/dotbabel + release.yml.
       - name: Publish to npm with provenance (Trusted Publishing / OIDC)
         run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,42 +12,37 @@ preserved verbatim because they describe state at the time of release.
 
 ## [2.1.0](https://github.com/kaiohenricunha/dotbabel/compare/v2.0.1...v2.1.0) (2026-05-07)
 
-
 ### Added
 
-* **plan-grader:** add reusable plan grader skill ([#194](https://github.com/kaiohenricunha/dotbabel/issues/194)) ([78bd8cc](https://github.com/kaiohenricunha/dotbabel/commit/78bd8cc76286eb731bf4c44b8f82088c8c48ddc2))
+- **plan-grader:** add reusable plan grader skill ([#194](https://github.com/kaiohenricunha/dotbabel/issues/194)) ([78bd8cc](https://github.com/kaiohenricunha/dotbabel/commit/78bd8cc76286eb731bf4c44b8f82088c8c48ddc2))
 
 ## [2.0.1](https://github.com/kaiohenricunha/dotbabel/compare/v2.0.0...v2.0.1) (2026-05-07)
 
-
 ### Fixed
 
-* **readme:** align lead description with model-agnostic positioning ([#192](https://github.com/kaiohenricunha/dotbabel/issues/192)) ([270a394](https://github.com/kaiohenricunha/dotbabel/commit/270a39400b08fa92a49c5d763d38aa7bed8915d0))
+- **readme:** align lead description with model-agnostic positioning ([#192](https://github.com/kaiohenricunha/dotbabel/issues/192)) ([270a394](https://github.com/kaiohenricunha/dotbabel/commit/270a39400b08fa92a49c5d763d38aa7bed8915d0))
 
 ## [2.0.0](https://github.com/kaiohenricunha/dotbabel/compare/v1.3.0...v2.0.0) (2026-05-06)
 
-
 ### ⚠ BREAKING CHANGES
 
-* rename project from dotclaude to dotbabel ([#186](https://github.com/kaiohenricunha/dotbabel/issues/186))
+- rename project from dotclaude to dotbabel ([#186](https://github.com/kaiohenricunha/dotbabel/issues/186))
 
 ### Added
 
-* **core:** migrate complex commands to skills ([#177](https://github.com/kaiohenricunha/dotbabel/issues/177)) ([13c105e](https://github.com/kaiohenricunha/dotbabel/commit/13c105e644be6f20bb446c0cd37a857dfaa2f7a9))
-* **handoff:** implement Gemini support ([#185](https://github.com/kaiohenricunha/dotbabel/issues/185)) ([1234b60](https://github.com/kaiohenricunha/dotbabel/commit/1234b6013109deba2075c6c8ff830e9cd44c1cff))
-* rename project from dotclaude to dotbabel ([#186](https://github.com/kaiohenricunha/dotbabel/issues/186)) ([5136140](https://github.com/kaiohenricunha/dotbabel/commit/51361409e3c75628c1cf54b8a8624ce79fdb44f3))
-* **skills:** add deploy status and rollback workflows ([#182](https://github.com/kaiohenricunha/dotbabel/issues/182)) ([28120b4](https://github.com/kaiohenricunha/dotbabel/commit/28120b40c2d90f58aff19b20ef2684df8ddf8fc2))
-
+- **core:** migrate complex commands to skills ([#177](https://github.com/kaiohenricunha/dotbabel/issues/177)) ([13c105e](https://github.com/kaiohenricunha/dotbabel/commit/13c105e644be6f20bb446c0cd37a857dfaa2f7a9))
+- **handoff:** implement Gemini support ([#185](https://github.com/kaiohenricunha/dotbabel/issues/185)) ([1234b60](https://github.com/kaiohenricunha/dotbabel/commit/1234b6013109deba2075c6c8ff830e9cd44c1cff))
+- rename project from dotclaude to dotbabel ([#186](https://github.com/kaiohenricunha/dotbabel/issues/186)) ([5136140](https://github.com/kaiohenricunha/dotbabel/commit/51361409e3c75628c1cf54b8a8624ce79fdb44f3))
+- **skills:** add deploy status and rollback workflows ([#182](https://github.com/kaiohenricunha/dotbabel/issues/182)) ([28120b4](https://github.com/kaiohenricunha/dotbabel/commit/28120b40c2d90f58aff19b20ef2684df8ddf8fc2))
 
 ### Fixed
 
-* **handoff:** partition push --delete stderr for accurate prune reporting ([#183](https://github.com/kaiohenricunha/dotbabel/issues/183)) ([7fa6b7f](https://github.com/kaiohenricunha/dotbabel/commit/7fa6b7f16c99d3477a26d23c63823d8652f01139))
-* **handoff:** seed main as transport repo default during bootstrap ([#184](https://github.com/kaiohenricunha/dotbabel/issues/184)) ([6c3dabf](https://github.com/kaiohenricunha/dotbabel/commit/6c3dabffd974df94035306f9630dbb8bb368fcd5))
-
+- **handoff:** partition push --delete stderr for accurate prune reporting ([#183](https://github.com/kaiohenricunha/dotbabel/issues/183)) ([7fa6b7f](https://github.com/kaiohenricunha/dotbabel/commit/7fa6b7f16c99d3477a26d23c63823d8652f01139))
+- **handoff:** seed main as transport repo default during bootstrap ([#184](https://github.com/kaiohenricunha/dotbabel/issues/184)) ([6c3dabf](https://github.com/kaiohenricunha/dotbabel/commit/6c3dabffd974df94035306f9630dbb8bb368fcd5))
 
 ### Documentation
 
-* clarify skills and command inventory ([#175](https://github.com/kaiohenricunha/dotbabel/issues/175)) ([42e1b5f](https://github.com/kaiohenricunha/dotbabel/commit/42e1b5f465d95462b9c684e24c172b058759b8bb))
+- clarify skills and command inventory ([#175](https://github.com/kaiohenricunha/dotbabel/issues/175)) ([42e1b5f](https://github.com/kaiohenricunha/dotbabel/commit/42e1b5f465d95462b9c684e24c172b058759b8bb))
 
 ## [2.0.0] - YYYY-MM-DD
 


### PR DESCRIPTION
## Summary

- Install npm `^11.5.1` in the release workflow before publishing, matching npm Trusted Publishing's current OIDC requirement
- Add a manual `workflow_dispatch` tag input so the fixed workflow can publish an already-created release tag without moving tags
- Format the release-please changelog entries so repo lint stays green after the 2.0.1/2.1.0 release PRs

## Test plan

- `npx prettier --check .github/workflows/release.yml`
- `npm run lint`

## No-spec rationale

Release automation repair only. This touches `.github/workflows/release.yml` to restore npm Trusted Publishing after the `v2.1.0` release job failed with npm CLI 10, which does not satisfy npm's current Trusted Publishing requirement for npm 11.5.1+.
