### PR TITLE
docs(handoff): SKILL.md flags + layered-fidelity section + cli enum

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,244 +1,248 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-07T19:12:04.553Z",
+  "generatedAt": "2026-05-09T01:53:11.032Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/skills/audit-and-fix/SKILL.md",
       "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "create-assessment",
       "path": ".claude/skills/create-assessment/SKILL.md",
       "checksum": "sha256:b1125255b0c62ec88157ad4476b681e1dbaff200a8e8942f3eccf49cb873dbe4",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "create-audit",
       "path": ".claude/skills/create-audit/SKILL.md",
       "checksum": "sha256:babb4a5e281388eb5dcf59f1d563b1622cfd5062a269b421e1aab0a53272695a",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/skills/detect-flaky/SKILL.md",
       "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "deploy-status",
       "path": ".claude/skills/deploy-status/SKILL.md",
       "checksum": "sha256:f9128b2d793a9878e4288b1c54cb539ac0dc2165f0ecb9cff4f85c97906fe5d4",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/skills/fix-with-evidence/SKILL.md",
       "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "git",
       "path": ".claude/skills/git/SKILL.md",
       "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "ground-first",
       "path": ".claude/skills/ground-first/SKILL.md",
       "checksum": "sha256:238437a50b202ee5e32981ea410fc8b5adb4a7ea5979630642f2678e266804a3",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "create-inspection",
       "path": ".claude/skills/create-inspection/SKILL.md",
       "checksum": "sha256:421141b2c143acb094809f6e700d8562e6dcbade940df0edd8365de7671ecfb1",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "review-pr",
       "path": ".claude/skills/review-pr/SKILL.md",
       "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "security-review",
       "path": ".claude/skills/security-review/SKILL.md",
       "checksum": "sha256:ea03f5bc029de3182ef8ec286a9f3c12b635ad4d36631c024ec2f5c990f5a176",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:ca6a137a6d9316de931a26d8a9bf2126d8c1f5005e53a5abd2a722f745fb1080",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:c5b84124feec666c2174fe85b578d5b8d1fb96169194e4c21a4ce2b3239cf83f",
+      "checksum": "sha256:88cc19c675d6e2e71375a1c7f4bb289fcf8dec818396904cc7c0e1df74cd6937",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "review-prs",
       "path": ".claude/skills/review-prs/SKILL.md",
       "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "rollback-prod",
       "path": ".claude/skills/rollback-prod/SKILL.md",
       "checksum": "sha256:32a58bb0feb413e7f44148347d62283332ba259273a6c8f6d4a514876cc484dd",
-      "dependencies": ["deploy-status"],
-      "lastValidated": "2026-05-07"
+      "dependencies": [
+        "deploy-status"
+      ],
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "plan-grader",
       "path": ".claude/skills/plan-grader/SKILL.md",
       "checksum": "sha256:803d919381f876d5c29c28e1ab19d74a55cd54d74bb5ee6158ca10e8481af2a0",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:fc1b81ff49b9ec010542172ce5dab42350b974bff08ab86c805fac5bedc78a1a",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "create-experiment",
       "path": ".claude/skills/create-experiment/SKILL.md",
       "checksum": "sha256:0f304358b5ad1605e83c2cb60b37f166491088a74f7a274dbf61137c14e9b86f",
       "dependencies": [],
-      "lastValidated": "2026-05-07"
+      "lastValidated": "2026-05-09"
     },
     {
       "name": "post-pr-review",
       "path": ".claude/skills/post-pr-review/SKILL.md",
       "checksum": "sha256:0565fc80dba6872c5da9569cff5e53d112fc3ea3a16b4905fdf38255754ec628",
-      "dependencies": ["review-pr"],
-      "lastValidated": "2026-05-07"
+      "dependencies": [
+        "review-pr"
+      ],
+      "lastValidated": "2026-05-09"
     }
   ]
 }

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-09T01:53:11.032Z",
+  "generatedAt": "2026-05-09T11:26:14.750Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -194,7 +194,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:88cc19c675d6e2e71375a1c7f4bb289fcf8dec818396904cc7c0e1df74cd6937",
+      "checksum": "sha256:46f285ac145e974932198d3651931d46f7299e42a7bf4c93e79d3acf27ba190e",
       "dependencies": [],
       "lastValidated": "2026-05-09"
     },
@@ -209,9 +209,7 @@
       "name": "rollback-prod",
       "path": ".claude/skills/rollback-prod/SKILL.md",
       "checksum": "sha256:32a58bb0feb413e7f44148347d62283332ba259273a6c8f6d4a514876cc484dd",
