### PR TITLE
docs(bootstrap): document codex/gemini skill fan-out paths

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -240,12 +240,12 @@ Pre-existing real files (not symlinks) are backed up to `<name>.bak-<timestamp>`
 > **Platform note:** Windows is not supported (symlinks require elevated
 > permissions). Use WSL or run `bootstrap.sh` from Git Bash instead.
 
-| Flag              | Default     |                                                 |
-| ----------------- | ----------- | ----------------------------------------------- |
-| `--source <path>` | npm install | Path to a local dotbabel git clone (clone mode) |
-| `--target <dir>`  | `~/.claude` | Override destination directory                  |
-| `--all`           | false       | Link Copilot/Codex/Gemini instructions too      |
-| `--quiet`         | false       | Suppress per-file progress; print summary only  |
+| Flag              | Default     |                                                                                                                                               |
+| ----------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--source <path>` | npm install | Path to a local dotbabel git clone (clone mode)                                                                                               |
+| `--target <dir>`  | `~/.claude` | Override destination directory                                                                                                                |
+| `--all`           | false       | Link Copilot/Codex/Gemini instructions and fan out skills to `~/.codex/skills`, `~/.gemini/skills` (Copilot has no skill auto-discovery dir). |
+| `--quiet`         | false       | Suppress per-file progress; print summary only                                                                                                |
 
 **Typical invocations:**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -240,12 +240,15 @@ Pre-existing real files (not symlinks) are backed up to `<name>.bak-<timestamp>`
 > **Platform note:** Windows is not supported (symlinks require elevated
 > permissions). Use WSL or run `bootstrap.sh` from Git Bash instead.
 
-| Flag              | Default     |                                                                                                                                               |
-| ----------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--source <path>` | npm install | Path to a local dotbabel git clone (clone mode)                                                                                               |
-| `--target <dir>`  | `~/.claude` | Override destination directory                                                                                                                |
-| `--all`           | false       | Link Copilot/Codex/Gemini instructions and fan out skills to `~/.codex/skills`, `~/.gemini/skills` (Copilot has no skill auto-discovery dir). |
-| `--quiet`         | false       | Suppress per-file progress; print summary only                                                                                                |
+| Flag              | Default     |                                                                                          |
+| ----------------- | ----------- | ---------------------------------------------------------------------------------------- |
+| `--source <path>` | npm install | Path to a local dotbabel git clone (clone mode)                                          |
+| `--target <dir>`  | `~/.claude` | Override destination directory                                                           |
+| `--all`           | false       | Link Copilot/Codex/Gemini instructions and fan out skills to `~/.codex/`, `~/.gemini/`.¹ |
+| `--quiet`         | false       | Suppress per-file progress; print summary only                                           |
+
+¹ Skills fan out to `~/.codex/skills/` and `~/.gemini/skills/`. Copilot has no
+skill auto-discovery directory, so only its instruction file is linked.
 
 **Typical invocations:**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -240,15 +240,14 @@ Pre-existing real files (not symlinks) are backed up to `<name>.bak-<timestamp>`
 > **Platform note:** Windows is not supported (symlinks require elevated
 > permissions). Use WSL or run `bootstrap.sh` from Git Bash instead.
 
-| Flag              | Default     |                                                                                          |
-| ----------------- | ----------- | ---------------------------------------------------------------------------------------- |
-| `--source <path>` | npm install | Path to a local dotbabel git clone (clone mode)                                          |
-| `--target <dir>`  | `~/.claude` | Override destination directory                                                           |
-| `--all`           | false       | Link Copilot/Codex/Gemini instructions and fan out skills to `~/.codex/`, `~/.gemini/`.¹ |
-| `--quiet`         | false       | Suppress per-file progress; print summary only                                           |
+| Flag              | Default     |                                                                                             |
+| ----------------- | ----------- | ------------------------------------------------------------------------------------------- |
+| `--source <path>` | npm install | Path to a local dotbabel git clone (clone mode)                                             |
+| `--target <dir>`  | `~/.claude` | Override destination directory                                                              |
+| `--all`           | false       | Link Copilot/Codex/Gemini instructions and fan out skills to `~/.codex/`, `~/.gemini/`.[^1] |
+| `--quiet`         | false       | Suppress per-file progress; print summary only                                              |
 
