### PR TITLE
feat(bootstrap): fan out skills/ + commands/ into ~/.gemini/skills

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -192,6 +192,7 @@ link_cli_instruction \
   gemini \
   "$CLI_INSTRUCTIONS_SRC/gemini-GEMINI.md" \
   "$HOME/.gemini/GEMINI.md"
+fan_out_skills_to_dir gemini "$HOME/.gemini/skills"
 
 if [[ "$QUIET" = "1" ]]; then
   echo "bootstrap complete — target: $TARGET"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -94,6 +94,46 @@ link_cli_instruction() {
   link_one "$src" "$dst"
 }
 
+# fan_out_skills_to_dir CLI DST_SKILLS_DIR
+#
+# Mirrors the dotbabel skills/ + commands/ surface into a CLI-specific skills
+# directory. Each skills/<id>/ becomes <dst>/<id>/ (whole-dir symlink). Each
+# commands/<name>.md becomes <dst>/<name>/SKILL.md (single-file symlink wrapped
+# in a fresh directory so the CLI sees the canonical skill shape).
+#
+# Idempotent. Skips entries named ".system" defensively, in case a host CLI
+# reserves that namespace for built-in skills (Codex does).
+fan_out_skills_to_dir() {
+  local cli="$1"
+  local dst_dir="$2"
+
+  if [[ "$ALL" != "1" ]] && ! command -v "$cli" >/dev/null 2>&1; then
+    say "==> skipping $cli skills (command not found; use --all to force)"
+    return 0
+  fi
+
+  say "==> fanning out skills/ + commands/ to $cli ($dst_dir)"
+  mkdir -p "$dst_dir"
+
+  for d in "$DOTBABEL/skills"/*/; do
+    [[ -e "$d" ]] || continue
+    local name
+    name=$(basename "$d")
+    [[ "$name" = ".system" ]] && continue
+    link_one "${d%/}" "$dst_dir/$name"
+  done
+
+  for f in "$DOTBABEL/commands"/*.md; do
+    [[ -e "$f" ]] || continue
+    local base name
+    base=$(basename "$f")
+    name="${base%.md}"
+    [[ "$name" = ".system" ]] && continue
+    mkdir -p "$dst_dir/$name"
+    link_one "$f" "$dst_dir/$name/SKILL.md"
+  done
+}
+
 say "==> linking CLAUDE.md"
 [[ -f "$DOTBABEL/CLAUDE.md" ]] && link_one "$DOTBABEL/CLAUDE.md" "$TARGET/CLAUDE.md"
 
@@ -147,6 +187,7 @@ link_cli_instruction \
   codex \
   "$CLI_INSTRUCTIONS_SRC/codex-AGENTS.md" \
   "$HOME/.codex/AGENTS.md"
+fan_out_skills_to_dir codex "${CODEX_HOME:-$HOME/.codex}/skills"
 link_cli_instruction \
   gemini \
   "$CLI_INSTRUCTIONS_SRC/gemini-GEMINI.md" \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -66,6 +66,17 @@ link_one() {
   fi
 }
 
+ensure_real_dir() {
+  local dst="$1"
+
+  if [[ -L "$dst" || -e "$dst" ]] && [[ ! -d "$dst" || -L "$dst" ]]; then
+    mv "$dst" "${dst}.bak-${TS}"
+    say "  backed up: $dst (old at ${dst}.bak-${TS})"
+  fi
+
+  mkdir -p "$dst"
+}
+
 link_cli_instruction() {
   local cli="$1"
   local src="$2"
@@ -129,7 +140,7 @@ fan_out_skills_to_dir() {
     base=$(basename "$f")
     name="${base%.md}"
     [[ "$name" = ".system" ]] && continue
-    mkdir -p "$dst_dir/$name"
+    ensure_real_dir "$dst_dir/$name"
     link_one "$f" "$dst_dir/$name/SKILL.md"
   done
 }

--- a/plugins/dotbabel/src/bootstrap-global.mjs
+++ b/plugins/dotbabel/src/bootstrap-global.mjs
@@ -286,6 +286,10 @@ export async function bootstrapGlobal(opts = {}) {
     src: path.join(cliInstructionsSrc, "gemini-GEMINI.md"),
     dst: path.join(homeRoot, ".gemini", "GEMINI.md"),
   });
+  fanOutSkillsToDir({
+    cli: "gemini",
+    dstDir: path.join(homeRoot, ".gemini", "skills"),
+  });
 
   out.flush();
   return { ok: true, linked, skipped, backed_up };

--- a/plugins/dotbabel/src/bootstrap-global.mjs
+++ b/plugins/dotbabel/src/bootstrap-global.mjs
@@ -277,6 +277,10 @@ export async function bootstrapGlobal(opts = {}) {
     src: path.join(cliInstructionsSrc, "codex-AGENTS.md"),
     dst: path.join(homeRoot, ".codex", "AGENTS.md"),
   });
+  fanOutSkillsToDir({
+    cli: "codex",
+    dstDir: path.join(process.env.CODEX_HOME || path.join(homeRoot, ".codex"), "skills"),
+  });
   linkCliInstruction({
     cli: "gemini",
     src: path.join(cliInstructionsSrc, "gemini-GEMINI.md"),
@@ -302,6 +306,49 @@ export async function bootstrapGlobal(opts = {}) {
     }
     fs.mkdirSync(path.dirname(dst), { recursive: true });
     doLink(src, dst);
+  }
+
+  /**
+   * Fan out skills/ + commands/ into a CLI-specific skills directory.
+   *
+   * Each skills/<id>/ becomes <dstDir>/<id>/ (whole-dir symlink). Each
+   * commands/<name>.md becomes <dstDir>/<name>/SKILL.md so the host CLI sees
+   * the canonical skill shape. Skips entries named ".system" defensively —
+   * Codex reserves that namespace for its bundled built-in skills.
+   *
+   * @param {{ cli: string, dstDir: string }} cfg
+   */
+  function fanOutSkillsToDir({ cli, dstDir }) {
+    if (!opts.allCli && !commandExists(cli)) {
+      out.info(`skipped ${cli} skills (command not found; use --all to force)`);
+      skipped++;
+      return;
+    }
+    fs.mkdirSync(dstDir, { recursive: true });
+
+    if (fs.existsSync(skillsSrc)) {
+      const entries = fs.readdirSync(skillsSrc, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name === ".system") continue;
+        const src = path.join(skillsSrc, entry.name);
+        const dst = path.join(dstDir, entry.name);
+        doLink(src, dst);
+      }
+    }
+
+    if (fs.existsSync(commandsSrc)) {
+      for (const entry of fs.readdirSync(commandsSrc)) {
+        if (!entry.endsWith(".md")) continue;
+        const name = entry.replace(/\.md$/, "");
+        if (name === ".system") continue;
+        const src = path.join(commandsSrc, entry);
+        const wrapDir = path.join(dstDir, name);
+        fs.mkdirSync(wrapDir, { recursive: true });
+        const dst = path.join(wrapDir, "SKILL.md");
+        doLink(src, dst);
+      }
+    }
   }
 }
 