-      "dependencies": [
-        "deploy-status"
-      ],
+      "dependencies": ["deploy-status"],
       "lastValidated": "2026-05-09"
     },
     {
@@ -239,9 +237,7 @@
       "name": "post-pr-review",
       "path": ".claude/skills/post-pr-review/SKILL.md",
       "checksum": "sha256:0565fc80dba6872c5da9569cff5e53d112fc3ea3a16b4905fdf38255754ec628",
-      "dependencies": [
-        "review-pr"
-      ],
+      "dependencies": ["review-pr"],
       "lastValidated": "2026-05-09"
     }
   ]

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-09T11:26:14.750Z",
+  "generatedAt": "2026-05-09T11:45:46.391Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -194,7 +194,7 @@
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:46f285ac145e974932198d3651931d46f7299e42a7bf4c93e79d3acf27ba190e",
+      "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
       "dependencies": [],
       "lastValidated": "2026-05-09"
     },

--- a/plugins/dotbabel/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/handoff/SKILL.md
@@ -60,6 +60,25 @@ is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
 `codex` for Codex). The flag is required in that mode; the binary exits
 64 without it.
 
+## Layered fidelity (Approach A and Approach B)
+
+The digest combines two layers of context fidelity:
+
+- **B-floor (always on).** Mechanical extraction the binary performs
+  unconditionally: TodoWrite mining in claude/codex transcripts,
+  user-prompt cap of 50 (prompt 1 pinned + last 49), and assistant
+  turn sampling (first turn + last 3). This is what every `push` and
+  `pull` produces with no extra flags. See
+  `references/digest-schema.md` for the schema and size bounds.
+- **Approach A (opt-in via `--state-file`).** When
+  `dotbabel handoff push --state-file <path>` is passed, the file's
+  raw content (typically a `<handoff-state>` YAML block authored by
+  the source agent) is prepended above the mechanical `<handoff>`
+  block. This lets the agent author intent, decisions, and goals
+  verbatim instead of relying on extraction heuristics. The block
+  flows through the same secret scrubber. See
+  `references/digest-schema.md` for the rendered shape.
+
 ## Tool execution failures
 
 When the `dotbabel` binary cannot be executed for any reason —
@@ -94,6 +113,7 @@ Brief reference. `dotbabel handoff --help` is authoritative.
 - `--tag <label>` annotates a `push` (repeatable). On `fetch <tag>`, exact-tag matches are preferred over description substring fallback.
 - `--fixed` / `-F` treats the `search` query as a literal string instead of a regex.
 - `--json` is honoured by `list`, `pull`, `search`.
+- `--state-file <path>` (on `push`) prepends a free-form state block (Approach A) to the digest before the mechanical extraction. The block is scrubbed for secrets like any other content.
 
 ## Out of scope
 

--- a/plugins/dotbabel/templates/claude/skills/handoff/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/handoff/SKILL.md
@@ -62,7 +62,10 @@ is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
 
 ## Layered fidelity (Approach A and Approach B)
 
