### PR TITLE
chore(scripts): add prune-merged-branches helper

### DIFF
--- a/plugins/dotbabel/tests/bats/prune-merged-branches.bats
+++ b/plugins/dotbabel/tests/bats/prune-merged-branches.bats
@@ -84,8 +84,31 @@ teardown() {
 }
 
 @test "refuses --delete-remote" {
-  
+
   run "$SCRIPT" --delete-remote
   [ "$status" -ne 0 ]
   [[ "$output" == *"local-only"* ]] || [[ "$output" == *"refuse"* ]] || [[ "$output" == *"not supported"* ]]
+}
+
+@test "--help exits 0 and prints usage" {
+
+  run "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--dry-run"* ]]
+  [[ "$output" == *"--confirm"* ]]
+}
+
+@test "-h exits 0 and prints usage" {
+
+  run "$SCRIPT" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "unknown argument exits 64 with usage error" {
+
+  run "$SCRIPT" --not-a-real-flag
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"unknown argument"* ]]
 }

--- a/plugins/dotbabel/tests/bats/prune-merged-branches.bats
+++ b/plugins/dotbabel/tests/bats/prune-merged-branches.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Tests for scripts/prune-merged-branches.sh — local-only branch pruner that
+# deletes empty-diff or merged-PR branches matching feat/handoff-*, fix/handoff-*,
+# test/handoff-*. Default is --dry-run; --confirm performs deletes.
+
+load helpers
+
+bats_require_minimum_version 1.5.0
+
+SCRIPT="$REPO_ROOT/scripts/prune-merged-branches.sh"
+
+setup() {
+  TEST_DIR=$(mktemp -d)
+  cd "$TEST_DIR"
+  git init -q -b main
+  git config user.email "bats@example.test"
+  git config user.name "bats"
+  echo "init" > README.md
+  git add README.md
+  git commit -q -m "init"
+
+  # Empty-diff branch: forks main, no new commits → diff stat is empty.
+  git branch feat/handoff-empty
+  # Has-changes branch: one new commit → not empty diff.
+  git checkout -q -b feat/handoff-real
+  echo "real change" > real.txt
+  git add real.txt
+  git commit -q -m "real work"
+  git checkout -q main
+  # Unrelated branch: should not match the default pattern.
+  git branch feat/other-unrelated
+}
+
+teardown() {
+  cd /
+  [ -n "${TEST_DIR:-}" ] && [ -d "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+@test "--dry-run lists empty-diff as deletable, has-changes as kept, deletes nothing" {
+  
+  before_count=$(git branch | wc -l)
+  run "$SCRIPT" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feat/handoff-empty"* ]]
+  [[ "$output" == *"feat/handoff-real"* ]]
+  # Output must distinguish deletable vs kept.
+  [[ "$output" == *"deletable"* ]] || [[ "$output" == *"would delete"* ]]
+  after_count=$(git branch | wc -l)
+  [ "$before_count" -eq "$after_count" ]
+}
+
+@test "default (no flag) is dry-run" {
+  
+  before_count=$(git branch | wc -l)
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  after_count=$(git branch | wc -l)
+  [ "$before_count" -eq "$after_count" ]
+}
+
+@test "--confirm deletes the empty-diff branch and keeps has-changes + unrelated" {
+  
+  run "$SCRIPT" --confirm
+  [ "$status" -eq 0 ]
+
+  # feat/handoff-empty is gone.
+  run git rev-parse --verify feat/handoff-empty
+  [ "$status" -ne 0 ]
+
+  # feat/handoff-real survives (has unique commits).
+  run git rev-parse --verify feat/handoff-real
+  [ "$status" -eq 0 ]
+
+  # feat/other-unrelated survives (does not match handoff pattern).
+  run git rev-parse --verify feat/other-unrelated
+  [ "$status" -eq 0 ]
+}
+
+@test "refuses --push" {
+  
+  run "$SCRIPT" --push
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"local-only"* ]] || [[ "$output" == *"refuse"* ]] || [[ "$output" == *"not supported"* ]]
+}
+
+@test "refuses --delete-remote" {
+  
+  run "$SCRIPT" --delete-remote
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"local-only"* ]] || [[ "$output" == *"refuse"* ]] || [[ "$output" == *"not supported"* ]]
+}

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# prune-merged-branches.sh — local-only pruner for empty-diff or merged-PR
+# branches matching the handoff cleanup patterns. Default is --dry-run; nothing
+# is deleted without an explicit --confirm.
+#
+# Usage:
+#   bash scripts/prune-merged-branches.sh                 # alias for --dry-run
+#   bash scripts/prune-merged-branches.sh --dry-run
+#   bash scripts/prune-merged-branches.sh --confirm
+#
+# Local-only by design — the script refuses any flag mentioning push or
+# delete-remote. Cleaning up published branches must be a separate, explicit
+# operation (no scope creep).
+
+set -euo pipefail
+
+PATTERNS=(
+  "feat/handoff-*"
+  "fix/handoff-*"
+  "test/handoff-*"
+)
+
+mode="dry-run"
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) mode="dry-run" ;;
+    --confirm) mode="confirm" ;;
+    --help | -h)
+      sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *push* | *delete-remote*)
+      echo "error: $arg is not supported — this script is local-only by design" >&2
+      exit 64
+      ;;
+    *)
+      echo "error: unknown argument: $arg" >&2
+      exit 64
+      ;;
+  esac
+done
+
+# Resolve the local "main" tip; tolerate detached HEAD by falling back to the
+# branch ref directly.
+if ! git rev-parse --verify --quiet main >/dev/null; then
+  echo "error: no local 'main' branch — refusing to evaluate empty-diff against an unknown base" >&2
+  exit 64
+fi
+
+deletable=()
+kept=()
+
+# Collect branches matching any pattern.
+mapfile -t branches < <(
+  for pat in "${PATTERNS[@]}"; do
+    git for-each-ref --format='%(refname:short)' "refs/heads/$pat" 2>/dev/null
+  done | sort -u
+)
+
+for branch in "${branches[@]}"; do
+  [[ -z "$branch" ]] && continue
+  # Skip the currently checked-out branch — it's never safe to delete.
+  current=$(git branch --show-current 2>/dev/null || true)
+  if [[ "$branch" = "$current" ]]; then
+    kept+=("$branch (current branch)")
+    continue
+  fi
+
+  # Empty-diff against main → deletable.
+  if [[ -z "$(git diff "main..$branch" --stat 2>/dev/null || true)" ]]; then
+    deletable+=("$branch")
+    continue
+  fi
+
+  # Otherwise, check if the corresponding remote PR is merged. This requires
+  # `gh` and a remote; tolerate absence by treating it as "kept".
+  if command -v gh >/dev/null 2>&1; then
+    merged_count=$(gh pr list --search "head:$branch" --state merged --json number --jq 'length' 2>/dev/null || echo 0)
+    if [[ "${merged_count:-0}" -gt 0 ]]; then
+      deletable+=("$branch")
+      continue
+    fi
+  fi
+
+  kept+=("$branch")
+done
+
+echo "prune-merged-branches.sh — mode: $mode"
+echo "  patterns: ${PATTERNS[*]}"
+echo
+echo "deletable (${#deletable[@]}):"
+for b in "${deletable[@]:-}"; do
+  [[ -z "$b" ]] && continue
+  echo "  - $b — would delete"
+done
+[[ "${#deletable[@]}" -eq 0 ]] && echo "  (none)"
+echo
+echo "kept (${#kept[@]}):"
+for b in "${kept[@]:-}"; do
+  [[ -z "$b" ]] && continue
+  echo "  - $b"
+done
+[[ "${#kept[@]}" -eq 0 ]] && echo "  (none)"
+
+if [[ "$mode" = "dry-run" ]]; then
+  echo
+  echo "dry-run: nothing deleted. Re-run with --confirm to delete the listed branches."
+  exit 0
+fi
+
+echo
+echo "deleting (--confirm):"
+for b in "${deletable[@]:-}"; do
+  [[ -z "$b" ]] && continue
+  git branch -D "$b"
+done
+echo "done."

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -84,16 +84,21 @@ for branch in "${branches[@]}"; do
     continue
   fi
 
