### PR TITLE
fix(project-sync): write relative symlink targets (closes #218)

### DIFF
--- a/plugins/dotbabel/src/check-project-sync.mjs
+++ b/plugins/dotbabel/src/check-project-sync.mjs
@@ -121,9 +121,10 @@ export async function checkProjectSync(opts) {
   const skillsAbs = path.join(repoRoot, cfg.skills_dir);
 
   /**
-   * Compare the symlink at `dstAbs` against the expected source `srcAbs`.
-   * `linkOne` writes the absolute source as the link target, so equality is
-   * absolute-path string equality.
+   * Compare the symlink at `dstAbs` against the expected source `srcAbs` by
+   * resolving both with `fs.realpathSync` and comparing canonical paths. This
+   * is robust against the link-target encoding (relative vs absolute) and
+   * naturally surfaces dangling symlinks when realpath throws.
    */
   function checkLink(dstAbs, srcAbs, kind = "symlink") {
     const relDst = path.relative(repoRoot, dstAbs);
@@ -145,10 +146,30 @@ export async function checkProjectSync(opts) {
       out.fail(`stale (not a symlink): ${relDst}`);
       return;
     }
-    const actual = fs.readlinkSync(dstAbs);
-    if (actual !== srcAbs) {
-      stale.push({ kind, path: relDst, expected: srcAbs, actual });
-      out.fail(`stale: ${relDst} -> ${actual} (expected ${srcAbs})`);
+    let resolved;
+    try {
+      resolved = fs.realpathSync(dstAbs);
+    } catch {
+      // Dangling symlink — readlink succeeds, but the target doesn't exist.
+      const target = fs.readlinkSync(dstAbs);
+      stale.push({
+        kind,
+        path: relDst,
+        expected: srcAbs,
+        actual: `dangling: ${target}`,
+      });
+      out.fail(`stale (dangling): ${relDst} -> ${target}`);
+      return;
+    }
+    const expectedResolved = fs.realpathSync(srcAbs);
+    if (resolved !== expectedResolved) {
+      stale.push({
+        kind,
+        path: relDst,
+        expected: expectedResolved,
+        actual: resolved,
+      });
+      out.fail(`stale: ${relDst} -> ${resolved} (expected ${expectedResolved})`);
       return;
     }
     okEntries.push({ kind, path: relDst });

--- a/plugins/dotbabel/src/project-sync.mjs
+++ b/plugins/dotbabel/src/project-sync.mjs
@@ -254,12 +254,17 @@ export async function projectSync(opts) {
   }
 
   function doLink(src, dst) {
+    // Store the symlink target as a path relative to the link's own
+    // directory. fs.symlinkSync persists the string verbatim, so a relative
+    // target keeps the link portable across clones and survives a parent-repo
+    // rename or worktree cleanup. See #218.
+    const linkSrc = path.relative(path.dirname(dst), src);
     if (opts.dryRun) {
-      out.info(`would link: ${dst} -> ${src}`);
+      out.info(`would link: ${dst} -> ${linkSrc}`);
       linked++;
       return;
     }
-    const r = linkOne(src, dst, out, timestamp);
+    const r = linkOne(linkSrc, dst, out, timestamp);
     if (r.action === "backed_up") backed_up++;
     if (
       r.action === "linked" ||

--- a/plugins/dotbabel/tests/bats/project-sync.bats
+++ b/plugins/dotbabel/tests/bats/project-sync.bats
@@ -61,8 +61,8 @@ teardown() {
   [ "$status" -eq 0 ]
   [ -L "$REPO/.codex/skills/deploy" ]
   [ -L "$REPO/.codex/skills/commit/SKILL.md" ]
-  target=$(readlink "$REPO/.codex/skills/commit/SKILL.md")
-  [ "$target" = "$REPO/.claude/commands/commit.md" ]
+  resolved=$(readlink -f "$REPO/.codex/skills/commit/SKILL.md")
+  [ "$resolved" = "$REPO/.claude/commands/commit.md" ]
 }
 
 @test "project-sync creates Gemini symlinks at .gemini/skills" {
@@ -77,8 +77,8 @@ teardown() {
   [ "$status" -eq 0 ]
   [ -L "$REPO/.github/prompts/commit.prompt.md" ]
   [ -L "$REPO/.github/instructions/deploy.instructions.md" ]
-  target=$(readlink "$REPO/.github/prompts/commit.prompt.md")
-  [ "$target" = "$REPO/.claude/commands/commit.md" ]
+  resolved=$(readlink -f "$REPO/.github/prompts/commit.prompt.md")
+  [ "$resolved" = "$REPO/.claude/commands/commit.md" ]
 }
 
 @test "project-sync --dry-run does not mutate the filesystem" {

--- a/plugins/dotbabel/tests/bats/project-sync.bats
+++ b/plugins/dotbabel/tests/bats/project-sync.bats
@@ -152,3 +152,35 @@ teardown() {
   [ -L "$PLAIN/.codex/skills/bar/SKILL.md" ]
   rm -rf "$PLAIN"
 }
+
+@test "symlink targets stored as relative paths, not absolute (issue #218)" {
+  $PSYNC --repo "$REPO" --all >/dev/null
+  target=$(readlink "$REPO/.codex/skills/commit/SKILL.md")
+  case "$target" in
+    /*) echo "BUG: target is absolute: $target" >&2; return 1 ;;
+    *)  : ;;
+  esac
+  prompt_target=$(readlink "$REPO/.github/prompts/commit.prompt.md")
+  case "$prompt_target" in
+    /*) echo "BUG: copilot prompt target is absolute: $prompt_target" >&2; return 1 ;;
+    *)  : ;;
+  esac
+}
+
+@test "symlinks survive a repo rename (regression #218)" {
+  $PSYNC --repo "$REPO" --all >/dev/null
+  RENAMED="${REPO}-renamed"
+  mv "$REPO" "$RENAMED"
+  REPO="$RENAMED"  # so teardown removes the renamed dir
+
+  [ -L "$RENAMED/.codex/skills/commit/SKILL.md" ]
+  resolved=$(readlink -f "$RENAMED/.codex/skills/commit/SKILL.md")
+  [ "$resolved" = "$RENAMED/.claude/commands/commit.md" ]
+
+  [ -L "$RENAMED/.github/prompts/commit.prompt.md" ]
+  resolved=$(readlink -f "$RENAMED/.github/prompts/commit.prompt.md")
+  [ "$resolved" = "$RENAMED/.claude/commands/commit.md" ]
+
+  run $PCHECK --repo "$RENAMED"
+  [ "$status" -eq 0 ]
+}

--- a/plugins/dotbabel/tests/check-project-sync.test.mjs
+++ b/plugins/dotbabel/tests/check-project-sync.test.mjs
@@ -80,7 +80,7 @@ describe("checkProjectSync", () => {
     expect(r.stale.some((e) => e.actual === "not a symlink")).toBe(true);
   });
 
-  it("reports stale when a symlink points at the wrong source", async () => {
+  it("reports stale (dangling) when a symlink points at a non-existent source", async () => {
     const repo = buildSyncedRepo();
     await projectSync({ repoRoot: repo, allCli: true, quiet: true });
     const linkPath = path.join(repo, ".codex", "skills", "commit", "SKILL.md");
@@ -90,9 +90,20 @@ describe("checkProjectSync", () => {
     expect(r.ok).toBe(false);
     expect(
       r.stale.some(
-        (e) => e.path.endsWith("commit/SKILL.md") && e.actual === "/some/other/place/foo.md",
+        (e) =>
+          e.path.endsWith("commit/SKILL.md") &&
+          /^dangling: /.test(e.actual ?? ""),
       ),
     ).toBe(true);
+  });
+
+  it("ok when the symlink points at the canonical source via a relative path (issue #218)", async () => {
+    const repo = buildSyncedRepo();
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    const linkPath = path.join(repo, ".codex", "skills", "commit", "SKILL.md");
+    expect(path.isAbsolute(fs.readlinkSync(linkPath))).toBe(false);
+    const r = await checkProjectSync({ repoRoot: repo, quiet: true });
+    expect(r.ok).toBe(true);
   });
 
   it("reports missing instruction file when AGENTS.md is deleted", async () => {

--- a/plugins/dotbabel/tests/project-sync.test.mjs
+++ b/plugins/dotbabel/tests/project-sync.test.mjs
@@ -141,11 +141,17 @@ describe("projectSync", () => {
 
     const skillLink = path.join(repo, ".codex", "skills", "deploy");
     expect(fs.lstatSync(skillLink).isSymbolicLink()).toBe(true);
-    expect(fs.readlinkSync(skillLink)).toBe(path.join(repo, ".claude", "skills", "deploy"));
+    expect(path.isAbsolute(fs.readlinkSync(skillLink))).toBe(false);
+    expect(fs.realpathSync(skillLink)).toBe(
+      fs.realpathSync(path.join(repo, ".claude", "skills", "deploy")),
+    );
 
     const cmdLink = path.join(repo, ".codex", "skills", "commit", "SKILL.md");
     expect(fs.lstatSync(cmdLink).isSymbolicLink()).toBe(true);
-    expect(fs.readlinkSync(cmdLink)).toBe(path.join(repo, ".claude", "commands", "commit.md"));
+    expect(path.isAbsolute(fs.readlinkSync(cmdLink))).toBe(false);
+    expect(fs.realpathSync(cmdLink)).toBe(
+      fs.realpathSync(path.join(repo, ".claude", "commands", "commit.md")),
+    );
   });
 
   it("creates Gemini symlinks with the same shape as Codex", async () => {
@@ -155,7 +161,10 @@ describe("projectSync", () => {
     const skillLink = path.join(repo, ".gemini", "skills", "deploy");
     expect(fs.lstatSync(skillLink).isSymbolicLink()).toBe(true);
     const cmdLink = path.join(repo, ".gemini", "skills", "review", "SKILL.md");
-    expect(fs.readlinkSync(cmdLink)).toBe(path.join(repo, ".claude", "commands", "review.md"));
+    expect(path.isAbsolute(fs.readlinkSync(cmdLink))).toBe(false);
+    expect(fs.realpathSync(cmdLink)).toBe(
+      fs.realpathSync(path.join(repo, ".claude", "commands", "review.md")),
+    );
   });
 
   it("creates Copilot artifacts at .github/prompts/<name>.prompt.md and .github/instructions/<id>.instructions.md", async () => {
@@ -165,11 +174,17 @@ describe("projectSync", () => {
 
     const prompt = path.join(repo, ".github", "prompts", "commit.prompt.md");
     expect(fs.lstatSync(prompt).isSymbolicLink()).toBe(true);
-    expect(fs.readlinkSync(prompt)).toBe(path.join(repo, ".claude", "commands", "commit.md"));
+    expect(path.isAbsolute(fs.readlinkSync(prompt))).toBe(false);
+    expect(fs.realpathSync(prompt)).toBe(
+      fs.realpathSync(path.join(repo, ".claude", "commands", "commit.md")),
+    );
 
     const instr = path.join(repo, ".github", "instructions", "deploy.instructions.md");
     expect(fs.lstatSync(instr).isSymbolicLink()).toBe(true);
-    expect(fs.readlinkSync(instr)).toBe(path.join(repo, ".claude", "skills", "deploy", "SKILL.md"));
+    expect(path.isAbsolute(fs.readlinkSync(instr))).toBe(false);
+    expect(fs.realpathSync(instr)).toBe(
+      fs.realpathSync(path.join(repo, ".claude", "skills", "deploy", "SKILL.md")),
+    );
   });
 
   it("is idempotent: second run produces no additional backups", async () => {
@@ -204,7 +219,10 @@ describe("projectSync", () => {
     fs.symlinkSync("/nonexistent-target", path.join(repo, ".codex", "skills", "commit", "SKILL.md"));
     await projectSync({ repoRoot: repo, allCli: true, quiet: true });
     const link = path.join(repo, ".codex", "skills", "commit", "SKILL.md");
-    expect(fs.readlinkSync(link)).toBe(path.join(repo, ".claude", "commands", "commit.md"));
+    expect(path.isAbsolute(fs.readlinkSync(link))).toBe(false);
+    expect(fs.realpathSync(link)).toBe(
+      fs.realpathSync(path.join(repo, ".claude", "commands", "commit.md")),
+    );
   });
 
   it("skips .system namespace defensively", async () => {
@@ -366,5 +384,73 @@ describe("projectSync", () => {
     });
     expect(r.ok).toBe(true);
     expect(fs.existsSync(path.join(repo, ".codex"))).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #218 — symlink targets must be relative for repo portability.
+  // The original v2.4.0 implementation wrote absolute targets, which broke
+  // every clone and even the original machine after worktree cleanup.
+  // -------------------------------------------------------------------------
+
+  it("symlink targets are stored as relative paths (issue #218)", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    for (const link of [
+      path.join(repo, ".codex", "skills", "commit", "SKILL.md"),
+      path.join(repo, ".codex", "skills", "deploy"),
+      path.join(repo, ".gemini", "skills", "commit", "SKILL.md"),
+      path.join(repo, ".github", "prompts", "commit.prompt.md"),
+      path.join(repo, ".github", "instructions", "deploy.instructions.md"),
+    ]) {
+      const target = fs.readlinkSync(link);
+      expect(path.isAbsolute(target)).toBe(false);
+      // The link must still resolve to the canonical source.
+      expect(fs.existsSync(link)).toBe(true);
+    }
+  });
+
+  it("symlinks survive a repo rename (the regression #218 caught)", async () => {
+    const original = makeTmpDir();
+    buildFakeRepo(original);
+    await projectSync({ repoRoot: original, allCli: true, quiet: true });
+
+    // Rename the entire repo to simulate a fresh clone at a different path
+    // (or, in the real-world scenario, a worktree cleanup followed by main
+    // checkout exercising the same tree).
+    const renamed = `${original}-renamed`;
+    fs.renameSync(original, renamed);
+    tmpDirs.push(renamed);
+    tmpDirs = tmpDirs.filter((d) => d !== original);
+
+    for (const [link, expectedRel] of [
+      [".codex/skills/commit/SKILL.md", ".claude/commands/commit.md"],
+      [".gemini/skills/commit/SKILL.md", ".claude/commands/commit.md"],
+      [".github/prompts/commit.prompt.md", ".claude/commands/commit.md"],
+      [".codex/skills/deploy", ".claude/skills/deploy"],
+      [".github/instructions/deploy.instructions.md", ".claude/skills/deploy/SKILL.md"],
+    ]) {
+      const linkPath = path.join(renamed, link);
+      const expectedAbs = path.join(renamed, expectedRel);
+      expect(fs.realpathSync(linkPath)).toBe(fs.realpathSync(expectedAbs));
+    }
+  });
+
+  it("upgrades absolute symlinks (from v2.4.0) to relative on next sync", async () => {
+    const repo = makeTmpDir();
+    buildFakeRepo(repo);
+    // Manually create a v2.4.0-style absolute symlink and run sync.
+    // linkOne's stale-symlink branch should detect the encoding change and
+    // re-link with the relative form.
+    const absSrc = path.join(repo, ".claude", "commands", "commit.md");
+    const linkPath = path.join(repo, ".codex", "skills", "commit", "SKILL.md");
+    fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+    fs.symlinkSync(absSrc, linkPath);
+    expect(path.isAbsolute(fs.readlinkSync(linkPath))).toBe(true);
+
+    await projectSync({ repoRoot: repo, allCli: true, quiet: true });
+    expect(path.isAbsolute(fs.readlinkSync(linkPath))).toBe(false);
+    // And it still resolves to the canonical source.
+    expect(fs.realpathSync(linkPath)).toBe(fs.realpathSync(absSrc));
   });
 });


### PR DESCRIPTION
## Summary

- Fix #218: `dotbabel project-sync` writes **relative** symlink targets so links survive clones, force-pushes, and parent-repo renames.
- `check-project-sync` compares via `fs.realpathSync` resolution; gains a clean dangling-link diagnostic.
- Backward-compatible: existing absolute symlinks committed by v2.4.0 are auto-upgraded to relative on the next sync run (verified end-to-end).

The bug shipped in #216 because the original tests asserted `fs.readlinkSync(link).toBe(path.join(repo, ".claude/commands/<name>.md"))` — the same absolute string the buggy code produced. Tests verified "link reads back as input" but never "link content is portable" or "link survives a directory move." This PR fixes both the code and the test gap.

## What's NOT changed

- `bootstrap-global` (user-scope `~/.claude/...`) keeps absolute symlinks. User-scope correctly points at fixed install locations; making those relative would break for users who move their dotbabel checkout.
- `linkOne`'s contract: still "write the target string you're given, verbatim." The conversion is the caller's responsibility — keeps the lib helper generic for both flows.

## Test additions

- **vitest:** 3 new portability tests in `project-sync.test.mjs` — relative-encoding assertion, repo-rename resolution (the killer test that would have caught H1), v2.4.0 → 2.4.1 upgrade scenario. Plus 1 new test in `check-project-sync.test.mjs` confirming ok-when-relative.
- **BATS:** 2 new tests in `project-sync.bats` — relative-target assertion + repo-rename portability with `readlink -f` resolution check.
- **Updated 4 existing readlink assertions** to use `path.isAbsolute(...).toBe(false)` + `fs.realpathSync` resolution — so a future absolute-symlink regression fails loudly.

Total: 697 vitest passing (was 693), 448 BATS passing (was 446).

## Test plan

- [x] `npm run build-plugin` (regenerator)
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs` (regenerator)
- [x] `npm test` — **697/697**
- [x] `npx bats plugins/dotbabel/tests/bats/` — **448/448**
- [x] `npm run lint` — clean except for pre-existing CHANGELOG.md warning (release-please vs prettier conflict; separate issue)
- [x] `npm run shellcheck` — pre-existing failures only (unchanged from main)
- [x] `npm run dogfood` — clean (only pre-existing iac-engineer/pulumi trigger warning)
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — fresh
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --strict` — 0 warnings
- [x] `node scripts/build-plugin.mjs --check` — fresh
- [x] End-to-end smoke: scratch repo → `project-init` → `project-sync` → assert relative target → `mv` repo → assert symlinks still resolve → `check-project-sync` exit 0
- [x] v2.4.0 upgrade smoke: pre-create absolute symlink → `project-sync` → assert link is now relative

## Release

`fix:` conventional commit prefix triggers release-please to cut **2.4.1** on merge.

## Downstream

[`kaiohenricunha/squadranks#394`](https://github.com/kaiohenricunha/squadranks/pull/394) is blocked by this. Once 2.4.1 is available (or via `npm link`), re-run `dotbabel project-sync` in that branch and force-push the regenerated relative-path symlinks.

## Spec ID

dotbabel-core