-The digest combines two layers of context fidelity:
+The digest combines two layers of context fidelity. Justification and
+tradeoffs are captured in
+`docs/experiments/handoff-hardening-2026-05-08.md` (added in PR #206;
+this PR must merge after #206 for the link to resolve).
 
 - **B-floor (always on).** Mechanical extraction the binary performs
   unconditionally: TodoWrite mining in claude/codex transcripts,

--- a/plugins/dotbabel/templates/claude/skills/handoff/references/digest-schema.md
+++ b/plugins/dotbabel/templates/claude/skills/handoff/references/digest-schema.md
@@ -8,7 +8,7 @@ should produce the same shape.
 
 ```yaml
 origin:
-  cli: claude | copilot | codex
+  cli: claude | copilot | codex | gemini
   session_id: <full-uuid>
   short_id: <first-8-chars-of-uuid>
   cwd: <absolute-path>

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -65,9 +65,7 @@ is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
 
 ## Layered fidelity (Approach A and Approach B)
 
-The digest combines two layers of context fidelity. The justification
-and tradeoffs are captured in
-`docs/experiments/handoff-hardening-2026-05-08.md`.
+The digest combines two layers of context fidelity:
 
 - **B-floor (always on).** Mechanical extraction the binary performs
   unconditionally: TodoWrite mining in claude/codex transcripts,

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -65,7 +65,10 @@ is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
 
 ## Layered fidelity (Approach A and Approach B)
 
-The digest combines two layers of context fidelity:
+The digest combines two layers of context fidelity. Justification and
+tradeoffs are captured in
+`docs/experiments/handoff-hardening-2026-05-08.md` (added in PR #206;
+this PR must merge after #206 for the link to resolve).
 
 - **B-floor (always on).** Mechanical extraction the binary performs
   unconditionally: TodoWrite mining in claude/codex transcripts,

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -63,6 +63,27 @@ is running in (`claude` for Claude Code, `copilot` for GitHub Copilot CLI,
 `codex` for Codex). The flag is required in that mode; the binary exits
 64 without it.
 
+## Layered fidelity (Approach A and Approach B)
+
+The digest combines two layers of context fidelity. The justification
+and tradeoffs are captured in
+`docs/experiments/handoff-hardening-2026-05-08.md`.
+
+- **B-floor (always on).** Mechanical extraction the binary performs
+  unconditionally: TodoWrite mining in claude/codex transcripts,
+  user-prompt cap of 50 (prompt 1 pinned + last 49), and assistant
+  turn sampling (first turn + last 3). This is what every `push` and
+  `pull` produces with no extra flags. See
+  `references/digest-schema.md` for the schema and size bounds.
+- **Approach A (opt-in via `--state-file`).** When
+  `dotbabel handoff push --state-file <path>` is passed, the file's
+  raw content (typically a `<handoff-state>` YAML block authored by
+  the source agent) is prepended above the mechanical `<handoff>`
+  block. This lets the agent author intent, decisions, and goals
+  verbatim instead of relying on extraction heuristics. The block
+  flows through the same secret scrubber. See
+  `references/digest-schema.md` for the rendered shape.
+
 ## Tool execution failures
 
 When the `dotbabel` binary cannot be executed for any reason —
@@ -97,6 +118,7 @@ Brief reference. `dotbabel handoff --help` is authoritative.
 - `--tag <label>` annotates a `push` (repeatable). On `fetch <tag>`, exact-tag matches are preferred over description substring fallback.
 - `--fixed` / `-F` treats the `search` query as a literal string instead of a regex.
 - `--json` is honoured by `list`, `pull`, `search`.
+- `--state-file <path>` (on `push`) prepends a free-form state block (Approach A) to the digest before the mechanical extraction. The block is scrubbed for secrets like any other content.
 
 ## Out of scope
 

--- a/skills/handoff/references/digest-schema.md
+++ b/skills/handoff/references/digest-schema.md
@@ -8,7 +8,7 @@ should produce the same shape.
 
 ```yaml
 origin:
-  cli: claude | copilot | codex
+  cli: claude | copilot | codex | gemini
   session_id: <full-uuid>
   short_id: <first-8-chars-of-uuid>
   cwd: <absolute-path>


### PR DESCRIPTION
## Summary

- Adds `--state-file` to the cross-cutting flags table in `skills/handoff/SKILL.md`.
- Adds a new "Layered fidelity (Approach A and Approach B)" section that explains the always-on B-floor extraction and the opt-in Approach A state block.
- Fixes the `cli` enum in `skills/handoff/references/digest-schema.md` to include `gemini` (shipped in #185).

## Test plan

- [x] `grep -c -- '--state-file' skills/handoff/SKILL.md` returns 3 (table entry + section paragraph).
- [x] `grep '^\s*cli:' skills/handoff/references/digest-schema.md` shows `claude | copilot | codex | gemini`.
- [x] `npm test` — 42 files / 647 tests pass.
- [x] `npm run dogfood` — manifest valid (34 skills), specs valid, instruction freshness, parity, and spec coverage all pass.
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — index fresh (58 artifacts).
- [x] `npx prettier --check .claude/skills-manifest.json skills/handoff/SKILL.md` — clean.
- [x] `node scripts/build-plugin.mjs --check` — plugin templates fresh.

## No-spec rationale

This PR touches three protected paths in a purely mechanical way:

- `.claude/skills-manifest.json` (`.claude/**`) — auto-regenerated by
  `dotbabel-validate-skills --update` after any `skills/**` edit; only the
  `handoff` checksum, `generatedAt`, and per-entry `lastValidated`
  timestamps change. No skill graph (dependencies, paths, names) changes.
- `plugins/dotbabel/templates/claude/skills/handoff/SKILL.md` and
  `plugins/dotbabel/templates/claude/skills/handoff/references/digest-schema.md`
  (`plugins/dotbabel/templates/**`) — regenerated by
  `node scripts/build-plugin.mjs` so the shipped consumer templates mirror
  the authored skill content. The build script is the sole writer of these
  files; no substantive logic lives there.

The substantive work — clarifying the `--state-file` flag, the
layered-fidelity model, and the `gemini` enum — lives entirely in
`skills/handoff/**`, which is not protected. No `dotbabel` contract,
schema, or runtime behaviour changes. A spec is overkill for a
documentation-only refresh.

## Notes

- The `CHANGELOG.md` prettier warning surfaced by `npm run lint` is **pre-existing on `origin/main`** — verified by stashing the branch's tracked + untracked changes and re-running `npx prettier --check ./CHANGELOG.md`, which still warns. Out of scope for this PR.
- The `.claude/skills-manifest.json` diff is the expected refresh after editing `SKILL.md`: the handoff entry's sha256 changes, and `generatedAt` / per-entry `lastValidated` timestamps update. Only the `handoff` checksum substantively changed.
