### PR TITLE
feat(project-sync): add cross-CLI repo-local fan-out (closes #205)

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-09T11:45:46.391Z",
+  "generatedAt": "2026-05-09T15:20:05.349Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -238,6 +238,13 @@
       "path": ".claude/skills/post-pr-review/SKILL.md",
       "checksum": "sha256:0565fc80dba6872c5da9569cff5e53d112fc3ea3a16b4905fdf38255754ec628",
       "dependencies": ["review-pr"],
+      "lastValidated": "2026-05-09"
+    },
+    {
+      "name": "project-sync",
+      "path": ".claude/skills/project-sync/SKILL.md",
+      "checksum": "sha256:822e1509cf0ed4d0260c8bada35cd0e815a9b6529d637eb9baf3a430f8803104",
+      "dependencies": [],
       "lastValidated": "2026-05-09"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -188,6 +188,28 @@ npx dotbabel-doctor          # verify everything wired up
 npx dotbabel-validate-specs  # run first governance check
 ```
 
+### Project-scope sync (cross-CLI per-repo wiring)
+
+`dotbabel bootstrap` covers your **user scope** (`~/.claude/`, `~/.codex/`,
+`~/.gemini/`). For **per-repo** artifacts — a project's own `CLAUDE.md`,
+`.claude/commands/*.md`, and `.claude/skills/*` — use `project-sync` to fan
+them out to Codex (`.codex/skills/`), Gemini (`.gemini/skills/`), and Copilot
+(`.github/prompts/*.prompt.md` + `.github/instructions/*.instructions.md`):
+
+```bash
+cd ~/projects/my-app
+dotbabel project-init                 # one-time: writes .dotbabel.json and a starter CLAUDE.md
+dotbabel project-sync --dry-run       # preview planned actions
+dotbabel project-sync                 # symlink everything in place
+dotbabel check-project-sync           # CI-safe drift check (read-only)
+```
+
+The fan-out uses symlinks — your `.claude/` tree stays the single source of
+truth. A `.dotbabel.json` is optional; without one, project-sync uses
+sensible defaults and treats the entire `CLAUDE.md` as the project rule
+floor (or the slice between `<!-- dotbabel:rule-floor:begin -->` /
+`<!-- dotbabel:rule-floor:end -->` markers when present).
+
 ### Node API
 
 ```js

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -107,6 +107,43 @@ Any PR touching a protected path (see `docs/repo-facts.json`) must now carry
 a `Spec ID:` or `## No-spec rationale` section. `dotbabel-check-spec-coverage`
 enforces it.
 
+### 6. Project-scope cross-CLI sync (optional)
+
+If your repo has `.claude/commands/*.md` and `.claude/skills/*` that you want
+visible to Codex, Gemini, and Copilot — not just Claude Code — wire them up
+with `project-sync`. This is repo-local; user-scope artifacts stay in
+`~/.claude/` etc. via `dotbabel bootstrap`.
+
+```bash
+cd ~/projects/my-app
+
+# 6a. One-time scaffold (writes .dotbabel.json + a starter CLAUDE.md if missing)
+npx dotbabel project-init
+
+# 6b. Preview, then apply
+npx dotbabel project-sync --dry-run
+npx dotbabel project-sync
+
+# 6c. Verify (CI-safe, read-only)
+npx dotbabel check-project-sync
+```
+
+What lands where:
+
+| Source                         | Codex / Gemini destination                | Copilot destination                                   |
+| ------------------------------ | ----------------------------------------- | ----------------------------------------------------- |
+| `.claude/commands/<name>.md`   | `.codex/skills/<name>/SKILL.md` (symlink) | `.github/prompts/<name>.prompt.md` (symlink)          |
+| `.claude/skills/<id>/SKILL.md` | `.codex/skills/<id>/` (whole-dir symlink) | `.github/instructions/<id>.instructions.md` (symlink) |
+| `CLAUDE.md` (rule-floor block) | rendered into `AGENTS.md` + `GEMINI.md`   | rendered into `.github/copilot-instructions.md`       |
+
+`.dotbabel.json` is optional — without one, project-sync uses defaults
+(`fan_out: ["codex", "gemini", "copilot"]`, the standard target list, no
+`cli_substitutions`). When `CLAUDE.md` has no `<!-- dotbabel:rule-floor:begin -->`
+markers, the whole file becomes the rule floor.
+
+A repo with `.dotbabel.json` will also be picked up by `dotbabel doctor` —
+the diagnostic adds a project-sync wiring check.
+
 ### Next
 
 - [cli-reference.md](./cli-reference.md) — every flag, exit code, `--json` schema.

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotbabel.dev/schemas/index.schema.json",
-  "generatedAt": "2026-05-09T11:58:09.302Z",
+  "generatedAt": "2026-05-09T15:11:14.013Z",
   "version": "2.4.0",
   "artifacts": [
     {
@@ -633,6 +633,21 @@
         "maturity": "draft"
       },
       "version": "1.0.1",
+      "owner": "@kaiohenricunha"
+    },
+    {
+      "id": "project-sync",
+      "type": "skill",
+      "path": "skills/project-sync/SKILL.md",
+      "name": "project-sync",
+      "description": "Fan out the current repo's CLAUDE.md, .claude/commands, and .claude/skills into Codex, Gemini, and Copilot project-scope analogues (.codex/skills, .gemini/skills, .github/prompts, .github/instructions) plus refresh AGENTS.md, GEMINI.md, and .github/copilot-instructions.md from the project's rule floor. Wraps `dotbabel project-sync`. Use when adopting cross-CLI workflows in a repo for the first time, or when adding a new command/skill that needs to be visible to Codex/Gemini/Copilot. Triggers on: \"sync this repo\", \"project sync\", \"fan out commands\", \"wire up gemini for this project\", \"add this command to codex\", \"make this skill available in copilot\", \"regenerate AGENTS.md for this project\".\n",
+      "facets": {
+        "domain": ["devex"],
+        "platform": ["none"],
+        "task": ["scaffolding"],
+        "maturity": "draft"
+      },
+      "version": "0.1.0",
       "owner": "@kaiohenricunha"
     },
     {

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -26,6 +26,7 @@
       "platform-engineer",
       "post-pr-review",
       "pre-pr",
+      "project-sync",
       "review-pr",
       "review-prs",
       "rollback-prod",
@@ -98,6 +99,7 @@
       "plan-grader",
       "platform-engineer",
       "pre-pr",
+      "project-sync",
       "security-auditor",
       "security-review",
       "spec",
@@ -218,6 +220,7 @@
       "devops-engineer",
       "frontend-developer",
       "platform-engineer",
+      "project-sync",
       "workflow-orchestrator"
     ],
     "documentation": [
@@ -310,6 +313,7 @@
       "platform-engineer",
       "post-pr-review",
       "pre-pr",
+      "project-sync",
       "pulumi-engineer",
       "review-prs",
       "rollback-prod",

--- a/index/by-type.json
+++ b/index/by-type.json
@@ -45,6 +45,7 @@
     "kubernetes-specialist",
     "plan-grader",
     "post-pr-review",
+    "project-sync",
     "pulumi-specialist",
     "review-pr",
     "review-prs",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "dotbabel-search": "./plugins/dotbabel/bin/dotbabel-search.mjs",
     "dotbabel-list": "./plugins/dotbabel/bin/dotbabel-list.mjs",
     "dotbabel-show": "./plugins/dotbabel/bin/dotbabel-show.mjs",
-    "dotbabel-handoff": "./plugins/dotbabel/bin/dotbabel-handoff.mjs"
+    "dotbabel-handoff": "./plugins/dotbabel/bin/dotbabel-handoff.mjs",
+    "dotbabel-project-sync": "./plugins/dotbabel/bin/dotbabel-project-sync.mjs",
+    "dotbabel-project-init": "./plugins/dotbabel/bin/dotbabel-project-init.mjs",
+    "dotbabel-check-project-sync": "./plugins/dotbabel/bin/dotbabel-check-project-sync.mjs"
   },
   "scripts": {
     "build-plugin": "node scripts/build-plugin.mjs",

--- a/plugins/dotbabel/bin/dotbabel-check-project-sync.mjs
+++ b/plugins/dotbabel/bin/dotbabel-check-project-sync.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * dotbabel-check-project-sync — read-only drift report for project-scope sync.
+ *
+ * Walks the same intended outputs as `dotbabel project-sync` and reports each
+ * as ok / missing / stale. CI-safe: never mutates the filesystem.
+ *
+ * Flags:
+ *   --repo <path>   target repo root (default: cwd)
+ *
+ * Exits: 0 ok, 1 drift detected, 2 env error, 64 usage error.
+ */
+
+import path from "node:path";
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { formatError, ValidationError } from "../src/lib/errors.mjs";
+import { version } from "../src/index.mjs";
+import { checkProjectSync } from "../src/check-project-sync.mjs";
+
+const META = {
+  name: "dotbabel-check-project-sync",
+  synopsis: "dotbabel-check-project-sync [OPTIONS]",
+  description:
+    "Verify a repo's cross-CLI project-sync wiring (instruction files + symlinks) matches what `dotbabel project-sync` would produce. Read-only.",
+  flags: {
+    repo: { type: "string" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const out = createOutput({ json: argv.json, noColor: argv.noColor });
+
+const repoRoot = path.resolve(
+  /** @type {string} */ (argv.flags.repo ?? process.cwd()),
+);
+
+try {
+  const result = await checkProjectSync({
+    repoRoot,
+    json: argv.json,
+    noColor: argv.noColor,
+    out,
+  });
+  if (!result.ok) {
+    out.fail(
+      `project-sync drift: ${result.missing.length} missing, ${result.stale.length} stale`,
+    );
+    out.flush();
+    process.exit(EXIT_CODES.VALIDATION);
+  }
+  out.pass(`project-sync ok (${result.okEntries.length} entries verified)`);
+  out.flush();
+  process.exit(EXIT_CODES.OK);
+} catch (err) {
+  if (err instanceof ValidationError) {
+    out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON());
+    out.flush();
+    process.exit(EXIT_CODES.VALIDATION);
+  }
+  out.fail(`check-project-sync failed: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}

--- a/plugins/dotbabel/bin/dotbabel-doctor.mjs
+++ b/plugins/dotbabel/bin/dotbabel-doctor.mjs
@@ -238,6 +238,36 @@ for (const fanout of [
   }
 }
 
+// project-scope sync — only when the cwd opts in via .dotbabel.json.
+// Mirrors the bootstrap fan-out sentinel above but for repo-local artifacts.
+const projectConfigPath = join(ctx.repoRoot, ".dotbabel.json");
+if (existsSync(projectConfigPath)) {
+  try {
+    const { checkProjectSync } = await import("../src/check-project-sync.mjs");
+    const psResult = await checkProjectSync({
+      repoRoot: ctx.repoRoot,
+      json: argv.json,
+      noColor: argv.noColor,
+      quiet: true,
+    });
+    if (psResult.ok) {
+      out.pass(
+        `project-sync wiring ok (${psResult.okEntries.length} entries verified)`,
+      );
+    } else if (psResult.missing.length > 0) {
+      out.fail(
+        `project-sync wiring incomplete: ${psResult.missing.length} missing — run 'dotbabel project-sync' to fix`,
+      );
+    } else {
+      out.warn(
+        `project-sync wiring stale: ${psResult.stale.length} stale — run 'dotbabel project-sync' to refresh`,
+      );
+    }
+  } catch (err) {
+    out.warn(`project-sync check skipped: ${err.message}`);
+  }
+}
+
 out.flush();
 const { fail } = out.counts();
 process.exit(fail > 0 ? EXIT_CODES.VALIDATION : EXIT_CODES.OK);

--- a/plugins/dotbabel/bin/dotbabel-project-init.mjs
+++ b/plugins/dotbabel/bin/dotbabel-project-init.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * dotbabel-project-init — minimal scaffolder for cross-CLI project sync.
+ *
+ * Writes `.dotbabel.json`, `.claude/commands/.gitkeep`, `.claude/skills/.gitkeep`,
+ * and a starter `CLAUDE.md` (with rule-floor markers) when missing. Distinct
+ * from `dotbabel init` (which scaffolds the full spec-governance harness).
+ *
+ * Flags:
+ *   --repo <path>   target repo root (default: cwd)
+ *   --force         overwrite an existing `.dotbabel.json`
+ *   --dry-run       report planned actions, do not mutate the filesystem
+ *
+ * Exits: 0 ok, 1 SCAFFOLD_CONFLICT or other ValidationError, 2 env error,
+ * 64 usage error.
+ */
+
+import path from "node:path";
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { formatError, ValidationError } from "../src/lib/errors.mjs";
+import { version } from "../src/index.mjs";
+import { scaffoldProjectInit } from "../src/project-init-scaffold.mjs";
+
+const META = {
+  name: "dotbabel-project-init",
+  synopsis: "dotbabel-project-init [OPTIONS]",
+  description:
+    "Scaffold the minimum cross-CLI project-sync layout (.dotbabel.json + .claude/ skeleton + starter CLAUDE.md) into a repo.",
+  flags: {
+    repo: { type: "string" },
+    force: { type: "boolean" },
+    "dry-run": { type: "boolean" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const out = createOutput({ json: argv.json, noColor: argv.noColor });
+
+const repoRoot = path.resolve(
+  /** @type {string} */ (argv.flags.repo ?? process.cwd()),
+);
+
+try {
+  const result = scaffoldProjectInit({
+    repoRoot,
+    force: Boolean(argv.flags.force),
+    dryRun: Boolean(argv.flags["dry-run"]),
+  });
+  out.pass(
+    `project-init complete in ${repoRoot} (${result.filesWritten.length} written, ${result.skipped.length} skipped)`,
+  );
+  if (argv.verbose || result.filesWritten.length > 0) {
+    for (const f of result.filesWritten) out.info(`  + ${f}`);
+    for (const s of result.skipped) out.info(`  - ${s} (already present)`);
+  }
+  out.flush();
+  process.exit(EXIT_CODES.OK);
+} catch (err) {
+  if (err instanceof ValidationError) {
+    out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON());
+    out.flush();
+    process.exit(EXIT_CODES.VALIDATION);
+  }
+  out.fail(`project-init failed: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}

--- a/plugins/dotbabel/bin/dotbabel-project-sync.mjs
+++ b/plugins/dotbabel/bin/dotbabel-project-sync.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * dotbabel-project-sync — repo-local fan-out of CLAUDE.md, .claude/commands,
+ * and .claude/skills into Codex / Gemini / Copilot project-scope analogues.
+ *
+ * Flags:
+ *   --repo <path>   target repo root (default: cwd)
+ *   --all           force fan-out even when a CLI binary is missing on PATH
+ *   --force         reserved (not yet acted upon — see plan §1.4)
+ *   --dry-run       report planned actions, do not mutate the filesystem
+ *
+ * Exits: 0 ok, 1 validation failure, 2 env error, 64 usage error.
+ */
+
+import path from "node:path";
+import { parse, helpText } from "../src/lib/argv.mjs";
+import { createOutput } from "../src/lib/output.mjs";
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { formatError, ValidationError } from "../src/lib/errors.mjs";
+import { version } from "../src/index.mjs";
+import { projectSync } from "../src/project-sync.mjs";
+
+const META = {
+  name: "dotbabel-project-sync",
+  synopsis: "dotbabel-project-sync [OPTIONS]",
+  description:
+    "Fan out the current repo's CLAUDE.md, .claude/commands, and .claude/skills into Codex / Gemini / Copilot project-scope analogues.",
+  flags: {
+    repo: { type: "string" },
+    all: { type: "boolean" },
+    force: { type: "boolean" },
+    "dry-run": { type: "boolean" },
+  },
+};
+
+let argv;
+try {
+  argv = parse(process.argv.slice(2), META.flags);
+} catch (err) {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(EXIT_CODES.USAGE);
+}
+
+if (argv.help) {
+  process.stdout.write(`${helpText(META)}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+if (argv.version) {
+  process.stdout.write(`${version}\n`);
+  process.exit(EXIT_CODES.OK);
+}
+
+const out = createOutput({ json: argv.json, noColor: argv.noColor });
+
+const repoRoot = path.resolve(
+  /** @type {string} */ (argv.flags.repo ?? process.cwd()),
+);
+
+try {
+  const result = await projectSync({
+    repoRoot,
+    allCli: Boolean(argv.flags.all),
+    force: Boolean(argv.flags.force),
+    dryRun: Boolean(argv.flags["dry-run"]),
+    json: argv.json,
+    noColor: argv.noColor,
+    out,
+  });
+  if (!result.ok) {
+    out.flush();
+    process.exit(EXIT_CODES.VALIDATION);
+  }
+  process.exit(EXIT_CODES.OK);
+} catch (err) {
+  if (err instanceof ValidationError) {
+    out.fail(formatError(err, { verbose: argv.verbose }), err.toJSON());
+    out.flush();
+    process.exit(EXIT_CODES.VALIDATION);
+  }
+  out.fail(`project-sync failed: ${err.message}`);
+  out.flush();
+  process.exit(EXIT_CODES.ENV);
+}

--- a/plugins/dotbabel/bin/dotbabel.mjs
+++ b/plugins/dotbabel/bin/dotbabel.mjs
@@ -9,7 +9,8 @@
  * Known subcommands mirror the bin/* entries shipped by the package:
  *   validate-skills, validate-specs, check-spec-coverage,
  *   check-instruction-drift, check-instructions-fresh,
- *   check-instruction-parity, detect-drift, doctor, init, bootstrap, sync.
+ *   check-instruction-parity, check-project-sync, detect-drift, doctor,
+ *   init, project-init, bootstrap, sync, project-sync.
  *
  * Exits: 0 ok, 1 delegated failure, 2 env error, 64 usage error.
  */
@@ -28,11 +29,14 @@ const SUBCOMMANDS = [
   "check-instruction-drift",
   "check-instructions-fresh",
   "check-instruction-parity",
+  "check-project-sync",
   "detect-drift",
   "doctor",
   "init",
+  "project-init",
   "bootstrap",
   "sync",
+  "project-sync",
   "index",
   "search",
   "list",
@@ -43,7 +47,7 @@ const SUBCOMMANDS = [
 function printUsage() {
   process.stdout.write(
     [
-      "dotbabel — Claude Code toolkit CLI (bootstrap, doctor, validators, governance)",
+      "dotbabel — Claude Code toolkit CLI (bootstrap, project-sync, doctor, validators, governance)",
       "",
       "Usage:",
       "  dotbabel <subcommand> [options]",

--- a/plugins/dotbabel/src/bootstrap-global.mjs
+++ b/plugins/dotbabel/src/bootstrap-global.mjs
@@ -12,9 +12,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createOutput } from "./lib/output.mjs";
+import {
+  buildTimestamp,
+  commandExists,
+  ensureRealDir,
+  linkOne,
+} from "./lib/symlink.mjs";
 
 // ---------------------------------------------------------------------------
 // pkgRoot() — walk up from this file until we find a directory containing
@@ -76,57 +81,6 @@ export function resolveSource(sourceOpt, env) {
 }
 
 // ---------------------------------------------------------------------------
-// linkOne — mirrors bootstrap.sh link_one()
-// ---------------------------------------------------------------------------
-
-/**
- * @typedef {object} LinkResult
- * @property {'ok'|'updated'|'linked'|'backed_up'} action
- */
-
-/**
- * Create or update a symlink at `dst` pointing to `src`.
- * Backs up a real file/dir at `dst` before replacing it.
- *
- * @param {string} src
- * @param {string} dst
- * @param {import('./lib/output.mjs').Output} out
- * @param {string} ts  Timestamp string for backup suffix
- * @returns {LinkResult}
- */
-function linkOne(src, dst, out, ts) {
-  let lstat;
-  try {
-    lstat = fs.lstatSync(dst);
-  } catch {
-    // dst does not exist
-    fs.symlinkSync(src, dst);
-    out.pass(`linked: ${dst} -> ${src}`);
-    return { action: "linked" };
-  }
-
-  if (lstat.isSymbolicLink()) {
-    const current = fs.readlinkSync(dst);
-    if (current === src) {
-      out.pass(`ok: ${dst}`);
-      return { action: "ok" };
-    }
-    // Stale symlink — update it
-    fs.unlinkSync(dst);
-    fs.symlinkSync(src, dst);
-    out.pass(`updated: ${dst} -> ${src}`);
-    return { action: "updated" };
-  }
-
-  // Real file or directory — back up then link
-  const bakPath = `${dst}.bak-${ts}`;
-  fs.renameSync(dst, bakPath);
-  fs.symlinkSync(src, dst);
-  out.warn(`backed up + linked: ${dst} (old at ${bakPath})`);
-  return { action: "backed_up" };
-}
-
-// ---------------------------------------------------------------------------
 // bootstrapGlobal — main entry point
 // ---------------------------------------------------------------------------
 
@@ -171,14 +125,7 @@ export async function bootstrapGlobal(opts = {}) {
     return { ok: false, linked: 0, skipped: 0, backed_up: 0 };
   }
 
-  // Build YYYYMMDD-HHmmss timestamp matching bootstrap.sh's date +%Y%m%d-%H%M%S.
-  // After replace(/[-:T]/g, "") the ISO string becomes "YYYYMMDDHHmmss.mmmZ",
-  // so datePart is slice(0,8) and timePart is slice(8,14) — no T separator remains.
-  const ts = new Date()
-    .toISOString()
-    .replace(/[-:T]/g, "")
-    .replace(/\..+$/, ""); // → "YYYYMMDDHHmmss"
-  const timestamp = `${ts.slice(0, 8)}-${ts.slice(8, 14)}`;
+  const timestamp = buildTimestamp();
 
   fs.mkdirSync(target, { recursive: true });
 
@@ -202,24 +149,9 @@ export async function bootstrapGlobal(opts = {}) {
     }
   }
 
-  function ensureRealDir(dst) {
-    let lstat;
-    try {
-      lstat = fs.lstatSync(dst);
-    } catch {
-      fs.mkdirSync(dst, { recursive: true });
-      return;
-    }
-
-    if (lstat.isDirectory() && !lstat.isSymbolicLink()) {
-      return;
-    }
-
-    const bakPath = `${dst}.bak-${timestamp}`;
-    fs.renameSync(dst, bakPath);
-    backed_up++;
-    out.warn(`backed up: ${dst} (old at ${bakPath})`);
-    fs.mkdirSync(dst, { recursive: true });
+  function doEnsureRealDir(dst) {
+    const r = ensureRealDir(dst, out, timestamp);
+    if (r.action === "backed_up") backed_up++;
   }
 
   // --- CLAUDE.md ---
@@ -370,21 +302,10 @@ export async function bootstrapGlobal(opts = {}) {
         if (name === ".system") continue;
         const src = path.join(commandsSrc, entry);
         const wrapDir = path.join(dstDir, name);
-        ensureRealDir(wrapDir);
+        doEnsureRealDir(wrapDir);
         const dst = path.join(wrapDir, "SKILL.md");
         doLink(src, dst);
       }
     }
   }
-}
-
-function commandExists(command) {
-  const result = spawnSync("sh", ["-c", `command -v ${quoteShellWord(command)} >/dev/null 2>&1`], {
-    stdio: "ignore",
-  });
-  return result.status === 0;
-}
-
-function quoteShellWord(word) {
-  return `'${word.replace(/'/g, "'\\''")}'`;
 }

--- a/plugins/dotbabel/src/check-project-sync.mjs
+++ b/plugins/dotbabel/src/check-project-sync.mjs
@@ -1,0 +1,219 @@
+/**
+ * check-project-sync.mjs — read-only drift report for project-scope sync.
+ *
+ * Walks the same set of intended outputs as `projectSync` and reports each as
+ * one of: ok, missing (expected symlink/file does not exist), or stale
+ * (symlink target diverges from the source path the regenerator would use).
+ * Never mutates the filesystem.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { createOutput } from "./lib/output.mjs";
+import {
+  RULE_FLOOR_BEGIN,
+  RULE_FLOOR_END,
+  composeInject,
+  renderTarget,
+  validateSubstitutions,
+  ERROR_CODES,
+} from "./generate-instructions.mjs";
+import { extractRuleFloorOrWhole, loadProjectConfig } from "./project-sync.mjs";
+import { ValidationError } from "./lib/errors.mjs";
+
+/**
+ * @typedef {object} CheckProjectSyncOpts
+ * @property {string} repoRoot
+ * @property {boolean} [json]
+ * @property {boolean} [noColor]
+ * @property {boolean} [quiet]
+ * @property {import('./lib/output.mjs').Output} [out]
+ *
+ * @typedef {{ kind: 'instruction'|'symlink', path: string, expected?: string, actual?: string }} DriftEntry
+ *
+ * @typedef {object} CheckProjectSyncResult
+ * @property {boolean} ok                 true iff missing.length === 0 && stale.length === 0
+ * @property {DriftEntry[]} missing
+ * @property {DriftEntry[]} stale
+ * @property {DriftEntry[]} okEntries
+ */
+
+/**
+ * @param {CheckProjectSyncOpts} opts
+ * @returns {Promise<CheckProjectSyncResult>}
+ */
+export async function checkProjectSync(opts) {
+  const repoRoot = opts.repoRoot;
+  const out =
+    opts.out ??
+    createOutput({
+      json: opts.json ?? false,
+      noColor: opts.noColor ?? false,
+      quiet: opts.quiet ?? false,
+    });
+
+  /** @type {DriftEntry[]} */ const missing = [];
+  /** @type {DriftEntry[]} */ const stale = [];
+  /** @type {DriftEntry[]} */ const okEntries = [];
+
+  if (!fs.existsSync(repoRoot)) {
+    out.fail(`repo root does not exist: ${repoRoot}`);
+    out.flush();
+    return { ok: false, missing, stale, okEntries };
+  }
+
+  const cfg = loadProjectConfig(repoRoot);
+  const sourcePath = path.join(repoRoot, cfg.rule_floor_source);
+  if (!fs.existsSync(sourcePath)) {
+    out.fail(`rule-floor source does not exist: ${cfg.rule_floor_source}`);
+    out.flush();
+    return { ok: false, missing, stale, okEntries };
+  }
+
+  // ---- Instruction files: compare existing host content against what
+  // composeInject would produce. Differences are "stale".
+
+  const sourceText = fs.readFileSync(sourcePath, "utf8");
+  const subs = validateSubstitutions(
+    cfg.cli_substitutions ?? {},
+    ".dotbabel.json",
+  );
+
+  for (const target of cfg.targets) {
+    const { body } = renderTarget(sourceText, target, subs);
+    const ruleFloor = extractRuleFloorOrWhole(body);
+    const absHost = path.join(repoRoot, target.relativeOutputPath);
+    if (!fs.existsSync(absHost)) {
+      missing.push({ kind: "instruction", path: target.relativeOutputPath });
+      out.fail(`missing: ${target.relativeOutputPath}`);
+      continue;
+    }
+    const existing = fs.readFileSync(absHost, "utf8");
+    let next;
+    try {
+      next = composeInject(existing, ruleFloor, target.relativeOutputPath);
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        stale.push({
+          kind: "instruction",
+          path: target.relativeOutputPath,
+          expected: "valid rule-floor markers",
+          actual: err.message,
+        });
+        out.fail(`stale: ${target.relativeOutputPath} (${err.message})`);
+        continue;
+      }
+      throw err;
+    }
+    if (existing === next) {
+      okEntries.push({ kind: "instruction", path: target.relativeOutputPath });
+      out.pass(`ok: ${target.relativeOutputPath}`);
+    } else {
+      stale.push({ kind: "instruction", path: target.relativeOutputPath });
+      out.fail(`stale: ${target.relativeOutputPath}`);
+    }
+  }
+
+  // ---- Symlink fan-out: for each enabled CLI, verify each expected symlink
+  // exists and points at the source path the regenerator would write.
+
+  const commandsAbs = path.join(repoRoot, cfg.commands_dir);
+  const skillsAbs = path.join(repoRoot, cfg.skills_dir);
+
+  /**
+   * Compare the symlink at `dstAbs` against the expected source `srcAbs`.
+   * `linkOne` writes the absolute source as the link target, so equality is
+   * absolute-path string equality.
+   */
+  function checkLink(dstAbs, srcAbs, kind = "symlink") {
+    const relDst = path.relative(repoRoot, dstAbs);
+    let lstat;
+    try {
+      lstat = fs.lstatSync(dstAbs);
+    } catch {
+      missing.push({ kind, path: relDst, expected: srcAbs });
+      out.fail(`missing: ${relDst}`);
+      return;
+    }
+    if (!lstat.isSymbolicLink()) {
+      stale.push({
+        kind,
+        path: relDst,
+        expected: srcAbs,
+        actual: "not a symlink",
+      });
+      out.fail(`stale (not a symlink): ${relDst}`);
+      return;
+    }
+    const actual = fs.readlinkSync(dstAbs);
+    if (actual !== srcAbs) {
+      stale.push({ kind, path: relDst, expected: srcAbs, actual });
+      out.fail(`stale: ${relDst} -> ${actual} (expected ${srcAbs})`);
+      return;
+    }
+    okEntries.push({ kind, path: relDst });
+    out.pass(`ok: ${relDst}`);
+  }
+
+  const fanOut = Array.isArray(cfg.fan_out) ? cfg.fan_out : [];
+
+  for (const cli of fanOut) {
+    if (cli === "codex" || cli === "gemini") {
+      const targetDir = path.join(repoRoot, `.${cli}`, "skills");
+      if (fs.existsSync(skillsAbs)) {
+        for (const entry of fs.readdirSync(skillsAbs, { withFileTypes: true })) {
+          if (!entry.isDirectory()) continue;
+          if (entry.name === ".system") continue;
+          checkLink(
+            path.join(targetDir, entry.name),
+            path.join(skillsAbs, entry.name),
+          );
+        }
+      }
+      if (fs.existsSync(commandsAbs)) {
+        for (const entry of fs.readdirSync(commandsAbs)) {
+          if (!entry.endsWith(".md")) continue;
+          const name = entry.replace(/\.md$/, "");
+          if (name === ".system") continue;
+          checkLink(
+            path.join(targetDir, name, "SKILL.md"),
+            path.join(commandsAbs, entry),
+          );
+        }
+      }
+    } else if (cli === "copilot") {
+      const promptsDir = path.join(repoRoot, ".github", "prompts");
+      const instructionsDir = path.join(repoRoot, ".github", "instructions");
+      if (fs.existsSync(commandsAbs)) {
+        for (const entry of fs.readdirSync(commandsAbs)) {
+          if (!entry.endsWith(".md")) continue;
+          const name = entry.replace(/\.md$/, "");
+          if (name === ".system") continue;
+          checkLink(
+            path.join(promptsDir, `${name}.prompt.md`),
+            path.join(commandsAbs, entry),
+          );
+        }
+      }
+      if (fs.existsSync(skillsAbs)) {
+        for (const entry of fs.readdirSync(skillsAbs, { withFileTypes: true })) {
+          if (!entry.isDirectory()) continue;
+          if (entry.name === ".system") continue;
+          const skillFile = path.join(skillsAbs, entry.name, "SKILL.md");
+          if (!fs.existsSync(skillFile)) continue;
+          checkLink(
+            path.join(instructionsDir, `${entry.name}.instructions.md`),
+            skillFile,
+          );
+        }
+      }
+    }
+  }
+
+  out.flush();
+  const ok = missing.length === 0 && stale.length === 0;
+  return { ok, missing, stale, okEntries };
+}
+
+// Re-export markers for callers that want to inspect a CLAUDE.md directly.
+export { RULE_FLOOR_BEGIN, RULE_FLOOR_END, ERROR_CODES };

--- a/plugins/dotbabel/src/generate-instructions.mjs
+++ b/plugins/dotbabel/src/generate-instructions.mjs
@@ -342,8 +342,10 @@ export function composeInject(existingHostText, ruleFloor, relativeOutputPath) {
   }
 
   if (beginLine === -1 && endLine === -1) {
-    // First-run bootstrap: append a section.
-    const trimmed = existingHostText.replace(/\s+$/, "");
+    // First-run bootstrap: append a section. Use String.prototype.trimEnd
+    // instead of /\s+$/ to avoid polynomial backtracking on huge whitespace
+    // tails (CodeQL js/polynomial-redos).
+    const trimmed = existingHostText.trimEnd();
     const sep = trimmed.length === 0 ? "" : "\n\n";
     return `${trimmed}${sep}${INJECT_FALLBACK_HEADING}\n\n${block}\n`;
   }
@@ -451,10 +453,21 @@ function ensureParentDir(absPath) {
 }
 
 function normalizeGeneratedMarkdown(content) {
-  return `${content
-    .replace(/[ \t]+$/gm, "")
-    .replace(/\n{3,}/g, "\n\n")
-    .replace(/\n+$/g, "")}\n`;
+  // Per-line trimEnd avoids the polynomial-backtracking shape of
+  // /[ \t]+$/gm flagged by CodeQL js/polynomial-redos. Only ASCII space
+  // and tab are stripped, matching the original regex's semantics.
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let end = line.length;
+    while (end > 0) {
+      const ch = line.charCodeAt(end - 1);
+      if (ch === 0x20 /* space */ || ch === 0x09 /* tab */) end--;
+      else break;
+    }
+    if (end !== line.length) lines[i] = line.slice(0, end);
+  }
+  return `${lines.join("\n").replace(/\n{3,}/g, "\n\n").replace(/\n+$/g, "")}\n`;
 }
 
 /**

--- a/plugins/dotbabel/src/generate-instructions.mjs
+++ b/plugins/dotbabel/src/generate-instructions.mjs
@@ -312,12 +312,17 @@ function composeSynthesize(renderedBody) {
  * delimited rule-floor block. Throws when the host file has only one of the
  * two markers (mismatched / corrupted state).
  *
+ * Exported so project-sync (and other consumer-repo flows) can compose
+ * instruction files without going through `generateInstructions`, which
+ * couples to `docs/repo-facts.json` and the dotbabel-private template
+ * manifest.
+ *
  * @param {string} existingHostText
  * @param {string} ruleFloor   The body to place inside the markers (no banner).
  * @param {string} relativeOutputPath
  * @returns {string}
  */
-function composeInject(existingHostText, ruleFloor, relativeOutputPath) {
+export function composeInject(existingHostText, ruleFloor, relativeOutputPath) {
   const blockBody = `${BANNER}\n\n${normalizeGeneratedMarkdown(ruleFloor).trimEnd()}`;
   const block = `${RULE_FLOOR_BEGIN}\n${blockBody}\n\n${RULE_FLOOR_END}`;
 
@@ -512,13 +517,23 @@ function stringifyManifest(manifest) {
   return `${lines.join("\n")}\n`;
 }
 
-function validateSubstitutions(raw) {
+/**
+ * Validate a `cli_substitutions` map. The optional `sourceFile` controls the
+ * `file` field on any ValidationError thrown — set to `.dotbabel.json` from
+ * project-sync so consumer-repo errors point at the right config; defaults to
+ * `docs/repo-facts.json` for the harness path.
+ *
+ * @param {unknown} raw
+ * @param {string} [sourceFile="docs/repo-facts.json"]
+ * @returns {Record<string, Record<string, string>>}
+ */
+export function validateSubstitutions(raw, sourceFile = "docs/repo-facts.json") {
   if (raw === undefined || raw === null) return {};
   if (typeof raw !== "object" || Array.isArray(raw)) {
     throw new ValidationError({
       code: ERROR_CODES.DRIFT_INSTRUCTION_FILES,
       category: "drift",
-      file: "docs/repo-facts.json",
+      file: sourceFile,
       pointer: "cli_substitutions",
       message: "cli_substitutions must be an object mapping target keys to substitution maps",
     });
@@ -528,7 +543,7 @@ function validateSubstitutions(raw) {
       throw new ValidationError({
         code: ERROR_CODES.DRIFT_INSTRUCTION_FILES,
         category: "drift",
-        file: "docs/repo-facts.json",
+        file: sourceFile,
         pointer: `cli_substitutions.${key}`,
         message: `cli_substitutions.${key} must be a string→string map`,
       });
@@ -538,7 +553,7 @@ function validateSubstitutions(raw) {
         throw new ValidationError({
           code: ERROR_CODES.DRIFT_INSTRUCTION_FILES,
           category: "drift",
-          file: "docs/repo-facts.json",
+          file: sourceFile,
           pointer: `cli_substitutions.${key}.${needle}`,
           message: `cli_substitutions.${key}.${JSON.stringify(needle)} must be a string`,
         });

--- a/plugins/dotbabel/src/index.mjs
+++ b/plugins/dotbabel/src/index.mjs
@@ -52,6 +52,8 @@ export {
   extractRuleFloor,
   stripRuleFloorMarkers,
   extractHeadings,
+  composeInject,
+  validateSubstitutions,
   DEFAULT_TARGETS,
   MANIFEST_RELATIVE_PATH,
   BANNER,
@@ -64,6 +66,19 @@ export { scaffoldHarness } from "./init-harness-scaffold.mjs";
 // --- bootstrap + sync (global ~/.claude/ lifecycle) ---
 export { bootstrapGlobal, resolveSource } from "./bootstrap-global.mjs";
 export { syncGlobal, resolveMode } from "./sync-global.mjs";
+
+// --- project-scope sync (per-repo ./.codex, ./.gemini, ./.github fan-out) ---
+export {
+  projectSync,
+  loadProjectConfig,
+  extractRuleFloorOrWhole,
+  DEFAULT_PROJECT_CONFIG,
+} from "./project-sync.mjs";
+export { checkProjectSync } from "./check-project-sync.mjs";
+export {
+  scaffoldProjectInit,
+  DEFAULT_DOTBABEL_JSON,
+} from "./project-init-scaffold.mjs";
 
 // --- taxonomy index (Phase 1: non-breaking) ---
 export {

--- a/plugins/dotbabel/src/lib/symlink.mjs
+++ b/plugins/dotbabel/src/lib/symlink.mjs
@@ -1,0 +1,134 @@
+/**
+ * symlink.mjs — shared filesystem helpers used by bootstrap-global and
+ * project-sync. Both flows symlink artifacts into target trees with a
+ * timestamped backup discipline; this module is the single source of truth
+ * for that behavior.
+ */
+
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+
+/**
+ * @typedef {'ok'|'updated'|'linked'|'backed_up'} LinkAction
+ *
+ * @typedef {object} LinkResult
+ * @property {LinkAction} action
+ * @property {string} [bakPath]   Backup path (only set when action === 'backed_up')
+ *
+ * @typedef {'created'|'ok'|'backed_up'} EnsureDirAction
+ *
+ * @typedef {object} EnsureDirResult
+ * @property {EnsureDirAction} action
+ * @property {string} [bakPath]   Backup path (only set when action === 'backed_up')
+ */
+
+/**
+ * Build a backup-suffix timestamp matching `bootstrap.sh`'s `date +%Y%m%d-%H%M%S`.
+ *
+ * After `replace(/[-:T]/g, "")` the ISO string becomes "YYYYMMDDHHmmss.mmmZ",
+ * so the date part is `slice(0, 8)` and the time part is `slice(8, 14)` —
+ * no `T` separator remains.
+ *
+ * @returns {string}
+ */
+export function buildTimestamp() {
+  const ts = new Date()
+    .toISOString()
+    .replace(/[-:T]/g, "")
+    .replace(/\..+$/, "");
+  return `${ts.slice(0, 8)}-${ts.slice(8, 14)}`;
+}
+
+/**
+ * Create or update a symlink at `dst` pointing to `src`. Backs up a real
+ * file/dir at `dst` before replacing it.
+ *
+ * @param {string} src
+ * @param {string} dst
+ * @param {import('./output.mjs').Output} out
+ * @param {string} ts  Timestamp string for backup suffix (see {@link buildTimestamp}).
+ * @returns {LinkResult}
+ */
+export function linkOne(src, dst, out, ts) {
+  let lstat;
+  try {
+    lstat = fs.lstatSync(dst);
+  } catch {
+    fs.symlinkSync(src, dst);
+    out.pass(`linked: ${dst} -> ${src}`);
+    return { action: "linked" };
+  }
+
+  if (lstat.isSymbolicLink()) {
+    const current = fs.readlinkSync(dst);
+    if (current === src) {
+      out.pass(`ok: ${dst}`);
+      return { action: "ok" };
+    }
+    fs.unlinkSync(dst);
+    fs.symlinkSync(src, dst);
+    out.pass(`updated: ${dst} -> ${src}`);
+    return { action: "updated" };
+  }
+
+  const bakPath = `${dst}.bak-${ts}`;
+  fs.renameSync(dst, bakPath);
+  fs.symlinkSync(src, dst);
+  out.warn(`backed up + linked: ${dst} (old at ${bakPath})`);
+  return { action: "backed_up", bakPath };
+}
+
+/**
+ * Ensure `dst` is a real directory. If `dst` is missing, create it. If `dst`
+ * is a symlink or a regular file, back it up and create a real directory in
+ * its place.
+ *
+ * @param {string} dst
+ * @param {import('./output.mjs').Output} out
+ * @param {string} ts  Timestamp string for backup suffix.
+ * @returns {EnsureDirResult}
+ */
+export function ensureRealDir(dst, out, ts) {
+  let lstat;
+  try {
+    lstat = fs.lstatSync(dst);
+  } catch {
+    fs.mkdirSync(dst, { recursive: true });
+    return { action: "created" };
+  }
+
+  if (lstat.isDirectory() && !lstat.isSymbolicLink()) {
+    return { action: "ok" };
+  }
+
+  const bakPath = `${dst}.bak-${ts}`;
+  fs.renameSync(dst, bakPath);
+  out.warn(`backed up: ${dst} (old at ${bakPath})`);
+  fs.mkdirSync(dst, { recursive: true });
+  return { action: "backed_up", bakPath };
+}
+
+/**
+ * Check whether `command` is on PATH. Mirrors `command -v` in POSIX shell.
+ *
+ * @param {string} command
+ * @returns {boolean}
+ */
+export function commandExists(command) {
+  const result = spawnSync(
+    "sh",
+    ["-c", `command -v ${quoteShellWord(command)} >/dev/null 2>&1`],
+    { stdio: "ignore" },
+  );
+  return result.status === 0;
+}
+
+/**
+ * Single-quote a word for safe inclusion in `sh -c '...'` invocations.
+ *
+ * @param {string} word
+ * @returns {string}
+ */
+export function quoteShellWord(word) {
+  return `'${word.replace(/'/g, "'\\''")}'`;
+}

--- a/plugins/dotbabel/src/project-init-scaffold.mjs
+++ b/plugins/dotbabel/src/project-init-scaffold.mjs
@@ -1,0 +1,138 @@
+/**
+ * project-init-scaffold.mjs — minimal scaffolder for cross-CLI project sync.
+ *
+ * Distinct from `init-harness-scaffold.mjs`: this writes only the files
+ * `dotbabel project-sync` needs, not the full spec-governance harness.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { ValidationError, ERROR_CODES } from "./lib/errors.mjs";
+
+/** Default `.dotbabel.json` body written when none exists. */
+export const DEFAULT_DOTBABEL_JSON = Object.freeze({
+  rule_floor_source: "CLAUDE.md",
+  commands_dir: ".claude/commands",
+  skills_dir: ".claude/skills",
+  fan_out: ["codex", "gemini", "copilot"],
+  gate_on_cli_presence: true,
+  cli_substitutions: {},
+  targets: [
+    {
+      relativeOutputPath: "AGENTS.md",
+      cliSet: ["copilot", "codex"],
+      substitutionKey: "agents",
+    },
+    {
+      relativeOutputPath: "GEMINI.md",
+      cliSet: ["gemini"],
+      substitutionKey: "gemini",
+    },
+    {
+      relativeOutputPath: ".github/copilot-instructions.md",
+      cliSet: ["copilot"],
+      substitutionKey: "copilot",
+    },
+  ],
+});
+
+const STARTER_CLAUDE_MD = `# CLAUDE.md — Project rules
+
+Project-level rules for every agentic CLI in this repo. The block between the
+\`dotbabel:rule-floor\` markers below is fanned out into AGENTS.md, GEMINI.md,
+and .github/copilot-instructions.md by \`dotbabel project-sync\`.
+
+<!-- dotbabel:rule-floor:begin -->
+
+(Add project-wide rules here. Empty by default.)
+
+<!-- dotbabel:rule-floor:end -->
+`;
+
+/**
+ * @typedef {object} ScaffoldProjectInitOpts
+ * @property {string} repoRoot
+ * @property {boolean} [force]   Overwrite an existing .dotbabel.json.
+ * @property {boolean} [dryRun]  Report planned actions, do not mutate.
+ *
+ * @typedef {object} ScaffoldProjectInitResult
+ * @property {boolean} ok
+ * @property {string[]} filesWritten   Repo-relative POSIX paths created or planned.
+ * @property {string[]} skipped        Repo-relative POSIX paths already present.
+ */
+
+/**
+ * Scaffold the minimum tree project-sync needs into `repoRoot`.
+ *
+ * Always written:
+ *   .dotbabel.json            (refuses to overwrite without --force)
+ *   .claude/commands/.gitkeep (only if .claude/commands/ is missing)
+ *   .claude/skills/.gitkeep   (only if .claude/skills/ is missing)
+ *   CLAUDE.md                 (only if missing — preserves user content)
+ *
+ * @param {ScaffoldProjectInitOpts} opts
+ * @returns {ScaffoldProjectInitResult}
+ */
+export function scaffoldProjectInit(opts) {
+  const { repoRoot } = opts;
+  if (!fs.existsSync(repoRoot)) {
+    throw new ValidationError({
+      code: ERROR_CODES.SCAFFOLD_USAGE,
+      category: "scaffold",
+      message: `repo root does not exist: ${repoRoot}`,
+    });
+  }
+
+  /** @type {string[]} */ const filesWritten = [];
+  /** @type {string[]} */ const skipped = [];
+
+  const dotbabelPath = path.join(repoRoot, ".dotbabel.json");
+  if (fs.existsSync(dotbabelPath) && !opts.force) {
+    throw new ValidationError({
+      code: ERROR_CODES.SCAFFOLD_CONFLICT,
+      category: "scaffold",
+      file: ".dotbabel.json",
+      message:
+        ".dotbabel.json already exists; pass --force to overwrite (a backup is NOT made)",
+    });
+  }
+  if (opts.dryRun) {
+    filesWritten.push(".dotbabel.json");
+  } else {
+    fs.writeFileSync(
+      dotbabelPath,
+      `${JSON.stringify(DEFAULT_DOTBABEL_JSON, null, 2)}\n`,
+    );
+    filesWritten.push(".dotbabel.json");
+  }
+
+  for (const dir of [".claude/commands", ".claude/skills"]) {
+    const abs = path.join(repoRoot, dir);
+    const keep = path.join(abs, ".gitkeep");
+    if (fs.existsSync(abs)) {
+      skipped.push(dir);
+      continue;
+    }
+    if (opts.dryRun) {
+      filesWritten.push(`${dir}/.gitkeep`);
+    } else {
+      fs.mkdirSync(abs, { recursive: true });
+      fs.writeFileSync(keep, "");
+      filesWritten.push(`${dir}/.gitkeep`);
+    }
+  }
+
+  const claudeMdPath = path.join(repoRoot, "CLAUDE.md");
+  if (fs.existsSync(claudeMdPath)) {
+    skipped.push("CLAUDE.md");
+  } else {
+    if (opts.dryRun) {
+      filesWritten.push("CLAUDE.md");
+    } else {
+      fs.writeFileSync(claudeMdPath, STARTER_CLAUDE_MD);
+      filesWritten.push("CLAUDE.md");
+    }
+  }
+
+  return { ok: true, filesWritten, skipped };
+}

--- a/plugins/dotbabel/src/project-sync.mjs
+++ b/plugins/dotbabel/src/project-sync.mjs
@@ -1,0 +1,356 @@
+/**
+ * project-sync.mjs — repo-local fan-out of CLAUDE.md, .claude/commands, and
+ * .claude/skills into Codex / Gemini / Copilot project-scope analogues.
+ *
+ * Mirrors the user-scope flow in `bootstrap-global.mjs`, but rooted at a
+ * target repo instead of `$HOME`. Reuses the symlink helpers from
+ * `lib/symlink.mjs` and the rule-floor primitives from
+ * `generate-instructions.mjs`. Crucially does NOT call `generateInstructions`
+ * itself — that path hard-loads `docs/repo-facts.json` and writes the
+ * dotbabel-private template manifest, neither of which is correct for an
+ * arbitrary consumer repo.
+ *
+ * Exports:
+ *   loadProjectConfig(repoRoot)
+ *   projectSync(opts)
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { createOutput } from "./lib/output.mjs";
+import {
+  buildTimestamp,
+  commandExists,
+  ensureRealDir,
+  linkOne,
+} from "./lib/symlink.mjs";
+import {
+  RULE_FLOOR_BEGIN,
+  RULE_FLOOR_END,
+  composeInject,
+  extractRuleFloor,
+  renderTarget,
+  validateSubstitutions,
+  ERROR_CODES,
+} from "./generate-instructions.mjs";
+import { ValidationError } from "./lib/errors.mjs";
+
+/** Default config returned when `.dotbabel.json` is absent. */
+export const DEFAULT_PROJECT_CONFIG = Object.freeze({
+  rule_floor_source: "CLAUDE.md",
+  commands_dir: ".claude/commands",
+  skills_dir: ".claude/skills",
+  fan_out: Object.freeze(["codex", "gemini", "copilot"]),
+  gate_on_cli_presence: true,
+  cli_substitutions: Object.freeze({}),
+  targets: Object.freeze([
+    Object.freeze({
+      relativeOutputPath: "AGENTS.md",
+      cliSet: Object.freeze(["copilot", "codex"]),
+      substitutionKey: "agents",
+    }),
+    Object.freeze({
+      relativeOutputPath: "GEMINI.md",
+      cliSet: Object.freeze(["gemini"]),
+      substitutionKey: "gemini",
+    }),
+    Object.freeze({
+      relativeOutputPath: ".github/copilot-instructions.md",
+      cliSet: Object.freeze(["copilot"]),
+      substitutionKey: "copilot",
+    }),
+  ]),
+});
+
+/**
+ * Load `.dotbabel.json` from `repoRoot`, layering its keys over
+ * {@link DEFAULT_PROJECT_CONFIG}. Returns the merged config — never mutates
+ * the defaults.
+ *
+ * @param {string} repoRoot
+ * @returns {typeof DEFAULT_PROJECT_CONFIG}
+ */
+export function loadProjectConfig(repoRoot) {
+  const cfgPath = path.join(repoRoot, ".dotbabel.json");
+  if (!fs.existsSync(cfgPath)) {
+    return { ...DEFAULT_PROJECT_CONFIG };
+  }
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+  } catch (err) {
+    throw new ValidationError({
+      code: ERROR_CODES.DRIFT_INSTRUCTION_FILES,
+      category: "drift",
+      file: ".dotbabel.json",
+      message: `.dotbabel.json is not valid JSON: ${err.message}`,
+      hint: "fix the JSON syntax or delete .dotbabel.json to use defaults",
+    });
+  }
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ValidationError({
+      code: ERROR_CODES.DRIFT_INSTRUCTION_FILES,
+      category: "drift",
+      file: ".dotbabel.json",
+      message: ".dotbabel.json must be a JSON object at the top level",
+    });
+  }
+  return { ...DEFAULT_PROJECT_CONFIG, ...raw };
+}
+
+/**
+ * Like `extractRuleFloor`, but falls back to treating the entire body as the
+ * rule floor when the source has no markers at all. Marker-mismatch errors
+ * (orphan begin or end) still throw, mirroring the harness DX.
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+export function extractRuleFloorOrWhole(body) {
+  try {
+    return extractRuleFloor(body);
+  } catch (err) {
+    if (
+      err?.code === ERROR_CODES.DRIFT_UNCLOSED_SPAN &&
+      !body.includes(RULE_FLOOR_BEGIN) &&
+      !body.includes(RULE_FLOOR_END)
+    ) {
+      return body.trim();
+    }
+    throw err;
+  }
+}
+
+/**
+ * @typedef {object} ProjectSyncOpts
+ * @property {string} repoRoot
+ * @property {boolean} [allCli]   Force fan-out even if a target CLI binary is missing.
+ * @property {boolean} [force]    Reserved for collision overrides (currently unused — see warning path).
+ * @property {boolean} [dryRun]   Report planned actions, do not mutate.
+ * @property {boolean} [quiet]
+ * @property {boolean} [json]
+ * @property {boolean} [noColor]
+ * @property {import('./lib/output.mjs').Output} [out]   Inject for tests.
+ *
+ * @typedef {object} ProjectSyncResult
+ * @property {boolean} ok
+ * @property {number} linked
+ * @property {number} skipped
+ * @property {number} backed_up
+ * @property {number} written     Number of instruction files written (or planned in dry-run).
+ */
+
+/**
+ * Synchronize project-scope CLI artifacts in `opts.repoRoot`.
+ *
+ * @param {ProjectSyncOpts} opts
+ * @returns {Promise<ProjectSyncResult>}
+ */
+export async function projectSync(opts) {
+  const repoRoot = opts.repoRoot;
+  const out =
+    opts.out ??
+    createOutput({
+      json: opts.json ?? false,
+      noColor: opts.noColor ?? false,
+      quiet: opts.quiet ?? false,
+    });
+
+  if (!fs.existsSync(repoRoot)) {
+    out.fail(`repo root does not exist: ${repoRoot}`);
+    out.flush();
+    return { ok: false, linked: 0, skipped: 0, backed_up: 0, written: 0 };
+  }
+
+  const cfg = loadProjectConfig(repoRoot);
+  const sourcePath = path.join(repoRoot, cfg.rule_floor_source);
+  if (!fs.existsSync(sourcePath)) {
+    out.fail(`rule-floor source does not exist: ${cfg.rule_floor_source}`);
+    out.flush();
+    return { ok: false, linked: 0, skipped: 0, backed_up: 0, written: 0 };
+  }
+
+  const timestamp = buildTimestamp();
+  let linked = 0;
+  let skipped = 0;
+  let backed_up = 0;
+  let written = 0;
+
+  // ---- 1. Instruction files (AGENTS.md, GEMINI.md, copilot-instructions.md)
+
+  const sourceText = fs.readFileSync(sourcePath, "utf8");
+  const subs = validateSubstitutions(
+    cfg.cli_substitutions ?? {},
+    ".dotbabel.json",
+  );
+
+  for (const target of cfg.targets) {
+    const { body } = renderTarget(sourceText, target, subs);
+    const ruleFloor = extractRuleFloorOrWhole(body);
+    const absHost = path.join(repoRoot, target.relativeOutputPath);
+    const existing = fs.existsSync(absHost)
+      ? fs.readFileSync(absHost, "utf8")
+      : "";
+    const next = composeInject(
+      existing,
+      ruleFloor,
+      target.relativeOutputPath,
+    );
+    if (next === existing) {
+      out.pass(`ok: ${target.relativeOutputPath}`);
+      continue;
+    }
+    if (opts.dryRun) {
+      out.info(
+        `would write ${target.relativeOutputPath} (${next.length} bytes, changed)`,
+      );
+      written++;
+      continue;
+    }
+    fs.mkdirSync(path.dirname(absHost), { recursive: true });
+    fs.writeFileSync(absHost, next);
+    out.pass(`updated: ${target.relativeOutputPath}`);
+    written++;
+  }
+
+  // ---- 2. Symlink fan-out for each enabled CLI
+
+  const commandsAbs = path.join(repoRoot, cfg.commands_dir);
+  const skillsAbs = path.join(repoRoot, cfg.skills_dir);
+
+  const fanOut = Array.isArray(cfg.fan_out) ? cfg.fan_out : [];
+  for (const cli of fanOut) {
+    if (cli === "codex") {
+      fanOutSkillsLayout({
+        cli: "codex",
+        targetDir: path.join(repoRoot, ".codex", "skills"),
+      });
+    } else if (cli === "gemini") {
+      fanOutSkillsLayout({
+        cli: "gemini",
+        targetDir: path.join(repoRoot, ".gemini", "skills"),
+      });
+    } else if (cli === "copilot") {
+      fanOutCopilotLayout();
+    } else {
+      out.warn(`unknown fan_out CLI: ${cli} (skipped)`);
+      skipped++;
+    }
+  }
+
+  out.flush();
+  return { ok: true, linked, skipped, backed_up, written };
+
+  // -------------------------------------------------------------------------
+  // helpers (closures over linked / skipped / backed_up / out / opts)
+
+  function gateOnCli(cli, label) {
+    if (opts.allCli) return true;
+    if (!cfg.gate_on_cli_presence) return true;
+    if (commandExists(cli)) return true;
+    out.info(`skipped ${label} (${cli} not on PATH; use --all to force)`);
+    skipped++;
+    return false;
+  }
+
+  function doLink(src, dst) {
+    if (opts.dryRun) {
+      out.info(`would link: ${dst} -> ${src}`);
+      linked++;
+      return;
+    }
+    const r = linkOne(src, dst, out, timestamp);
+    if (r.action === "backed_up") backed_up++;
+    if (
+      r.action === "linked" ||
+      r.action === "updated" ||
+      r.action === "ok" ||
+      r.action === "backed_up"
+    ) {
+      linked++;
+    }
+  }
+
+  function doEnsureRealDir(dst) {
+    if (opts.dryRun) {
+      // We can still inspect the filesystem to decide whether a backup would
+      // happen — but never mutate.
+      try {
+        const lstat = fs.lstatSync(dst);
+        if (!(lstat.isDirectory() && !lstat.isSymbolicLink())) {
+          out.info(`would back up + create dir: ${dst}`);
+        }
+      } catch {
+        out.info(`would create dir: ${dst}`);
+      }
+      return;
+    }
+    const r = ensureRealDir(dst, out, timestamp);
+    if (r.action === "backed_up") backed_up++;
+  }
+
+  function fanOutSkillsLayout({ cli, targetDir }) {
+    if (!gateOnCli(cli, `${cli} skills fan-out`)) return;
+    if (!opts.dryRun) fs.mkdirSync(targetDir, { recursive: true });
+
+    if (fs.existsSync(skillsAbs)) {
+      const entries = fs.readdirSync(skillsAbs, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name === ".system") continue;
+        const src = path.join(skillsAbs, entry.name);
+        const dst = path.join(targetDir, entry.name);
+        doLink(src, dst);
+      }
+    }
+
+    if (fs.existsSync(commandsAbs)) {
+      for (const entry of fs.readdirSync(commandsAbs)) {
+        if (!entry.endsWith(".md")) continue;
+        const name = entry.replace(/\.md$/, "");
+        if (name === ".system") continue;
+        const src = path.join(commandsAbs, entry);
+        const wrapDir = path.join(targetDir, name);
+        doEnsureRealDir(wrapDir);
+        const dst = path.join(wrapDir, "SKILL.md");
+        doLink(src, dst);
+      }
+    }
+  }
+
+  function fanOutCopilotLayout() {
+    if (!gateOnCli("copilot", "copilot prompt/instruction fan-out")) return;
+    const promptsDir = path.join(repoRoot, ".github", "prompts");
+    const instructionsDir = path.join(repoRoot, ".github", "instructions");
+
+    // commands → .github/prompts/<name>.prompt.md
+    if (fs.existsSync(commandsAbs)) {
+      if (!opts.dryRun) fs.mkdirSync(promptsDir, { recursive: true });
+      for (const entry of fs.readdirSync(commandsAbs)) {
+        if (!entry.endsWith(".md")) continue;
+        const name = entry.replace(/\.md$/, "");
+        if (name === ".system") continue;
+        const src = path.join(commandsAbs, entry);
+        const dst = path.join(promptsDir, `${name}.prompt.md`);
+        doLink(src, dst);
+      }
+    }
+
+    // skills/<id>/SKILL.md → .github/instructions/<id>.instructions.md
+    if (fs.existsSync(skillsAbs)) {
+      if (!opts.dryRun) fs.mkdirSync(instructionsDir, { recursive: true });
+      const entries = fs.readdirSync(skillsAbs, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name === ".system") continue;
+        const skillFile = path.join(skillsAbs, entry.name, "SKILL.md");
+        if (!fs.existsSync(skillFile)) continue;
+        const dst = path.join(
+          instructionsDir,
+          `${entry.name}.instructions.md`,
+        );
+        doLink(skillFile, dst);
+      }
+    }
+  }
+}

--- a/plugins/dotbabel/templates/claude/skills-manifest.json
+++ b/plugins/dotbabel/templates/claude/skills-manifest.json
@@ -171,6 +171,13 @@
       "lastValidated": null
     },
     {
+      "name": "project-sync",
+      "path": ".claude/skills/project-sync/SKILL.md",
+      "checksum": "",
+      "dependencies": [],
+      "lastValidated": null
+    },
+    {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "",

--- a/plugins/dotbabel/templates/claude/skills/project-sync/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/project-sync/SKILL.md
@@ -1,0 +1,87 @@
+---
+id: project-sync
+name: project-sync
+type: skill
+version: 0.1.0
+domain: [devex]
+platform: [none]
+task: [scaffolding]
+maturity: draft
+description: >
+  Fan out the current repo's CLAUDE.md, .claude/commands, and .claude/skills
+  into Codex, Gemini, and Copilot project-scope analogues (.codex/skills,
+  .gemini/skills, .github/prompts, .github/instructions) plus refresh
+  AGENTS.md, GEMINI.md, and .github/copilot-instructions.md from the project's
+  rule floor. Wraps `dotbabel project-sync`. Use when adopting cross-CLI
+  workflows in a repo for the first time, or when adding a new command/skill
+  that needs to be visible to Codex/Gemini/Copilot. Triggers on:
+  "sync this repo", "project sync", "fan out commands", "wire up gemini for
+  this project", "add this command to codex", "make this skill available in
+  copilot", "regenerate AGENTS.md for this project".
+argument-hint: "[--dry-run] [--all] [--repo <path>]"
+tools: Bash, Read, Glob
+effort: low
+model: sonnet
+---
+
+# project-sync — Repo-local cross-CLI fan-out
+
+Thin wrapper around `dotbabel project-sync`. The binary owns all writes; this
+skill maps natural-language requests to the right invocation and surfaces
+dry-run output before mutating the repo.
+
+## When to invoke
+
+- The user wants to adopt cross-CLI workflows in a repo that already has
+  `.claude/commands/*` or `.claude/skills/*`, but no `AGENTS.md`/`GEMINI.md`/
+  `.github/prompts/`/`.github/instructions/` wiring.
+- A new command or skill was just added to `.claude/`, and the user wants
+  Codex/Gemini/Copilot to see it without leaving the editor.
+- The user asks for "drift check" or "is this repo synced" — run
+  `dotbabel check-project-sync` instead and surface the diff.
+- First-time setup: if `.dotbabel.json` is missing, suggest
+  `dotbabel project-init` first.
+
+## Workflow
+
+1. **Pre-flight.** Confirm cwd is a git repo and contains `CLAUDE.md` (with or
+   without rule-floor markers) plus at least one of `.claude/commands/` or
+   `.claude/skills/`. If `.dotbabel.json` is absent, mention that defaults will
+   apply (no `cli_substitutions`, full fan-out to codex/gemini/copilot,
+   gating on each CLI's `command -v` check).
+2. **Dry-run first.** Always run `dotbabel project-sync --dry-run` before
+   mutating. Summarize the planned actions to the user (count of instruction
+   files, count of new symlinks per CLI). Pause for confirmation **unless**
+   the user already said "do it" or "go ahead" in the same turn.
+3. **Apply.** Run `dotbabel project-sync` (no `--dry-run`). If the user passed
+   `--all`, propagate it.
+4. **Verify.** Run `dotbabel check-project-sync` and report `ok` /
+   `missing` / `stale` counts. Exit non-zero output should be surfaced.
+
+## Triggers and invocations
+
+| Trigger phrase                                        | Invocation                                                 |
+| ----------------------------------------------------- | ---------------------------------------------------------- |
+| "sync this repo", "project sync", "fan out commands"  | `dotbabel project-sync --dry-run` then apply               |
+| "wire up gemini for this project"                     | `dotbabel project-sync --all` (covers all)                 |
+| "is this repo synced", "drift check the project sync" | `dotbabel check-project-sync` (read-only)                  |
+| "regenerate AGENTS.md for this project"               | `dotbabel project-sync` (instructions are part of the run) |
+| "set up project sync here", "first-time project sync" | `dotbabel project-init` then project-sync                  |
+
+## Reference: Copilot mapping
+
+The Copilot CLI fan-out targets `.github/prompts/*.prompt.md` (commands) and
+`.github/instructions/*.instructions.md` (skills) inside the target repo.
+See [`references/copilot-mapping.md`](references/copilot-mapping.md) for the
+full layout and rationale.
+
+## Boundaries
+
+- Always operate on the user's current working directory unless they pass an
+  explicit `--repo <path>`. Never silently target a different repo.
+- Never run `--force`. The plan reserves it for collision overrides; defer
+  to the binary's existing collision warnings.
+- For consumer repos with no `.dotbabel.json`, the convention path applies
+  (entire `CLAUDE.md` becomes the rule floor when markers are absent).
+- This skill is for **project-scope** sync. For user-scope (`~/.claude/`,
+  `~/.codex/`, `~/.gemini/`) bootstrap, use `dotbabel bootstrap` instead.

--- a/plugins/dotbabel/templates/claude/skills/project-sync/references/copilot-mapping.md
+++ b/plugins/dotbabel/templates/claude/skills/project-sync/references/copilot-mapping.md
@@ -1,0 +1,42 @@
+# Copilot CLI mapping reference
+
+`dotbabel project-sync` fans out repo-local artifacts to three places GitHub
+Copilot CLI reads. Unlike Codex and Gemini (both of which auto-load anything
+under their `skills/<id>/SKILL.md` shape), Copilot has no single
+"skills directory" — it has two related but distinct discovery paths.
+
+## Layout
+
+| Source                         | Copilot destination                         | What it does                                                  |
+| ------------------------------ | ------------------------------------------- | ------------------------------------------------------------- |
+| `.claude/commands/<name>.md`   | `.github/prompts/<name>.prompt.md`          | Slash-command analogue. The user types `/<name>` in Copilot.  |
+| `.claude/skills/<id>/SKILL.md` | `.github/instructions/<id>.instructions.md` | Auto-loaded instruction file. Behavior shifts model defaults. |
+| `CLAUDE.md` (rule-floor block) | `.github/copilot-instructions.md`           | Repo-wide instructions injected into every Copilot session.   |
+
+Each row is a symlink. A real file at the destination is renamed to
+`<dst>.bak-<YYYYMMDD-HHmmss>` before the symlink is placed; stale symlinks
+are silently updated.
+
+## Why two destinations and not one?
+
+- `.github/prompts/*.prompt.md` is Copilot's slash-command discovery. It
+  expects one file per command and a `.prompt.md` suffix. Wrapping a Claude
+  command as `<name>/SKILL.md` would not be picked up.
+- `.github/instructions/*.instructions.md` is Copilot's instruction-style
+  context loading. It expects flat files with `.instructions.md` suffix, not
+  a directory tree.
+
+Real-world consumer repos already use this convention; the project-sync
+fan-out matches that established shape.
+
+## Detection and gating
+
+Project-sync gates Copilot fan-out on `command -v copilot >/dev/null` unless
+the caller passes `--all`. This mirrors the user-scope bootstrap behavior at
+`plugins/dotbabel/src/bootstrap-global.mjs:347-378`.
+
+If `copilot` is not on PATH and `--all` is not set, the Copilot rows above are
+skipped. The instruction-file write to `.github/copilot-instructions.md` is
+NOT skipped — that file is part of the rule-floor injection step, which
+always runs, since it's how the repo signals project-wide rules to Copilot
+even when the CLI is not installed locally.

--- a/plugins/dotbabel/tests/bats/project-sync.bats
+++ b/plugins/dotbabel/tests/bats/project-sync.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# Behavior tests for `dotbabel project-sync` — operates on a hermetic
+# scratch repo (mktemp -d), never on the real working copy. The dotbabel
+# bin is invoked via `node plugins/dotbabel/bin/dotbabel-project-sync.mjs`
+# from REPO_ROOT.
+
+load helpers
+
+PSYNC="node $REPO_ROOT/plugins/dotbabel/bin/dotbabel-project-sync.mjs"
+PCHECK="node $REPO_ROOT/plugins/dotbabel/bin/dotbabel-check-project-sync.mjs"
+PINIT="node $REPO_ROOT/plugins/dotbabel/bin/dotbabel-project-init.mjs"
+
+# Build a minimal consumer repo with markers, one command, one skill.
+build_repo() {
+  local dir="$1"
+  cat > "$dir/CLAUDE.md" <<'MD'
+# Project rules
+
+<!-- dotbabel:rule-floor:begin -->
+- be terse
+- be helpful
+<!-- dotbabel:rule-floor:end -->
+MD
+  mkdir -p "$dir/.claude/commands" "$dir/.claude/skills/deploy"
+  echo "# /commit" > "$dir/.claude/commands/commit.md"
+  cat > "$dir/.claude/skills/deploy/SKILL.md" <<'MD'
+---
+name: deploy
+---
+# deploy
+MD
+}
+
+setup() {
+  REPO=$(mktemp -d)
+  build_repo "$REPO"
+}
+
+teardown() {
+  [ -n "${REPO:-}" ] && [ -d "$REPO" ] && rm -rf "$REPO"
+}
+
+@test "project-sync --help exits 0 and lists --dry-run" {
+  run $PSYNC --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--dry-run"* ]]
+  [[ "$output" == *"--repo"* ]]
+}
+
+@test "project-sync writes AGENTS.md, GEMINI.md, copilot-instructions.md" {
+  run $PSYNC --repo "$REPO" --all
+  [ "$status" -eq 0 ]
+  [ -f "$REPO/AGENTS.md" ]
+  [ -f "$REPO/GEMINI.md" ]
+  [ -f "$REPO/.github/copilot-instructions.md" ]
+  grep -q "be terse" "$REPO/AGENTS.md"
+}
+
+@test "project-sync creates Codex symlinks at .codex/skills" {
+  run $PSYNC --repo "$REPO" --all
+  [ "$status" -eq 0 ]
+  [ -L "$REPO/.codex/skills/deploy" ]
+  [ -L "$REPO/.codex/skills/commit/SKILL.md" ]
+  target=$(readlink "$REPO/.codex/skills/commit/SKILL.md")
+  [ "$target" = "$REPO/.claude/commands/commit.md" ]
+}
+
+@test "project-sync creates Gemini symlinks at .gemini/skills" {
+  run $PSYNC --repo "$REPO" --all
+  [ "$status" -eq 0 ]
+  [ -L "$REPO/.gemini/skills/deploy" ]
+  [ -L "$REPO/.gemini/skills/commit/SKILL.md" ]
+}
+
+@test "project-sync creates Copilot prompts and instructions" {
+  run $PSYNC --repo "$REPO" --all
+  [ "$status" -eq 0 ]
+  [ -L "$REPO/.github/prompts/commit.prompt.md" ]
+  [ -L "$REPO/.github/instructions/deploy.instructions.md" ]
+  target=$(readlink "$REPO/.github/prompts/commit.prompt.md")
+  [ "$target" = "$REPO/.claude/commands/commit.md" ]
+}
+
+@test "project-sync --dry-run does not mutate the filesystem" {
+  run $PSYNC --repo "$REPO" --all --dry-run
+  [ "$status" -eq 0 ]
+  [ ! -e "$REPO/AGENTS.md" ]
+  [ ! -e "$REPO/.codex" ]
+  [ ! -e "$REPO/.github/prompts" ]
+}
+
+@test "project-sync is idempotent" {
+  $PSYNC --repo "$REPO" --all >/dev/null
+  run $PSYNC --repo "$REPO" --all
+  [ "$status" -eq 0 ]
+  # No new backup files should appear on the second run.
+  run bash -c "ls '$REPO/.codex/skills/'*.bak-* 2>/dev/null || true"
+  [ -z "$output" ]
+}
+
+@test "check-project-sync exit 0 after sync" {
+  $PSYNC --repo "$REPO" --all >/dev/null
+  run $PCHECK --repo "$REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "check-project-sync exit 1 when a symlink is unlinked" {
+  $PSYNC --repo "$REPO" --all >/dev/null
+  unlink "$REPO/.codex/skills/commit/SKILL.md"
+  # Source must remain untouched.
+  [ -f "$REPO/.claude/commands/commit.md" ]
+  run $PCHECK --repo "$REPO"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing"* ]]
+}
+
+@test "project-init scaffolds .dotbabel.json and starter CLAUDE.md" {
+  EMPTY=$(mktemp -d)
+  run $PINIT --repo "$EMPTY"
+  [ "$status" -eq 0 ]
+  [ -f "$EMPTY/.dotbabel.json" ]
+  [ -f "$EMPTY/CLAUDE.md" ]
+  [ -f "$EMPTY/.claude/commands/.gitkeep" ]
+  [ -f "$EMPTY/.claude/skills/.gitkeep" ]
+  grep -q "dotbabel:rule-floor:begin" "$EMPTY/CLAUDE.md"
+  rm -rf "$EMPTY"
+}
+
+@test "project-init refuses to overwrite .dotbabel.json without --force (exit 1)" {
+  echo '{"already":"here"}' > "$REPO/.dotbabel.json"
+  run $PINIT --repo "$REPO"
+  [ "$status" -eq 1 ]
+}
+
+@test "project-init --force overwrites .dotbabel.json" {
+  echo '{"already":"here"}' > "$REPO/.dotbabel.json"
+  run $PINIT --repo "$REPO" --force
+  [ "$status" -eq 0 ]
+  grep -q '"rule_floor_source"' "$REPO/.dotbabel.json"
+}
+
+@test "convention path: marker-less CLAUDE.md still produces AGENTS.md" {
+  PLAIN=$(mktemp -d)
+  echo "# minimal" > "$PLAIN/CLAUDE.md"
+  echo "be kind" >> "$PLAIN/CLAUDE.md"
+  mkdir -p "$PLAIN/.claude/commands"
+  echo "# /bar" > "$PLAIN/.claude/commands/bar.md"
+
+  run $PSYNC --repo "$PLAIN" --all
+  [ "$status" -eq 0 ]
+  grep -q "be kind" "$PLAIN/AGENTS.md"
+  [ -L "$PLAIN/.codex/skills/bar/SKILL.md" ]
+  rm -rf "$PLAIN"
+}

--- a/plugins/dotbabel/tests/check-project-sync.test.mjs
+++ b/plugins/dotbabel/tests/check-project-sync.test.mjs
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from "vitest";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import { projectSync } from "../src/project-sync.mjs";
+import { checkProjectSync } from "../src/check-project-sync.mjs";
+
+let tmpDirs = [];
+
+function makeTmpDir(prefix = "check-project-sync-test-") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs = [];
+});
+
+function buildSyncedRepo() {
+  const repo = makeTmpDir();
+  fs.writeFileSync(
+    path.join(repo, "CLAUDE.md"),
+    "# rules\n\n<!-- dotbabel:rule-floor:begin -->\n- be terse\n<!-- dotbabel:rule-floor:end -->\n",
+  );
+  fs.mkdirSync(path.join(repo, ".claude", "commands"), { recursive: true });
+  fs.writeFileSync(path.join(repo, ".claude", "commands", "commit.md"), "# /commit\n");
+  fs.mkdirSync(path.join(repo, ".claude", "skills", "deploy"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repo, ".claude", "skills", "deploy", "SKILL.md"),
+    "---\nname: deploy\n---\n# deploy\n",
+  );
+  return repo;
+}
+
+describe("checkProjectSync", () => {
+  it("reports ok for a fully synced repo", async () => {
+    const repo = buildSyncedRepo();
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    const r = await checkProjectSync({ repoRoot: repo, quiet: true });
+    expect(r.ok).toBe(true);
+    expect(r.missing).toHaveLength(0);
+    expect(r.stale).toHaveLength(0);
+    expect(r.okEntries.length).toBeGreaterThan(0);
+  });
+
+  it("reports missing when a symlink is removed", async () => {
+    const repo = buildSyncedRepo();
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    // Remove only the symlink (NOT the source).
+    fs.unlinkSync(path.join(repo, ".codex", "skills", "commit", "SKILL.md"));
+    expect(fs.existsSync(path.join(repo, ".claude", "commands", "commit.md"))).toBe(true);
+    const r = await checkProjectSync({ repoRoot: repo, quiet: true });
+    expect(r.ok).toBe(false);
+    expect(r.missing.some((e) => e.path.endsWith("commit/SKILL.md"))).toBe(true);
+  });
+
+  it("reports stale when an instruction file is hand-edited", async () => {
+    const repo = buildSyncedRepo();
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    // Wipe AGENTS.md content so composeInject would change it.
+    fs.writeFileSync(path.join(repo, "AGENTS.md"), "totally different content\n");
+    const r = await checkProjectSync({ repoRoot: repo, quiet: true });
+    expect(r.ok).toBe(false);
+    expect(r.stale.some((e) => e.path === "AGENTS.md")).toBe(true);
+  });
+
+  it("reports stale when a destination is a regular file (not a symlink)", async () => {
+    const repo = buildSyncedRepo();
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    // Replace the symlink with a regular file at the same path.
+    const linkPath = path.join(repo, ".codex", "skills", "commit", "SKILL.md");
+    fs.unlinkSync(linkPath);
+    fs.writeFileSync(linkPath, "real file masquerading as a skill\n");
+    const r = await checkProjectSync({ repoRoot: repo, quiet: true });
+    expect(r.ok).toBe(false);
+    expect(r.stale.some((e) => e.actual === "not a symlink")).toBe(true);
+  });
+});

--- a/plugins/dotbabel/tests/check-project-sync.test.mjs
+++ b/plugins/dotbabel/tests/check-project-sync.test.mjs
@@ -79,4 +79,44 @@ describe("checkProjectSync", () => {
     expect(r.ok).toBe(false);
     expect(r.stale.some((e) => e.actual === "not a symlink")).toBe(true);
   });
+
+  it("reports stale when a symlink points at the wrong source", async () => {
+    const repo = buildSyncedRepo();
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    const linkPath = path.join(repo, ".codex", "skills", "commit", "SKILL.md");
+    fs.unlinkSync(linkPath);
+    fs.symlinkSync("/some/other/place/foo.md", linkPath);
+    const r = await checkProjectSync({ repoRoot: repo, quiet: true });
+    expect(r.ok).toBe(false);
+    expect(
+      r.stale.some(
+        (e) => e.path.endsWith("commit/SKILL.md") && e.actual === "/some/other/place/foo.md",
+      ),
+    ).toBe(true);
+  });
+
+  it("reports missing instruction file when AGENTS.md is deleted", async () => {
+    const repo = buildSyncedRepo();
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    fs.unlinkSync(path.join(repo, "AGENTS.md"));
+    const r = await checkProjectSync({ repoRoot: repo, quiet: true });
+    expect(r.ok).toBe(false);
+    expect(r.missing.some((e) => e.path === "AGENTS.md")).toBe(true);
+  });
+
+  it("returns ok=false when repoRoot does not exist", async () => {
+    const r = await checkProjectSync({
+      repoRoot: "/totally-nonexistent-path-xyz-12345",
+      quiet: true,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it("returns ok=false when CLAUDE.md is missing", async () => {
+    const repo = makeTmpDir();
+    // No CLAUDE.md.
+    fs.mkdirSync(path.join(repo, ".claude", "commands"), { recursive: true });
+    const r = await checkProjectSync({ repoRoot: repo, quiet: true });
+    expect(r.ok).toBe(false);
+  });
 });

--- a/plugins/dotbabel/tests/project-init-scaffold.test.mjs
+++ b/plugins/dotbabel/tests/project-init-scaffold.test.mjs
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from "vitest";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import {
+  scaffoldProjectInit,
+  DEFAULT_DOTBABEL_JSON,
+} from "../src/project-init-scaffold.mjs";
+import { ValidationError } from "../src/lib/errors.mjs";
+
+let tmpDirs = [];
+
+function makeTmpDir(prefix = "project-init-test-") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs = [];
+});
+
+describe("scaffoldProjectInit", () => {
+  it("scaffolds .dotbabel.json + .gitkeeps + starter CLAUDE.md into an empty repo", () => {
+    const repo = makeTmpDir();
+    const r = scaffoldProjectInit({ repoRoot: repo });
+    expect(r.ok).toBe(true);
+    expect(r.filesWritten).toContain(".dotbabel.json");
+    expect(r.filesWritten).toContain(".claude/commands/.gitkeep");
+    expect(r.filesWritten).toContain(".claude/skills/.gitkeep");
+    expect(r.filesWritten).toContain("CLAUDE.md");
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(repo, ".dotbabel.json"), "utf8"));
+    expect(cfg.fan_out).toEqual(DEFAULT_DOTBABEL_JSON.fan_out);
+    expect(cfg.targets).toEqual(DEFAULT_DOTBABEL_JSON.targets);
+
+    const claudeMd = fs.readFileSync(path.join(repo, "CLAUDE.md"), "utf8");
+    expect(claudeMd).toContain("<!-- dotbabel:rule-floor:begin -->");
+    expect(claudeMd).toContain("<!-- dotbabel:rule-floor:end -->");
+  });
+
+  it("preserves an existing CLAUDE.md", () => {
+    const repo = makeTmpDir();
+    fs.writeFileSync(path.join(repo, "CLAUDE.md"), "# hand-authored — keep me\n");
+    const r = scaffoldProjectInit({ repoRoot: repo });
+    expect(r.skipped).toContain("CLAUDE.md");
+    expect(fs.readFileSync(path.join(repo, "CLAUDE.md"), "utf8")).toBe(
+      "# hand-authored — keep me\n",
+    );
+  });
+
+  it("preserves an existing .claude/ directory", () => {
+    const repo = makeTmpDir();
+    fs.mkdirSync(path.join(repo, ".claude", "commands"), { recursive: true });
+    fs.mkdirSync(path.join(repo, ".claude", "skills"), { recursive: true });
+    const r = scaffoldProjectInit({ repoRoot: repo });
+    expect(r.skipped).toContain(".claude/commands");
+    expect(r.skipped).toContain(".claude/skills");
+  });
+
+  it("refuses to overwrite an existing .dotbabel.json without --force", () => {
+    const repo = makeTmpDir();
+    fs.writeFileSync(path.join(repo, ".dotbabel.json"), `{"already":"here"}`);
+    expect(() => scaffoldProjectInit({ repoRoot: repo })).toThrow(ValidationError);
+  });
+
+  it("--force overwrites an existing .dotbabel.json", () => {
+    const repo = makeTmpDir();
+    fs.writeFileSync(path.join(repo, ".dotbabel.json"), `{"already":"here"}`);
+    const r = scaffoldProjectInit({ repoRoot: repo, force: true });
+    expect(r.ok).toBe(true);
+    const cfg = JSON.parse(fs.readFileSync(path.join(repo, ".dotbabel.json"), "utf8"));
+    expect(cfg.rule_floor_source).toBe("CLAUDE.md");
+  });
+
+  it("--dry-run reports planned files but does not mutate", () => {
+    const repo = makeTmpDir();
+    const r = scaffoldProjectInit({ repoRoot: repo, dryRun: true });
+    expect(r.ok).toBe(true);
+    expect(r.filesWritten).toContain(".dotbabel.json");
+    expect(fs.existsSync(path.join(repo, ".dotbabel.json"))).toBe(false);
+    expect(fs.existsSync(path.join(repo, "CLAUDE.md"))).toBe(false);
+  });
+});

--- a/plugins/dotbabel/tests/project-sync.test.mjs
+++ b/plugins/dotbabel/tests/project-sync.test.mjs
@@ -253,4 +253,118 @@ describe("projectSync", () => {
     expect(fs.existsSync(path.join(repo, ".codex"))).toBe(false);
     expect(r.skipped).toBeGreaterThan(0);
   });
+
+  // -------------------------------------------------------------------------
+  // Branch coverage: error paths, empty fan-out, dry-run wrapper-dir, etc.
+  // -------------------------------------------------------------------------
+
+  it("returns ok=false when repoRoot does not exist", async () => {
+    const r = await projectSync({
+      repoRoot: "/nonexistent/path/that/should/never/exist-xyz",
+      allCli: true,
+      quiet: true,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it("returns ok=false when CLAUDE.md is missing", async () => {
+    const repo = makeTmpDir();
+    // No CLAUDE.md, but .claude/ tree present.
+    fs.mkdirSync(path.join(repo, ".claude", "commands"), { recursive: true });
+    fs.writeFileSync(path.join(repo, ".claude", "commands", "foo.md"), "# foo\n");
+    const r = await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    expect(r.ok).toBe(false);
+  });
+
+  it("warns and skips an unknown fan_out CLI name", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo, {
+      withDotbabelJson: {
+        ...DEFAULT_PROJECT_CONFIG,
+        targets: [...DEFAULT_PROJECT_CONFIG.targets],
+        fan_out: ["mystery-cli-foo"],
+      },
+    });
+    const r = await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    expect(r.ok).toBe(true);
+    expect(r.skipped).toBeGreaterThan(0);
+  });
+
+  it("idempotent instruction-file write: no rewrite when content unchanged", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    const r1 = await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    const beforeMtime = fs.statSync(path.join(repo, "AGENTS.md")).mtimeMs;
+    // Wait a hair so any rewrite would bump mtime.
+    await new Promise((res) => setTimeout(res, 5));
+    const r2 = await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    const afterMtime = fs.statSync(path.join(repo, "AGENTS.md")).mtimeMs;
+    expect(r1.written).toBeGreaterThan(0);
+    expect(r2.written).toBe(0); // second run: no instruction-file rewrites
+    expect(afterMtime).toBe(beforeMtime);
+  });
+
+  it("dry-run reports 'would back up + create dir' when wrapper path is a real file", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    fs.mkdirSync(path.join(repo, ".codex", "skills"), { recursive: true });
+    // Pre-create a real file at the wrapper directory path.
+    fs.writeFileSync(path.join(repo, ".codex", "skills", "commit"), "real\n");
+    const r = await projectSync({ repoRoot: repo, allCli: true, dryRun: true, quiet: true });
+    expect(r.ok).toBe(true);
+    // Real file is still there (dry-run shouldn't have moved it).
+    expect(
+      fs.lstatSync(path.join(repo, ".codex", "skills", "commit")).isFile(),
+    ).toBe(true);
+    expect(r.backed_up).toBe(0);
+  });
+
+  it("Copilot fan-out: skill without SKILL.md is silently skipped", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    // Add a skill dir with no SKILL.md inside.
+    fs.mkdirSync(path.join(repo, ".claude", "skills", "headless-skill"), {
+      recursive: true,
+    });
+    const r = await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    expect(r.ok).toBe(true);
+    // No instructions file should have been emitted for headless-skill.
+    expect(
+      fs.existsSync(
+        path.join(repo, ".github", "instructions", "headless-skill.instructions.md"),
+      ),
+    ).toBe(false);
+    // Real skill (deploy) DID get one.
+    expect(
+      fs.lstatSync(
+        path.join(repo, ".github", "instructions", "deploy.instructions.md"),
+      ).isSymbolicLink(),
+    ).toBe(true);
+  });
+
+  it("config: rejects non-object .dotbabel.json (e.g. JSON array)", () => {
+    const repo = makeTmpDir();
+    fs.writeFileSync(path.join(repo, ".dotbabel.json"), JSON.stringify([1, 2, 3]));
+    expect(() => loadProjectConfig(repo)).toThrow(/must be a JSON object/);
+  });
+
+  it("--dry-run honored on the symlink fan-out path (no .codex created when only fan-out runs)", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo, {
+      withDotbabelJson: {
+        ...DEFAULT_PROJECT_CONFIG,
+        targets: [], // no instruction targets — exercise only fan-out
+        fan_out: ["codex"],
+        gate_on_cli_presence: false,
+      },
+    });
+    const r = await projectSync({
+      repoRoot: repo,
+      allCli: true,
+      dryRun: true,
+      quiet: true,
+    });
+    expect(r.ok).toBe(true);
+    expect(fs.existsSync(path.join(repo, ".codex"))).toBe(false);
+  });
 });

