### PR TITLE
feat(project-sync): dogfood per-repo cross-CLI fan-out on dotbabel itself

### DIFF
--- a/.codex/skills/agents-search
+++ b/.codex/skills/agents-search
@@ -1,0 +1,1 @@
+../../.claude/skills/agents-search

--- a/.codex/skills/audit-and-fix
+++ b/.codex/skills/audit-and-fix
@@ -1,0 +1,1 @@
+../../.claude/skills/audit-and-fix

--- a/.codex/skills/aws-specialist
+++ b/.codex/skills/aws-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/aws-specialist

--- a/.codex/skills/azure-specialist
+++ b/.codex/skills/azure-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/azure-specialist

--- a/.codex/skills/changelog/SKILL.md
+++ b/.codex/skills/changelog/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/changelog.md

--- a/.codex/skills/create-assessment
+++ b/.codex/skills/create-assessment
@@ -1,0 +1,1 @@
+../../.claude/skills/create-assessment

--- a/.codex/skills/create-audit
+++ b/.codex/skills/create-audit
@@ -1,0 +1,1 @@
+../../.claude/skills/create-audit

--- a/.codex/skills/create-experiment
+++ b/.codex/skills/create-experiment
@@ -1,0 +1,1 @@
+../../.claude/skills/create-experiment

--- a/.codex/skills/create-inspection
+++ b/.codex/skills/create-inspection
@@ -1,0 +1,1 @@
+../../.claude/skills/create-inspection

--- a/.codex/skills/crossplane-specialist
+++ b/.codex/skills/crossplane-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/crossplane-specialist

--- a/.codex/skills/dependabot-sweep/SKILL.md
+++ b/.codex/skills/dependabot-sweep/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/dependabot-sweep.md

--- a/.codex/skills/deploy-status
+++ b/.codex/skills/deploy-status
@@ -1,0 +1,1 @@
+../../.claude/skills/deploy-status

--- a/.codex/skills/detect-flaky
+++ b/.codex/skills/detect-flaky
@@ -1,0 +1,1 @@
+../../.claude/skills/detect-flaky

--- a/.codex/skills/fix-with-evidence
+++ b/.codex/skills/fix-with-evidence
@@ -1,0 +1,1 @@
+../../.claude/skills/fix-with-evidence

--- a/.codex/skills/gcp-specialist
+++ b/.codex/skills/gcp-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/gcp-specialist

--- a/.codex/skills/git
+++ b/.codex/skills/git
@@ -1,0 +1,1 @@
+../../.claude/skills/git

--- a/.codex/skills/ground-first
+++ b/.codex/skills/ground-first
@@ -1,0 +1,1 @@
+../../.claude/skills/ground-first

--- a/.codex/skills/handoff
+++ b/.codex/skills/handoff
@@ -1,0 +1,1 @@
+../../.claude/skills/handoff

--- a/.codex/skills/kubernetes-specialist
+++ b/.codex/skills/kubernetes-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/kubernetes-specialist

--- a/.codex/skills/markdown/SKILL.md
+++ b/.codex/skills/markdown/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/markdown.md

--- a/.codex/skills/merge-pr/SKILL.md
+++ b/.codex/skills/merge-pr/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/merge-pr.md

--- a/.codex/skills/plan-grader
+++ b/.codex/skills/plan-grader
@@ -1,0 +1,1 @@
+../../.claude/skills/plan-grader

--- a/.codex/skills/post-pr-review
+++ b/.codex/skills/post-pr-review
@@ -1,0 +1,1 @@
+../../.claude/skills/post-pr-review

--- a/.codex/skills/pre-pr/SKILL.md
+++ b/.codex/skills/pre-pr/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/pre-pr.md

--- a/.codex/skills/project-sync
+++ b/.codex/skills/project-sync
@@ -1,0 +1,1 @@
+../../.claude/skills/project-sync

--- a/.codex/skills/pulumi-specialist
+++ b/.codex/skills/pulumi-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/pulumi-specialist

