### PR TITLE
feat(bootstrap): honor GEMINI_HOME for parity with CODEX_HOME

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -189,6 +189,8 @@ if [[ -d "$AGENTS_SRC" ]]; then
 fi
 
 CLI_INSTRUCTIONS_SRC="$DOTBABEL/plugins/dotbabel/templates/cli-instructions"
+# Copilot CLI has no skill auto-discovery dir (~/.copilot/), so we link only
+# the instruction file, not skills.
 link_cli_instruction \
   copilot \
   "$CLI_INSTRUCTIONS_SRC/copilot-instructions.md" \
@@ -203,7 +205,7 @@ link_cli_instruction \
   gemini \
   "$CLI_INSTRUCTIONS_SRC/gemini-GEMINI.md" \
   "$HOME/.gemini/GEMINI.md"
-fan_out_skills_to_dir gemini "$HOME/.gemini/skills"
+fan_out_skills_to_dir gemini "${GEMINI_HOME:-$HOME/.gemini}/skills"
 
 if [[ "$QUIET" = "1" ]]; then
   echo "bootstrap complete — target: $TARGET"

--- a/plugins/dotbabel/src/bootstrap-global.mjs
+++ b/plugins/dotbabel/src/bootstrap-global.mjs
@@ -287,6 +287,8 @@ export async function bootstrapGlobal(opts = {}) {
   }
 
   const cliInstructionsSrc = path.join(source, "plugins", "dotbabel", "templates", "cli-instructions");
+  // Copilot CLI has no skill auto-discovery dir (~/.copilot/), so we link only
+  // the instruction file, not skills.
   linkCliInstruction({
     cli: "copilot",
     src: path.join(cliInstructionsSrc, "copilot-instructions.md"),
@@ -308,7 +310,7 @@ export async function bootstrapGlobal(opts = {}) {
   });
   fanOutSkillsToDir({
     cli: "gemini",
-    dstDir: path.join(homeRoot, ".gemini", "skills"),
+    dstDir: path.join(process.env.GEMINI_HOME || path.join(homeRoot, ".gemini"), "skills"),
   });
 
   out.flush();

--- a/plugins/dotbabel/tests/bats/bootstrap.bats
+++ b/plugins/dotbabel/tests/bats/bootstrap.bats
@@ -93,3 +93,19 @@ teardown() {
   run bash -c "ls '$HOME/.codex/skills/'changelog.bak-*"
   [ "$status" -eq 0 ]
 }
+
+@test "gemini fan-out honors GEMINI_HOME" {
+  GEMINI_HOME="$HOME/custom-gemini"
+  export GEMINI_HOME
+
+  run "$BOOT" --all --quiet
+  [ "$status" -eq 0 ]
+  [ -L "$GEMINI_HOME/skills/changelog/SKILL.md" ]
+  target=$(readlink "$GEMINI_HOME/skills/changelog/SKILL.md")
+  [ "$target" = "$REPO_ROOT/commands/changelog.md" ]
+
+  # Default $HOME/.gemini/skills must NOT be populated when override is set.
+  [ ! -e "$HOME/.gemini/skills/changelog/SKILL.md" ]
+
+  unset GEMINI_HOME
+}

--- a/plugins/dotbabel/tests/bootstrap-global.test.mjs
+++ b/plugins/dotbabel/tests/bootstrap-global.test.mjs
@@ -245,6 +245,39 @@ describe("bootstrapGlobal", () => {
   });
 
   // -------------------------------------------------------------------------
+  // GEMINI_HOME parity with CODEX_HOME — the gemini fan-out target must honor
+  // process.env.GEMINI_HOME when set, falling back to <homeRoot>/.gemini.
+  // -------------------------------------------------------------------------
+
+  it("honors GEMINI_HOME when fanning out gemini skills", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    const customGemini = makeTmpDir("custom-gemini-");
+    buildFakeSource(src);
+
+    const prev = process.env.GEMINI_HOME;
+    process.env.GEMINI_HOME = customGemini;
+    try {
+      const result = await bootstrapGlobal({ source: src, target: tgt, allCli: true });
+      expect(result.ok).toBe(true);
+
+      // Skill should land in the override path.
+      const overrideSkill = path.join(customGemini, "skills", "alpha");
+      expect(fs.lstatSync(overrideSkill).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(overrideSkill)).toBe(path.join(src, "skills", "alpha"));
+
+      // Default path must NOT be populated when override is set.
+      const defaultSkillsDir = path.join(tgt, ".gemini", "skills");
+      const defaultExists =
+        fs.existsSync(defaultSkillsDir) && fs.readdirSync(defaultSkillsDir).length > 0;
+      expect(defaultExists).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.GEMINI_HOME;
+      else process.env.GEMINI_HOME = prev;
+    }
+  });
+
+  // -------------------------------------------------------------------------
   // Test 7 — returns { ok: false } when source directory does not exist
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Bash and Node bootstrap paths now honor `$GEMINI_HOME` (with fallback to `$HOME/.gemini`) for the gemini skill fan-out, matching the existing `$CODEX_HOME` pattern.
- Adds an inline comment explaining why Copilot CLI gets only the instruction file (no skill auto-discovery dir at `~/.copilot/`).

## Test plan

- [x] **TDD red first** — added failing vitest case `honors GEMINI_HOME when fanning out gemini skills` in `plugins/dotbabel/tests/bootstrap-global.test.mjs` and failing bats case `gemini fan-out honors GEMINI_HOME` in `plugins/dotbabel/tests/bats/bootstrap.bats`. Both failed on the parent commit (`49ebfdc`).
- [x] After implementing the bash + Node changes, both tests pass.
- [x] `npm test` — 648/648 pass.
- [x] `npx bats plugins/dotbabel/tests/bats/bootstrap.bats` — 10/10 pass.
- [x] `shellcheck -x bootstrap.sh` — clean.
- [x] `npm run dogfood` — passes (`spec coverage ok (1 protected file(s) changed)` with No-spec rationale below).
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — passes.

## Notes

- Pre-existing `npm run lint` failure on `CHANGELOG.md` and `npm run shellcheck` style warnings on `plugins/dotbabel/templates/claude/hooks/guard-destructive-git.sh` are present on `origin/main` independent of this change (verified via `git stash --include-untracked` round-trip). Out of scope.

## No-spec rationale

This change introduces no new spec contract — it is a parity fix completing the env-var override pattern already established for `$CODEX_HOME`. The change conforms to the established CLI surface and validators in `npm run dogfood`. Audit reference: `/home/kaioh/.claude/plans/plan-it-out-in-joyful-kay.md`.
