### PR TITLE
fix(index): emit prettier-compatible JSON from writer (closes #224)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
 CHANGELOG.md
-index/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.1.1",
+        "prettier": "^3.5.0"
       },
       "bin": {
         "dotbabel": "plugins/dotbabel/bin/dotbabel.mjs",
@@ -19,6 +20,7 @@
         "dotbabel-check-instruction-drift": "plugins/dotbabel/bin/dotbabel-check-instruction-drift.mjs",
         "dotbabel-check-instruction-parity": "plugins/dotbabel/bin/dotbabel-check-instruction-parity.mjs",
         "dotbabel-check-instructions-fresh": "plugins/dotbabel/bin/dotbabel-check-instructions-fresh.mjs",
+        "dotbabel-check-project-sync": "plugins/dotbabel/bin/dotbabel-check-project-sync.mjs",
         "dotbabel-check-spec-coverage": "plugins/dotbabel/bin/dotbabel-check-spec-coverage.mjs",
         "dotbabel-detect-drift": "plugins/dotbabel/bin/dotbabel-detect-drift.mjs",
         "dotbabel-doctor": "plugins/dotbabel/bin/dotbabel-doctor.mjs",
@@ -27,6 +29,8 @@
         "dotbabel-index": "plugins/dotbabel/bin/dotbabel-index.mjs",
         "dotbabel-init": "plugins/dotbabel/bin/dotbabel-init.mjs",
         "dotbabel-list": "plugins/dotbabel/bin/dotbabel-list.mjs",
+        "dotbabel-project-init": "plugins/dotbabel/bin/dotbabel-project-init.mjs",
+        "dotbabel-project-sync": "plugins/dotbabel/bin/dotbabel-project-sync.mjs",
         "dotbabel-search": "plugins/dotbabel/bin/dotbabel-search.mjs",
         "dotbabel-show": "plugins/dotbabel/bin/dotbabel-show.mjs",
         "dotbabel-sync": "plugins/dotbabel/bin/dotbabel-sync.mjs",
@@ -37,7 +41,6 @@
         "@vitest/coverage-v8": "^4.1.5",
         "bats": "^1.11.1",
         "markdownlint-cli2": "^0.22.1",
-        "prettier": "^3.5.0",
         "vitest": "^4.1.4"
       },
       "engines": {
@@ -2440,7 +2443,6 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@vitest/coverage-v8": "^4.1.5",
     "bats": "^1.11.1",
     "markdownlint-cli2": "^0.22.1",
-    "prettier": "^3.5.0",
     "vitest": "^4.1.4"
   },
   "repository": {
@@ -100,6 +99,7 @@
   "dependencies": {
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "prettier": "^3.5.0"
   }
 }