--- a/.codex/skills/review-pr
+++ b/.codex/skills/review-pr
@@ -1,0 +1,1 @@
+../../.claude/skills/review-pr

--- a/.codex/skills/review-prs
+++ b/.codex/skills/review-prs
@@ -1,0 +1,1 @@
+../../.claude/skills/review-prs

--- a/.codex/skills/rollback-prod
+++ b/.codex/skills/rollback-prod
@@ -1,0 +1,1 @@
+../../.claude/skills/rollback-prod

--- a/.codex/skills/security-review
+++ b/.codex/skills/security-review
@@ -1,0 +1,1 @@
+../../.claude/skills/security-review

--- a/.codex/skills/spec
+++ b/.codex/skills/spec
@@ -1,0 +1,1 @@
+../../.claude/skills/spec

--- a/.codex/skills/terraform-specialist
+++ b/.codex/skills/terraform-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/terraform-specialist

--- a/.codex/skills/terragrunt-specialist
+++ b/.codex/skills/terragrunt-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/terragrunt-specialist

--- a/.codex/skills/validate-spec
+++ b/.codex/skills/validate-spec
@@ -1,0 +1,1 @@
+../../.claude/skills/validate-spec

--- a/.codex/skills/veracity-audit
+++ b/.codex/skills/veracity-audit
@@ -1,0 +1,1 @@
+../../.claude/skills/veracity-audit

--- a/.dotbabel.json
+++ b/.dotbabel.json
@@ -1,0 +1,9 @@
+{
+  "rule_floor_source": "CLAUDE.md",
+  "commands_dir": ".claude/commands",
+  "skills_dir": ".claude/skills",
+  "fan_out": ["codex", "gemini", "copilot"],
+  "gate_on_cli_presence": true,
+  "cli_substitutions": {},
+  "targets": []
+}

--- a/.gemini/skills/agents-search
+++ b/.gemini/skills/agents-search
@@ -1,0 +1,1 @@
+../../.claude/skills/agents-search

--- a/.gemini/skills/audit-and-fix
+++ b/.gemini/skills/audit-and-fix
@@ -1,0 +1,1 @@
+../../.claude/skills/audit-and-fix

--- a/.gemini/skills/aws-specialist
+++ b/.gemini/skills/aws-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/aws-specialist

--- a/.gemini/skills/azure-specialist
+++ b/.gemini/skills/azure-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/azure-specialist

--- a/.gemini/skills/changelog/SKILL.md
+++ b/.gemini/skills/changelog/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/changelog.md

--- a/.gemini/skills/create-assessment
+++ b/.gemini/skills/create-assessment
@@ -1,0 +1,1 @@
+../../.claude/skills/create-assessment

--- a/.gemini/skills/create-audit
+++ b/.gemini/skills/create-audit
@@ -1,0 +1,1 @@
+../../.claude/skills/create-audit

--- a/.gemini/skills/create-experiment
+++ b/.gemini/skills/create-experiment
@@ -1,0 +1,1 @@
+../../.claude/skills/create-experiment

--- a/.gemini/skills/create-inspection
+++ b/.gemini/skills/create-inspection
@@ -1,0 +1,1 @@
+../../.claude/skills/create-inspection

--- a/.gemini/skills/crossplane-specialist
+++ b/.gemini/skills/crossplane-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/crossplane-specialist

--- a/.gemini/skills/dependabot-sweep/SKILL.md
+++ b/.gemini/skills/dependabot-sweep/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/dependabot-sweep.md

--- a/.gemini/skills/deploy-status
+++ b/.gemini/skills/deploy-status
@@ -1,0 +1,1 @@
+../../.claude/skills/deploy-status

--- a/.gemini/skills/detect-flaky
+++ b/.gemini/skills/detect-flaky
@@ -1,0 +1,1 @@
+../../.claude/skills/detect-flaky