-¹ Skills fan out to `~/.codex/skills/` and `~/.gemini/skills/`. Copilot has no
-skill auto-discovery directory, so only its instruction file is linked.
+[^1]: Skills fan out to `~/.codex/skills/` and `~/.gemini/skills/`. Copilot has no skill auto-discovery directory, so only its instruction file is linked.
 
 **Typical invocations:**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -214,6 +214,21 @@ ls -la ~/.claude/skills/aws-specialist/SKILL.md
 If missing: re-run `./bootstrap.sh`. If present: restart the Claude Code session
 (`/clear` or quit and reopen) — the session may have cached the pre-bootstrap state.
 
+### A skill isn't available in Codex / Gemini CLI
+
+Skills are fanned out to `~/.codex/skills/<id>/SKILL.md` and `~/.gemini/skills/<id>/SKILL.md` during `dotbabel bootstrap`. Two reasons a skill might be missing there:
+
+- **Fan-out was skipped because the host CLI wasn't on `$PATH`.** The bootstrap only fans out to a CLI it can find. Re-run with `dotbabel bootstrap --all` (or `./bootstrap.sh --all`) to force fan-out regardless of `$PATH`.
+- **Custom config dir.** Both `$CODEX_HOME` and `$GEMINI_HOME` override the default `~/.codex` and `~/.gemini` parents. Check the active values:
+
+```bash
+echo "$CODEX_HOME" "$GEMINI_HOME"
+ls -la "${CODEX_HOME:-$HOME/.codex}/skills/<id>/SKILL.md"
+ls -la "${GEMINI_HOME:-$HOME/.gemini}/skills/<id>/SKILL.md"
+```
+
+`dotbabel doctor` validates these symlinks resolve when the matching CLI is on `$PATH`.
+
 ### A skill runs but uses outdated behavior
 
 The session cached an older version. Run `./sync.sh pull` (or `dotbabel sync pull`)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -218,7 +218,7 @@ If missing: re-run `./bootstrap.sh`. If present: restart the Claude Code session
 
 Skills are fanned out to `~/.codex/skills/<id>/SKILL.md` and `~/.gemini/skills/<id>/SKILL.md` during `dotbabel bootstrap`. Two reasons a skill might be missing there:
 
-- **Fan-out was skipped because the host CLI wasn't on `$PATH`.** The bootstrap only fans out to a CLI it can find. Re-run with `dotbabel bootstrap --all` (or `./bootstrap.sh --all`) to force fan-out regardless of `$PATH`.
+- **Fan-out was skipped because the host CLI wasn't on `$PATH`.** Bootstrap only fans out to a CLI it can find. Re-run with `dotbabel bootstrap --all` (or `./bootstrap.sh --all`) to force fan-out even when the CLI isn't installed yet.
 - **Custom config dir.** Both `$CODEX_HOME` and `$GEMINI_HOME` override the default `~/.codex` and `~/.gemini` parents. Check the active values:
 
 ```bash


### PR DESCRIPTION
## Summary

- Updates the `--all` flag row in `docs/cli-reference.md` so it documents the actual behavior: it fans out skills to `~/.codex/skills` and `~/.gemini/skills` in addition to linking the per-CLI instruction files.
- Adds a new `### A skill isn't available in Codex / Gemini CLI` subsection to `docs/troubleshooting.md` covering the two known failure modes: host CLI not on `$PATH` (skipped fan-out) and a non-default `$CODEX_HOME` / `$GEMINI_HOME` parent.
- Pairs with #207 (GEMINI_HOME parity, open) and #210 (doctor fan-out check, open) — the docs were the only public surface still lying about what `--all` does. **Merge order: #207 must merge before this PR**, otherwise the GEMINI_HOME mention here is a documented-but-unimplemented promise.

## Test plan

- [x] `grep -n '~/.codex/skills' docs/cli-reference.md docs/troubleshooting.md` returns at least two hits (one per file).
- [x] `grep -n '~/.gemini/skills' docs/cli-reference.md docs/troubleshooting.md` returns at least two hits.
- [x] `grep -n '\$CODEX_HOME\|\$GEMINI_HOME' docs/troubleshooting.md` shows both env vars referenced.
- [x] `npm run lint` — passes for the changed files; the only failure is `CHANGELOG.md` which is **pre-existing on `origin/main`** (verified with `git stash --include-untracked && npm run lint; git stash pop`).
- [x] `npm run dogfood` — all six dogfood gates green (validate-skills, validate-specs, check-instruction-drift, check-instructions-fresh, check-instruction-parity, check-spec-coverage).

