### PR TITLE
feat(bootstrap): add user-scope rule-floor overlay (closes #228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,36 @@ npx dotbabel-doctor          # verify everything wired up
 npx dotbabel-validate-specs  # run first governance check
 ```
 
+### User-scope rule-floor overlay (`~/.config/dotbabel/local-rules.md`)
+
+`dotbabel bootstrap` (npm CLI, 2.7.0+) generates `~/.claude/CLAUDE.md` as a
+real file containing the canonical dotbabel rule floor followed by a
+marker-delimited overlay block. To layer your own personal rules on top
+without forking dotbabel's source, drop them into
+`~/.config/dotbabel/local-rules.md`:
+
+```bash
+mkdir -p ~/.config/dotbabel
+cat > ~/.config/dotbabel/local-rules.md <<'EOF'
+## My personal rules
+
+- Default to drafts when opening PRs.
+- Always link the Linear ticket in the PR body.
+EOF
+dotbabel bootstrap   # regenerates ~/.claude/CLAUDE.md with your overlay merged in
+```
+
+The overlay sits AFTER the canonical content (Claude Code's top-to-bottom
+read order means your rules trump dotbabel defaults). Future `dotbabel
+bootstrap` and `dotbabel sync` runs preserve the overlay, regenerating the
+merged file on every invocation. Direct edits to `~/.claude/CLAUDE.md` are
+backed up to `~/.claude/CLAUDE.md.bak-<timestamp>` before regen — always
+edit `local-rules.md`, not the generated file.
+
+The shell-only `./bootstrap.sh` quickstart still uses the legacy symlink
+shape and does not support overlays. Install the npm package for overlay
+support.
+
 ### Project-scope sync (cross-CLI per-repo wiring)
 
 `dotbabel bootstrap` covers your **user scope** (`~/.claude/`, `~/.codex/`,

--- a/plugins/dotbabel/bin/dotbabel-doctor.mjs
+++ b/plugins/dotbabel/bin/dotbabel-doctor.mjs
@@ -44,6 +44,7 @@ import {
   generateInstructions,
   pathExists,
 } from "../src/index.mjs";
+import { USER_OVERLAY_BEGIN } from "../src/lib/user-overlay.mjs";
 
 const META = {
   name: "dotbabel-doctor",
@@ -181,16 +182,25 @@ if (argv.flags["install-hooks"]) {
 }
 
 // bootstrap: is ~/.claude/ wired up? (informational — warn only)
+// As of 2.7.0 (#228), ~/.claude/CLAUDE.md is a generated file with
+// dotbabel:user-overlay markers, not a symlink. Migrate legacy symlinks on
+// next bootstrap.
 const globalClaudeMd = join(homedir(), ".claude", "CLAUDE.md");
+let globalLstat = null;
 try {
-  const l = lstatSync(globalClaudeMd);
-  if (l.isSymbolicLink()) {
-    out.pass(`~/.claude/CLAUDE.md is a symlink (bootstrap active)`);
-  } else {
-    out.warn(`~/.claude/CLAUDE.md exists but is not a symlink — run 'dotbabel bootstrap' to wire it up`);
-  }
+  globalLstat = lstatSync(globalClaudeMd);
 } catch {
+  // not present — handled below
+}
+
+if (globalLstat === null) {
   out.warn(`~/.claude/CLAUDE.md missing — run 'dotbabel bootstrap' to install global config`);
+} else if (globalLstat.isSymbolicLink()) {
+  out.warn(`~/.claude/CLAUDE.md is a symlink (legacy ≤2.6.x layout) — run 'dotbabel bootstrap' to migrate to a generated file with overlay support (#228)`);
+} else if (!readFileSync(globalClaudeMd, "utf8").includes(USER_OVERLAY_BEGIN)) {
+  out.warn(`~/.claude/CLAUDE.md is a regular file but lacks the user-overlay markers — run 'dotbabel bootstrap' to regenerate`);
+} else {
+  out.pass(`~/.claude/CLAUDE.md is a generated file with overlay support (bootstrap active)`);
 }
 
 for (const link of [

--- a/plugins/dotbabel/src/bootstrap-global.mjs
+++ b/plugins/dotbabel/src/bootstrap-global.mjs
@@ -20,6 +20,10 @@ import {
   ensureRealDir,
   linkOne,
 } from "./lib/symlink.mjs";
+import {
+  resolveLocalRulesPath,
+  writeUserScopeClaudeMd,
+} from "./lib/user-overlay.mjs";
 
 // ---------------------------------------------------------------------------
 // pkgRoot() — walk up from this file until we find a directory containing
@@ -154,10 +158,23 @@ export async function bootstrapGlobal(opts = {}) {
     if (r.action === "backed_up") backed_up++;
   }
 
-  // --- CLAUDE.md ---
+  // --- CLAUDE.md (user-scope: canonical + optional user overlay; #228) ---
+  // Pre-2.7.0 this was a plain symlink to the canonical source. Now it's a
+  // generated file: <canonical> + a marker-delimited overlay block populated
+  // from ~/.config/dotbabel/local-rules.md (when present). Bootstrap
+  // regenerates the merged file every run, backing up direct edits or the
+  // legacy symlink before overwriting.
   const claudeMdSrc = path.join(source, "CLAUDE.md");
   if (fs.existsSync(claudeMdSrc)) {
-    doLink(claudeMdSrc, path.join(target, "CLAUDE.md"));
+    const r = writeUserScopeClaudeMd({
+      canonicalSrc: claudeMdSrc,
+      target: path.join(target, "CLAUDE.md"),
+      overlaySrc: resolveLocalRulesPath(process.env),
+      out,
+      timestamp,
+    });
+    if (r.action === "migrated" || r.action === "regenerated") backed_up++;
+    linked++;
   }
 
   // --- commands/*.md ---

--- a/plugins/dotbabel/src/lib/user-overlay.mjs
+++ b/plugins/dotbabel/src/lib/user-overlay.mjs
@@ -1,0 +1,150 @@
+/**
+ * user-overlay.mjs — user-scope rule-floor overlay machinery for #228.
+ *
+ * Background. Pre-2.7.0, `~/.claude/CLAUDE.md` was a symlink straight to
+ * dotbabel's repo `CLAUDE.md`. That made personal additions unsafe — any
+ * edit went into dotbabel's source. This module replaces that symlink with
+ * a generated file: `<canonical content>` followed by a marker-delimited
+ * overlay block populated from `~/.config/dotbabel/local-rules.md`. Users
+ * own the overlay file; bootstrap regenerates the merged user-scope file
+ * on every run, backing up direct edits before overwriting.
+ *
+ * Exports:
+ *   USER_OVERLAY_BEGIN / USER_OVERLAY_END  marker constants
+ *   NO_OVERLAY_PLACEHOLDER                 rendered when no overlay content
+ *   composeUserScopeClaudeMd               pure compose function
+ *   resolveLocalRulesPath                  env -> overlay path
+ *   writeUserScopeClaudeMd                 the bootstrap-side write driver
+ *
+ * @module lib/user-overlay
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Marker that opens the user-overlay block in `~/.claude/CLAUDE.md`. */
+export const USER_OVERLAY_BEGIN = "<!-- dotbabel:user-overlay:begin -->";
+/** Marker that closes the user-overlay block in `~/.claude/CLAUDE.md`. */
+export const USER_OVERLAY_END = "<!-- dotbabel:user-overlay:end -->";
+/**
+ * Rendered between the user-overlay markers when no overlay content
+ * applies (file absent, or empty/whitespace-only). All three "no real
+ * overlay" states render identically so users see the same shape
+ * regardless of whether they created an empty file or no file at all.
+ */
+export const NO_OVERLAY_PLACEHOLDER = "(no user overlay)";
+
+/**
+ * Compose the merged user-scope CLAUDE.md content from canonical + overlay.
+ *
+ * Contract:
+ *   - The canonical content is emitted with its trailing whitespace trimmed
+ *     so the overlay block sits below exactly one blank line.
+ *   - If `overlay` is `null`, an empty string, or whitespace-only after
+ *     trim, the user-overlay block contains the literal NO_OVERLAY_PLACEHOLDER
+ *     ("(no user overlay)") on its own line. All three states render
+ *     identically so users see the same shape regardless of whether they
+ *     created an empty file or no file at all.
+ *   - Otherwise, the trimmed overlay content sits between the markers,
+ *     followed by exactly one trailing newline before the close marker.
+ *   - Output ends with exactly one trailing `\n` so:
+ *     `compose(canonical, x) === compose(canonical, x)` byte-equal across
+ *     runs, and trim-equivalent overlays produce identical output.
+ *
+ * @param {string} canonical    Full content of dotbabel's repo CLAUDE.md.
+ * @param {string|null|undefined} overlay  Contents of local-rules.md, or
+ *   null/empty/whitespace-only when no overlay applies.
+ * @returns {string}
+ */
+export function composeUserScopeClaudeMd(canonical, overlay) {
+  const canonicalBody = canonical.replace(/\s+$/, "");
+  const overlayTrimmed =
+    overlay == null ? "" : overlay.replace(/^\s+|\s+$/g, "");
+  const overlayBody =
+    overlayTrimmed === "" ? NO_OVERLAY_PLACEHOLDER : overlayTrimmed;
+  return `${canonicalBody}\n\n${USER_OVERLAY_BEGIN}\n${overlayBody}\n${USER_OVERLAY_END}\n`;
+}
+
+/**
+ * Resolve the user-overlay source path from environment.
+ *
+ * Priority:
+ *   1. `env.DOTBABEL_LOCAL_RULES` — explicit override (tests + power users).
+ *   2. `${env.XDG_CONFIG_HOME ?? env.HOME + "/.config"}/dotbabel/local-rules.md`.
+ *
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string}  Absolute path; the file may or may not exist.
+ */
+export function resolveLocalRulesPath(env) {
+  if (env.DOTBABEL_LOCAL_RULES) return env.DOTBABEL_LOCAL_RULES;
+  const configHome = env.XDG_CONFIG_HOME ?? path.join(env.HOME ?? "", ".config");
+  return path.join(configHome, "dotbabel", "local-rules.md");
+}
+
+/**
+ * @typedef {object} WriteResult
+ * @property {'created'|'unchanged'|'migrated'|'regenerated'} action
+ * @property {string} [bakPath]   Backup path (set when action === 'migrated' or 'regenerated')
+ */
+
+/**
+ * Write `~/.claude/CLAUDE.md` (or the supplied target) as a generated file
+ * containing the canonical content + user-overlay block. Backs up any
+ * pre-existing real file or symlink before overwriting.
+ *
+ * @param {object} cfg
+ * @param {string} cfg.canonicalSrc  Path to dotbabel's repo CLAUDE.md.
+ * @param {string} cfg.target        Destination, typically `~/.claude/CLAUDE.md`.
+ * @param {string} cfg.overlaySrc    Path to local-rules.md (may not exist).
+ * @param {import('./output.mjs').Output} cfg.out
+ * @param {string} cfg.timestamp     YYYYMMDD-HHmmss for backup suffix.
+ * @returns {WriteResult}
+ */
+export function writeUserScopeClaudeMd({
+  canonicalSrc,
+  target,
+  overlaySrc,
+  out,
+  timestamp,
+}) {
+  const canonical = fs.readFileSync(canonicalSrc, "utf8");
+  const overlay = fs.existsSync(overlaySrc)
+    ? fs.readFileSync(overlaySrc, "utf8")
+    : null;
+  const expected = composeUserScopeClaudeMd(canonical, overlay);
+
+  let lstat = null;
+  try {
+    lstat = fs.lstatSync(target);
+  } catch {
+    // target doesn't exist
+  }
+
+  if (lstat === null) {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, expected);
+    out.pass(`generated: ${target}`);
+    return { action: "created" };
+  }
+
+  if (lstat.isSymbolicLink()) {
+    const bakPath = `${target}.bak-${timestamp}`;
+    fs.renameSync(target, bakPath);
+    fs.writeFileSync(target, expected);
+    out.warn(`migrated symlink to generated file: ${target} (old at ${bakPath})`);
+    return { action: "migrated", bakPath };
+  }
+
+  // Real file. Compare against expected.
+  const actual = fs.readFileSync(target, "utf8");
+  if (actual === expected) {
+    out.pass(`ok: ${target}`);
+    return { action: "unchanged" };
+  }
+
+  const bakPath = `${target}.bak-${timestamp}`;
+  fs.renameSync(target, bakPath);
+  fs.writeFileSync(target, expected);
+  out.warn(`backed up + regenerated: ${target} (old at ${bakPath})`);
+  return { action: "regenerated", bakPath };
+}

--- a/plugins/dotbabel/tests/bats/user-overlay.bats
+++ b/plugins/dotbabel/tests/bats/user-overlay.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# Hermetic-HOME tests for the user-scope rule-floor overlay (#228).
+#
+# These tests target `node plugins/dotbabel/bin/dotbabel-bootstrap.mjs`
+# (the npm CLI), NOT bootstrap.sh. bootstrap.sh is the lightweight
+# "TL;DR" entrypoint and intentionally stays symlink-based; the npm CLI
+# adds overlay support.
+
+load helpers
+
+DOTBABEL_BOOTSTRAP="node $REPO_ROOT/plugins/dotbabel/bin/dotbabel-bootstrap.mjs"
+
+setup() {
+  export HOME
+  HOME=$(make_tmp_home)
+  export OVERLAY_TMP
+  OVERLAY_TMP=$(mktemp -d)
+  # Force bootstrap to look at OUR test overlay path, not the user's real one.
+  export DOTBABEL_LOCAL_RULES="$OVERLAY_TMP/local-rules.md"
+}
+
+teardown() {
+  unset DOTBABEL_LOCAL_RULES
+  [ -n "${HOME:-}" ] && [ -d "$HOME" ] && rm -rf "$HOME"
+  [ -n "${OVERLAY_TMP:-}" ] && [ -d "$OVERLAY_TMP" ] && rm -rf "$OVERLAY_TMP"
+}
+
+@test "bootstrap creates ~/.claude/CLAUDE.md as a regular file with overlay markers when DOTBABEL_LOCAL_RULES points at a populated tmp file" {
+  cat > "$DOTBABEL_LOCAL_RULES" <<'MD'
+## My personal rules
+
+- be terse
+- be helpful
+MD
+
+  run $DOTBABEL_BOOTSTRAP --quiet
+  [ "$status" -eq 0 ]
+  [ -f "$HOME/.claude/CLAUDE.md" ]
+  [ ! -L "$HOME/.claude/CLAUDE.md" ]
+  grep -q "<!-- dotbabel:user-overlay:begin -->" "$HOME/.claude/CLAUDE.md"
+  grep -q "<!-- dotbabel:user-overlay:end -->" "$HOME/.claude/CLAUDE.md"
+  grep -q "be terse" "$HOME/.claude/CLAUDE.md"
+  grep -q "be helpful" "$HOME/.claude/CLAUDE.md"
+  ! grep -q "(no user overlay)" "$HOME/.claude/CLAUDE.md"
+}
+
+@test "bootstrap migrates a pre-2.7.0 symlink at ~/.claude/CLAUDE.md to a generated file (no data loss)" {
+  # Pre-create a symlink in the hermetic HOME, mirroring the legacy install state.
+  mkdir -p "$HOME/.claude"
+  ln -s "/some/legacy/symlink/target" "$HOME/.claude/CLAUDE.md"
+  [ -L "$HOME/.claude/CLAUDE.md" ]
+
+  run $DOTBABEL_BOOTSTRAP --quiet
+  [ "$status" -eq 0 ]
+  [ -f "$HOME/.claude/CLAUDE.md" ]
+  [ ! -L "$HOME/.claude/CLAUDE.md" ]
+  grep -q "<!-- dotbabel:user-overlay:begin -->" "$HOME/.claude/CLAUDE.md"
+
+  # Backup of the original symlink should exist.
+  run bash -c "ls '$HOME/.claude/'CLAUDE.md.bak-*"
+  [ "$status" -eq 0 ]
+}
+
+@test "bootstrap treats an empty local-rules.md as absent (placeholder in overlay block, no user content leaked)" {
+  : > "$DOTBABEL_LOCAL_RULES"   # zero-byte file
+
+  run $DOTBABEL_BOOTSTRAP --quiet
+  [ "$status" -eq 0 ]
+  grep -q "<!-- dotbabel:user-overlay:begin -->" "$HOME/.claude/CLAUDE.md"
+  grep -q "(no user overlay)" "$HOME/.claude/CLAUDE.md"
+}

--- a/plugins/dotbabel/tests/bootstrap-global.test.mjs
+++ b/plugins/dotbabel/tests/bootstrap-global.test.mjs
@@ -68,10 +68,14 @@ describe("bootstrapGlobal", () => {
 
     expect(result.ok).toBe(true);
 
-    // CLAUDE.md symlink
+    // CLAUDE.md is now a generated file with user-overlay markers (#228),
+    // not a symlink.
     const claudeMd = path.join(tgt, "CLAUDE.md");
-    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(true);
-    expect(fs.readlinkSync(claudeMd)).toBe(path.join(src, "CLAUDE.md"));
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(false);
+    expect(fs.lstatSync(claudeMd).isFile()).toBe(true);
+    expect(fs.readFileSync(claudeMd, "utf8")).toContain(
+      "<!-- dotbabel:user-overlay:begin -->",
+    );
 
     // commands/foo.md symlink
     const fooCmd = path.join(tgt, "commands", "foo.md");
@@ -107,12 +111,15 @@ describe("bootstrapGlobal", () => {
     // No new backups on second run
     expect(result2.backed_up).toBe(0);
 
-    // symlinks still correct
+    // CLAUDE.md is a generated file with overlay markers (#228), not a symlink.
     const claudeMd = path.join(tgt, "CLAUDE.md");
-    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(true);
-    expect(fs.readlinkSync(claudeMd)).toBe(path.join(src, "CLAUDE.md"));
+    expect(fs.lstatSync(claudeMd).isFile()).toBe(true);
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(claudeMd, "utf8")).toContain(
+      "<!-- dotbabel:user-overlay:begin -->",
+    );
 
-    // No extra .bak files created
+    // No extra .bak files created (idempotent on second run).
     const tgtEntries = fs.readdirSync(tgt);
     expect(tgtEntries.some((e) => e.includes(".bak"))).toBe(false);
   });
@@ -121,7 +128,7 @@ describe("bootstrapGlobal", () => {
   // Test 3 — backs up a real file before overwriting with symlink
   // -------------------------------------------------------------------------
 
-  it("backs up a real file before overwriting with symlink", async () => {
+  it("backs up a real file before overwriting with the generated CLAUDE.md (#228)", async () => {
     const src = makeTmpDir("bg-src-");
     const tgt = makeTmpDir("bg-tgt-");
     buildFakeSource(src);
@@ -134,16 +141,18 @@ describe("bootstrapGlobal", () => {
     expect(result.ok).toBe(true);
     expect(result.backed_up).toBeGreaterThan(0);
 
-    // The destination is now a symlink
+    // The destination is now a generated file with overlay markers, not a symlink.
     const claudeMd = path.join(tgt, "CLAUDE.md");
-    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(true);
+    expect(fs.lstatSync(claudeMd).isFile()).toBe(true);
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(claudeMd, "utf8")).toContain(
+      "<!-- dotbabel:user-overlay:begin -->",
+    );
 
-    // A backup file with .bak- prefix exists
+    // A backup file with .bak- prefix exists with the original content.
     const tgtEntries = fs.readdirSync(tgt);
     const bak = tgtEntries.find((e) => e.startsWith("CLAUDE.md.bak-"));
     expect(bak).toBeDefined();
-
-    // Backup has the old content
     expect(fs.readFileSync(path.join(tgt, bak), "utf8")).toBe("# old content\n");
   });
 
@@ -165,13 +174,20 @@ describe("bootstrapGlobal", () => {
 
     expect(result.ok).toBe(true);
 
-    // Symlink should now point to the correct CLAUDE.md
+    // Stale legacy symlink at the target is migrated to a generated file (#228).
     const claudeMd = path.join(tgt, "CLAUDE.md");
-    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(true);
-    expect(fs.readlinkSync(claudeMd)).toBe(path.join(src, "CLAUDE.md"));
+    expect(fs.lstatSync(claudeMd).isFile()).toBe(true);
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(claudeMd, "utf8")).toContain(
+      "<!-- dotbabel:user-overlay:begin -->",
+    );
 
-    // No backup was made (stale symlinks are just replaced)
-    expect(result.backed_up).toBe(0);
+    // Per #228, the legacy symlink is BACKED UP before the file is generated
+    // (old behavior was silent replace via linkOne; new behavior preserves
+    // the symlink target as a .bak so users can recover anything they had).
+    expect(result.backed_up).toBeGreaterThan(0);
+    const baks = fs.readdirSync(tgt).filter((e) => /^CLAUDE\.md\.bak-/.test(e));
+    expect(baks.length).toBeGreaterThan(0);
   });
 
   // -------------------------------------------------------------------------
@@ -288,6 +304,148 @@ describe("bootstrapGlobal", () => {
     const result = await bootstrapGlobal({ source: nonexistent, target: tgt });
 
     expect(result.ok).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #228 — ~/.claude/CLAUDE.md is now a generated file with overlay
+  // markers, not a symlink. The next 5 tests pin that contract.
+  //
+  // Each test patches process.env.DOTBABEL_LOCAL_RULES so the bootstrap call
+  // looks at a fixture-controlled overlay path instead of the real
+  // ~/.config/dotbabel/local-rules.md.
+  // -------------------------------------------------------------------------
+
+  function withOverlayEnv(overlayPath, fn) {
+    const prev = process.env.DOTBABEL_LOCAL_RULES;
+    process.env.DOTBABEL_LOCAL_RULES = overlayPath ?? "/nonexistent-overlay-source";
+    try {
+      return fn();
+    } finally {
+      if (prev === undefined) delete process.env.DOTBABEL_LOCAL_RULES;
+      else process.env.DOTBABEL_LOCAL_RULES = prev;
+    }
+  }
+
+  it("creates ~/.claude/CLAUDE.md as a real file with user-overlay markers when no local-rules.md exists (#228)", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    await withOverlayEnv(null, () =>
+      bootstrapGlobal({ source: src, target: tgt }),
+    );
+
+    const claudeMd = path.join(tgt, "CLAUDE.md");
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(false);
+    expect(fs.lstatSync(claudeMd).isFile()).toBe(true);
+    const content = fs.readFileSync(claudeMd, "utf8");
+    expect(content).toContain("<!-- dotbabel:user-overlay:begin -->");
+    expect(content).toContain("<!-- dotbabel:user-overlay:end -->");
+    expect(content).toContain("(no user overlay)");
+    // Canonical content from the fixture's CLAUDE.md is preserved.
+    expect(content).toContain("# CLAUDE");
+  });
+
+  it("inlines local-rules.md content between the user-overlay markers when the overlay file exists (#228)", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    const overlayDir = makeTmpDir("bg-overlay-");
+    buildFakeSource(src);
+
+    const overlayPath = path.join(overlayDir, "local-rules.md");
+    fs.writeFileSync(
+      overlayPath,
+      "## My personal rules\n\n- be terse\n- be helpful\n",
+    );
+
+    await withOverlayEnv(overlayPath, () =>
+      bootstrapGlobal({ source: src, target: tgt }),
+    );
+
+    const content = fs.readFileSync(path.join(tgt, "CLAUDE.md"), "utf8");
+    expect(content).toContain("- be terse");
+    expect(content).toContain("- be helpful");
+    expect(content).toContain("## My personal rules");
+    expect(content).not.toContain("(no user overlay)");
+    // Overlay sits AFTER canonical content (top-to-bottom precedence: user trumps).
+    const canonicalIdx = content.indexOf("# CLAUDE");
+    const overlayIdx = content.indexOf("- be terse");
+    expect(overlayIdx).toBeGreaterThan(canonicalIdx);
+  });
+
+  it("migrates an existing pre-2.7.0 symlink to a generated file (no data loss) (#228)", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    // Pre-create a symlink at the target path, mirroring the legacy install state.
+    const claudeMd = path.join(tgt, "CLAUDE.md");
+    fs.symlinkSync("/some/legacy/symlink/target", claudeMd);
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(true);
+
+    const result = await withOverlayEnv(null, () =>
+      bootstrapGlobal({ source: src, target: tgt }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(fs.lstatSync(claudeMd).isSymbolicLink()).toBe(false);
+    expect(fs.lstatSync(claudeMd).isFile()).toBe(true);
+    // Backup of the original symlink should exist.
+    const entries = fs.readdirSync(tgt);
+    expect(entries.some((e) => /^CLAUDE\.md\.bak-/.test(e))).toBe(true);
+  });
+
+  it("backs up direct edits to ~/.claude/CLAUDE.md before regenerating (#228)", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    // First bootstrap to create the file.
+    await withOverlayEnv(null, () =>
+      bootstrapGlobal({ source: src, target: tgt }),
+    );
+    const claudeMd = path.join(tgt, "CLAUDE.md");
+
+    // User mucks with the file directly.
+    fs.appendFileSync(claudeMd, "\n\n# UNAUTHORIZED EDIT\n");
+    expect(fs.readFileSync(claudeMd, "utf8")).toContain("UNAUTHORIZED EDIT");
+
+    // Re-bootstrap.
+    await withOverlayEnv(null, () =>
+      bootstrapGlobal({ source: src, target: tgt }),
+    );
+
+    // The unauthorized edit is gone from the live file.
+    expect(fs.readFileSync(claudeMd, "utf8")).not.toContain("UNAUTHORIZED EDIT");
+    // And it survives in a backup.
+    const entries = fs.readdirSync(tgt);
+    const baks = entries.filter((e) => /^CLAUDE\.md\.bak-/.test(e));
+    expect(baks.length).toBeGreaterThanOrEqual(1);
+    const bakContent = fs.readFileSync(path.join(tgt, baks[0]), "utf8");
+    expect(bakContent).toContain("UNAUTHORIZED EDIT");
+  });
+
+  it("is idempotent: second bootstrap run with same overlay produces no new backups (#228)", async () => {
+    const src = makeTmpDir("bg-src-");
+    const tgt = makeTmpDir("bg-tgt-");
+    buildFakeSource(src);
+
+    await withOverlayEnv(null, () =>
+      bootstrapGlobal({ source: src, target: tgt }),
+    );
+    const baksAfterFirst = fs
+      .readdirSync(tgt)
+      .filter((e) => /^CLAUDE\.md\.bak-/.test(e)).length;
+
+    // Second run.
+    await withOverlayEnv(null, () =>
+      bootstrapGlobal({ source: src, target: tgt }),
+    );
+    const baksAfterSecond = fs
+      .readdirSync(tgt)
+      .filter((e) => /^CLAUDE\.md\.bak-/.test(e)).length;
+
+    expect(baksAfterSecond).toBe(baksAfterFirst);
   });
 });
 

--- a/plugins/dotbabel/tests/user-overlay.test.mjs
+++ b/plugins/dotbabel/tests/user-overlay.test.mjs
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterEach } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+import {
+  USER_OVERLAY_BEGIN,
+  USER_OVERLAY_END,
+  NO_OVERLAY_PLACEHOLDER,
+  composeUserScopeClaudeMd,
+  resolveLocalRulesPath,
+} from "../src/lib/user-overlay.mjs";
+
+let tmpDirs = [];
+
+function makeTmpDir(prefix = "user-overlay-test-") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs = [];
+});
+
+const CANONICAL = `# CLAUDE.md — Global Claude Code Rules
+
+> Sample canonical content.
+
+## Some heading
+
+- bullet
+- another bullet
+`;
+
+describe("composeUserScopeClaudeMd", () => {
+  it("appends overlay block with content when overlay arg is non-null", () => {
+    const overlay = "## Local rules\n\n- be terse\n- be helpful";
+    const out = composeUserScopeClaudeMd(CANONICAL, overlay);
+    // Canonical content present verbatim
+    expect(out).toContain("# CLAUDE.md — Global Claude Code Rules");
+    expect(out).toContain("Sample canonical content.");
+    // User-overlay block present with content
+    expect(out).toContain(USER_OVERLAY_BEGIN);
+    expect(out).toContain(USER_OVERLAY_END);
+    expect(out).toContain("- be terse");
+    expect(out).toContain("- be helpful");
+    // Overlay sits AFTER canonical (not before)
+    const canonicalIdx = out.indexOf("Sample canonical content.");
+    const overlayIdx = out.indexOf(USER_OVERLAY_BEGIN);
+    expect(overlayIdx).toBeGreaterThan(canonicalIdx);
+    // Placeholder must NOT appear when real content is provided
+    expect(out).not.toContain(NO_OVERLAY_PLACEHOLDER);
+  });
+
+  it('appends "(no user overlay)" placeholder when overlay arg is null', () => {
+    const out = composeUserScopeClaudeMd(CANONICAL, null);
+    expect(out).toContain(USER_OVERLAY_BEGIN);
+    expect(out).toContain(USER_OVERLAY_END);
+    expect(out).toContain(NO_OVERLAY_PLACEHOLDER);
+  });
+
+  it('appends "(no user overlay)" placeholder when overlay is empty or whitespace-only', () => {
+    const outEmpty = composeUserScopeClaudeMd(CANONICAL, "");
+    const outWhitespace = composeUserScopeClaudeMd(CANONICAL, "   \n\n  \t\n");
+    expect(outEmpty).toContain(NO_OVERLAY_PLACEHOLDER);
+    expect(outWhitespace).toContain(NO_OVERLAY_PLACEHOLDER);
+    // All three "no real overlay" states render IDENTICALLY
+    const outNull = composeUserScopeClaudeMd(CANONICAL, null);
+    expect(outEmpty).toBe(outNull);
+    expect(outWhitespace).toBe(outNull);
+  });
+
+  it("output ends with exactly one trailing newline; idempotent on re-compose", () => {
+    const overlay = "- be terse";
+    const out1 = composeUserScopeClaudeMd(CANONICAL, overlay);
+    // Exactly one trailing newline
+    expect(out1.endsWith("\n")).toBe(true);
+    expect(out1.endsWith("\n\n")).toBe(false);
+    // Idempotence: composing with the same inputs is byte-identical
+    const out2 = composeUserScopeClaudeMd(CANONICAL, overlay);
+    expect(out1).toBe(out2);
+    // Even when re-composed from a slightly-mangled overlay (extra newlines
+    // around the same content) — the trim normalization should produce the
+    // same output.
+    const out3 = composeUserScopeClaudeMd(CANONICAL, `\n\n${overlay}\n\n`);
+    expect(out3).toBe(out1);
+  });
+});
+
+describe("resolveLocalRulesPath", () => {
+  it("honors DOTBABEL_LOCAL_RULES env override", () => {
+    const env = {
+      DOTBABEL_LOCAL_RULES: "/custom/path/to/local-rules.md",
+      HOME: "/home/test",
+    };
+    expect(resolveLocalRulesPath(env)).toBe("/custom/path/to/local-rules.md");
+  });
+
+  it("honors XDG_CONFIG_HOME", () => {
+    const env = {
+      XDG_CONFIG_HOME: "/custom/xdg/config",
+      HOME: "/home/test",
+    };
+    expect(resolveLocalRulesPath(env)).toBe(
+      "/custom/xdg/config/dotbabel/local-rules.md",
+    );
+  });
+
+  it("defaults to ~/.config/dotbabel/local-rules.md when neither override is set", () => {
+    const env = { HOME: "/home/test" };
+    expect(resolveLocalRulesPath(env)).toBe(
+      "/home/test/.config/dotbabel/local-rules.md",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes [#228](https://github.com/kaiohenricunha/dotbabel/issues/228). Replace the `~/.claude/CLAUDE.md` symlink with a generated file containing the canonical rule floor + a marker-delimited overlay block populated from `~/.config/dotbabel/local-rules.md`. Users now have a safe, layered way to add personal rules at user scope without forking dotbabel's source.

- Generated file shape: `<canonical>\n\n<!-- dotbabel:user-overlay:begin -->\n<overlay or "(no user overlay)" placeholder>\n<!-- dotbabel:user-overlay:end -->\n`
- Overlay sits AFTER the canonical content — Claude Code's top-to-bottom read order means user rules trump dotbabel defaults.
- Direct edits to `~/.claude/CLAUDE.md` are backed up to `~/.claude/CLAUDE.md.bak-<ts>` before regen. `local-rules.md` is the single source of truth for the overlay; in-file edits are not honored.
- Migration from existing pre-2.7.0 symlinks is automatic on next `dotbabel bootstrap`.

## What's NOT changed

- **`bootstrap.sh`** — the lightweight shell quickstart stays symlink-based. README explicitly markets it as "TL;DR" and the npm CLI as "want more". Adding overlay logic to a pure-shell path would be significant scope creep for marginal benefit.
- **`composeInject`** in `generate-instructions.mjs` — different invariants (host-file-aware, single rule-floor block); kept separate for both modules' simplicity.
- **`sync-global.mjs`** — `sync` calls `bootstrapGlobal` internally, so the new write path applies to both `dotbabel bootstrap` AND `dotbabel sync` automatically. No separate edit needed; the existing 13 sync tests pass unchanged.

## Test plan

- [x] `npm ci` (AGENTS.md mandate)
- [x] `npm test` — 709/709 (was 697; +12 new: 7 user-overlay unit + 5 bootstrap-global integration)
- [x] `npx bats plugins/dotbabel/tests/bats/` — 451/451 (was 448; +3 new in `user-overlay.bats`)
- [x] `npm run lint` — clean
- [x] `npm run shellcheck` — exit 0
- [x] `npm run dogfood` — clean (only pre-existing iac-engineer/pulumi trigger warning)
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` / `--strict` — fresh / 0 warnings
- [x] `node scripts/build-plugin.mjs --check` — fresh
- [x] `npx vitest run plugins/dotbabel/tests/sync-global.test.mjs` — 13/13 (sync regression check, no breakage from bootstrap change)
- [x] **Phase B sandbox smoke** (real `dotbabel bootstrap` with hermetic `HOME`): all 6 steps green — file shape, drift backup, idempotence, and pre-2.7.0 symlink migration scenarios
- [x] **Phase C real-install canary** (own `~/.claude/CLAUDE.md`): pre-bootstrap doctor warned about legacy symlink → `dotbabel bootstrap` migrated → post-bootstrap doctor passed with "generated file with overlay support". Original symlink backed up.

## How users opt in (after this lands)

```bash
mkdir -p ~/.config/dotbabel
cat > ~/.config/dotbabel/local-rules.md <<'EOF'
## My personal rules

- Default to drafts when opening PRs.
- Always link the Linear ticket in the PR body.
EOF
dotbabel bootstrap
```

The merged file gets written to `~/.claude/CLAUDE.md`. Future `dotbabel bootstrap` and `dotbabel sync` runs preserve the overlay. Direct edits to the generated file are backed up before regen.

## Out of scope (intentional follow-ups)

- **Per-CLI overlays** for `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`, `~/.github/copilot-instructions.md` — same mechanism applied at three more bootstrap call sites; follow-up PR.
- **Project-scope overlay** (`<repo>/.claude/local-rules.md` for repo-specific personal context) — different problem; could be a separate issue.
- **Auto-creation of `local-rules.md`** — users opt in by creating it themselves; no near-empty placeholder shipped to every install.
- **`dotbabel doctor` overlay validation** — markdownlint pass on `local-rules.md`; low-priority polish.
- **`#188` cleanup** (remove dotclaude→dotbabel compat shims in 3.0.0) — independent; this PR doesn't touch the legacy paths.

## Release

`feat:` conventional commit triggers release-please minor bump → **2.7.0**. The migration note in the commit body gets pulled into the 2.7.0 release notes verbatim.

## Spec ID

dotbabel-core
