### PR TITLE
ci(lint): clear pre-existing prettier and shellcheck gate noise (closes #223)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 CHANGELOG.md
+index/

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
-    "lint": "prettier --check \"**/*.{json,yml,yaml,md}\" --ignore-path .gitignore --ignore-unknown && markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.claude/worktrees\" && node scripts/check-jsdoc-coverage.mjs plugins/dotbabel/src",
-    "format": "prettier --write \"**/*.{json,yml,yaml,md}\" --ignore-path .gitignore --ignore-unknown",
-    "shellcheck": "shellcheck -x bootstrap.sh sync.sh plugins/dotbabel/scripts/*.sh plugins/dotbabel/hooks/*.sh plugins/dotbabel/tests/*.sh plugins/dotbabel/templates/claude/hooks/*.sh plugins/dotbabel/templates/githooks/pre-commit",
+    "lint": "prettier --check \"**/*.{json,yml,yaml,md}\" --ignore-path .gitignore --ignore-path .prettierignore --ignore-unknown && markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.claude/worktrees\" && node scripts/check-jsdoc-coverage.mjs plugins/dotbabel/src",
+    "format": "prettier --write \"**/*.{json,yml,yaml,md}\" --ignore-path .gitignore --ignore-path .prettierignore --ignore-unknown",
+    "shellcheck": "shellcheck --severity=warning -x bootstrap.sh sync.sh plugins/dotbabel/scripts/*.sh plugins/dotbabel/hooks/*.sh plugins/dotbabel/tests/*.sh plugins/dotbabel/templates/claude/hooks/*.sh plugins/dotbabel/templates/githooks/pre-commit",
     "dogfood": "npx dotbabel-validate-skills && npx dotbabel-validate-specs && npx dotbabel-check-instruction-drift && npx dotbabel-check-instructions-fresh && npx dotbabel-check-instruction-parity && npx dotbabel-check-spec-coverage",
     "docs:stamp": "node scripts/stamp-doc-versions.mjs",
     "docs:stamp-check": "node scripts/stamp-doc-versions.mjs --check"


### PR DESCRIPTION
## Summary

- Tighten `npm run shellcheck` to `--severity=warning` so SC2292/SC2310/SC2312 style/info findings don't fail the gate. Real warnings + errors still fail. Closes [#223](https://github.com/kaiohenricunha/dotbabel/issues/223).
- Make `.prettierignore` actually take effect: add `--ignore-path .prettierignore` to the `lint` and `format` scripts. Without this, prettier's `.prettierignore` lookup is suppressed by the explicit `--ignore-path .gitignore` (prettier 3.x supports multiple `--ignore-path` flags as a union — verified). `CHANGELOG.md` (already in `.prettierignore`) now stops warning. **No separate issue — folded here.**
- Add `index/` to `.prettierignore`. The three index files (`artifacts.json`, `by-type.json`, `by-facet.json`) are deterministically regenerated by `dotbabel-index.mjs:161-169`; their structural-compare check at `dotbabel-index.mjs:147-148` is the canonical correctness gate. Stopgap for [#224](https://github.com/kaiohenricunha/dotbabel/issues/224) — the proper fix (wire prettier into the writer) ships separately.

Three files-of-impact at the source level (`package.json` 3-line edit + `.prettierignore` 1-line add). All three pre-existing CI gate noises that have spammed the verification matrix in #216, #220, #221 are now silenced.

## Why now

Each of the previous three PRs in this session had to add a "pre-existing CI gate noise" footnote to its verification matrix. Fixing them once removes a recurring tax on every future PR.

## What's NOT changed

- `plugins/dotbabel/bin/dotbabel-index.mjs` writer — the proper #224 fix is intentionally split out. That fix touches a protected path (`plugins/dotbabel/bin/**`), needs a dependency decision (prettier as runtime dep ~6MB vs hand-rolled compact stringifier mirroring `stringifyManifest` in `plugins/dotbabel/src/generate-instructions.mjs:486-513`), and warrants its own review.
- Any individual SC2292/SC2310/SC2312 pattern in the shell scripts — opportunistic when those scripts are touched for unrelated work.
- `release-please` config for #7 (alternative path: change bullet style at the source). Not pursued — `.prettierignore` route is simpler and reversible.

## Test plan

- [x] `npm run shellcheck` — exits 0 (was exit 1)
- [x] `npm run lint` — silent (was `[warn] CHANGELOG.md`)
- [x] `! npm run lint 2>&1 | grep -qi "CHANGELOG"` — passes (negative assertion)
- [x] `! npm run lint 2>&1 | grep -q "index/"` — passes (negative assertion)
- [x] `! npm run shellcheck 2>&1 | grep -qE "SC[0-9]+ \(warning\)|SC[0-9]+ \(error\)"` — passes (no real warnings hiding)
- [x] **Sandbox test**: temporarily corrupt `README.md` formatting → `npm run lint` flags it → revert → silent again. Proves the ignore widening is scoped to the two known files, not blanket.
- [x] `npm test` — 697/697
- [x] `npx bats plugins/dotbabel/tests/bats/` — 448/448
- [x] `npm run dogfood` — clean: `✓ spec coverage ok (0 protected file(s) changed)`
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — fresh
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --strict` — 0 warnings
- [x] `node scripts/build-plugin.mjs --check` — fresh

## No-spec rationale

Changes touch `package.json` (script lines only) and `.prettierignore`. Neither is in `docs/repo-facts.json:protected_paths`. `dotbabel-check-spec-coverage` reports `0 protected file(s) changed`. No `## Spec ID` heading is included — `plugins/dotbabel/src/check-spec-coverage.mjs:76` parses any non-empty content under that heading as a literal spec ID and would treat sentinel placeholders like `_None_` as an unknown-spec lookup, failing the gate. Omitting the heading is the correct shape when no spec applies.