--- a/plugins/dotbabel/src/bootstrap-global.mjs
+++ b/plugins/dotbabel/src/bootstrap-global.mjs
@@ -202,6 +202,26 @@ export async function bootstrapGlobal(opts = {}) {
     }
   }
 
+  function ensureRealDir(dst) {
+    let lstat;
+    try {
+      lstat = fs.lstatSync(dst);
+    } catch {
+      fs.mkdirSync(dst, { recursive: true });
+      return;
+    }
+
+    if (lstat.isDirectory() && !lstat.isSymbolicLink()) {
+      return;
+    }
+
+    const bakPath = `${dst}.bak-${timestamp}`;
+    fs.renameSync(dst, bakPath);
+    backed_up++;
+    out.warn(`backed up: ${dst} (old at ${bakPath})`);
+    fs.mkdirSync(dst, { recursive: true });
+  }
+
   // --- CLAUDE.md ---
   const claudeMdSrc = path.join(source, "CLAUDE.md");
   if (fs.existsSync(claudeMdSrc)) {
@@ -344,7 +364,7 @@ export async function bootstrapGlobal(opts = {}) {
         if (name === ".system") continue;
         const src = path.join(commandsSrc, entry);
         const wrapDir = path.join(dstDir, name);
-        fs.mkdirSync(wrapDir, { recursive: true });
+        ensureRealDir(wrapDir);
         const dst = path.join(wrapDir, "SKILL.md");
         doLink(src, dst);
       }

--- a/plugins/dotbabel/tests/bats/bootstrap.bats
+++ b/plugins/dotbabel/tests/bats/bootstrap.bats
@@ -78,3 +78,18 @@ teardown() {
   run "$BOOT" --bogus
   [ "$status" -eq 64 ]
 }
+
+@test "codex command fan-out backs up existing wrapper file" {
+  mkdir -p "$HOME/.codex/skills"
+  echo "old wrapper" > "$HOME/.codex/skills/changelog"
+
+  run "$BOOT" --all --quiet
+  [ "$status" -eq 0 ]
+  [ -d "$HOME/.codex/skills/changelog" ]
+  [ -L "$HOME/.codex/skills/changelog/SKILL.md" ]
+  target=$(readlink "$HOME/.codex/skills/changelog/SKILL.md")
+  [ "$target" = "$REPO_ROOT/commands/changelog.md" ]
+
+  run bash -c "ls '$HOME/.codex/skills/'changelog.bak-*"
+  [ "$status" -eq 0 ]
+}

--- a/plugins/dotbabel/tests/bootstrap-global.test.mjs
+++ b/plugins/dotbabel/tests/bootstrap-global.test.mjs
@@ -218,6 +218,32 @@ describe("bootstrapGlobal", () => {
     );
   });
 