--- a/.gemini/skills/fix-with-evidence
+++ b/.gemini/skills/fix-with-evidence
@@ -1,0 +1,1 @@
+../../.claude/skills/fix-with-evidence

--- a/.gemini/skills/gcp-specialist
+++ b/.gemini/skills/gcp-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/gcp-specialist

--- a/.gemini/skills/git
+++ b/.gemini/skills/git
@@ -1,0 +1,1 @@
+../../.claude/skills/git

--- a/.gemini/skills/ground-first
+++ b/.gemini/skills/ground-first
@@ -1,0 +1,1 @@
+../../.claude/skills/ground-first

--- a/.gemini/skills/handoff
+++ b/.gemini/skills/handoff
@@ -1,0 +1,1 @@
+../../.claude/skills/handoff

--- a/.gemini/skills/kubernetes-specialist
+++ b/.gemini/skills/kubernetes-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/kubernetes-specialist

--- a/.gemini/skills/markdown/SKILL.md
+++ b/.gemini/skills/markdown/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/markdown.md

--- a/.gemini/skills/merge-pr/SKILL.md
+++ b/.gemini/skills/merge-pr/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/merge-pr.md

--- a/.gemini/skills/plan-grader
+++ b/.gemini/skills/plan-grader
@@ -1,0 +1,1 @@
+../../.claude/skills/plan-grader

--- a/.gemini/skills/post-pr-review
+++ b/.gemini/skills/post-pr-review
@@ -1,0 +1,1 @@
+../../.claude/skills/post-pr-review

--- a/.gemini/skills/pre-pr/SKILL.md
+++ b/.gemini/skills/pre-pr/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/pre-pr.md

--- a/.gemini/skills/project-sync
+++ b/.gemini/skills/project-sync
@@ -1,0 +1,1 @@
+../../.claude/skills/project-sync

--- a/.gemini/skills/pulumi-specialist
+++ b/.gemini/skills/pulumi-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/pulumi-specialist

--- a/.gemini/skills/review-pr
+++ b/.gemini/skills/review-pr
@@ -1,0 +1,1 @@
+../../.claude/skills/review-pr

--- a/.gemini/skills/review-prs
+++ b/.gemini/skills/review-prs
@@ -1,0 +1,1 @@
+../../.claude/skills/review-prs

--- a/.gemini/skills/rollback-prod
+++ b/.gemini/skills/rollback-prod
@@ -1,0 +1,1 @@
+../../.claude/skills/rollback-prod

--- a/.gemini/skills/security-review
+++ b/.gemini/skills/security-review
@@ -1,0 +1,1 @@
+../../.claude/skills/security-review

--- a/.gemini/skills/spec
+++ b/.gemini/skills/spec
@@ -1,0 +1,1 @@
+../../.claude/skills/spec

--- a/.gemini/skills/terraform-specialist
+++ b/.gemini/skills/terraform-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/terraform-specialist

--- a/.gemini/skills/terragrunt-specialist
+++ b/.gemini/skills/terragrunt-specialist
@@ -1,0 +1,1 @@
+../../.claude/skills/terragrunt-specialist

--- a/.gemini/skills/validate-spec
+++ b/.gemini/skills/validate-spec
@@ -1,0 +1,1 @@
+../../.claude/skills/validate-spec

--- a/.gemini/skills/veracity-audit
+++ b/.gemini/skills/veracity-audit
@@ -1,0 +1,1 @@
+../../.claude/skills/veracity-audit

--- a/.github/instructions/agents-search.instructions.md
+++ b/.github/instructions/agents-search.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/agents-search/SKILL.md

--- a/.github/instructions/audit-and-fix.instructions.md
+++ b/.github/instructions/audit-and-fix.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/audit-and-fix/SKILL.md

--- a/.github/instructions/aws-specialist.instructions.md
+++ b/.github/instructions/aws-specialist.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/aws-specialist/SKILL.md

--- a/.github/instructions/azure-specialist.instructions.md
+++ b/.github/instructions/azure-specialist.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/azure-specialist/SKILL.md