-  # Empty-diff against main → deletable.
-  if [[ -z "$(git diff "main..$branch" --stat 2>/dev/null || true)" ]]; then
+  # Branch tip already reachable from main (fully merged or empty) → deletable.
+  # Use `merge-base --is-ancestor` rather than a two-dot diff stat: it's the
+  # exact primitive for "this branch contains nothing main doesn't already
+  # have", and stays correct even after main advances past the fork point.
+  if git merge-base --is-ancestor "$branch" main 2>/dev/null; then
     deletable+=("$branch")
     continue
   fi
 
   # Otherwise, check if the corresponding remote PR is merged. This requires
   # `gh` and a remote; tolerate absence by treating it as "kept".
+  # Use `--head` (exact branch-name match) rather than `--search "head:..."`
+  # so partial-name matches across forks/states can't inflate the count.
   if command -v gh >/dev/null 2>&1; then
-    merged_count=$(gh pr list --search "head:$branch" --state merged --json number --jq 'length' 2>/dev/null || echo 0)
+    merged_count=$(gh pr list --head "$branch" --state merged --json number --jq 'length' 2>/dev/null || echo 0)
     if [[ "${merged_count:-0}" -gt 0 ]]; then
       deletable+=("$branch")
       continue

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -20,6 +20,23 @@ PATTERNS=(
   "test/handoff-*"
 )
 
