### PR TITLE
ci(release): use node 24 for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,9 @@ jobs:
           ref: ${{ inputs.tag || github.ref_name }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Use npm 11 for Trusted Publishing
-        run: |
-          npm install -g npm@^11.5.1
-          npm --version
 
       - run: npm ci
       - name: Verify tag matches package.json version
@@ -50,9 +45,9 @@ jobs:
       - run: npm test
       - run: bash plugins/dotbabel/tests/test_validate_settings.sh
 
-      # Trusted Publishing: npm CLI 11.5.1+ auto-detects the GitHub Actions
-      # OIDC env and exchanges it for a short-lived publish token. No NPM_TOKEN
-      # secret is required as long as the @dotbabel org (or this package) has a
-      # Trusted Publisher configured for kaiohenricunha/dotbabel + release.yml.
+      # Trusted Publishing: Node 24 ships an npm CLI new enough to auto-detect
+      # the GitHub Actions OIDC env and exchange it for a short-lived publish
+      # token. No NPM_TOKEN secret is required as long as the @dotbabel org (or
+      # this package) has a Trusted Publisher configured for this repo + workflow.
       - name: Publish to npm with provenance (Trusted Publishing / OIDC)
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Switch the release publish job from Node 22 to Node 24 so the bundled npm CLI is new enough for Trusted Publishing / OIDC
- Keep the manual `workflow_dispatch` tag input added in #196 so the fixed workflow can republish the existing `v2.1.0` tag without moving tags
- Remove the explicit global npm upgrade step because it failed on the runner before publishing

## Test plan

- `npx prettier --check .github/workflows/release.yml`
- `npm run lint`

## No-spec rationale

Release automation repair only. This follows up #196 after the manual dispatch failed while trying to upgrade npm globally on the runner; Node 24 should provide a Trusted-Publishing-capable npm without mutating the runner's global npm install.