--- a/.github/instructions/create-assessment.instructions.md
+++ b/.github/instructions/create-assessment.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/create-assessment/SKILL.md

--- a/.github/instructions/create-audit.instructions.md
+++ b/.github/instructions/create-audit.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/create-audit/SKILL.md

--- a/.github/instructions/create-experiment.instructions.md
+++ b/.github/instructions/create-experiment.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/create-experiment/SKILL.md

--- a/.github/instructions/create-inspection.instructions.md
+++ b/.github/instructions/create-inspection.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/create-inspection/SKILL.md

--- a/.github/instructions/crossplane-specialist.instructions.md
+++ b/.github/instructions/crossplane-specialist.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/crossplane-specialist/SKILL.md

--- a/.github/instructions/deploy-status.instructions.md
+++ b/.github/instructions/deploy-status.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/deploy-status/SKILL.md

--- a/.github/instructions/detect-flaky.instructions.md
+++ b/.github/instructions/detect-flaky.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/detect-flaky/SKILL.md

--- a/.github/instructions/fix-with-evidence.instructions.md
+++ b/.github/instructions/fix-with-evidence.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/fix-with-evidence/SKILL.md

--- a/.github/instructions/gcp-specialist.instructions.md
+++ b/.github/instructions/gcp-specialist.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/gcp-specialist/SKILL.md

--- a/.github/instructions/git.instructions.md
+++ b/.github/instructions/git.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/git/SKILL.md

--- a/.github/instructions/ground-first.instructions.md
+++ b/.github/instructions/ground-first.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/ground-first/SKILL.md

--- a/.github/instructions/handoff.instructions.md
+++ b/.github/instructions/handoff.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/handoff/SKILL.md

--- a/.github/instructions/kubernetes-specialist.instructions.md
+++ b/.github/instructions/kubernetes-specialist.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/kubernetes-specialist/SKILL.md

--- a/.github/instructions/plan-grader.instructions.md
+++ b/.github/instructions/plan-grader.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/plan-grader/SKILL.md

--- a/.github/instructions/post-pr-review.instructions.md
+++ b/.github/instructions/post-pr-review.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/post-pr-review/SKILL.md

--- a/.github/instructions/project-sync.instructions.md
+++ b/.github/instructions/project-sync.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/project-sync/SKILL.md

--- a/.github/instructions/pulumi-specialist.instructions.md
+++ b/.github/instructions/pulumi-specialist.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/pulumi-specialist/SKILL.md

--- a/.github/instructions/review-pr.instructions.md
+++ b/.github/instructions/review-pr.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/review-pr/SKILL.md

--- a/.github/instructions/review-prs.instructions.md
+++ b/.github/instructions/review-prs.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/review-prs/SKILL.md

--- a/.github/instructions/rollback-prod.instructions.md
+++ b/.github/instructions/rollback-prod.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/rollback-prod/SKILL.md

--- a/.github/instructions/security-review.instructions.md
+++ b/.github/instructions/security-review.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/security-review/SKILL.md

--- a/.github/instructions/spec.instructions.md
+++ b/.github/instructions/spec.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/spec/SKILL.md

--- a/.github/instructions/terraform-specialist.instructions.md
+++ b/.github/instructions/terraform-specialist.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/terraform-specialist/SKILL.md

--- a/.github/instructions/terragrunt-specialist.instructions.md
+++ b/.github/instructions/terragrunt-specialist.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/terragrunt-specialist/SKILL.md

--- a/.github/instructions/validate-spec.instructions.md
+++ b/.github/instructions/validate-spec.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/validate-spec/SKILL.md

--- a/.github/instructions/veracity-audit.instructions.md
+++ b/.github/instructions/veracity-audit.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/veracity-audit/SKILL.md

--- a/.github/prompts/changelog.prompt.md
+++ b/.github/prompts/changelog.prompt.md
@@ -1,0 +1,1 @@
+../../.claude/commands/changelog.md

