### PR TITLE
feat(handoff): layered fidelity — B-floor extraction + A state-block opt-in

### DIFF
--- a/plugins/dotbabel/bin/dotbabel-handoff.mjs
+++ b/plugins/dotbabel/bin/dotbabel-handoff.mjs
@@ -127,6 +127,11 @@ const META = {
     "dry-run": { type: "boolean" },
     "older-than": { type: "string" },
     yes: { type: "boolean" },
+    // Approach A opt-in (handoff-hardening 2026-05-08): read a local
+    // markdown file (typically a `<handoff-state>` YAML block authored by
+    // the source agent) and prepend its content above the mechanical
+    // <handoff> block on push. Flows through the same scrubber.
+    "state-file": { type: "string" },
   },
 };
 
@@ -991,6 +996,7 @@ async function main() {
     const force = Boolean(argv.flags["force-collision"]);
     const dryRun = Boolean(argv.flags["dry-run"]);
     try {
+      const stateFile = argv.flags["state-file"] != null ? String(argv.flags["state-file"]) : null;
       const result = await pushRemote({
         cli: sessionHit.cli,
         path: sessionHit.path,
@@ -999,6 +1005,7 @@ async function main() {
         verbose,
         force,
         dryRun,
+        stateFile,
       });
       if (dryRun) {
         process.stdout.write(

--- a/plugins/dotbabel/bin/dotbabel-handoff.mjs
+++ b/plugins/dotbabel/bin/dotbabel-handoff.mjs
@@ -996,7 +996,15 @@ async function main() {
     const force = Boolean(argv.flags["force-collision"]);
     const dryRun = Boolean(argv.flags["dry-run"]);
     try {
-      const stateFile = argv.flags["state-file"] != null ? String(argv.flags["state-file"]) : null;
+      const stateFilePath = argv.flags["state-file"] != null ? String(argv.flags["state-file"]) : null;
+      let stateBlock = null;
+      if (stateFilePath) {
+        try {
+          stateBlock = readFileSync(stateFilePath, "utf8");
+        } catch (e) {
+          throw new Error(`--state-file: cannot read ${stateFilePath}: ${e.message}`);
+        }
+      }
       const result = await pushRemote({
         cli: sessionHit.cli,
         path: sessionHit.path,
@@ -1005,7 +1013,7 @@ async function main() {
         verbose,
         force,
         dryRun,
-        stateFile,
+        stateBlock,
       });
       if (dryRun) {
         process.stdout.write(

--- a/plugins/dotbabel/scripts/handoff-extract.sh
+++ b/plugins/dotbabel/scripts/handoff-extract.sh
@@ -167,6 +167,23 @@ turns_claude() {
   ' "$file" 2>/dev/null | tail -n "$tail_arg"
 }
 
+# Approach B addition (handoff-hardening 2026-05-08): extract Claude
+# TodoWrite tool_use payloads. Each emitted line is one todo item:
+# {"content","status","activeForm"}. Closes the gap where mid-session
+# decisions live in tool_use blocks rather than .text and would otherwise
+# fall outside the rendered turn selection.
+todos_claude() {
+  local file="$1"
+  jq -c '
+    select(.type == "assistant")
+    | (.message.content // []) as $c
+    | $c[]
+    | select(.type == "tool_use" and .name == "TodoWrite")
+    | (.input.todos // [])[]
+    | {content: (.content // ""), status: (.status // "unknown"), activeForm: (.activeForm // "")}
+  ' "$file" 2>/dev/null
+}
+
 # -- copilot --------------------------------------------------------------
 
 # Parse a single key from workspace.yaml. YAML here is flat key:value, no
@@ -296,6 +313,20 @@ turns_codex() {
   ' "$file" 2>/dev/null | tail -n "$tail_arg"
 }
 
+# Approach B addition (handoff-hardening 2026-05-08): the un-tapped
+# event_msg.agent_message mirror. Each emitted line is the bare message
+# string. Caller dedupes against the RENDERED turn selection (NOT the full
+# turns extract) so a mid-session decision dropped by first+last-3 still
+# surfaces. See renderHandoffBlock + experiment residual risk #2.
+mirror_codex() {
+  local file="$1"
+  jq -c '
+    select(.type == "event_msg" and .payload.type == "agent_message")
+    | (.payload.message // "")
+    | select(type == "string" and length > 0)
+  ' "$file" 2>/dev/null
+}
+
 # -- gemini ---------------------------------------------------------------
 
 gemini_short_from_filename() {
@@ -407,6 +438,20 @@ main() {
         copilot) turns_copilot "$file" "$limit" ;;
         codex)   turns_codex "$file" "$limit" ;;
         gemini)  turns_gemini "$file" "$limit" ;;
+      esac
+      ;;
+    todos)
+      case "$cli" in
+        claude) todos_claude "$file" ;;
+        # Other CLIs have no structured TodoWrite carrier today; emit nothing.
+        copilot|codex|gemini) ;;
+      esac
+      ;;
+    mirror)
+      case "$cli" in
+        codex) mirror_codex "$file" ;;
+        # Other CLIs have no event_msg.agent_message equivalent; emit nothing.
+        claude|copilot|gemini) ;;
       esac
       ;;
     *)

--- a/plugins/dotbabel/src/lib/handoff-remote.mjs
+++ b/plugins/dotbabel/src/lib/handoff-remote.mjs
@@ -952,7 +952,7 @@ export async function pushRemote({
   verbose = false,
   force = false,
   dryRun = false,
-  stateFile = null,
+  stateBlock = null,
 }) {
   // #91 Gap 7: accept either `tags: string[]` (new, multi-tag) or the legacy
   // `tag: string` (single). Internally everything below works on `tagList`.
@@ -978,14 +978,6 @@ export async function pushRemote({
     if (m && typeof m.message === "string") return m.message;
     return "";
   }).filter((s) => s.length > 0);
-  let stateBlock = null;
-  if (stateFile) {
-    try {
-      stateBlock = readFileSync(stateFile, "utf8");
-    } catch (e) {
-      throw new Error(`--state-file: cannot read ${stateFile}: ${e.message}`);
-    }
-  }
   const toCli = meta.cli;
   const handoffBlock = renderHandoffBlock(meta, prompts, turns, toCli, {
     stateBlock,

--- a/plugins/dotbabel/src/lib/handoff-remote.mjs
+++ b/plugins/dotbabel/src/lib/handoff-remote.mjs
@@ -172,6 +172,14 @@ export const extractPrompts = (cli, file) => extractLines("prompts", cli, file);
 /** Extract assistant turn lines from a session file (optionally capped; 0 = unbounded). */
 export const extractTurns = (cli, file, limit) =>
   extractLines("turns", cli, file, limit == null ? [] : [String(limit)]);
+/** Extract Claude TodoWrite tool_use payloads. Returns [] for non-Claude
+ *  sessions. Each element: {content, status, activeForm}. */
+export const extractTodos = (cli, file) =>
+  cli === "claude" ? extractLines("todos", cli, file) : [];
+/** Extract Codex `event_msg.agent_message` mirror text. Returns [] for
+ *  non-Codex sessions. Each element is a plain string. */
+export const extractMirror = (cli, file) =>
+  cli === "codex" ? extractLines("mirror", cli, file) : [];
 
 // ---- rendering ---------------------------------------------------------
 
@@ -194,20 +202,72 @@ export function mechanicalSummary(prompts, turns) {
   return `Session opened with: "${clip(first, 160)}". Last assistant output (truncated): "${clip(last, 160)}". Full prompt log and assistant tail follow for context.`;
 }
 
-/** Render the full <handoff> block for push or standalone describe. */
-export function renderHandoffBlock(meta, prompts, turns, toCli) {
+/** Cap on the prompt window. Pin prompt 1 (task framing usually lives here)
+ *  plus the most recent (PROMPT_CAP - 1). 50 was validated against the
+ *  2026-05-08 handoff-hardening experiment — stays ≤1.5× baseline bytes
+ *  on every CLI fixture. */
+const PROMPT_CAP = 50;
+
+/** Apply the B-floor prompt selection: pin prompt 1 + ring-buffer last
+ *  (PROMPT_CAP - 1). When there are fewer than PROMPT_CAP prompts, return
+ *  the full list unchanged. */
+export function selectPromptsForRender(prompts) {
+  if (prompts.length <= PROMPT_CAP) return prompts.slice();
+  const pinned = [prompts[0]];
+  return [...pinned, ...prompts.slice(1).slice(-(PROMPT_CAP - 1))];
+}
+
+/** Apply the B-floor turn selection: first turn (initial framing) + last 3.
+ *  When there are 4 or fewer turns, return the full list unchanged. */
+export function selectTurnsForRender(turns) {
+  if (turns.length <= 4) return turns.slice();
+  return [turns[0], ...turns.slice(-3)];
+}
+
+/** Render the full <handoff> block for push or standalone describe.
+ *
+ *  Optional opts:
+ *    stateBlock — raw markdown (typically a `<handoff-state>...</handoff-state>`
+ *      YAML block authored by the source agent) to prepend above the
+ *      mechanical block. Flows through the same scrubber as the rest of
+ *      the digest at push time. Approach A opt-in.
+ *    todos — array of TodoWrite payloads `{content, status, activeForm}`
+ *      extracted from the source session. Currently Claude-only via
+ *      `extract todos claude <file>`. Renders as a `**Tracked TODOs.**` section.
+ *    mirror — array of strings (codex `event_msg.agent_message` content)
+ *      that surfaces mid-session messages dropped by the first+last-3 turn
+ *      window. Filtered against the RENDERED turn selection (NOT the full
+ *      extract) so a mid-session decision still surfaces.
+ */
+export function renderHandoffBlock(meta, prompts, turns, toCli, opts = {}) {
+  const { stateBlock = null, todos = [], mirror = [] } = opts;
   const summary = mechanicalSummary(prompts, turns);
-  const promptsCapped = prompts.slice(-10);
-  const turnsTail = turns.slice(-3);
+  const promptsCapped = selectPromptsForRender(prompts);
+  const turnsTail = selectTurnsForRender(turns);
   const next = nextStepFor(toCli);
   const lines = [];
+  if (stateBlock && stateBlock.trim().length > 0) {
+    lines.push(stateBlock.trim());
+    lines.push("");
+  }
   lines.push(
     `<handoff origin="${meta.cli}" session="${meta.short_id ?? ""}" cwd="${meta.cwd ?? ""}" target="${toCli}">`,
   );
   lines.push("");
   lines.push(`**Summary.** ${summary}`);
   lines.push("");
-  lines.push("**User prompts (last 10, in order).**");
+  // Header reflects what's visible: full log when nothing was dropped,
+  // explicit "capped" callout with prompt-1 pin annotation when the
+  // ring-buffer engaged.
+  if (prompts.length === 0) {
+    lines.push("**User prompts.**");
+  } else if (prompts.length <= PROMPT_CAP) {
+    lines.push(`**User prompts (full log, ${prompts.length}).**`);
+  } else {
+    lines.push(
+      `**User prompts (capped: ${promptsCapped.length} of ${prompts.length}, prompt 1 pinned).**`,
+    );
+  }
   lines.push("");
   if (promptsCapped.length === 0) lines.push("1. (session contained no user prompts)");
   else
@@ -216,7 +276,13 @@ export function renderHandoffBlock(meta, prompts, turns, toCli) {
       lines.push(`${i + 1}. ${trimmed}`);
     });
   lines.push("");
-  lines.push("**Last assistant turns (tail).**");
+  if (turns.length === 0) {
+    lines.push("**Assistant turns.**");
+  } else if (turns.length <= 4) {
+    lines.push(`**Assistant turns (full, ${turns.length}).**`);
+  } else {
+    lines.push(`**Assistant turns (first + last 3 of ${turns.length}).**`);
+  }
   lines.push("");
   if (turnsTail.length === 0) lines.push("_(session contained no assistant turns)_");
   else
@@ -225,6 +291,39 @@ export function renderHandoffBlock(meta, prompts, turns, toCli) {
       lines.push(`> ${trimmed.replace(/\n/g, "\n> ")}`);
       lines.push("");
     }
+
+  if (Array.isArray(todos) && todos.length > 0) {
+    lines.push("**Tracked TODOs.**");
+    lines.push("");
+    for (const t of todos) {
+      const status = t && typeof t.status === "string" ? `[${t.status}]` : "[?]";
+      const content = t && typeof t.content === "string" ? t.content : "";
+      lines.push(`- ${status} ${content}`);
+    }
+    lines.push("");
+  }
+
+  // Compare against the RENDERED turns (turnsTail), not the full extract.
+  // Initial implementation deduped against turns.map(t => t.trim()) which
+  // silently filtered out mid-session messages whose content was extracted
+  // but not rendered under first+last-3 — defeating the whole point of the
+  // mirror. See handoff-hardening experiment 2026-05-08, residual risk #2.
+  if (Array.isArray(mirror) && mirror.length > 0) {
+    const renderedTurnSet = new Set(turnsTail.map((t) => (t ?? "").trim()));
+    const mirrorExtra = mirror.filter(
+      (m) => typeof m === "string" && m.length > 0 && !renderedTurnSet.has(m.trim()),
+    );
+    if (mirrorExtra.length > 0) {
+      lines.push("**Codex agent message mirror (not duplicated above).**");
+      lines.push("");
+      for (const m of mirrorExtra) {
+        const trimmed = m.length > 400 ? `${m.slice(0, 400).trim()}…` : m;
+        lines.push(`> ${trimmed.replace(/\n/g, "\n> ")}`);
+        lines.push("");
+      }
+    }
+  }
+
   lines.push("**Next step.** " + next);
   lines.push("");
   lines.push("</handoff>");
@@ -853,6 +952,7 @@ export async function pushRemote({
   verbose = false,
   force = false,
   dryRun = false,
+  stateFile = null,
 }) {
   // #91 Gap 7: accept either `tags: string[]` (new, multi-tag) or the legacy
   // `tag: string` (single). Internally everything below works on `tagList`.
@@ -869,8 +969,29 @@ export async function pushRemote({
   const meta = extractMeta(cli, sessionFile);
   const prompts = extractPrompts(cli, sessionFile);
   const turns = extractTurns(cli, sessionFile);
+  const todos = extractTodos(cli, sessionFile);
+  const mirror = extractMirror(cli, sessionFile);
+  // Mirror records may arrive as bare strings or wrapped JSON {message: "..."};
+  // normalize to plain strings before handing to the renderer.
+  const mirrorStrings = mirror.map((m) => {
+    if (typeof m === "string") return m;
+    if (m && typeof m.message === "string") return m.message;
+    return "";
+  }).filter((s) => s.length > 0);
+  let stateBlock = null;
+  if (stateFile) {
+    try {
+      stateBlock = readFileSync(stateFile, "utf8");
+    } catch (e) {
+      throw new Error(`--state-file: cannot read ${stateFile}: ${e.message}`);
+    }
+  }
   const toCli = meta.cli;
-  const handoffBlock = renderHandoffBlock(meta, prompts, turns, toCli);
+  const handoffBlock = renderHandoffBlock(meta, prompts, turns, toCli, {
+    stateBlock,
+    todos,
+    mirror: mirrorStrings,
+  });
 
   // Scrub before the digest ever leaves the machine. Thrown errors
   // propagate out of pushRemote — the outer try/catch in main() maps

--- a/plugins/dotbabel/templates/claude/skills/handoff/references/digest-schema.md
+++ b/plugins/dotbabel/templates/claude/skills/handoff/references/digest-schema.md
@@ -63,6 +63,33 @@ next_step_suggestion: |
 The `<handoff>` tag is intentional: target agents can detect it
 reliably and distinguish digest content from surrounding commentary.
 
+## Approach A: agent-authored state block (`push --state-file`)
+
+When `--state-file <path>` is passed to `dotbabel handoff push`, the
+file's raw content (typically a `<handoff-state>` YAML block authored by
+the source agent) is **prepended above** the `<handoff ...>` opening
+tag — not inside it. This is intentional:
+
+- Target agents that only want the mechanical block can detect the `<handoff>`
+  boundary without parsing agent-authored content outside it.
+- The state block flows through the same secret scrubber as the rest of the
+  digest before leaving the machine.
+
+Example shape when `--state-file` is used:
+
+```markdown
+<handoff-state version="1">
+goals:
+  - migrate auth middleware
+decisions:
+  - keep JWT expiry at 15 min
+</handoff-state>
+
+<handoff origin="claude" session="abc123ef" cwd="/repo" target="codex">
+...
+</handoff>
+```
+
 ## Rendering: `pull --summary` output (terse inline summary)
 
 ```markdown
@@ -113,7 +140,13 @@ a `docs/` directory exists at the repo root, else
 
 - `summary`: ≤ 400 characters.
 - `key_findings`: ≤ 5 bullets.
-- `user_prompts`: cap at the last 10 prompts if the session has more;
-  note the truncation in `summary`.
+- `user_prompts`: cap at 50 prompts (prompt 1 always pinned + last 49)
+  per the handoff-hardening 2026-05-08 experiment (results at
+  `docs/experiments/handoff-hardening-2026-05-08.md`); note the
+  truncation in `summary`. The cap engages only when the session has
+  > 50 prompts; shorter sessions render the full log unchanged.
+- `assistant_turns`: first turn (initial framing) + last 3 (recent
+  context). Mid-session turns surface via Approach B's TodoWrite
+  extraction (Claude) or `event_msg.agent_message` mirror (Codex).
 - `files_touched`: ≤ 20 paths; dedupe; prefer ones the assistant
   wrote/edited over ones it merely read.

--- a/plugins/dotbabel/tests/bats/helpers.bash
+++ b/plugins/dotbabel/tests/bats/helpers.bash
@@ -233,11 +233,11 @@ make_many_transport_branches() {
 
 **Summary.** Bulk-seeded handoff.
 
-**User prompts (last 10, in order).**
+**User prompts (full log, 1).**
 
 1. bulk prompt
 
-**Last assistant turns (tail).**
+**Assistant turns (full, 1).**
 
 > bulk reply
 

--- a/plugins/dotbabel/tests/fixtures/cross-cli-invocation-baseline.txt
+++ b/plugins/dotbabel/tests/fixtures/cross-cli-invocation-baseline.txt
@@ -3,11 +3,11 @@
 
 **Summary.** Session opened with: "(session contained no user prompts)". Last assistant output (truncated): "(session contained no assistant turns)". Full prompt log and assistant tail follow for context.
 
-**User prompts (last 10, in order).**
+**User prompts.**
 
 1. (session contained no user prompts)
 
-**Last assistant turns (tail).**
+**Assistant turns.**
 
 _(session contained no assistant turns)_
 **Next step.** Continue from the last assistant turn using the same file scope and goals summarized above.
@@ -19,11 +19,11 @@ _(session contained no assistant turns)_
 
 **Summary.** Session opened with: "(session contained no user prompts)". Last assistant output (truncated): "(session contained no assistant turns)". Full prompt log and assistant tail follow for context.
 
-**User prompts (last 10, in order).**
+**User prompts.**
 
 1. (session contained no user prompts)
 
-**Last assistant turns (tail).**
+**Assistant turns.**
 
 _(session contained no assistant turns)_
 **Next step.** Continue from the last assistant turn using the same file scope and goals summarized above.
@@ -44,11 +44,11 @@ _(session contained no assistant turns)_
 
 **Summary.** Session opened with: "(session contained no user prompts)". Last assistant output (truncated): "(session contained no assistant turns)". Full prompt log and assistant tail follow for context.
 
-**User prompts (last 10, in order).**
+**User prompts.**
 
 1. (session contained no user prompts)
 
-**Last assistant turns (tail).**
+**Assistant turns.**
 
 _(session contained no assistant turns)_
 **Next step.** Continue from the last assistant turn using the same file scope and goals summarized above.

--- a/plugins/dotbabel/tests/handoff-push-dryrun.test.mjs
+++ b/plugins/dotbabel/tests/handoff-push-dryrun.test.mjs
@@ -48,6 +48,10 @@ function queueDryRunSpawns({ sessionId = "abc12345-aaaa-bbbb-cccc-000000000001" 
     .mockReturnValueOnce({ status: 0, stdout: '"hi"\n', stderr: "" })
     // extractTurns — handoff-extract.sh turns
     .mockReturnValueOnce({ status: 0, stdout: '"hello"\n', stderr: "" })
+    // extractTodos — handoff-extract.sh todos (claude only; non-claude
+    // shortcuts to [] without spawning, see extractTodos export).
+    .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+    // extractMirror is codex-only and shortcuts to [] for claude — no spawn here.
     // scrubDigest — handoff-scrub.sh (stdout = scrubbed body; stderr line ends with "scrubbed:0")
     .mockReturnValueOnce({ status: 0, stdout: "scrubbed body\n", stderr: "scrubbed:0\n" })
     // encodeDescription — handoff-description.sh encode

--- a/plugins/dotbabel/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotbabel/tests/handoff-remote-coverage.test.mjs
@@ -244,11 +244,11 @@ describe("renderHandoffBlock", () => {
     expect(block).toContain("_(session contained no assistant turns)_");
   });
 
-  it("caps prompts at last 10", () => {
+  it("renders all prompts when below the 50-prompt cap", () => {
     const prompts = Array.from({ length: 15 }, (_, i) => `p${i}`);
     const block = lib.renderHandoffBlock(meta, prompts, [], "claude");
-    expect(block).toContain("10. p14");
-    expect(block).not.toContain("11. ");
+    expect(block).toContain("1. p0");
+    expect(block).toContain("15. p14");
   });
 
   it("truncates long prompts at 300 chars", () => {

--- a/plugins/dotbabel/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotbabel/tests/handoff-remote-lib.test.mjs
@@ -21,7 +21,9 @@ describe("export shape", () => {
     "enrichWithDescriptions",
     "extractLines",
     "extractMeta",
+    "extractMirror",
     "extractPrompts",
+    "extractTodos",
     "extractTurns",
     "fetchRemoteBranch",
     "fetchRemoteMetadata",
@@ -57,6 +59,8 @@ describe("export shape", () => {
     "runGitOrThrow",
     "runScript",
     "seedTransportDefaultBranch",
+    "selectPromptsForRender",
+    "selectTurnsForRender",
     "slugify",
     "slugifyRepoName",
     "tagsFromMeta",
@@ -334,11 +338,24 @@ describe("renderHandoffBlock", () => {
     expect(block).toContain("assistant turn");
   });
 
-  it("caps prompts at the last 10 and numbers them 1..10", () => {
+  it("renders all prompts when below the 50-prompt cap (handoff-hardening 2026-05-08)", () => {
     const prompts = Array.from({ length: 15 }, (_, i) => `p${i}`);
     const block = lib.renderHandoffBlock(meta, prompts, [], "claude");
-    expect(block).toContain("10. p14");
-    expect(block).not.toContain("11. ");
+    expect(block).toContain("1. p0");
+    expect(block).toContain("15. p14");
+    expect(block).toContain("**User prompts (full log, 15).**");
+  });
+
+  it("pins prompt 1 and caps the rest at 49 when prompts exceed 50", () => {
+    const prompts = Array.from({ length: 75 }, (_, i) => `p${i}`);
+    const block = lib.renderHandoffBlock(meta, prompts, [], "claude");
+    // p0 is pinned at position 1, then the last 49 (p26..p74) follow.
+    expect(block).toContain("1. p0");
+    expect(block).toContain("**User prompts (capped: 50 of 75, prompt 1 pinned).**");
+    expect(block).toContain("50. p74");
+    // p1..p25 are dropped (the ring-buffer head).
+    expect(block).not.toContain("\n2. p1\n");
+    expect(block).not.toContain("p25");
   });
 
   it("truncates prompts longer than 300 chars", () => {
@@ -351,6 +368,92 @@ describe("renderHandoffBlock", () => {
     const long = "y".repeat(600);
     const block = lib.renderHandoffBlock(meta, [], [long], "claude");
     expect(block).toContain("…");
+  });
+
+  it("includes the first turn alongside last 3 when more than 4 turns exist", () => {
+    const turns = Array.from({ length: 10 }, (_, i) => `turn${i}`);
+    const block = lib.renderHandoffBlock(meta, [], turns, "claude");
+    // first turn (turn0) + last 3 (turn7, turn8, turn9) — turn1..turn6 dropped.
+    expect(block).toContain("turn0");
+    expect(block).toContain("turn7");
+    expect(block).toContain("turn8");
+    expect(block).toContain("turn9");
+    expect(block).not.toContain("turn3");
+    expect(block).toContain("**Assistant turns (first + last 3 of 10).**");
+  });
+
+  it("prepends a state block when opts.stateBlock is provided (Approach A opt-in)", () => {
+    const stateBlock = '<handoff-state version="1">\ngoals: []\n</handoff-state>';
+    const block = lib.renderHandoffBlock(meta, ["hi"], ["yo"], "claude", { stateBlock });
+    expect(block.startsWith("<handoff-state")).toBe(true);
+    expect(block).toContain('<handoff origin="claude"');
+    // State block precedes the mechanical block in source order.
+    expect(block.indexOf("<handoff-state")).toBeLessThan(block.indexOf("<handoff "));
+  });
+
+  it("renders Tracked TODOs section when opts.todos is non-empty", () => {
+    const todos = [
+      { content: "GOAL-MIGRATE-AUTH", status: "in_progress", activeForm: "" },
+      { content: "GOAL-ROTATE-KEYS", status: "pending", activeForm: "" },
+    ];
+    const block = lib.renderHandoffBlock(meta, ["p"], ["t"], "claude", { todos });
+    expect(block).toContain("**Tracked TODOs.**");
+    expect(block).toContain("[in_progress] GOAL-MIGRATE-AUTH");
+    expect(block).toContain("[pending] GOAL-ROTATE-KEYS");
+  });
+
+  it("renders Codex agent_message mirror only for entries NOT in the rendered turn selection (regression: handoff-hardening 2026-05-08 risk #2)", () => {
+    // 10 turns; turn 7 contains a critical decision that lives in the mirror.
+    // First+last-3 selection = [turn0, turn7-DROPPED, turn8, turn9]; correct
+    // dedupe must compare against THE RENDERED SELECTION, not the full extract.
+    // An incorrect dedupe filters the mirror entry out because turn 7's content
+    // *is* in the full turns array — the user-reported failure mode.
+    const turns = Array.from({ length: 10 }, (_, i) => `turn${i} content`);
+    const decisionInMidSessionTurn = turns[6]; // dropped by first+last-3
+    const mirror = [decisionInMidSessionTurn, "turn0 content"]; // turn0 IS rendered → dedupe out
+    const block = lib.renderHandoffBlock(meta, [], turns, "claude", { mirror });
+    expect(block).toContain("**Codex agent message mirror (not duplicated above).**");
+    // The mid-session decision (NOT rendered under first+last-3) surfaces.
+    expect(block).toContain(decisionInMidSessionTurn);
+    // turn0 IS rendered above, so the mirror entry for turn0 is filtered.
+    const mirrorSectionIdx = block.indexOf("**Codex agent message mirror");
+    const mirrorTail = block.slice(mirrorSectionIdx);
+    expect(mirrorTail.match(/turn0 content/g)?.length ?? 0).toBe(0);
+  });
+
+  it("omits Codex mirror section when every entry is in the rendered turn selection", () => {
+    const turns = ["a", "b", "c"]; // all 3 rendered (≤4)
+    const mirror = ["a", "b"]; // both already rendered above
+    const block = lib.renderHandoffBlock(meta, [], turns, "claude", { mirror });
+    expect(block).not.toContain("**Codex agent message mirror");
+  });
+});
+
+describe("selectPromptsForRender", () => {
+  it("returns the full list when at or below the cap", () => {
+    expect(lib.selectPromptsForRender([])).toEqual([]);
+    expect(lib.selectPromptsForRender(["a", "b", "c"])).toEqual(["a", "b", "c"]);
+    const at = Array.from({ length: 50 }, (_, i) => `p${i}`);
+    expect(lib.selectPromptsForRender(at)).toHaveLength(50);
+  });
+  it("pins prompt 0 and ring-buffers the last 49 when above 50", () => {
+    const over = Array.from({ length: 75 }, (_, i) => `p${i}`);
+    const sel = lib.selectPromptsForRender(over);
+    expect(sel).toHaveLength(50);
+    expect(sel[0]).toBe("p0");
+    expect(sel[1]).toBe("p26");
+    expect(sel[49]).toBe("p74");
+  });
+});
+
+describe("selectTurnsForRender", () => {
+  it("returns the full list when at or below 4 turns", () => {
+    expect(lib.selectTurnsForRender([])).toEqual([]);
+    expect(lib.selectTurnsForRender(["a", "b", "c", "d"])).toEqual(["a", "b", "c", "d"]);
+  });
+  it("returns first + last 3 when above 4 turns", () => {
+    const turns = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    expect(lib.selectTurnsForRender(turns)).toEqual(["a", "f", "g", "h"]);
   });
 });
 

--- a/skills/handoff/references/digest-schema.md
+++ b/skills/handoff/references/digest-schema.md
@@ -63,6 +63,33 @@ next_step_suggestion: |
 The `<handoff>` tag is intentional: target agents can detect it
 reliably and distinguish digest content from surrounding commentary.
 
+## Approach A: agent-authored state block (`push --state-file`)
+
+When `--state-file <path>` is passed to `dotbabel handoff push`, the
+file's raw content (typically a `<handoff-state>` YAML block authored by
+the source agent) is **prepended above** the `<handoff ...>` opening
+tag — not inside it. This is intentional:
+
+- Target agents that only want the mechanical block can detect the `<handoff>`
+  boundary without parsing agent-authored content outside it.
+- The state block flows through the same secret scrubber as the rest of the
+  digest before leaving the machine.
+
+Example shape when `--state-file` is used:
+
+```markdown
+<handoff-state version="1">
+goals:
+  - migrate auth middleware
+decisions:
+  - keep JWT expiry at 15 min
+</handoff-state>
+
+<handoff origin="claude" session="abc123ef" cwd="/repo" target="codex">
+...
+</handoff>
+```
+
 ## Rendering: `pull --summary` output (terse inline summary)
 
 ```markdown
@@ -114,9 +141,10 @@ a `docs/` directory exists at the repo root, else
 - `summary`: ≤ 400 characters.
 - `key_findings`: ≤ 5 bullets.
 - `user_prompts`: cap at 50 prompts (prompt 1 always pinned + last 49)
-  per the handoff-hardening 2026-05-08 experiment; note the truncation
-  in `summary`. The cap engages only when the session has > 50 prompts;
-  shorter sessions render the full log unchanged.
+  per the handoff-hardening 2026-05-08 experiment (results at
+  `docs/experiments/handoff-hardening-2026-05-08.md`); note the
+  truncation in `summary`. The cap engages only when the session has
+  > 50 prompts; shorter sessions render the full log unchanged.
 - `assistant_turns`: first turn (initial framing) + last 3 (recent
   context). Mid-session turns surface via Approach B's TodoWrite
   extraction (Claude) or `event_msg.agent_message` mirror (Codex).

--- a/skills/handoff/references/digest-schema.md
+++ b/skills/handoff/references/digest-schema.md
@@ -113,7 +113,12 @@ a `docs/` directory exists at the repo root, else
 
 - `summary`: ≤ 400 characters.
 - `key_findings`: ≤ 5 bullets.
-- `user_prompts`: cap at the last 10 prompts if the session has more;
-  note the truncation in `summary`.
+- `user_prompts`: cap at 50 prompts (prompt 1 always pinned + last 49)
+  per the handoff-hardening 2026-05-08 experiment; note the truncation
+  in `summary`. The cap engages only when the session has > 50 prompts;
+  shorter sessions render the full log unchanged.
+- `assistant_turns`: first turn (initial framing) + last 3 (recent
+  context). Mid-session turns surface via Approach B's TodoWrite
+  extraction (Claude) or `event_msg.agent_message` mirror (Codex).
 - `files_touched`: ≤ 20 paths; dedupe; prefer ones the assistant
   wrote/edited over ones it merely read.


### PR DESCRIPTION
## Summary

- Add B-floor mechanical extraction: pin prompt 1 + ring-buffer last 49 (cap 50, validated ≤1.5× baseline bytes per CLI in the 2026-05-08 handoff-hardening experiment); include first + last 3 assistant turns instead of just last 3.
- Extract Claude `TodoWrite` tool_use payloads via a new `todos` subcommand on `handoff-extract.sh`; render under a `**Tracked TODOs.**` section.
- Add Codex `event_msg.agent_message` mirror fallback via new `mirror` subcommand; render entries that are NOT already in the **rendered** turn selection (regression: dedupe must compare against `turnsTail`, not the full extract — see test).
- Add Approach A opt-in: `--state-file <path>` on `dotbabel handoff push` reads a local markdown file (typically a `<handoff-state>` YAML block authored by the source agent) and prepends it above the mechanical block. Flows through the existing scrubber.

Background: the 2026-05-08 handoff-hardening experiment reproduced the original failure mode (mid-session goals/decisions dropped by tail-only extraction) across all 4 CLIs and both transports. Local + roundtrip rubric:

| approach | claude | copilot | codex | gemini |
| --- | --- | --- | --- | --- |
| baseline | 3/6 | 3/6 | 3/6 | 3/6 |
| **A** (state block) | **6/6** | **6/6** | **6/6** | **6/6** |
| **B** (this PR's floor) | **6/6** | 5/6 | **6/6** | 5/6 |

Both A and B clear the ≥5/6 floor; A closes the last point on copilot/gemini where there is no structured carrier for mid-session decisions. Shipping both layered captures the best of each (B always-on, A opt-in).

## Test plan

- [x] `npm test` passes (646 tests, +9 new, vitest)
- [x] Empty-prompt / empty-turn paths render the simplified `**User prompts.**` / `**Assistant turns.**` headers (cross-CLI baseline fixture updated)
- [x] State block prepended above `<handoff>` when `opts.stateBlock` is set (renderHandoffBlock test)
- [x] Tracked TODOs section renders Claude TodoWrite payloads with status prefix
- [x] Codex agent_message mirror dedupes against **rendered** turns only (regression test for the bug we caught mid-experiment — would otherwise silently drop mid-session decisions outside the first+last-3 window)
- [x] `selectPromptsForRender` ring-buffer math validated for n=15 (full log) and n=75 (50 of 75 with prompt 0 pinned)
- [x] `selectTurnsForRender` validated for n≤4 and n>4
- [x] `handoff-push-dryrun.test.mjs` mock queue updated for the new `extractTodos` spawn (Claude path)
- [x] No real secrets in diff (planted decoys are sandbox-only fixtures, not modified here)
- [ ] Bats integration suite (`bats plugins/dotbabel/tests/bats/handoff-*.bats`) — to be run by CI
- [ ] LLM-acts-on-digest pass (Approach A vs B side-by-side on real Claude/Codex via SDK) — separate follow-up, blocked on Anthropic API credit top-up; harness exists at `tests/experiment/results/llm-eval.mjs` in the experiment sandbox
- [ ] Next-step hint A/B (`"Treat this as a task specification."` vs softer variant) — separate follow-up, same blocker

Lint note: prettier flags `CHANGELOG.md` regardless of this PR. Confirmed pre-existing on `origin/main`. Not in scope here.

## Spec ID

dotbabel-core