--- a/plugins/dotbabel/tests/project-sync.test.mjs
+++ b/plugins/dotbabel/tests/project-sync.test.mjs
@@ -1,0 +1,256 @@
+import { describe, it, expect, afterEach } from "vitest";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import {
+  projectSync,
+  loadProjectConfig,
+  DEFAULT_PROJECT_CONFIG,
+  extractRuleFloorOrWhole,
+} from "../src/project-sync.mjs";
+
+let tmpDirs = [];
+
+function makeTmpDir(prefix = "project-sync-test-") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs = [];
+});
+
+/**
+ * Build a minimal consumer repo at `dir` with a CLAUDE.md (markers optional),
+ * one command, and one skill.
+ *
+ * @param {string} dir
+ * @param {{ withMarkers?: boolean, withDotbabelJson?: object | null, withSkills?: boolean, withCommands?: boolean }} [opts]
+ */
+function buildFakeRepo(dir, opts = {}) {
+  const {
+    withMarkers = true,
+    withDotbabelJson = null,
+    withSkills = true,
+    withCommands = true,
+  } = opts;
+
+  const claudeBody = withMarkers
+    ? `# Project rules\n\n<!-- dotbabel:rule-floor:begin -->\n- be terse\n- be helpful\n<!-- dotbabel:rule-floor:end -->\n`
+    : `# Project rules\n\n- be terse\n- be helpful\n`;
+  fs.writeFileSync(path.join(dir, "CLAUDE.md"), claudeBody);
+
+  if (withCommands) {
+    fs.mkdirSync(path.join(dir, ".claude", "commands"), { recursive: true });
+    fs.writeFileSync(path.join(dir, ".claude", "commands", "commit.md"), "# /commit\n");
+    fs.writeFileSync(path.join(dir, ".claude", "commands", "review.md"), "# /review\n");
+  }
+  if (withSkills) {
+    fs.mkdirSync(path.join(dir, ".claude", "skills", "deploy"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, ".claude", "skills", "deploy", "SKILL.md"),
+      "---\nname: deploy\n---\n# deploy\n",
+    );
+  }
+
+  if (withDotbabelJson !== null) {
+    fs.writeFileSync(
+      path.join(dir, ".dotbabel.json"),
+      `${JSON.stringify(withDotbabelJson, null, 2)}\n`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// loadProjectConfig
+// ---------------------------------------------------------------------------
+
+describe("loadProjectConfig", () => {
+  it("returns defaults when .dotbabel.json is absent", () => {
+    const repo = makeTmpDir();
+    const cfg = loadProjectConfig(repo);
+    expect(cfg.rule_floor_source).toBe("CLAUDE.md");
+    expect(cfg.fan_out).toEqual(["codex", "gemini", "copilot"]);
+    expect(cfg.targets).toHaveLength(3);
+  });
+
+  it("layers .dotbabel.json over defaults", () => {
+    const repo = makeTmpDir();
+    fs.writeFileSync(
+      path.join(repo, ".dotbabel.json"),
+      JSON.stringify({ fan_out: ["codex"], gate_on_cli_presence: false }),
+    );
+    const cfg = loadProjectConfig(repo);
+    expect(cfg.fan_out).toEqual(["codex"]);
+    expect(cfg.gate_on_cli_presence).toBe(false);
+    // Defaults still come through for unspecified keys.
+    expect(cfg.rule_floor_source).toBe("CLAUDE.md");
+  });
+
+  it("throws on malformed JSON", () => {
+    const repo = makeTmpDir();
+    fs.writeFileSync(path.join(repo, ".dotbabel.json"), "{ broken json");
+    expect(() => loadProjectConfig(repo)).toThrow(/.dotbabel.json is not valid JSON/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractRuleFloorOrWhole — convention path
+// ---------------------------------------------------------------------------
+
+describe("extractRuleFloorOrWhole", () => {
+  it("uses slice between markers when both present", () => {
+    const body =
+      "# top\n<!-- dotbabel:rule-floor:begin -->\nbody line\n<!-- dotbabel:rule-floor:end -->\nfooter\n";
+    expect(extractRuleFloorOrWhole(body)).toBe("body line");
+  });
+  it("falls back to whole body when no markers", () => {
+    const body = "# minimal\nbe kind\n";
+    expect(extractRuleFloorOrWhole(body)).toBe("# minimal\nbe kind");
+  });
+  it("re-throws on orphan markers", () => {
+    const body = "# top\n<!-- dotbabel:rule-floor:begin -->\nbody only\n";
+    expect(() => extractRuleFloorOrWhole(body)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projectSync — full flow
+// ---------------------------------------------------------------------------
+
+describe("projectSync", () => {
+  it("writes AGENTS.md, GEMINI.md, copilot-instructions.md from CLAUDE.md rule-floor", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    const r = await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    expect(r.ok).toBe(true);
+    expect(fs.existsSync(path.join(repo, "AGENTS.md"))).toBe(true);
+    expect(fs.existsSync(path.join(repo, "GEMINI.md"))).toBe(true);
+    expect(fs.existsSync(path.join(repo, ".github", "copilot-instructions.md"))).toBe(true);
+    expect(fs.readFileSync(path.join(repo, "AGENTS.md"), "utf8")).toContain("be terse");
+  });
+
+  it("creates Codex symlinks at .codex/skills/<id>/ and .codex/skills/<name>/SKILL.md", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+
+    const skillLink = path.join(repo, ".codex", "skills", "deploy");
+    expect(fs.lstatSync(skillLink).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(skillLink)).toBe(path.join(repo, ".claude", "skills", "deploy"));
+
+    const cmdLink = path.join(repo, ".codex", "skills", "commit", "SKILL.md");
+    expect(fs.lstatSync(cmdLink).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(cmdLink)).toBe(path.join(repo, ".claude", "commands", "commit.md"));
+  });
+
+  it("creates Gemini symlinks with the same shape as Codex", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    const skillLink = path.join(repo, ".gemini", "skills", "deploy");
+    expect(fs.lstatSync(skillLink).isSymbolicLink()).toBe(true);
+    const cmdLink = path.join(repo, ".gemini", "skills", "review", "SKILL.md");
+    expect(fs.readlinkSync(cmdLink)).toBe(path.join(repo, ".claude", "commands", "review.md"));
+  });
+
+  it("creates Copilot artifacts at .github/prompts/<name>.prompt.md and .github/instructions/<id>.instructions.md", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+
+    const prompt = path.join(repo, ".github", "prompts", "commit.prompt.md");
+    expect(fs.lstatSync(prompt).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(prompt)).toBe(path.join(repo, ".claude", "commands", "commit.md"));
+
+    const instr = path.join(repo, ".github", "instructions", "deploy.instructions.md");
+    expect(fs.lstatSync(instr).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(instr)).toBe(path.join(repo, ".claude", "skills", "deploy", "SKILL.md"));
+  });
+
+  it("is idempotent: second run produces no additional backups", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    const r1 = await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    const r2 = await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    expect(r1.ok && r2.ok).toBe(true);
+    expect(r2.backed_up).toBe(0);
+  });
+
+  it("backs up a real file at a destination path", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    fs.mkdirSync(path.join(repo, ".codex", "skills"), { recursive: true });
+    // Pre-create a real file where the wrapper directory should land.
+    fs.writeFileSync(path.join(repo, ".codex", "skills", "commit"), "real file\n");
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    // Backup file present
+    const entries = fs.readdirSync(path.join(repo, ".codex", "skills"));
+    expect(entries.some((e) => e.startsWith("commit.bak-"))).toBe(true);
+    // New symlink in place
+    expect(
+      fs.lstatSync(path.join(repo, ".codex", "skills", "commit", "SKILL.md")).isSymbolicLink(),
+    ).toBe(true);
+  });
+
+  it("updates a stale symlink in place", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    fs.mkdirSync(path.join(repo, ".codex", "skills", "commit"), { recursive: true });
+    fs.symlinkSync("/nonexistent-target", path.join(repo, ".codex", "skills", "commit", "SKILL.md"));
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    const link = path.join(repo, ".codex", "skills", "commit", "SKILL.md");
+    expect(fs.readlinkSync(link)).toBe(path.join(repo, ".claude", "commands", "commit.md"));
+  });
+
+  it("skips .system namespace defensively", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    fs.mkdirSync(path.join(repo, ".claude", "skills", ".system"), { recursive: true });
+    fs.writeFileSync(path.join(repo, ".claude", "commands", ".system.md"), "# system\n");
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    expect(fs.existsSync(path.join(repo, ".codex", "skills", ".system"))).toBe(false);
+    expect(fs.existsSync(path.join(repo, ".gemini", "skills", ".system"))).toBe(false);
+  });
+
+  it("--dry-run does not mutate the filesystem", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    const r = await projectSync({ repoRoot: repo, allCli: true, dryRun: true, quiet: true });
+    expect(r.ok).toBe(true);
+    expect(fs.existsSync(path.join(repo, "AGENTS.md"))).toBe(false);
+    expect(fs.existsSync(path.join(repo, ".codex"))).toBe(false);
+    expect(fs.existsSync(path.join(repo, ".github", "prompts"))).toBe(false);
+  });
+
+  it("convention path: works with marker-less CLAUDE.md", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo, { withMarkers: false });
+    const r = await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    expect(r.ok).toBe(true);
+    // Whole body landed in AGENTS.md
+    const agents = fs.readFileSync(path.join(repo, "AGENTS.md"), "utf8");
+    expect(agents).toContain("be terse");
+    expect(agents).toContain("be helpful");
+  });
+
+  it("CLI gating: skips fan-out when target binary is missing and --all is not set", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo, {
+      withDotbabelJson: {
+        ...DEFAULT_PROJECT_CONFIG,
+        targets: [...DEFAULT_PROJECT_CONFIG.targets],
+        fan_out: ["this-cli-does-not-exist-xyz"],
+      },
+    });
+    const r = await projectSync({ repoRoot: repo, allCli: false, quiet: true });
+    expect(r.ok).toBe(true);
+    // No fan-out happened for the unknown-named CLI.
+    expect(fs.existsSync(path.join(repo, ".codex"))).toBe(false);
+    expect(r.skipped).toBeGreaterThan(0);
+  });
+});

