### PR TITLE
test(bats): backfill codex/gemini fan-out + handoff --state-file/extract

### DIFF
--- a/plugins/dotbabel/tests/bats/bootstrap.bats
+++ b/plugins/dotbabel/tests/bats/bootstrap.bats
@@ -113,7 +113,9 @@ teardown() {
   # Strip nvm bin (which carries `codex`) and any other dirs that might
   # leak the binary; keep only the system minimums git/jq/bash need.
   local sanitized_path="/usr/bin:/bin"
-  ! PATH="$sanitized_path" command -v codex >/dev/null 2>&1
+  if PATH="$sanitized_path" command -v codex >/dev/null 2>&1; then
+    skip "codex unexpectedly on sanitized PATH ($sanitized_path); cannot exercise the absent-binary path"
+  fi
 
   run env -i HOME="$HOME" PATH="$sanitized_path" "$BOOT"
   [ "$status" -eq 0 ]
@@ -124,9 +126,18 @@ teardown() {
 }
 
 @test "fan-out is idempotent — second run produces no new .bak-* files" {
+  # Pre-seed a real wrapper file so the first run actually creates a backup.
+  # Without this, both counts are 0 and the equality is trivially satisfied —
+  # a regression that spawned a stray .bak-* on the second run could still
+  # slip through.
+  mkdir -p "$HOME/.codex/skills"
+  echo "old wrapper" > "$HOME/.codex/skills/changelog"
+
   "$BOOT" --all --quiet
   local count_after_first
   count_after_first=$(find "$HOME/.codex/skills" -name '*.bak-*' 2>/dev/null | wc -l)
+  [ "$count_after_first" -gt 0 ]
+
   "$BOOT" --all --quiet
   local count_after_second
   count_after_second=$(find "$HOME/.codex/skills" -name '*.bak-*' 2>/dev/null | wc -l)

--- a/plugins/dotbabel/tests/bats/bootstrap.bats
+++ b/plugins/dotbabel/tests/bats/bootstrap.bats
@@ -93,3 +93,54 @@ teardown() {
   run bash -c "ls '$HOME/.codex/skills/'changelog.bak-*"
   [ "$status" -eq 0 ]
 }
+
+@test "gemini command fan-out backs up existing wrapper file" {
+  mkdir -p "$HOME/.gemini/skills"
+  echo "old wrapper" > "$HOME/.gemini/skills/changelog"
+
+  run "$BOOT" --all --quiet
+  [ "$status" -eq 0 ]
+  [ -d "$HOME/.gemini/skills/changelog" ]
+  [ -L "$HOME/.gemini/skills/changelog/SKILL.md" ]
+  target=$(readlink "$HOME/.gemini/skills/changelog/SKILL.md")
+  [ "$target" = "$REPO_ROOT/commands/changelog.md" ]
+
+  run bash -c "ls '$HOME/.gemini/skills/'changelog.bak-*"
+  [ "$status" -eq 0 ]
+}
+
+@test "codex fan-out skipped when codex not on PATH and --all not passed" {
+  # Strip nvm bin (which carries `codex`) and any other dirs that might
+  # leak the binary; keep only the system minimums git/jq/bash need.
+  local sanitized_path="/usr/bin:/bin"
+  ! PATH="$sanitized_path" command -v codex >/dev/null 2>&1
+
+  run env -i HOME="$HOME" PATH="$sanitized_path" "$BOOT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping codex"* ]]
+  # No fan-out happened: zero SKILL.md symlinks under ~/.codex/skills/.
+  run bash -c "find '$HOME/.codex/skills' -name SKILL.md -type l 2>/dev/null | wc -l"
+  [ "$output" = "0" ]
+}
+
+@test "fan-out is idempotent — second run produces no new .bak-* files" {
+  "$BOOT" --all --quiet
+  local count_after_first
+  count_after_first=$(find "$HOME/.codex/skills" -name '*.bak-*' 2>/dev/null | wc -l)
+  "$BOOT" --all --quiet
+  local count_after_second
+  count_after_second=$(find "$HOME/.codex/skills" -name '*.bak-*' 2>/dev/null | wc -l)
+  [ "$count_after_first" -eq "$count_after_second" ]
+}
+
+@test "CODEX_HOME override populates custom path" {
+  export CODEX_HOME="$HOME/custom-codex"
+  run "$BOOT" --all --quiet
+  [ "$status" -eq 0 ]
+  [ -L "$CODEX_HOME/skills/changelog/SKILL.md" ]
+  target=$(readlink "$CODEX_HOME/skills/changelog/SKILL.md")
+  [ "$target" = "$REPO_ROOT/commands/changelog.md" ]
+  # Default ~/.codex/skills/ must NOT have been populated.
+  run bash -c "find '$HOME/.codex/skills' -name SKILL.md -type l 2>/dev/null | wc -l"
+  [ "$output" = "0" ]
+}