+print_help() {
+  cat <<'EOF'
+prune-merged-branches.sh — local-only pruner for empty-diff or merged-PR
+branches matching the handoff cleanup patterns. Default is --dry-run; nothing
+is deleted without an explicit --confirm.
+
+Usage:
+  bash scripts/prune-merged-branches.sh                 # alias for --dry-run
+  bash scripts/prune-merged-branches.sh --dry-run
+  bash scripts/prune-merged-branches.sh --confirm
+
+Local-only by design — the script refuses any flag mentioning push or
+delete-remote. Cleaning up published branches must be a separate, explicit
+operation (no scope creep).
+EOF
+}
+
 mode="dry-run"
 
 for arg in "$@"; do
@@ -27,7 +44,7 @@ for arg in "$@"; do
     --dry-run) mode="dry-run" ;;
     --confirm) mode="confirm" ;;
     --help | -h)
-      sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+      print_help
       exit 0
       ;;
     *push* | *delete-remote*)
@@ -41,12 +58,13 @@ for arg in "$@"; do
   esac
 done
 
-# Resolve the local "main" tip; tolerate detached HEAD by falling back to the
-# branch ref directly.
+# Require a local 'main' to anchor empty-diff comparisons.
 if ! git rev-parse --verify --quiet main >/dev/null; then
   echo "error: no local 'main' branch — refusing to evaluate empty-diff against an unknown base" >&2
   exit 64
 fi
+
+current=$(git branch --show-current 2>/dev/null || true)
 
 deletable=()
 kept=()
@@ -61,7 +79,6 @@ mapfile -t branches < <(
 for branch in "${branches[@]}"; do
   [[ -z "$branch" ]] && continue
   # Skip the currently checked-out branch — it's never safe to delete.
-  current=$(git branch --show-current 2>/dev/null || true)
   if [[ "$branch" = "$current" ]]; then
     kept+=("$branch (current branch)")
     continue


### PR DESCRIPTION
## Summary

- Adds `scripts/prune-merged-branches.sh` — a local-only pruner for handoff-pattern branches (`feat/handoff-*`, `fix/handoff-*`, `test/handoff-*`) with empty diffs vs `main` or merged remote PRs.
- Default is `--dry-run`; nothing is deleted without explicit `--confirm`.
- Refuses any flag mentioning `push` or `delete-remote` (exit 64) — published-branch cleanup must be a separate, explicit operation.
- The 24 stale handoff branches in this checkout (16 confirmed empty-diff or merged) are the immediate target. PR 8b (operational, gated) will run the destructive pass.

## Test plan

- [x] **TDD red first** — added 5-case `plugins/dotbabel/tests/bats/prune-merged-branches.bats` with mktemp fake-repo fixtures (empty-diff branch, has-changes branch, unrelated branch). All 5 failed on the parent commit (script absent → exit 127).
- [x] After implementing the script, all 5 pass.
- [x] `npx bats plugins/dotbabel/tests/bats/prune-merged-branches.bats` — 5/5 pass.
- [x] `shellcheck -x scripts/prune-merged-branches.sh` — exits 0 (only SC2312 info-level masked-return warnings remain, matching project tolerance on `guard-destructive-git.sh`).
- [x] `npm test` — 647/647 pass.
- [x] `npx bats plugins/dotbabel/tests/bats/` — full suite passes.
- [x] `npm run dogfood` — passes.

## Notes

- Pre-existing `npm run lint` failure on `CHANGELOG.md` (prettier) is present on `origin/main` independent of this change — verified via `git stash --include-untracked` round-trip.
- Pairs with PR 8b (operational, requires user `--confirm`).
- NOT protected (`scripts/` is not in `docs/repo-facts.json:protected_paths`).