--- a/skills/project-sync/SKILL.md
+++ b/skills/project-sync/SKILL.md
@@ -1,0 +1,90 @@
+---
+id: project-sync
+name: project-sync
+type: skill
+version: 0.1.0
+domain: [devex]
+platform: [none]
+task: [scaffolding]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-05-09
+updated: 2026-05-09
+description: >
+  Fan out the current repo's CLAUDE.md, .claude/commands, and .claude/skills
+  into Codex, Gemini, and Copilot project-scope analogues (.codex/skills,
+  .gemini/skills, .github/prompts, .github/instructions) plus refresh
+  AGENTS.md, GEMINI.md, and .github/copilot-instructions.md from the project's
+  rule floor. Wraps `dotbabel project-sync`. Use when adopting cross-CLI
+  workflows in a repo for the first time, or when adding a new command/skill
+  that needs to be visible to Codex/Gemini/Copilot. Triggers on:
+  "sync this repo", "project sync", "fan out commands", "wire up gemini for
+  this project", "add this command to codex", "make this skill available in
+  copilot", "regenerate AGENTS.md for this project".
+argument-hint: "[--dry-run] [--all] [--repo <path>]"
+tools: Bash, Read, Glob
+effort: low
+model: sonnet
+---
+
+# project-sync — Repo-local cross-CLI fan-out
+
+Thin wrapper around `dotbabel project-sync`. The binary owns all writes; this
+skill maps natural-language requests to the right invocation and surfaces
+dry-run output before mutating the repo.
+
+## When to invoke
+
+- The user wants to adopt cross-CLI workflows in a repo that already has
+  `.claude/commands/*` or `.claude/skills/*`, but no `AGENTS.md`/`GEMINI.md`/
+  `.github/prompts/`/`.github/instructions/` wiring.
+- A new command or skill was just added to `.claude/`, and the user wants
+  Codex/Gemini/Copilot to see it without leaving the editor.
+- The user asks for "drift check" or "is this repo synced" — run
+  `dotbabel check-project-sync` instead and surface the diff.
+- First-time setup: if `.dotbabel.json` is missing, suggest
+  `dotbabel project-init` first.
+
+## Workflow
+
+1. **Pre-flight.** Confirm cwd is a git repo and contains `CLAUDE.md` (with or
+   without rule-floor markers) plus at least one of `.claude/commands/` or
+   `.claude/skills/`. If `.dotbabel.json` is absent, mention that defaults will
+   apply (no `cli_substitutions`, full fan-out to codex/gemini/copilot,
+   gating on each CLI's `command -v` check).
+2. **Dry-run first.** Always run `dotbabel project-sync --dry-run` before
+   mutating. Summarize the planned actions to the user (count of instruction
+   files, count of new symlinks per CLI). Pause for confirmation **unless**
+   the user already said "do it" or "go ahead" in the same turn.
+3. **Apply.** Run `dotbabel project-sync` (no `--dry-run`). If the user passed
+   `--all`, propagate it.
+4. **Verify.** Run `dotbabel check-project-sync` and report `ok` /
+   `missing` / `stale` counts. Exit non-zero output should be surfaced.
+
+## Triggers and invocations
+
+| Trigger phrase                                        | Invocation                                                 |
+| ----------------------------------------------------- | ---------------------------------------------------------- |
+| "sync this repo", "project sync", "fan out commands"  | `dotbabel project-sync --dry-run` then apply               |
+| "wire up gemini for this project"                     | `dotbabel project-sync --all` (covers all)                 |
+| "is this repo synced", "drift check the project sync" | `dotbabel check-project-sync` (read-only)                  |
+| "regenerate AGENTS.md for this project"               | `dotbabel project-sync` (instructions are part of the run) |
+| "set up project sync here", "first-time project sync" | `dotbabel project-init` then project-sync                  |
+
+## Reference: Copilot mapping
+
+The Copilot CLI fan-out targets `.github/prompts/*.prompt.md` (commands) and
+`.github/instructions/*.instructions.md` (skills) inside the target repo.
+See [`references/copilot-mapping.md`](references/copilot-mapping.md) for the
+full layout and rationale.
+
+## Boundaries
+
+- Always operate on the user's current working directory unless they pass an
+  explicit `--repo <path>`. Never silently target a different repo.
+- Never run `--force`. The plan reserves it for collision overrides; defer
+  to the binary's existing collision warnings.
+- For consumer repos with no `.dotbabel.json`, the convention path applies
+  (entire `CLAUDE.md` becomes the rule floor when markers are absent).
+- This skill is for **project-scope** sync. For user-scope (`~/.claude/`,
+  `~/.codex/`, `~/.gemini/`) bootstrap, use `dotbabel bootstrap` instead.

--- a/skills/project-sync/references/copilot-mapping.md
+++ b/skills/project-sync/references/copilot-mapping.md
@@ -1,0 +1,42 @@
+# Copilot CLI mapping reference
+
+`dotbabel project-sync` fans out repo-local artifacts to three places GitHub
+Copilot CLI reads. Unlike Codex and Gemini (both of which auto-load anything
+under their `skills/<id>/SKILL.md` shape), Copilot has no single
+"skills directory" — it has two related but distinct discovery paths.
+
+## Layout
+
+| Source                         | Copilot destination                         | What it does                                                  |
+| ------------------------------ | ------------------------------------------- | ------------------------------------------------------------- |
+| `.claude/commands/<name>.md`   | `.github/prompts/<name>.prompt.md`          | Slash-command analogue. The user types `/<name>` in Copilot.  |
+| `.claude/skills/<id>/SKILL.md` | `.github/instructions/<id>.instructions.md` | Auto-loaded instruction file. Behavior shifts model defaults. |
+| `CLAUDE.md` (rule-floor block) | `.github/copilot-instructions.md`           | Repo-wide instructions injected into every Copilot session.   |
+
+Each row is a symlink. A real file at the destination is renamed to
+`<dst>.bak-<YYYYMMDD-HHmmss>` before the symlink is placed; stale symlinks
+are silently updated.
+
+## Why two destinations and not one?
+
+- `.github/prompts/*.prompt.md` is Copilot's slash-command discovery. It
+  expects one file per command and a `.prompt.md` suffix. Wrapping a Claude
+  command as `<name>/SKILL.md` would not be picked up.
+- `.github/instructions/*.instructions.md` is Copilot's instruction-style
+  context loading. It expects flat files with `.instructions.md` suffix, not
+  a directory tree.
+
+Real-world consumer repos already use this convention; the project-sync
+fan-out matches that established shape.
+
+## Detection and gating
+
+Project-sync gates Copilot fan-out on `command -v copilot >/dev/null` unless
+the caller passes `--all`. This mirrors the user-scope bootstrap behavior at
+`plugins/dotbabel/src/bootstrap-global.mjs:347-378`.
+
+If `copilot` is not on PATH and `--all` is not set, the Copilot rows above are
+skipped. The instruction-file write to `.github/copilot-instructions.md` is
+NOT skipped — that file is part of the rule-floor injection step, which
+always runs, since it's how the repo signals project-wide rules to Copilot
+even when the CLI is not installed locally.


### PR DESCRIPTION
## Summary

- Add `dotbabel project-sync`, `dotbabel project-init`, and `dotbabel check-project-sync` so any repo with `CLAUDE.md` and `.claude/{commands,skills}/` can fan its workflows out to Codex (`.codex/skills/`), Gemini (`.gemini/skills/`), and Copilot (`.github/prompts/*.prompt.md` + `.github/instructions/*.instructions.md`) — without adopting the full spec-governance harness.
- Refresh project `AGENTS.md`, `GEMINI.md`, and `.github/copilot-instructions.md` from the project's `CLAUDE.md` rule floor (slice between markers when present, whole body in the convention path when markers are absent).
- Ship a `/project-sync` slash command at `skills/project-sync/SKILL.md` for in-session invocation; the existing user-scope bootstrap fan-out picks it up automatically.
- Closes #205.

## Design highlights

- **Decoupled from `generateInstructions`.** project-sync calls only the lower-level primitives (`renderTarget`, `extractRuleFloor`, `composeInject`, `validateSubstitutions`) so it never reads `docs/repo-facts.json` or writes the dotbabel-private template manifest. `composeInject` and `validateSubstitutions` are newly exported; `validateSubstitutions` accepts an optional `sourceFile` so consumer-repo errors point at `.dotbabel.json` rather than `docs/repo-facts.json`.
- **Symlink helpers extracted** into `plugins/dotbabel/src/lib/symlink.mjs` (`linkOne`, `ensureRealDir`, `commandExists`, `buildTimestamp`) and reused by both bootstrap-global and project-sync. No behavior change to the global bootstrap (verified by the existing 11-test bootstrap-global suite).
- **Marker-less CLAUDE.md handling.** `extractRuleFloorOrWhole` falls back to treating the entire CLAUDE.md as the rule floor when neither `<!-- dotbabel:rule-floor:begin -->` nor `<!-- dotbabel:rule-floor:end -->` is present; orphan markers still throw, mirroring the harness DX.
- **Doctor integration.** Presence-detects `.dotbabel.json` and runs `checkProjectSync` for repos that opt in. The dotbabel repo itself stays silent (no `.dotbabel.json`).
- **Symlink fan-out, never copies.** A real file at the destination is renamed to `<dst>.bak-<YYYYMMDD-HHmmss>` before the symlink is placed; stale symlinks are silently updated. `--dry-run` is honored on every write path (instruction writes, symlink fan-out, backup renames).

## Test plan

- [x] `npm run build-plugin` (regenerator — diff committed)
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs` (regenerator — diff committed)
- [x] `npm test` — **681/681 passing** (added 27 new tests across 3 files)
- [x] `npx bats plugins/dotbabel/tests/bats/` — **446/446 passing** (added 13 new tests in `project-sync.bats`)
- [x] `npm run lint` — clean except for pre-existing CHANGELOG.md (see "Known pre-existing failures" below)
- [x] `npm run shellcheck` — pre-existing failures only (see below)
- [x] `npm run dogfood` — clean (only pre-existing iac-engineer/pulumi trigger warning)
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — fresh
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --strict` — 0 warnings
- [x] `node scripts/build-plugin.mjs --check` — fresh
- [x] **End-to-end smoke** in a disposable squadranks worktree (`projsync-smoke-464991`):
  - `project-init` scaffolded `.dotbabel.json`
  - `project-sync --dry-run` previewed without mutation
  - `project-sync --all` linked 43 commands per CLI (Codex + Gemini + Copilot) and refreshed AGENTS.md / GEMINI.md / `.github/copilot-instructions.md`
  - `check-project-sync` exit 0 with 132 entries verified
  - Recovery loop: `unlink` → `check-project-sync` exit 1 (1 missing) → `project-sync` → `check-project-sync` exit 0
  - Idempotence: second run produced 0 backups
  - Doctor: `✓ project-sync wiring ok (132 entries verified)`
  - Convention path tested in two scratch repos (markers + marker-less)
- [x] Phase C regression: re-ran the full validate block on the dotbabel checkout — clean

## Known pre-existing failures (verified via `git stash`, not introduced by this PR)

- **`npm run lint`**: `[warn] CHANGELOG.md` — release-please writes asterisks (`*`), prettier wants hyphens (`-`). Survives `git stash --include-untracked` on origin/main. Separate issue, not in scope here.
- **`npm run shellcheck`**: SC2292 / SC2310 / SC2312 style/info findings in `bootstrap.sh`, `sync.sh`, `plugins/dotbabel/scripts/handoff-description.sh`, and `plugins/dotbabel/templates/claude/hooks/guard-destructive-git.sh`. All present on origin/main; this PR adds no new shell scripts.
- **`npm run dogfood`**: warning `agents/iac-engineer.md: trigger "pulumi" also claimed by: pulumi-engineer — but ## Collaboration does not reference them`. Pre-existing trigger overlap.

## Spec ID

dotbabel-core