--- a/plugins/dotbabel/tests/bats/handoff-extract.bats
+++ b/plugins/dotbabel/tests/bats/handoff-extract.bats
@@ -32,6 +32,7 @@ setup() {
 {"type":"user","promptId":"p-slash","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"Review a pull request: fetch comments, apply fixes.\nARGUMENTS: #80"}}
 {"type":"user","promptId":"p-bare","cwd":"/home/u/proj","sessionId":"aaaa1111-1111-1111-1111-111111111111","message":{"content":"<command-name>/clear</command-name>"}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"Sure, running tests now."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TodoWrite","input":{"todos":[{"content":"GOAL-FINISH-RETRY-LOOP","status":"in_progress","activeForm":"Finishing retry loop fix"},{"content":"GOAL-WRITE-REGRESSION-TEST","status":"pending","activeForm":"Writing regression test"}]}}]}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"All 205 tests passed."}]}}
 EOF
 
@@ -287,6 +288,44 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *'"session_id":"ffff6666-6666-6666-6666-666666666666"'* ]]
   [[ "$output" == *'"cwd":"/work/empty"'* ]]
+}
+
+# -- todos / mirror (Approach B layered fidelity) -------------------------
+
+@test "todos claude emits one JSON line per TodoWrite entry" {
+  run "$EX" todos claude "$CLAUDE_FILE"
+  [ "$status" -eq 0 ]
+  # Two todos in the fixture's TodoWrite tool_use record.
+  local count
+  count=$(printf '%s\n' "$output" | grep -c .)
+  [ "$count" -eq 2 ]
+  [[ "$output" == *'"content":"GOAL-FINISH-RETRY-LOOP"'* ]]
+  [[ "$output" == *'"status":"in_progress"'* ]]
+  [[ "$output" == *'"content":"GOAL-WRITE-REGRESSION-TEST"'* ]]
+  [[ "$output" == *'"status":"pending"'* ]]
+}
+
+@test "todos non-claude cli emits empty (no carrier today)" {
+  run "$EX" todos codex "$CODEX_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "mirror codex emits each event_msg agent_message in order" {
+  run "$EX" mirror codex "$CODEX_FILE"
+  [ "$status" -eq 0 ]
+  # Two agent_message events in the fixture: "I'll read README.md first." and "Done.".
+  local count
+  count=$(printf '%s\n' "$output" | grep -c .)
+  [ "$count" -eq 2 ]
+  [[ "$output" == *"I'll read README.md first."* ]]
+  [[ "$output" == *"Done."* ]]
+}
+
+@test "mirror non-codex cli emits empty (no event_msg equivalent)" {
+  run "$EX" mirror claude "$CLAUDE_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 }
 
 # -- usage / errors -------------------------------------------------------

--- a/plugins/dotbabel/tests/bats/handoff-push-dryrun.bats
+++ b/plugins/dotbabel/tests/bats/handoff-push-dryrun.bats
@@ -87,6 +87,45 @@ teardown() {
 
 # ---- test 4: dry-run does NOT invoke the doctor script --------------------
 
+@test "push --state-file accepted; dry-run JSON reflects digestBytes delta" {
+  # CLI-contract test for --state-file. The dry-run JSON only exposes metadata
+  # (dryRun, branch, digestBytes, ...), not the rendered <handoff-state> text
+  # — content visibility is asserted at the lib layer (handoff-remote-lib.test.mjs
+  # `places opts.stateBlock above the mechanical Summary line`). Here we lock
+  # the bin contract: --state-file is accepted, value flows through pushRemote,
+  # and a 16 KB state file inflates digestBytes by at least ~15 KB vs an empty
+  # state file. This catches a regression where the flag is parsed but dropped
+  # before reaching pushRemote (e.g. lost in argv refactor).
+  local empty_state="$TEST_HOME/state-empty.txt"
+  local big_state="$TEST_HOME/state-big.txt"
+  : > "$empty_state"
+  # Realistic-shape state block: ~16 KB of content within a wrapper element
+  # so the renderHandoffBlock trim() guard treats it as non-empty content.
+  printf '<handoff-state version="1">\n' > "$big_state"
+  yes "active-goal-line padding for digest size delta assertion" \
+    | head -c 16000 >> "$big_state"
+  printf '\n</handoff-state>\n' >> "$big_state"
+
+  run --separate-stderr node "$BIN" push --from claude --state-file "$empty_state" \
+    --dry-run --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.dryRun == true' >/dev/null
+  local empty_bytes
+  empty_bytes=$(echo "$output" | jq -r '.digestBytes')
+
+  run --separate-stderr node "$BIN" push --from claude --state-file "$big_state" \
+    --dry-run --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.dryRun == true' >/dev/null
+  local big_bytes
+  big_bytes=$(echo "$output" | jq -r '.digestBytes')
+
+  # Sanity: both are integers and big_bytes is at least empty + 15 000.
+  [[ "$empty_bytes" =~ ^[0-9]+$ ]]
+  [[ "$big_bytes" =~ ^[0-9]+$ ]]
+  [ "$big_bytes" -ge "$((empty_bytes + 15000))" ]
+}
+
 @test "push --dry-run: autoPreflight is skipped (doctor stub never runs)" {
   # Replace the passing stub with one that writes a sentinel file and
   # exits non-zero. If dry-run invokes preflight, the sentinel appears

--- a/plugins/dotbabel/tests/handoff-remote-lib.test.mjs
+++ b/plugins/dotbabel/tests/handoff-remote-lib.test.mjs
@@ -391,6 +391,23 @@ describe("renderHandoffBlock", () => {
     expect(block.indexOf("<handoff-state")).toBeLessThan(block.indexOf("<handoff "));
   });
 
+  it("places opts.stateBlock above the mechanical Summary line (CLI --state-file contract)", () => {
+    // Pin the exact source-ordering contract used by `dotbabel handoff push
+    // --state-file <file>`: the user-authored state block must appear before
+    // the mechanical `**Summary.**` line so an agent reading the digest sees
+    // active goals first, not the mechanical first-prompt/last-turn pair.
+    // Heading text is `**Summary.**` (markdown bold), not `### Summary`.
+    const stateBlock =
+      '<handoff-state version="1">\ngoals:\n  - finish gateway refactor\n</handoff-state>';
+    const block = lib.renderHandoffBlock(meta, ["p"], ["t"], "claude", { stateBlock });
+    const stateIdx = block.indexOf("<handoff-state");
+    const summaryIdx = block.indexOf("**Summary.**");
+    expect(stateIdx).toBeGreaterThanOrEqual(0);
+    expect(summaryIdx).toBeGreaterThan(0);
+    expect(stateIdx).toBeLessThan(summaryIdx);
+    expect(block).toContain("finish gateway refactor");
+  });
+
   it("renders Tracked TODOs section when opts.todos is non-empty", () => {
     const todos = [
       { content: "GOAL-MIGRATE-AUTH", status: "in_progress", activeForm: "" },


### PR DESCRIPTION
## Summary

- Backfill bats coverage for the codex/gemini skill fan-out paths added in v2.3.0: gemini wrapper-file backup, codex on-PATH gate (no `--all`), idempotency (no new `.bak-*` on second run), and `CODEX_HOME` override.
- Backfill CLI-contract coverage for `dotbabel handoff push --state-file <file>`: a 16 KB state block inflates the dry-run JSON `digestBytes` by ≥ 15 KB versus an empty file, locking the `--state-file → pushRemote` plumbing without requiring rendered-content visibility (which the dry-run JSON does not expose, see `plugins/dotbabel/bin/dotbabel-handoff.mjs:1018-1026`).
- Add a vitest assertion that `renderHandoffBlock(..., { stateBlock })` places the state block **before** the mechanical `**Summary.**` line — the source-ordering contract the CLI relies on.
- Add bats tests for the `todos` and `mirror` subcommands of `plugins/dotbabel/scripts/handoff-extract.sh` (the internal extractor — there is no `dotbabel handoff extract` bin subcommand).

## Test plan

- [x] `npx vitest run plugins/dotbabel/tests/handoff-remote-lib.test.mjs` — 64/64 pass
- [x] `npm test` — 648/648 vitest pass
- [x] `npx bats plugins/dotbabel/tests/bats/bootstrap.bats` — 13/13 pass (4 new)
- [x] `npx bats plugins/dotbabel/tests/bats/handoff-extract.bats` — 29/29 pass (4 new)
- [x] `npx bats plugins/dotbabel/tests/bats/handoff-push-dryrun.bats` — 5/5 pass (1 new)
- [x] `npm run lint` — pre-existing CHANGELOG.md prettier warning (verified via `git stash` on `main`); no new lint failures
- [x] `npm run dogfood` — all 6 validators green

## Notes

- **GEMINI_HOME bats test deferred.** The plan pairs PR 7 with PR 5 (`feat(bootstrap): honor GEMINI_HOME`); PR 5 has not landed yet. Adding a `GEMINI_HOME` override test now would be red-on-main. Will follow up alongside PR 5.
- **`.system` skip test deferred.** Exercising the `[[ "$name" = ".system" ]] && continue` guard in `bootstrap.sh:133,142` would require seeding a `.system/` directory under the source `skills/` of the live `$DOTBABEL` checkout (which is `$REPO_ROOT` per `bootstrap.sh:32`); writing a tracked `.system` fixture into the repo or relocating `$DOTBABEL` are both out of proportion for a backfill PR.
- **`extract` subcommand surface.** The plan and audit reference `extract todos|mirror`; the actual surface is `plugins/dotbabel/scripts/handoff-extract.sh todos|mirror <cli> <file>`, not a `dotbabel handoff` bin subcommand. Tests live in `handoff-extract.bats` (the existing bats file for that script).