--- a/.github/prompts/dependabot-sweep.prompt.md
+++ b/.github/prompts/dependabot-sweep.prompt.md
@@ -1,0 +1,1 @@
+../../.claude/commands/dependabot-sweep.md

--- a/.github/prompts/markdown.prompt.md
+++ b/.github/prompts/markdown.prompt.md
@@ -1,0 +1,1 @@
+../../.claude/commands/markdown.md

--- a/.github/prompts/merge-pr.prompt.md
+++ b/.github/prompts/merge-pr.prompt.md
@@ -1,0 +1,1 @@
+../../.claude/commands/merge-pr.md

--- a/.github/prompts/pre-pr.prompt.md
+++ b/.github/prompts/pre-pr.prompt.md
@@ -1,0 +1,1 @@
+../../.claude/commands/pre-pr.md


### PR DESCRIPTION
## Summary

- Dogfood `dotbabel project-sync` (v2.5.0) on the dotbabel repo itself. Same shape we just shipped to consumers.
- 105 symlinks land under `.codex/skills/`, `.gemini/skills/`, `.github/prompts/`, and `.github/instructions/`. All targets relative — exercises the [#218](https://github.com/kaiohenricunha/dotbabel/issues/218) fix we shipped in [#220](https://github.com/kaiohenricunha/dotbabel/pull/220) end-to-end on the source-of-truth tree.
- `.dotbabel.json` with `targets: []` so project-sync only manages the symlink fan-out. Instruction files (`AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`) stay owned by the existing harness — `dotbabel-generate-instructions` applies the CLI-specific substitutions defined in `docs/repo-facts.json` that project-sync wouldn't know about. Two flows coexist cleanly.

## Why dogfood here

The user-scope `dotbabel bootstrap` already populates `~/.codex/skills/` and `~/.gemini/skills/` for anyone who's bootstrapped — but that doesn't help a contributor who clones dotbabel and opens it in Codex/Gemini without bootstrapping. Per-repo `.codex/.gemini/.github/prompts/` makes the slash-commands discoverable on first clone, no setup step needed.

It also gives us a continuous integration of the project-sync feature against its own source — every change to `dotbabel project-sync` runs against this repo's full skill+command catalog (35 skills + various commands, totaling 105 fan-out entries).

## Configuration (`.dotbabel.json`)

```json
{
  "rule_floor_source": "CLAUDE.md",
  "commands_dir": ".claude/commands",
  "skills_dir": ".claude/skills",
  "fan_out": ["codex", "gemini", "copilot"],
  "gate_on_cli_presence": true,
  "cli_substitutions": {},
  "targets": []
}
```

`targets: []` is the conscious choice — see Summary for why.

## Verification

- [x] `dotbabel project-sync --dry-run --all` — 105 actions previewed
- [x] `dotbabel project-sync --all` — 105 symlinks created
- [x] `dotbabel check-project-sync` — 105 entries verified, exit 0
- [x] `readlink .codex/skills/handoff` → `../../.claude/skills/handoff` (relative ✓)
- [x] `readlink .github/prompts/changelog.prompt.md` → `../../.claude/commands/changelog.md` (relative ✓)
- [x] `npm test` — **697/697**
- [x] `npx bats plugins/dotbabel/tests/bats/` — **448/448**
- [x] `npm run lint` — clean except pre-existing CHANGELOG.md warning
- [x] `npm run dogfood` — clean: `✓ spec coverage ok (0 protected file(s) changed)`
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — fresh
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --strict` — 0 warnings
- [x] `node scripts/build-plugin.mjs --check` — fresh

## No-spec rationale

None of the changed paths (`.codex/**`, `.gemini/**`, `.github/prompts/**`, `.github/instructions/**`, `.dotbabel.json`) are in `docs/repo-facts.json:protected_paths`. `dotbabel-check-spec-coverage` explicitly reports `0 protected file(s) changed`. No spec governs this change.