--- a/plugins/dotbabel/bin/dotbabel-index.mjs
+++ b/plugins/dotbabel/bin/dotbabel-index.mjs
@@ -31,6 +31,7 @@ import {
 import { mkdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
+import { format as prettierFormat, resolveConfig as prettierResolveConfig } from "prettier";
 
 const META = {
   name: "dotbabel-index",
@@ -156,18 +157,21 @@ if (existsSync(artifactsPath)) {
 bundle.artifactsJson.generatedAt =
   preservedGeneratedAt ?? new Date().toISOString();
 
-writeFileSync(
-  artifactsPath,
-  JSON.stringify(bundle.artifactsJson, null, 2) + "\n",
-);
-writeFileSync(
-  join(indexDir, "by-type.json"),
-  JSON.stringify(bundle.byType, null, 2) + "\n",
-);
-writeFileSync(
-  join(indexDir, "by-facet.json"),
-  JSON.stringify(bundle.byFacet, null, 2) + "\n",
-);
+// Format each index file via prettier (same gate `npm run lint` runs) so
+// the regenerator output is lint-clean by construction. Closes #224 — the
+// previous JSON.stringify(..., null, 2) path always-expanded arrays,
+// fighting prettier's "inline short, expand long" heuristic and forcing a
+// manual `prettier --write` after every taxonomy change.
+//
+// resolveConfig is required so prettier honors the repo's .prettierrc
+// (notably `printWidth: 100`); without it prettier falls back to its
+// built-in 80-char default and the output diverges from `npm run lint`.
+const prettierConfig = (await prettierResolveConfig(artifactsPath)) ?? {};
+const formatJson = (value) =>
+  prettierFormat(JSON.stringify(value), { ...prettierConfig, parser: "json" });
+writeFileSync(artifactsPath, await formatJson(bundle.artifactsJson));
+writeFileSync(join(indexDir, "by-type.json"), await formatJson(bundle.byType));
+writeFileSync(join(indexDir, "by-facet.json"), await formatJson(bundle.byFacet));
 
 // Write a README once if absent; never overwrite user edits.
 const readmePath = join(indexDir, "README.md");


### PR DESCRIPTION
## Summary

- Replace the three `JSON.stringify(value, null, 2) + "\n"` writes in `plugins/dotbabel/bin/dotbabel-index.mjs:159-170` with calls into prettier itself, so the regenerator output is lint-clean by construction. Closes [#224](https://github.com/kaiohenricunha/dotbabel/issues/224).
- Drop the `index/` line from `.prettierignore` — the stopgap from [#225](https://github.com/kaiohenricunha/dotbabel/pull/225) is no longer needed; the writer's output now matches what `npm run lint` expects.
- Move `prettier` from `devDependencies` to `dependencies` since it now runs at runtime when consumers invoke `dotbabel-index`.

The recurring "regenerator → expanded → lint fails → prettier --write → compact → next regenerator → expanded again" loop documented in #224 is gone. Verified by running `dotbabel-index --strict` twice in a row and observing no `index/*` diff appears.

## Why prettier-as-runtime-dep over a hand-rolled stringifier

I tried the hand-rolled path first (mirroring `stringifyManifest` in `plugins/dotbabel/src/generate-instructions.mjs:486-513`). It works for object shapes but doesn't reproduce prettier's "sibling array consistency" heuristic — when prettier sees a sibling array inside an object that has to expand for length, it expands ALL the sibling arrays for visual consistency, even short ones that would otherwise inline. Reproducing that exactly in pure JS is brittle (failure mode: silent drift on next prettier minor release). Per AGENTS.md "Avoid adding new runtime dependencies without a strong justification" — the strong justification here is that this prettier dep eliminates a recurring source of friction, removes the `.prettierignore` stopgap, and makes the regenerator's output canonically lint-clean for every consumer (not just dotbabel maintainers).

## Implementation notes

- `prettier.resolveConfig(filepath)` is required so the writer honors the repo's `.prettierrc` (notably `printWidth: 100`); without it prettier falls back to its built-in 80-char default and the output diverges from `npm run lint`. Verified with both probes inline in the implementation comment.
- The writer becomes async via top-level `await`. Node 20+ (current `engines.node`) supports top-level await natively in `.mjs` modules.
- Bundle impact: prettier is ~3MB tarball / ~6MB unpacked. Acceptable cost for a dev-tool CLI; not in any hot path.

## Test plan

- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs` writes the three index files
- [x] `npm run lint` — silent on `index/*` (no `[warn]` for the regenerated files)
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --strict` then `git status` → no diff in `index/*` (was always-expanded vs prettier-inline mismatch — the canary for the bug)
- [x] Run `--strict` twice in a row → no new `index/*` diff on second run (idempotent)
- [x] `npm test` — 697/697
- [x] `npx bats plugins/dotbabel/tests/bats/` — 448/448
- [x] `npm run dogfood` — all gates clean (only pre-existing iac-engineer/pulumi trigger warning)
- [x] `npm run shellcheck` — exit 0
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — fresh
- [x] `node scripts/build-plugin.mjs --check` — fresh

## Migration / consumer impact

Existing consumers' `.prettierignore` entries that included `index/` (added by the #225 stopgap, then never adopted by consumers) are now no-ops. No action required from consumers — the next `dotbabel-index` run will write lint-clean output natively.

`fix:` conventional commit triggers a release-please patch bump (2.6.0 → 2.6.1).

## Spec ID

dotbabel-core