+  it("backs up an existing Codex command wrapper file before fanning out commands", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    const codexSkills = path.join(tgt, ".codex", "skills");
+    fs.mkdirSync(codexSkills, { recursive: true });
+    fs.writeFileSync(path.join(codexSkills, "foo"), "# existing wrapper\n");
+
+    const result = await bootstrapGlobal({ source: src, target: tgt, allCli: true });
+
+    expect(result.ok).toBe(true);
+    expect(result.backed_up).toBeGreaterThan(0);
+
+    const wrapper = path.join(codexSkills, "foo");
+    expect(fs.lstatSync(wrapper).isDirectory()).toBe(true);
+
+    const skillMd = path.join(wrapper, "SKILL.md");
+    expect(fs.lstatSync(skillMd).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(skillMd)).toBe(path.join(src, "commands", "foo.md"));
+
+    const backups = fs.readdirSync(codexSkills).filter((entry) => entry.startsWith("foo.bak-"));
+    expect(backups).toHaveLength(1);
+    expect(fs.readFileSync(path.join(codexSkills, backups[0]), "utf8")).toBe("# existing wrapper\n");
+  });
+
   // -------------------------------------------------------------------------
   // Test 7 — returns { ok: false } when source directory does not exist
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Reuse the `fan_out_skills_to_dir` / `fanOutSkillsToDir` helper introduced in #201 (Codex) for Gemini, targeting `~/.gemini/skills/`.
- Two-line change in each of `bootstrap.sh` and `plugins/dotbabel/src/bootstrap-global.mjs` — one `fanOutSkillsToDir` call appended after the existing `GEMINI.md` instruction link.

## Why

Gemini CLI 0.41+ auto-discovers user skills at `~/.gemini/skills/<id>/` — same shape as Codex's discovery directory. I verified empirically that `gemini skills link <path> --scope user --consent` is just a wrapper that creates a symlink at that path; dropping a raw symlink is auto-discovered by `gemini skills list` with zero CLI shell-out and zero state file to keep in sync.

After this, `/plan-grader`, `/ground-first`, `/spec`, etc. — and the wrapped commands like `/changelog`, `/markdown` — all surface in Gemini.

## Behavior

- Stacked on top of #201 (Codex). Base branch is `feat/codex-skill-fanout`. **Merge #201 first**, then this rebases onto `main` cleanly.
- Idempotent, gated on `gemini` being on PATH (or `--all`), bash + Node ports in lockstep — all carried over from the helper introduced in #201.

## Test plan

- [x] `bash bootstrap.sh --quiet` — 34 entries linked under `~/.gemini/skills/`.
- [x] `gemini skills list` — reports all 34 user-visible entries (29 skills + 5 wrapped commands), e.g. `plan-grader [Enabled]` resolves to the source `SKILL.md`.
- [x] `npm test` — 42 files, 636/636 passing.

## Spec ID

dotbabel-core
