### PR TITLE
feat(skills): add portable /flyctl skill for fly.io ops

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,251 +1,258 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-09T15:20:05.349Z",
+  "generatedAt": "2026-05-11T00:07:32.987Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/skills/audit-and-fix/SKILL.md",
       "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "create-assessment",
       "path": ".claude/skills/create-assessment/SKILL.md",
       "checksum": "sha256:b1125255b0c62ec88157ad4476b681e1dbaff200a8e8942f3eccf49cb873dbe4",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "create-audit",
       "path": ".claude/skills/create-audit/SKILL.md",
       "checksum": "sha256:babb4a5e281388eb5dcf59f1d563b1622cfd5062a269b421e1aab0a53272695a",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/skills/detect-flaky/SKILL.md",
       "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "deploy-status",
       "path": ".claude/skills/deploy-status/SKILL.md",
       "checksum": "sha256:f9128b2d793a9878e4288b1c54cb539ac0dc2165f0ecb9cff4f85c97906fe5d4",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/skills/fix-with-evidence/SKILL.md",
       "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "git",
-      "path": ".claude/skills/git/SKILL.md",
-      "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "ground-first",
-      "path": ".claude/skills/ground-first/SKILL.md",
-      "checksum": "sha256:238437a50b202ee5e32981ea410fc8b5adb4a7ea5979630642f2678e266804a3",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "markdown",
-      "path": ".claude/commands/markdown.md",
-      "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "merge-pr",
-      "path": ".claude/commands/merge-pr.md",
-      "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "create-inspection",
       "path": ".claude/skills/create-inspection/SKILL.md",
       "checksum": "sha256:421141b2c143acb094809f6e700d8562e6dcbade940df0edd8365de7671ecfb1",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "review-pr",
-      "path": ".claude/skills/review-pr/SKILL.md",
-      "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "security-review",
-      "path": ".claude/skills/security-review/SKILL.md",
-      "checksum": "sha256:ea03f5bc029de3182ef8ec286a9f3c12b635ad4d36631c024ec2f5c990f5a176",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "spec",
-      "path": ".claude/skills/spec/SKILL.md",
-      "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "validate-spec",
-      "path": ".claude/skills/validate-spec/SKILL.md",
-      "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "kubernetes-specialist",
-      "path": ".claude/skills/kubernetes-specialist/SKILL.md",
-      "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "gcp-specialist",
-      "path": ".claude/skills/gcp-specialist/SKILL.md",
-      "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "terraform-specialist",
-      "path": ".claude/skills/terraform-specialist/SKILL.md",
-      "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "terragrunt-specialist",
-      "path": ".claude/skills/terragrunt-specialist/SKILL.md",
-      "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "pulumi-specialist",
-      "path": ".claude/skills/pulumi-specialist/SKILL.md",
-      "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "veracity-audit",
-      "path": ".claude/skills/veracity-audit/SKILL.md",
-      "checksum": "sha256:ca6a137a6d9316de931a26d8a9bf2126d8c1f5005e53a5abd2a722f745fb1080",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "handoff",
-      "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "review-prs",
-      "path": ".claude/skills/review-prs/SKILL.md",
-      "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "rollback-prod",
-      "path": ".claude/skills/rollback-prod/SKILL.md",
-      "checksum": "sha256:32a58bb0feb413e7f44148347d62283332ba259273a6c8f6d4a514876cc484dd",
-      "dependencies": ["deploy-status"],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "plan-grader",
-      "path": ".claude/skills/plan-grader/SKILL.md",
-      "checksum": "sha256:803d919381f876d5c29c28e1ab19d74a55cd54d74bb5ee6158ca10e8481af2a0",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
-    },
-    {
-      "name": "pre-pr",
-      "path": ".claude/commands/pre-pr.md",
-      "checksum": "sha256:fc1b81ff49b9ec010542172ce5dab42350b974bff08ab86c805fac5bedc78a1a",
-      "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "create-experiment",
       "path": ".claude/skills/create-experiment/SKILL.md",
       "checksum": "sha256:0f304358b5ad1605e83c2cb60b37f166491088a74f7a274dbf61137c14e9b86f",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "flyctl",
+      "path": ".claude/skills/flyctl/SKILL.md",
+      "checksum": "sha256:40de8f58d66bfb8b3ff5f8ca843f3f349c7ae4c67eeefbc52e13b0d704c30979",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "git",
+      "path": ".claude/skills/git/SKILL.md",
+      "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "ground-first",
+      "path": ".claude/skills/ground-first/SKILL.md",
+      "checksum": "sha256:238437a50b202ee5e32981ea410fc8b5adb4a7ea5979630642f2678e266804a3",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "markdown",
+      "path": ".claude/commands/markdown.md",
+      "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "merge-pr",
+      "path": ".claude/commands/merge-pr.md",
+      "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "review-pr",
+      "path": ".claude/skills/review-pr/SKILL.md",
+      "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "security-review",
+      "path": ".claude/skills/security-review/SKILL.md",
+      "checksum": "sha256:ea03f5bc029de3182ef8ec286a9f3c12b635ad4d36631c024ec2f5c990f5a176",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "spec",
+      "path": ".claude/skills/spec/SKILL.md",
+      "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "validate-spec",
+      "path": ".claude/skills/validate-spec/SKILL.md",
+      "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "kubernetes-specialist",
+      "path": ".claude/skills/kubernetes-specialist/SKILL.md",
+      "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "gcp-specialist",
+      "path": ".claude/skills/gcp-specialist/SKILL.md",
+      "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "terraform-specialist",
+      "path": ".claude/skills/terraform-specialist/SKILL.md",
+      "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "terragrunt-specialist",
+      "path": ".claude/skills/terragrunt-specialist/SKILL.md",
+      "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "pulumi-specialist",
+      "path": ".claude/skills/pulumi-specialist/SKILL.md",
+      "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "veracity-audit",
+      "path": ".claude/skills/veracity-audit/SKILL.md",
+      "checksum": "sha256:ca6a137a6d9316de931a26d8a9bf2126d8c1f5005e53a5abd2a722f745fb1080",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "handoff",
+      "path": ".claude/skills/handoff/SKILL.md",
+      "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "review-prs",
+      "path": ".claude/skills/review-prs/SKILL.md",
+      "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "rollback-prod",
+      "path": ".claude/skills/rollback-prod/SKILL.md",
+      "checksum": "sha256:32a58bb0feb413e7f44148347d62283332ba259273a6c8f6d4a514876cc484dd",
+      "dependencies": ["deploy-status"],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "plan-grader",
+      "path": ".claude/skills/plan-grader/SKILL.md",
+      "checksum": "sha256:803d919381f876d5c29c28e1ab19d74a55cd54d74bb5ee6158ca10e8481af2a0",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
+    },
+    {
+      "name": "pre-pr",
+      "path": ".claude/commands/pre-pr.md",
+      "checksum": "sha256:fc1b81ff49b9ec010542172ce5dab42350b974bff08ab86c805fac5bedc78a1a",
+      "dependencies": [],
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "post-pr-review",
       "path": ".claude/skills/post-pr-review/SKILL.md",
       "checksum": "sha256:0565fc80dba6872c5da9569cff5e53d112fc3ea3a16b4905fdf38255754ec628",
       "dependencies": ["review-pr"],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     },
     {
       "name": "project-sync",
       "path": ".claude/skills/project-sync/SKILL.md",
       "checksum": "sha256:822e1509cf0ed4d0260c8bada35cd0e815a9b6529d637eb9baf3a430f8803104",
       "dependencies": [],
-      "lastValidated": "2026-05-09"
+      "lastValidated": "2026-05-11"
     }
   ]
 }

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-11T00:07:32.987Z",
+  "generatedAt": "2026-05-11T10:58:24.002Z",
   "skills": [
     {
       "name": "audit-and-fix",
@@ -103,7 +103,7 @@
     {
       "name": "flyctl",
       "path": ".claude/skills/flyctl/SKILL.md",
-      "checksum": "sha256:40de8f58d66bfb8b3ff5f8ca843f3f349c7ae4c67eeefbc52e13b0d704c30979",
+      "checksum": "sha256:360f2cd7b13c0ac53988ee7de4eb99704860a331c3f9c0b73b4837e05a0fa453",
       "dependencies": [],
       "lastValidated": "2026-05-11"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -103,7 +103,7 @@
     {
       "name": "flyctl",
       "path": ".claude/skills/flyctl/SKILL.md",
-      "checksum": "sha256:360f2cd7b13c0ac53988ee7de4eb99704860a331c3f9c0b73b4837e05a0fa453",
+      "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
       "dependencies": [],
       "lastValidated": "2026-05-11"
     },

--- a/.codex/skills/flyctl
+++ b/.codex/skills/flyctl
@@ -1,0 +1,1 @@
+../../.claude/skills/flyctl

--- a/.gemini/skills/flyctl
+++ b/.gemini/skills/flyctl
@@ -1,0 +1,1 @@
+../../.claude/skills/flyctl

--- a/.github/instructions/flyctl.instructions.md
+++ b/.github/instructions/flyctl.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/flyctl/SKILL.md

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotbabel.dev/schemas/index.schema.json",
-  "generatedAt": "2026-05-10T01:16:26.278Z",
+  "generatedAt": "2026-05-11T00:00:54.573Z",
   "version": "2.7.0",
   "artifacts": [
     {
@@ -405,6 +405,21 @@
         "platform": ["none"],
         "task": ["debugging", "testing"],
         "maturity": "validated"
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
+    },
+    {
+      "id": "flyctl",
+      "type": "skill",
+      "path": "skills/flyctl/SKILL.md",
+      "name": "flyctl",
+      "description": "Explicit-invocation Fly.io operations wrapper. Run `/flyctl <subcommand>` to deploy (with --image), tail logs, manage secrets, inspect machines, scale, SSH, proxy, check health, list releases, and show status. Auto-discovers the app from fly.toml in the current directory. Side-effectful ops on prod-flavored apps require typed confirmation matching the app name. Rollback is delegated to /rollback-prod; cross-provider SHA reporting is delegated to /deploy-status. For any subcommand not enumerated in references/, run `flyctl <subcommand> --help` for canonical reference.\n",
+      "facets": {
+        "domain": ["infra", "devex", "observability"],
+        "platform": ["flyio"],
+        "task": ["runtime-ops", "diagnostics", "incident-response"],
+        "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha"

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotbabel.dev/schemas/index.schema.json",
-  "generatedAt": "2026-05-11T00:00:54.573Z",
+  "generatedAt": "2026-05-11T10:57:41.362Z",
   "version": "2.7.0",
   "artifacts": [
     {
@@ -414,7 +414,7 @@
       "type": "skill",
       "path": "skills/flyctl/SKILL.md",
       "name": "flyctl",
-      "description": "Explicit-invocation Fly.io operations wrapper. Run `/flyctl <subcommand>` to deploy (with --image), tail logs, manage secrets, inspect machines, scale, SSH, proxy, check health, list releases, and show status. Auto-discovers the app from fly.toml in the current directory. Side-effectful ops on prod-flavored apps require typed confirmation matching the app name. Rollback is delegated to /rollback-prod; cross-provider SHA reporting is delegated to /deploy-status. For any subcommand not enumerated in references/, run `flyctl <subcommand> --help` for canonical reference.\n",
+      "description": "Explicit-invocation Fly.io operations wrapper. Run `/flyctl <subcommand>` to deploy (with --image), tail logs, manage secrets, inspect machines, scale, SSH, proxy, check health, list releases, and show status. Auto-discovers the app from fly.toml in the current directory. Side-effectful ops on prod-flavored apps require typed confirmation matching the app name. Rollback is delegated to /rollback-prod; cross-provider SHA reporting is delegated to /deploy-status. Unlisted subcommands require `flyctl <subcommand> --help` first.\n",
       "facets": {
         "domain": ["infra", "devex", "observability"],
         "platform": ["flyio"],

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -17,6 +17,7 @@
       "devops-engineer",
       "documentation-writer",
       "fix-with-evidence",
+      "flyctl",
       "git",
       "ground-first",
       "handoff",
@@ -47,6 +48,7 @@
       "deploy-status",
       "deployment-engineer",
       "docker-engineer",
+      "flyctl",
       "gcp-engineer",
       "gcp-specialist",
       "iac-engineer",
@@ -71,6 +73,7 @@
       "security-review"
     ],
     "data": ["data-scientist"],
+    "observability": ["flyctl"],
     "frontend": ["frontend-developer", "test-engineer"]
   },
   "platform": {
@@ -128,7 +131,7 @@
       "review-prs"
     ],
     "vercel": ["deploy-status", "rollback-prod"],
-    "flyio": ["deploy-status", "rollback-prod"],
+    "flyio": ["deploy-status", "flyctl", "rollback-prod"],
     "gcp": ["gcp-engineer", "gcp-specialist"],
     "terraform": [
       "iac-engineer",
@@ -240,6 +243,7 @@
       "compliance-auditor",
       "data-scientist",
       "deploy-status",
+      "flyctl",
       "kubernetes-specialist",
       "security-auditor"
     ],
@@ -247,6 +251,7 @@
       "deploy-status",
       "deployment-engineer",
       "docker-engineer",
+      "flyctl",
       "kubernetes-specialist"
     ],
     "testing": [
@@ -258,7 +263,7 @@
       "validate-spec",
       "veracity-audit"
     ],
-    "incident-response": ["rollback-prod"]
+    "incident-response": ["flyctl", "rollback-prod"]
   },
   "maturity": {
     "validated": [
@@ -304,6 +309,7 @@
       "devops-engineer",
       "docker-engineer",
       "documentation-writer",
+      "flyctl",
       "frontend-developer",
       "gcp-engineer",
       "handoff",

--- a/index/by-type.json
+++ b/index/by-type.json
@@ -38,6 +38,7 @@
     "deploy-status",
     "detect-flaky",
     "fix-with-evidence",
+    "flyctl",
     "gcp-specialist",
     "git",
     "ground-first",

--- a/plugins/dotbabel/templates/claude/skills-manifest.json
+++ b/plugins/dotbabel/templates/claude/skills-manifest.json
@@ -101,6 +101,13 @@
       "lastValidated": null
     },
     {
+      "name": "flyctl",
+      "path": ".claude/skills/flyctl/SKILL.md",
+      "checksum": "",
+      "dependencies": [],
+      "lastValidated": null
+    },
+    {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "",

--- a/plugins/dotbabel/templates/claude/skills/deploy-status/references/fly.md
+++ b/plugins/dotbabel/templates/claude/skills/deploy-status/references/fly.md
@@ -38,3 +38,8 @@ target reports `unknown SHA` and exits `2` instead of guessing.
 - CLI not installed or not authenticated: target error, status exit `2`.
 - No successful releases: target error, status exit `2`.
 - Release metadata has no git SHA: target error, status exit `2`.
+
+## See also
+
+- `/flyctl` — fly-specific deploy, logs, secrets, scale, and machine ops outside the read-only status flow.
+- `/rollback-prod` — confirmation-gated rollback to the previous release.

--- a/plugins/dotbabel/templates/claude/skills/flyctl/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/SKILL.md
@@ -1,0 +1,192 @@
+---
+id: flyctl
+name: flyctl
+type: skill
+version: 1.0.0
+domain: [infra, devex, observability]
+platform: [flyio]
+task: [runtime-ops, diagnostics, incident-response]
+maturity: draft
+description: >
+  Explicit-invocation Fly.io operations wrapper. Run `/flyctl <subcommand>` to
+  deploy (with --image), tail logs, manage secrets, inspect machines, scale,
+  SSH, proxy, check health, list releases, and show status. Auto-discovers
+  the app from fly.toml in the current directory. Side-effectful ops on
+  prod-flavored apps require typed confirmation matching the app name.
+  Rollback is delegated to /rollback-prod; cross-provider SHA reporting is
+  delegated to /deploy-status. For any subcommand not enumerated in
+  references/, run `flyctl <subcommand> --help` for canonical reference.
+argument-hint: "<subcommand> [-a <app>] [--no-confirm] [...]"
+tools: Bash, Read, Grep, Glob
+model: sonnet
+effort: medium
+disable-model-invocation: true
+user-invocable: true
+---
+
+# flyctl
+
+Portable Fly.io operations wrapper. Invoke as `/flyctl <subcommand>`.
+
+## When to Use
+
+This skill is **explicit-invocation only** (`disable-model-invocation: true`). The
+model will not auto-route phrases like "tail fly logs" or "fly deploy" to this
+skill — the operator must type `/flyctl <subcommand>` directly. This is the
+safe contract for a side-effectful skill (deploy, secrets-set, scale, machines
+destroy).
+
+Use `/flyctl` when you have an existing Fly.io app (its `fly.toml` is in the
+current directory) and you want to perform any of the operations enumerated in
+the Subcommands table below. The skill auto-discovers the app from `fly.toml`;
+all subcommands accept `-a <app>` to override.
+
+## Out of Scope
+
+This skill does **not** perform rollback or cross-provider release reporting.
+
+- For rollback to the previous release, use `/rollback-prod`.
+- For deployed git-SHA reporting across Vercel/Fly/AWS, use `/deploy-status`.
+- For app provisioning (`fly launch`, region setup), use the Fly UI or your IaC layer.
+- For any subcommand not enumerated above, run `flyctl <subcommand> --help` for
+  canonical reference. Read-only verbs (list, show, status, info, history,
+  version) may proceed without confirmation; mutating verbs (create, destroy,
+  delete, scale, restart, update, set, unset, deploy, suspend, resume,
+  regions add/remove, and any verb whose `--help` text mentions "destructive",
+  "irreversible", or "will redeploy") MUST be presented to the operator with
+  the exact command and require explicit y/N approval before executing.
+
+## Auto-Discovery
+
+Every subcommand begins by resolving the CLI binary and the target app. The
+operator may override the app with `-a <app>`; otherwise the skill reads the
+root `fly.toml` in the current working directory. Multi-app monorepos require
+the operator to `cd` into the per-app directory first — this skill refuses to
+guess across nested `fly.toml` files.
+
+```bash
+# CLI: prefer flyctl, fall back to fly
+FLY="$(command -v flyctl || command -v fly)" \
+  || { echo "flyctl/fly not on PATH; see https://fly.io/docs/flyctl/install/" >&2; exit 2; }
+
+# App: -a flag wins; otherwise parse root fly.toml only.
+# Mirrors parseFlyApp() in deploy-ops.mjs — supports leading whitespace
+# around the key, optional whitespace around '=', and BOTH double- and
+# single-quoted values.
+APP="${ARG_APP:-}"
+if [ -z "$APP" ]; then
+  if [ ! -f fly.toml ]; then
+    echo "no fly.toml in $(pwd); pass -a <app> or cd into the app directory" >&2
+    exit 2
+  fi
+  # Try double-quoted form first, then single-quoted as fallback.
+  APP="$(awk -F'"' '/^[[:space:]]*app[[:space:]]*=[[:space:]]*"/{print $2; exit}' fly.toml)"
+  if [ -z "$APP" ]; then
+    APP="$(awk -F"'" '/^[[:space:]]*app[[:space:]]*=[[:space:]]*'"'"'/{print $2; exit}' fly.toml)"
+  fi
+fi
+[ -z "$APP" ] && { echo "could not resolve app name from fly.toml; pass -a <app>" >&2; exit 2; }
+
+# Auth: existing CLI session only — never prompt
+"$FLY" auth whoami >/dev/null 2>&1 \
+  || { echo "not authenticated; run: $FLY auth login" >&2; exit 2; }
+```
+
+## Subcommands
+
+| Sub                                      | Args                                     | Invocation                                                                                                                          | Confirm?                        | Reference                               |
+| ---------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------------------- |
+| `status`                                 | `[-a $APP]`                              | `flyctl status -a $APP`                                                                                                             | no                              | –                                       |
+| `logs`                                   | `[-a $APP] [-i ID] [--region R]`         | `flyctl logs -a $APP $EXTRA`                                                                                                        | no                              | [`logs.md`](references/logs.md)         |
+| `releases`                               | `[-a $APP] [--image]`                    | `flyctl releases -a $APP --json`                                                                                                    | no                              | [`releases.md`](references/releases.md) |
+| `deploy`                                 | `[-a $APP] [--image REF] [--strategy S]` | `flyctl deploy -a $APP --image $REF`                                                                                                | **YES if prod**                 | [`deploy.md`](references/deploy.md)     |
+| `secrets list`                           | `[-a $APP]`                              | `flyctl secrets list -a $APP`                                                                                                       | no                              | [`secrets.md`](references/secrets.md)   |
+| `secrets set`                            | `[-a $APP] [--stage] K=V...`             | `flyctl secrets set -a $APP $KV`                                                                                                    | **YES if prod**                 | [`secrets.md`](references/secrets.md)   |
+| `secrets unset`                          | `[-a $APP] K...`                         | `flyctl secrets unset -a $APP $K`                                                                                                   | **YES if prod**                 | [`secrets.md`](references/secrets.md)   |
+| `machines list`                          | `[-a $APP]`                              | `flyctl machines list -a $APP --json`                                                                                               | no                              | [`machines.md`](references/machines.md) |
+| `machines restart\|stop\|start\|destroy` | `<id> [-a $APP]`                         | `flyctl machines <op> $ID -a $APP`                                                                                                  | **YES if stop/destroy on prod** | [`machines.md`](references/machines.md) |
+| `scale show`                             | `[-a $APP]`                              | `flyctl scale show -a $APP`                                                                                                         | no                              | [`scale.md`](references/scale.md)       |
+| `scale count <n>`                        | `[-a $APP]`                              | `flyctl scale count $N -a $APP`                                                                                                     | **YES if prod or n=0**          | [`scale.md`](references/scale.md)       |
+| `scale vm <preset>`                      | `[-a $APP] [--memory MB]`                | `flyctl scale vm $P -a $APP`                                                                                                        | **YES if prod**                 | [`scale.md`](references/scale.md)       |
+| `ssh`                                    | `[console\|sftp] [-a $APP] [-s ID]`      | `flyctl ssh $SUB -a $APP`                                                                                                           | no                              | [`ssh.md`](references/ssh.md)           |
+| `proxy`                                  | `<local:remote> [-a $APP]`               | `flyctl proxy $P -a $APP`                                                                                                           | no                              | [`proxy.md`](references/proxy.md)       |
+| `health`                                 | `[-a $APP] [--path P]`                   | discover endpoints from `fly.toml`, proxy + curl                                                                                    | no                              | [`health.md`](references/health.md)     |
+| _any other_                              | –                                        | run `flyctl <cmd> --help`, classify the verb, **stop and prompt for explicit operator approval before executing any mutating verb** | per-op                          | –                                       |
+
+## Confirmation Contract
+
+Destructive ops on prod-flavored apps require the operator to type the exact app
+name. The heuristic for "prod-flavored" is: app name does NOT match
+`*-staging*`, `*-preview*`, `*-pr-*`, `*-dev*`, or `*-test*`.
+
+```bash
+# no_confirm_flag MUST be derived ONLY from an explicitly parsed --no-confirm
+# flag in $@. The skill never reads any environment variable (e.g. NO_CONFIRM)
+# as a bypass — operator intent must be on the command line for each invocation.
+confirm_if_prod() {
+  local app="$1" op="$2" no_confirm_flag="$3"
+  [ "$no_confirm_flag" = "1" ] && return 0
+  case "$app" in
+    *-staging*|*-preview*|*-pr-*|*-dev*|*-test*) return 0 ;;
+  esac
+  printf 'About to run %s on PROD app %s.\nType the app name to confirm: ' "$op" "$app" >&2
+  read -r reply
+  [ "$reply" = "$app" ] || { echo "confirmation failed" >&2; exit 1; }
+}
+
+# Argument-parsing stub the skill MUST follow before calling confirm_if_prod:
+no_confirm_flag=0
+parsed=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-confirm) no_confirm_flag=1 ;;
+    *) parsed+=("$arg") ;;
+  esac
+done
+set -- "${parsed[@]}"
+```
+
+Lighter than `/rollback-prod`'s `ROLLBACK PROD` literal because deploy/scale are
+less catastrophic than rollback; typing the app name is harder to muscle-memory
+than a fixed string and is context-aware. Confirmation bypass derives from the
+parsed CLI flag only — env vars cannot grant it.
+
+## Rules
+
+- Auto-discover `app` from root `fly.toml`; never hardcode names, regions, VM presets, or secret names.
+- Resolve CLI as `flyctl` first, `fly` second; never re-install.
+- Use existing CLI auth (`flyctl auth whoami`); never prompt for tokens.
+- Destructive ops on prod-flavored apps require typed confirmation matching the app name.
+- `--no-confirm` is honored only when passed explicitly; never via env or autonomous routing.
+- Print the exact `flyctl ...` command before executing (audit trail).
+- Preserve flyctl native exit codes; remap only discovery/auth failures to `2`.
+- Multi-app monorepos: refuse to guess — operator must `cd` into the app dir or pass `-a <app>`.
+- Never echo secret values to chat — only names.
+- For unlisted subcommands: run `flyctl <subcommand> --help` first, classify mutability from the verb and the help text, and **require explicit operator y/N approval before executing any mutating op**. Read-only verbs (`list`, `show`, `status`, `info`, `history`, `version`) may run without prompting.
+
+## Failure Modes
+
+| Condition                                | Exit | Behavior                                                                      |
+| ---------------------------------------- | ---- | ----------------------------------------------------------------------------- |
+| Success                                  | `0`  | preserve flyctl exit                                                          |
+| Confirmation declined / flyctl exit 1    | `1`  | preserve                                                                      |
+| No `fly.toml` in cwd and no `-a`         | `2`  | print: "no fly.toml in `<pwd>`; pass -a `<app>` or cd into the app directory" |
+| `flyctl`/`fly` not on PATH               | `2`  | print install URL                                                             |
+| `auth whoami` fails                      | `2`  | print `flyctl auth login`                                                     |
+| `fly.toml` exists but `app` line missing | `2`  | print: "could not resolve app name from fly.toml; pass -a `<app>`"            |
+| Invalid `--image` ref (pre-flight regex) | `2`  | print expected format                                                         |
+
+## Optional Config
+
+This file is **not consumed by v1.0.0** — it documents the v1.1 config surface
+so contributors can preview it. Operators whose prod apps don't match
+`*-staging*` / `*-preview*` / `*-pr-*` / `*-dev*` / `*-test*` will get
+typed-confirmation prompts on every mutating op until v1.1 wires `confirm_never`
+to override the heuristic; pass `--no-confirm` per-invocation until then.
+
+See [`examples/fly-targets.example.json`](examples/fly-targets.example.json).
+
+## See also
+
+- [`/deploy-status`](../deploy-status/SKILL.md) — read-only SHA / release status across all configured deploy targets (use this when you want a snapshot, not an action).
+- [`/rollback-prod`](../rollback-prod/SKILL.md) — confirmation-gated rollback across all targets (use this for incident response; `/flyctl` is for non-incident, fly-only ops).

--- a/plugins/dotbabel/templates/claude/skills/flyctl/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/SKILL.md
@@ -14,8 +14,8 @@ description: >
   the app from fly.toml in the current directory. Side-effectful ops on
   prod-flavored apps require typed confirmation matching the app name.
   Rollback is delegated to /rollback-prod; cross-provider SHA reporting is
-  delegated to /deploy-status. For any subcommand not enumerated in
-  references/, run `flyctl <subcommand> --help` for canonical reference.
+  delegated to /deploy-status. Unlisted subcommands require
+  `flyctl <subcommand> --help` first.
 argument-hint: "<subcommand> [-a <app>] [--no-confirm] [...]"
 tools: Bash, Read, Grep, Glob
 model: sonnet
@@ -30,16 +30,13 @@ Portable Fly.io operations wrapper. Invoke as `/flyctl <subcommand>`.
 
 ## When to Use
 
-This skill is **explicit-invocation only** (`disable-model-invocation: true`). The
-model will not auto-route phrases like "tail fly logs" or "fly deploy" to this
-skill — the operator must type `/flyctl <subcommand>` directly. This is the
-safe contract for a side-effectful skill (deploy, secrets-set, scale, machines
-destroy).
+This skill is **explicit-invocation only** (`disable-model-invocation: true`).
+The operator must type `/flyctl <subcommand>` directly; the model must not
+auto-route phrases like "tail fly logs" or "fly deploy" to this side-effectful
+skill.
 
-Use `/flyctl` when you have an existing Fly.io app (its `fly.toml` is in the
-current directory) and you want to perform any of the operations enumerated in
-the Subcommands table below. The skill auto-discovers the app from `fly.toml`;
-all subcommands accept `-a <app>` to override.
+Use `/flyctl` from a Fly.io app directory containing `fly.toml`, or pass
+`-a <app>` to override auto-discovery.
 
 ## Out of Scope
 
@@ -48,13 +45,14 @@ This skill does **not** perform rollback or cross-provider release reporting.
 - For rollback to the previous release, use `/rollback-prod`.
 - For deployed git-SHA reporting across Vercel/Fly/AWS, use `/deploy-status`.
 - For app provisioning (`fly launch`, region setup), use the Fly UI or your IaC layer.
-- For any subcommand not enumerated above, run `flyctl <subcommand> --help` for
-  canonical reference. Read-only verbs (list, show, status, info, history,
-  version) may proceed without confirmation; mutating verbs (create, destroy,
-  delete, scale, restart, update, set, unset, deploy, suspend, resume,
-  regions add/remove, and any verb whose `--help` text mentions "destructive",
-  "irreversible", or "will redeploy") MUST be presented to the operator with
-  the exact command and require explicit y/N approval before executing.
+- For any subcommand not listed in the table or reference files, run
+  `flyctl <subcommand> --help` for canonical reference. Read-only verbs (list,
+  show, status, info, history, version) may proceed without confirmation;
+  mutating verbs (create, destroy, delete, scale, restart, update, set, unset,
+  deploy, suspend, resume, regions add/remove, and any verb whose `--help` text
+  mentions "destructive", "irreversible", or "will redeploy") MUST be presented
+  to the operator with the exact command and require explicit y/N approval before
+  executing.
 
 ## Auto-Discovery
 
@@ -66,8 +64,11 @@ guess across nested `fly.toml` files.
 
 ```bash
 # CLI: prefer flyctl, fall back to fly
-FLY="$(command -v flyctl || command -v fly)" \
-  || { echo "flyctl/fly not on PATH; see https://fly.io/docs/flyctl/install/" >&2; exit 2; }
+FLY="$(command -v flyctl || command -v fly || true)"
+if [ -z "$FLY" ]; then
+  echo "flyctl/fly not on PATH; see https://fly.io/docs/flyctl/install/" >&2
+  exit 2
+fi
 
 # App: -a flag wins; otherwise parse root fly.toml only.
 # Mirrors parseFlyApp() in deploy-ops.mjs — supports leading whitespace
@@ -79,11 +80,7 @@ if [ -z "$APP" ]; then
     echo "no fly.toml in $(pwd); pass -a <app> or cd into the app directory" >&2
     exit 2
   fi
-  # Try double-quoted form first, then single-quoted as fallback.
-  APP="$(awk -F'"' '/^[[:space:]]*app[[:space:]]*=[[:space:]]*"/{print $2; exit}' fly.toml)"
-  if [ -z "$APP" ]; then
-    APP="$(awk -F"'" '/^[[:space:]]*app[[:space:]]*=[[:space:]]*'"'"'/{print $2; exit}' fly.toml)"
-  fi
+  APP="$(sed -nE "s/^[[:space:]]*app[[:space:]]*=[[:space:]]*['\"]([^'\"]+)['\"].*/\1/p" fly.toml | head -n 1)"
 fi
 [ -z "$APP" ] && { echo "could not resolve app name from fly.toml; pass -a <app>" >&2; exit 2; }
 

--- a/plugins/dotbabel/templates/claude/skills/flyctl/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/SKILL.md
@@ -91,30 +91,42 @@ fi
 
 ## Subcommands
 
-| Sub                                      | Args                                     | Invocation                                                                                                                          | Confirm?                        | Reference                               |
-| ---------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------------------- |
-| `status`                                 | `[-a $APP]`                              | `flyctl status -a $APP`                                                                                                             | no                              | –                                       |
-| `logs`                                   | `[-a $APP] [-i ID] [--region R]`         | `flyctl logs -a $APP $EXTRA`                                                                                                        | no                              | [`logs.md`](references/logs.md)         |
-| `releases`                               | `[-a $APP] [--image]`                    | `flyctl releases -a $APP --json`                                                                                                    | no                              | [`releases.md`](references/releases.md) |
-| `deploy`                                 | `[-a $APP] [--image REF] [--strategy S]` | `flyctl deploy -a $APP --image $REF`                                                                                                | **YES if prod**                 | [`deploy.md`](references/deploy.md)     |
-| `secrets list`                           | `[-a $APP]`                              | `flyctl secrets list -a $APP`                                                                                                       | no                              | [`secrets.md`](references/secrets.md)   |
-| `secrets set`                            | `[-a $APP] [--stage] K=V...`             | `flyctl secrets set -a $APP $KV`                                                                                                    | **YES if prod**                 | [`secrets.md`](references/secrets.md)   |
-| `secrets unset`                          | `[-a $APP] K...`                         | `flyctl secrets unset -a $APP $K`                                                                                                   | **YES if prod**                 | [`secrets.md`](references/secrets.md)   |
-| `machines list`                          | `[-a $APP]`                              | `flyctl machines list -a $APP --json`                                                                                               | no                              | [`machines.md`](references/machines.md) |
-| `machines restart\|stop\|start\|destroy` | `<id> [-a $APP]`                         | `flyctl machines <op> $ID -a $APP`                                                                                                  | **YES if stop/destroy on prod** | [`machines.md`](references/machines.md) |
-| `scale show`                             | `[-a $APP]`                              | `flyctl scale show -a $APP`                                                                                                         | no                              | [`scale.md`](references/scale.md)       |
-| `scale count <n>`                        | `[-a $APP]`                              | `flyctl scale count $N -a $APP`                                                                                                     | **YES if prod or n=0**          | [`scale.md`](references/scale.md)       |
-| `scale vm <preset>`                      | `[-a $APP] [--memory MB]`                | `flyctl scale vm $P -a $APP`                                                                                                        | **YES if prod**                 | [`scale.md`](references/scale.md)       |
-| `ssh`                                    | `[console\|sftp] [-a $APP] [-s ID]`      | `flyctl ssh $SUB -a $APP`                                                                                                           | no                              | [`ssh.md`](references/ssh.md)           |
-| `proxy`                                  | `<local:remote> [-a $APP]`               | `flyctl proxy $P -a $APP`                                                                                                           | no                              | [`proxy.md`](references/proxy.md)       |
-| `health`                                 | `[-a $APP] [--path P]`                   | discover endpoints from `fly.toml`, proxy + curl                                                                                    | no                              | [`health.md`](references/health.md)     |
-| _any other_                              | –                                        | run `flyctl <cmd> --help`, classify the verb, **stop and prompt for explicit operator approval before executing any mutating verb** | per-op                          | –                                       |
+| Sub                     | Args                                     | Invocation                                                                                                                          | Confirm?               | Reference                               |
+| ----------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | --------------------------------------- |
+| `status`                | `[-a $APP]`                              | `flyctl status -a $APP`                                                                                                             | no                     | –                                       |
+| `logs`                  | `[-a $APP] [-i ID] [--region R]`         | `flyctl logs -a $APP $EXTRA`                                                                                                        | no                     | [`logs.md`](references/logs.md)         |
+| `releases`              | `[-a $APP] [--image]`                    | `flyctl releases -a $APP --json`                                                                                                    | no                     | [`releases.md`](references/releases.md) |
+| `deploy`                | `[-a $APP] [--image REF] [--strategy S]` | `flyctl deploy -a $APP --image $REF`                                                                                                | **YES if prod**        | [`deploy.md`](references/deploy.md)     |
+| `secrets list`          | `[-a $APP]`                              | `flyctl secrets list -a $APP`                                                                                                       | no                     | [`secrets.md`](references/secrets.md)   |
+| `secrets set`           | `[-a $APP] [--stage] K=V...`             | `flyctl secrets set -a $APP $KV`                                                                                                    | **YES if prod**        | [`secrets.md`](references/secrets.md)   |
+| `secrets unset`         | `[-a $APP] K...`                         | `flyctl secrets unset -a $APP $K`                                                                                                   | **YES if prod**        | [`secrets.md`](references/secrets.md)   |
+| `machines list`         | `[-a $APP]`                              | `flyctl machines list -a $APP --json`                                                                                               | no                     | [`machines.md`](references/machines.md) |
+| `machines restart <id>` | `[-a $APP]`                              | `flyctl machines restart $ID -a $APP`                                                                                               | no                     | [`machines.md`](references/machines.md) |
+| `machines stop <id>`    | `[-a $APP]`                              | `flyctl machines stop $ID -a $APP`                                                                                                  | **YES if prod**        | [`machines.md`](references/machines.md) |
+| `machines start <id>`   | `[-a $APP]`                              | `flyctl machines start $ID -a $APP`                                                                                                 | no                     | [`machines.md`](references/machines.md) |
+| `machines destroy <id>` | `[-a $APP]`                              | `flyctl machines destroy $ID --force -a $APP`                                                                                       | **YES if prod**        | [`machines.md`](references/machines.md) |
+| `scale show`            | `[-a $APP]`                              | `flyctl scale show -a $APP`                                                                                                         | no                     | [`scale.md`](references/scale.md)       |
+| `scale count <n>`       | `[-a $APP]`                              | `flyctl scale count $N -a $APP`                                                                                                     | **YES if prod or n=0** | [`scale.md`](references/scale.md)       |
+| `scale vm <preset>`     | `[-a $APP] [--memory MB]`                | `flyctl scale vm $P -a $APP`                                                                                                        | **YES if prod**        | [`scale.md`](references/scale.md)       |
+| `scale memory <mb>`     | `[-a $APP]`                              | `flyctl scale memory $MB -a $APP`                                                                                                   | **YES if prod**        | [`scale.md`](references/scale.md)       |
+| `ssh console`           | `[-a $APP] [-s ID]`                      | `flyctl ssh console -a $APP`                                                                                                        | no (interactive)       | [`ssh.md`](references/ssh.md)           |
+| `ssh console -C <cmd>`  | `[-a $APP] [-s ID]`                      | `flyctl ssh console -C "$CMD" -a $APP`                                                                                              | **YES if prod**        | [`ssh.md`](references/ssh.md)           |
+| `ssh sftp`              | `[-a $APP]`                              | `flyctl ssh sftp shell -a $APP`                                                                                                     | no                     | [`ssh.md`](references/ssh.md)           |
+| `proxy`                 | `<local:remote> [-a $APP]`               | `flyctl proxy $P -a $APP`                                                                                                           | no                     | [`proxy.md`](references/proxy.md)       |
+| `health`                | `[-a $APP] [--path P]`                   | discover endpoints from `fly.toml`, proxy + curl                                                                                    | no                     | [`health.md`](references/health.md)     |
+| _any other_             | –                                        | run `flyctl <cmd> --help`, classify the verb, **stop and prompt for explicit operator approval before executing any mutating verb** | per-op                 | –                                       |
 
 ## Confirmation Contract
 
 Destructive ops on prod-flavored apps require the operator to type the exact app
 name. The heuristic for "prod-flavored" is: app name does NOT match
 `*-staging*`, `*-preview*`, `*-pr-*`, `*-dev*`, or `*-test*`.
+
+> **Heuristic is best-effort.** App names that _contain_ these substrings but
+> are nonetheless prod (e.g. `my-developer-portal`, `payments-test-of-record`)
+> will silently skip the confirmation gate. Until v1.1 ships `confirm_always`
+> config, use `--no-confirm` deliberately for known non-prod apps with unusual
+> names, and add a comment in your runbook for prod apps that would false-match.
 
 ```bash
 # no_confirm_flag MUST be derived ONLY from an explicitly parsed --no-confirm
@@ -127,7 +139,7 @@ confirm_if_prod() {
     *-staging*|*-preview*|*-pr-*|*-dev*|*-test*) return 0 ;;
   esac
   printf 'About to run %s on PROD app %s.\nType the app name to confirm: ' "$op" "$app" >&2
-  read -r reply
+  read -r reply < /dev/tty || { echo "no interactive TTY; pass --no-confirm explicitly or run interactively" >&2; exit 2; }
   [ "$reply" = "$app" ] || { echo "confirmation failed" >&2; exit 1; }
 }
 
@@ -154,8 +166,8 @@ parsed CLI flag only — env vars cannot grant it.
 - Resolve CLI as `flyctl` first, `fly` second; never re-install.
 - Use existing CLI auth (`flyctl auth whoami`); never prompt for tokens.
 - Destructive ops on prod-flavored apps require typed confirmation matching the app name.
-- `--no-confirm` is honored only when passed explicitly; never via env or autonomous routing.
-- Print the exact `flyctl ...` command before executing (audit trail).
+- `--no-confirm` is honored only when passed explicitly as a deliberate operator flag; never via env, templates, or instructions that may reach automated invocations.
+- Print the exact `flyctl ...` command before executing (audit trail — terminal scrollback only, not durable).
 - Preserve flyctl native exit codes; remap only discovery/auth failures to `2`.
 - Multi-app monorepos: refuse to guess — operator must `cd` into the app dir or pass `-a <app>`.
 - Never echo secret values to chat — only names.
@@ -175,13 +187,24 @@ parsed CLI flag only — env vars cannot grant it.
 
 ## Optional Config
 
-This file is **not consumed by v1.0.0** — it documents the v1.1 config surface
+**This file is NOT consumed by v1.0.0.** It documents the v1.1 config surface
 so contributors can preview it. Operators whose prod apps don't match
 `*-staging*` / `*-preview*` / `*-pr-*` / `*-dev*` / `*-test*` will get
 typed-confirmation prompts on every mutating op until v1.1 wires `confirm_never`
 to override the heuristic; pass `--no-confirm` per-invocation until then.
 
 See [`examples/fly-targets.example.json`](examples/fly-targets.example.json).
+
+Planned v1.1 config schema (not yet wired — for preview only):
+
+| Key                     | Type       | Semantics                                                                                        |
+| ----------------------- | ---------- | ------------------------------------------------------------------------------------------------ |
+| `confirm_always`        | `string[]` | App names that always require typed confirmation, regardless of the prod-name heuristic.         |
+| `confirm_never`         | `string[]` | App names that never require typed confirmation (overrides heuristic for known non-prod apps).   |
+| `deploy.strategy`       | `string`   | Default `--strategy` value for `flyctl deploy` (e.g. `bluegreen`). Overridable per-invocation.   |
+| `deploy.require_digest` | `boolean`  | If `true`, reject `--image` refs without a `@sha256:` digest suffix (enforce immutable deploys). |
+
+When v1.1 wires this file, it will be read via `jq` from `.claude/flyctl.json` at skill startup.
 
 ## See also
 

--- a/plugins/dotbabel/templates/claude/skills/flyctl/examples/fly-targets.example.json
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/examples/fly-targets.example.json
@@ -1,0 +1,14 @@
+{
+  "default_app": "my-api",
+  "environments": {
+    "prod": "my-api",
+    "staging": "my-api-staging",
+    "preview": "my-api-pr-{N}"
+  },
+  "deploy": {
+    "strategy": "bluegreen",
+    "require_digest": true
+  },
+  "confirm_always": ["my-api", "my-api-db"],
+  "confirm_never": ["my-api-dev"]
+}

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/deploy.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/deploy.md
@@ -1,0 +1,101 @@
+# `/flyctl deploy`
+
+Deploy a Fly.io app from source or from a pre-built container image.
+
+## Pre-flight: validate `--image` reference
+
+Before invoking `flyctl deploy --image`, validate the image reference matches the
+expected format. Reject anything that doesn't match:
+
+```bash
+IMAGE_RE='^[a-z0-9._/-]+(:[A-Za-z0-9._-]+)?(@sha256:[a-f0-9]{64})?$'
+if ! echo "$IMAGE" | grep -Eq "$IMAGE_RE"; then
+  echo "invalid image ref: $IMAGE" >&2
+  echo "expected: <registry>/<repo>[:tag][@sha256:<digest>]" >&2
+  exit 2
+fi
+```
+
+**Strongly recommend digest pinning** (`@sha256:...`) for production deploys. A
+mutable `:tag` reference is resolved by Fly's builder at deploy time and
+introduces ambiguity if the registry is repushed mid-deploy.
+
+If `--image` is missing the digest, warn but do not block:
+
+```bash
+case "$IMAGE" in
+  *@sha256:*) ;;
+  *) echo "warning: deploying mutable tag $IMAGE — recommend digest pinning" >&2 ;;
+esac
+```
+
+## Source vs image deploys
+
+| Form                   | Command                                                   | When to use                                               |
+| ---------------------- | --------------------------------------------------------- | --------------------------------------------------------- |
+| Source build (default) | `flyctl deploy -a $APP`                                   | Local source + Dockerfile, builder runs on Fly            |
+| Source, remote builder | `flyctl deploy -a $APP --remote-only`                     | No local Docker; offload to Fly's remote builder          |
+| Source, local builder  | `flyctl deploy -a $APP --local-only`                      | Force local Docker (faster iteration on big images)       |
+| Pre-built image        | `flyctl deploy -a $APP --image $REF`                      | CI built the image and pushed to a registry; just promote |
+| Pre-built, no fly.toml | `flyctl deploy -a $APP --image $REF --strategy bluegreen` | Need explicit strategy override                           |
+
+## `--strategy` semantics
+
+| Strategy            | Behavior                                                   | Use when                                                |
+| ------------------- | ---------------------------------------------------------- | ------------------------------------------------------- |
+| `immediate`         | All machines updated at once; brief outage                 | Single-machine dev/preview apps                         |
+| `rolling` (default) | One machine at a time                                      | Most multi-machine apps                                 |
+| `bluegreen`         | Spin up new machines alongside old, swap traffic           | Zero-downtime prod deploys; doubles cost during rollout |
+| `canary`            | Deploy to one machine, hold for health check, then proceed | High-risk releases                                      |
+
+Read the value from `fly.toml` `deploy.strategy` first; honor an explicit
+`--strategy` override only when the operator passes it.
+
+## `--build-arg` and `--build-secret`
+
+Repeatable. Form: `--build-arg KEY=VALUE`. Build secrets are not persisted in
+the image (Docker buildkit secret-mount semantics):
+
+```bash
+flyctl deploy -a $APP --build-arg NODE_ENV=production --build-secret npmrc="$(cat .npmrc)"
+```
+
+Never paste secret values into chat. If a build secret is needed, prompt the
+operator for the source.
+
+## `release_command` failure
+
+If `fly.toml` defines `[deploy].release_command`, Fly runs it in a one-shot
+machine after the build and before swapping traffic. A non-zero exit aborts the
+deploy. Common causes:
+
+- Database migration failure — check `flyctl logs -a $APP` for the one-shot
+  machine output
+- Missing env/secret in the new release — check the secrets diff against the
+  previous release with `flyctl releases -a $APP --json | jq '.[0:2]'`
+
+Recovery: roll back via `/rollback-prod` (this skill does NOT do rollback).
+
+## Confirmation rail
+
+For prod-flavored apps, always run `confirm_if_prod "$APP" deploy "$no_confirm_flag"`
+before invoking `flyctl deploy`. The operator must type the exact app name to
+proceed. `--no-confirm` is only honored when passed explicitly on the command
+line.
+
+## Post-deploy verification
+
+After `flyctl deploy` returns 0, verify the new release is healthy:
+
+```bash
+flyctl status -a "$APP"
+flyctl releases -a "$APP" --json | jq '.[0]'
+```
+
+For end-to-end health, see [`health.md`](health.md) for the `flyctl proxy` + curl
+pattern.
+
+## See also
+
+- [`/rollback-prod`](../../rollback-prod/SKILL.md) — rollback the release this deploy created.
+- [`/deploy-status`](../../deploy-status/SKILL.md) — confirm the new SHA matches `origin/main`.

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/deploy.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/deploy.md
@@ -9,7 +9,7 @@ expected format. Reject anything that doesn't match:
 
 ```bash
 IMAGE_RE='^[a-z0-9._/-]+(:[A-Za-z0-9._-]+)?(@sha256:[a-f0-9]{64})?$'
-if ! echo "$IMAGE" | grep -Eq "$IMAGE_RE"; then
+if ! printf '%s\n' "$IMAGE" | grep -Eq "$IMAGE_RE"; then
   echo "invalid image ref: $IMAGE" >&2
   echo "expected: <registry>/<repo>[:tag][@sha256:<digest>]" >&2
   exit 2
@@ -57,7 +57,9 @@ Repeatable. Form: `--build-arg KEY=VALUE`. Build secrets are not persisted in
 the image (Docker buildkit secret-mount semantics):
 
 ```bash
-flyctl deploy -a $APP --build-arg NODE_ENV=production --build-secret npmrc="$(cat .npmrc)"
+flyctl deploy -a $APP \
+  --build-arg NODE_ENV=production \
+  --build-secret npmrc="$(cat .npmrc)"
 ```
 
 Never paste secret values into chat. If a build secret is needed, prompt the
@@ -78,10 +80,10 @@ Recovery: roll back via `/rollback-prod` (this skill does NOT do rollback).
 
 ## Confirmation rail
 
-For prod-flavored apps, always run `confirm_if_prod "$APP" deploy "$no_confirm_flag"`
-before invoking `flyctl deploy`. The operator must type the exact app name to
-proceed. `--no-confirm` is only honored when passed explicitly on the command
-line.
+For prod-flavored apps, run
+`confirm_if_prod "$APP" deploy "$no_confirm_flag"` before invoking
+`flyctl deploy`; the shared confirmation contract handles app-name confirmation
+and CLI-only `--no-confirm`.
 
 ## Post-deploy verification
 

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/deploy.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/deploy.md
@@ -59,8 +59,13 @@ the image (Docker buildkit secret-mount semantics):
 ```bash
 flyctl deploy -a $APP \
   --build-arg NODE_ENV=production \
-  --build-secret npmrc="$(cat .npmrc)"
+  --build-secret npmrc=@.npmrc
 ```
+
+Use `name=@path` (file reference) rather than `name="$(cat ...)"` — the
+`$(cat ...)` substitution inlines the secret into argv, exposing it in `ps`
+output and the skill's audit print. Docker buildkit's secret-mount keeps the
+file contents out of the process argument list when the `@path` form is used.
 
 Never paste secret values into chat. If a build secret is needed, prompt the
 operator for the source.

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/health.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/health.md
@@ -1,0 +1,94 @@
+# `/flyctl health`
+
+Run a quick health check against the app's HTTP endpoints via `flyctl proxy` and
+`curl`. Endpoints are **NOT universal** — every project picks its own
+(`/livez`, `/readyz`, `/healthz`, `/_health`, none-at-all). This skill never
+hardcodes paths; it discovers them from `fly.toml` or asks the operator.
+
+## Discovery strategy
+
+1. **Parse `fly.toml`** for health-check paths. Fly supports two main forms:
+
+   ```toml
+   # Form A (current)
+   [[http_service.checks]]
+   path = "/healthz"
+   interval = "10s"
+
+   # Form B (legacy v2 services)
+   [[services.http_checks]]
+   path = "/healthz"
+   ```
+
+   Extract paths:
+
+   ```bash
+   paths=$(grep -E '^[[:space:]]*path[[:space:]]*=' fly.toml | sed -E 's/.*path[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+   ```
+
+2. **Override via `--path`** if the operator passes a specific endpoint:
+
+   ```bash
+   /flyctl health --path /custom-health
+   ```
+
+3. **Fallback prompt** when no checks are configured AND no `--path` was given.
+   Ask the operator:
+
+   > No health-check paths found in `fly.toml`. Provide one (e.g. `/healthz`)
+   > or use `--path <p>`.
+
+   Do NOT guess `/livez` / `/readyz` / `/healthz` — many apps don't expose
+   those, and a 404 from a guessed path is worse than no check at all.
+
+## Probe via `flyctl proxy`
+
+```bash
+INTERNAL_PORT=$(awk -F'=' '/^[[:space:]]*internal_port[[:space:]]*=/{gsub(/[[:space:]]/,""); print $2; exit}' fly.toml)
+INTERNAL_PORT="${INTERNAL_PORT:-8080}"
+LOCAL_PORT=18080
+
+flyctl proxy "$LOCAL_PORT:$INTERNAL_PORT" -a "$APP" &
+PROXY_PID=$!
+sleep 2
+
+for p in $paths; do
+  echo "=== $p ==="
+  curl -sf -w 'HTTP %{http_code} in %{time_total}s\n' "http://localhost:$LOCAL_PORT$p" || echo "FAILED: $p"
+done
+
+kill $PROXY_PID 2>/dev/null
+wait $PROXY_PID 2>/dev/null || true
+```
+
+## Authenticated endpoints
+
+Some apps gate health endpoints behind a header (e.g. `X-Admin-Secret`). Don't
+auto-fetch the secret from `flyctl secrets` (values are not retrievable —
+secrets are write-only from outside the running app). Either:
+
+- The operator pastes the secret into the prompt (skill never logs it)
+- The operator runs the curl manually after the proxy is up
+- The app exposes a public, unauthenticated liveness path (recommended)
+
+## Multi-endpoint sequencing
+
+If `fly.toml` declares multiple checks (e.g., `/livez` + `/readyz`), probe both
+in order. Stop on the first failure and surface that endpoint's response body
+to the operator for triage.
+
+## Interpretation
+
+| Outcome                     | Meaning                                                                       |
+| --------------------------- | ----------------------------------------------------------------------------- |
+| All paths 2xx               | App is responding                                                             |
+| Liveness 2xx, readiness 5xx | Process is up but dependencies (DB, cache) are unhealthy                      |
+| All paths timeout           | Machine likely stopped or unreachable — check `flyctl status`                 |
+| 404 on a documented path    | Path mismatch — verify the path against the running code, not just `fly.toml` |
+
+## Project-specific health workflows
+
+This reference covers generic discovery. Project-specific multi-step health
+playbooks (e.g., "after deploy, check `/livez`, `/readyz`, `/api/data-health`,
+then Sentry") belong in a project-scoped slash command that calls `/flyctl
+health` plus any project-specific endpoints.

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/health.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/health.md
@@ -23,7 +23,7 @@ hardcodes paths; it discovers them from `fly.toml` or asks the operator.
    Extract paths:
 
    ```bash
-   paths=$(grep -E '^[[:space:]]*path[[:space:]]*=' fly.toml | sed -E 's/.*path[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+   paths=$(sed -nE "s/^[[:space:]]*path[[:space:]]*=[[:space:]]*['\"]([^'\"]+)['\"].*/\1/p" fly.toml)
    ```
 
 2. **Override via `--path`** if the operator passes a specific endpoint:
@@ -52,13 +52,14 @@ flyctl proxy "$LOCAL_PORT:$INTERNAL_PORT" -a "$APP" &
 PROXY_PID=$!
 sleep 2
 
-for p in $paths; do
-  echo "=== $p ==="
-  curl -sf -w 'HTTP %{http_code} in %{time_total}s\n' "http://localhost:$LOCAL_PORT$p" || echo "FAILED: $p"
+for health_path in $paths; do
+  echo "=== $health_path ==="
+  curl -sf -w 'HTTP %{http_code} in %{time_total}s\n' "http://localhost:$LOCAL_PORT$health_path" \
+    || echo "FAILED: $health_path"
 done
 
-kill $PROXY_PID 2>/dev/null
-wait $PROXY_PID 2>/dev/null || true
+kill "$PROXY_PID" 2>/dev/null
+wait "$PROXY_PID" 2>/dev/null || true
 ```
 
 ## Authenticated endpoints

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/logs.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/logs.md
@@ -1,0 +1,54 @@
+# `/flyctl logs`
+
+Tail or one-shot fetch logs from a Fly.io app.
+
+## Forms
+
+| Goal                     | Command                                     |
+| ------------------------ | ------------------------------------------- |
+| Live tail                | `flyctl logs -a $APP`                       |
+| One-shot, last ~50 lines | `flyctl logs -a $APP --no-tail \| tail -50` |
+| Filter to one machine    | `flyctl logs -a $APP -i <machine-id>`       |
+| Filter to one region     | `flyctl logs -a $APP --region gru`          |
+| JSON output for piping   | `flyctl logs -a $APP --json`                |
+
+`-i` machine IDs are volatile — re-run `flyctl machines list -a $APP --json` to
+get the current set before targeting.
+
+## Common grep patterns
+
+```bash
+# Errors, fatals, panics
+flyctl logs -a $APP --no-tail 2>&1 | grep -E "FTL|ERR|panic|fatal"
+
+# Specific request-id (when the app logs structured fields)
+flyctl logs -a $APP --json | jq -r 'select(.attributes.request_id=="<id>")'
+
+# Timeouts and connection failures
+flyctl logs -a $APP --no-tail 2>&1 | grep -Ei "timeout|connection refused|EOF"
+
+# Database-flavored errors
+flyctl logs -a $APP --no-tail 2>&1 | grep -Ei "postgres|database|pgx|sqlx"
+```
+
+## When the app logs are quiet
+
+If `flyctl logs` returns nothing recent, check that the app is actually
+receiving traffic:
+
+```bash
+flyctl status -a $APP            # machines running?
+flyctl checks list -a $APP       # health checks passing?
+```
+
+A machine in `stopped` state with `auto_stop: true` is expected when there's
+been no traffic — logs will resume on the next request that wakes the machine.
+
+## Triage workflow
+
+For a structured incident-triage flow (1: confirm the problem, 2: find the
+error in logs, 3: classify, 4: correlate with the latest deploy, 5: check
+resource pressure, 6: check Sentry / external monitoring), this skill does NOT
+encode the project-specific playbook. Author it in your project's
+`.claude/commands/` directory, calling `/flyctl logs` and `/flyctl releases`
+from within it.

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/machines.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/machines.md
@@ -1,0 +1,67 @@
+# `/flyctl machines`
+
+Inspect and manipulate individual Fly Machines under an app.
+
+## Verbs
+
+| Verb           | Command                                        | Confirm on prod? |
+| -------------- | ---------------------------------------------- | ---------------- |
+| `list`         | `flyctl machines list -a $APP --json`          | no               |
+| `status <id>`  | `flyctl machines status <id> -a $APP`          | no               |
+| `restart <id>` | `flyctl machines restart <id> -a $APP`         | no (transient)   |
+| `stop <id>`    | `flyctl machines stop <id> -a $APP`            | **yes**          |
+| `start <id>`   | `flyctl machines start <id> -a $APP`           | no               |
+| `destroy <id>` | `flyctl machines destroy <id> --force -a $APP` | **yes**          |
+
+## List with JSON for scripting
+
+```bash
+flyctl machines list -a $APP --json | jq '.[] | {id, name, state, checks: .checks[]?.status}'
+```
+
+State values: `created`, `started`, `stopped`, `suspended`, `replacing`,
+`destroyed`, `destroying`.
+
+## Machine IDs are volatile
+
+After `flyctl scale count`, `flyctl machines destroy`, or `flyctl deploy
+--strategy bluegreen`, the set of machine IDs changes. Always re-query before
+targeting:
+
+```bash
+ids=$(flyctl machines list -a $APP --json | jq -r '.[].id')
+```
+
+## `stop` vs `apps suspend`
+
+| Action                         | Scope                            | Reversible?                          |
+| ------------------------------ | -------------------------------- | ------------------------------------ |
+| `flyctl machines stop <id>`    | One machine                      | yes — `flyctl machines start <id>`   |
+| `flyctl scale count 0 -a $APP` | All machines, app stays          | yes — scale back up                  |
+| `flyctl apps suspend -a $APP`  | Whole app, traffic blocked       | yes — `flyctl apps resume -a $APP`   |
+| `flyctl apps destroy -a $APP`  | App + machines + volumes deleted | **no** — out of scope for this skill |
+
+## Stuck `stopped` machines
+
+With `auto_stop = true` in `fly.toml`, a machine in `stopped` state is normal
+behavior between requests. Only intervene if:
+
+- ALL machines are stopped AND traffic should be active
+- A machine has been stopped for > 5 minutes AND health checks were failing
+  before it stopped (suggests OOM-kill or panic)
+
+To force-wake one:
+
+```bash
+ID=$(flyctl machines list -a $APP --json | jq -r '.[] | select(.state=="stopped") | .id' | head -1)
+flyctl machines start "$ID" -a $APP
+```
+
+## Destroy
+
+`flyctl machines destroy <id> --force` is irreversible from this skill's
+perspective. Always confirm on prod. After destruction, a `flyctl deploy` will
+recreate machines from the latest release.
+
+For full app destruction (`flyctl apps destroy`), this skill refuses — use the
+Fly UI explicitly.

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/proxy.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/proxy.md
@@ -1,0 +1,59 @@
+# `/flyctl proxy`
+
+Forward a local port to an internal Fly service.
+
+## Form
+
+```bash
+flyctl proxy <local-port>[:<remote-port>] [-a $APP]
+```
+
+If `<remote-port>` is omitted, Fly uses the app's primary internal port (read
+from `fly.toml` `[services]` or `[http_service]`).
+
+## Common use cases
+
+| Goal                      | Command                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------- |
+| Hit `/healthz` on prod    | `flyctl proxy 8080 -a $APP` → `curl http://localhost:8080/healthz`                                |
+| Connect to Fly Postgres   | `flyctl proxy 5432 -a $APP-db` → `psql postgres://...@localhost:5432/...`                         |
+| Connect to internal Redis | `flyctl proxy 6379 -a $APP-redis` → `redis-cli -p 6379`                                           |
+| Hit admin endpoint        | `flyctl proxy 8080 -a $APP` → `curl -H "X-Admin-Secret: $SECRET" http://localhost:8080/admin/...` |
+
+## `.flycast` internal hostnames
+
+Fly's internal networking exposes apps to each other via `.flycast` and
+`.internal` hostnames. `flyctl proxy` is the bridge that brings these into the
+operator's local machine. The proxy listens on `127.0.0.1` by default; bind to
+all interfaces with `--bind-addr 0.0.0.0:<port>` if you need WSL/host access
+(rarely needed).
+
+## Lifecycle
+
+`flyctl proxy` runs in the foreground until killed. Common pattern in scripts:
+
+```bash
+flyctl proxy 8080 -a $APP &
+PROXY_PID=$!
+sleep 2
+curl -sf http://localhost:8080/healthz
+kill $PROXY_PID 2>/dev/null
+wait $PROXY_PID 2>/dev/null || true
+```
+
+Always clean up the proxy PID — leaving it running blocks the port for the next
+invocation.
+
+## Authentication
+
+The proxy inherits `flyctl auth` state. If the proxy fails to connect, run
+`flyctl auth whoami` to verify the session is valid for the app's org.
+
+## Limitations
+
+- One port per `flyctl proxy` invocation. Multiple internal services require
+  multiple background proxies on different local ports.
+- TCP only. WebSocket and HTTP/2 work because they ride on TCP, but UDP services
+  are not supported.
+- Long-running proxies survive flyctl auth refresh; if auth expires mid-session,
+  the proxy reports broken pipe and exits.

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/proxy.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/proxy.md
@@ -37,8 +37,8 @@ flyctl proxy 8080 -a $APP &
 PROXY_PID=$!
 sleep 2
 curl -sf http://localhost:8080/healthz
-kill $PROXY_PID 2>/dev/null
-wait $PROXY_PID 2>/dev/null || true
+kill "$PROXY_PID" 2>/dev/null
+wait "$PROXY_PID" 2>/dev/null || true
 ```
 
 Always clean up the proxy PID — leaving it running blocks the port for the next

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/releases.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/releases.md
@@ -1,0 +1,72 @@
+# `/flyctl releases`
+
+List Fly.io app releases — version, status, image, deployer, timestamp.
+
+## Forms
+
+```bash
+flyctl releases -a $APP                  # human-readable table
+flyctl releases -a $APP --json           # structured output for piping
+flyctl releases -a $APP --image          # include image refs (some older flyctl versions)
+```
+
+## Columns (JSON)
+
+Per release object:
+
+| Field                 | Meaning                                             |
+| --------------------- | --------------------------------------------------- |
+| `version`             | Monotonic release number (v1, v2, ...)              |
+| `status`              | `succeeded`, `failed`, `pending`, `running`         |
+| `image_ref` / `image` | Container image reference deployed (when available) |
+| `deployer`            | User or bot that triggered the deploy               |
+| `created_at`          | ISO 8601 timestamp                                  |
+| `description`         | Deploy reason or release-command summary            |
+
+## Common queries
+
+```bash
+# Most recent successful release
+flyctl releases -a $APP --json \
+  | jq -r '[.[] | select(.status=="succeeded")][0]'
+
+# Diff the two most recent releases' image refs
+flyctl releases -a $APP --json \
+  | jq -r '.[0:2] | map(.image_ref // .image) | @tsv'
+
+# Find releases by a specific deployer
+flyctl releases -a $APP --json \
+  | jq '.[] | select(.deployer=="github-actions[bot]")'
+```
+
+## Cross-reference with deploy status
+
+`/flyctl releases` shows the release sequence; `/deploy-status` resolves the
+deployed git SHA and compares against `origin/main`. Together:
+
+```bash
+# Latest release
+flyctl releases -a $APP --json | jq -r '.[0] | {version, image_ref, created_at}'
+
+# Compare against main (cross-provider, includes Vercel/AWS too)
+# /deploy-status
+```
+
+## Failed-release recovery
+
+If the most recent release shows `status: "failed"`, the previous successful
+release is still serving traffic. Roll forward (fix + redeploy) is usually the
+right answer, not roll back. For an explicit rollback to the previous
+succeeded release, use `/rollback-prod` (this skill does not roll back).
+
+To inspect why a release failed:
+
+```bash
+flyctl logs -a $APP --no-tail 2>&1 | head -100   # release_command output is in logs
+flyctl releases -a $APP --json | jq '.[0].description'
+```
+
+## See also
+
+- [`/deploy-status`](../../deploy-status/SKILL.md) — read-only SHA reconciliation.
+- [`/rollback-prod`](../../rollback-prod/SKILL.md) — gated rollback to previous release.

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/scale.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/scale.md
@@ -1,0 +1,71 @@
+# `/flyctl scale`
+
+Adjust Fly Machines: how many, what VM size, how much memory, what regions.
+
+## Subverbs
+
+| Verb                     | Command                                     | Confirm on prod?       |
+| ------------------------ | ------------------------------------------- | ---------------------- |
+| `show`                   | `flyctl scale show -a $APP`                 | no                     |
+| `count <n>`              | `flyctl scale count $N -a $APP`             | **yes if prod or n=0** |
+| `count <n> --region <r>` | `flyctl scale count $N --region $R -a $APP` | **yes if prod or n=0** |
+| `vm <preset>`            | `flyctl scale vm $PRESET -a $APP`           | **yes if prod**        |
+| `memory <mb>`            | `flyctl scale memory $MB -a $APP`           | **yes if prod**        |
+
+## `scale count 0` is destructive on prod
+
+Scaling to zero machines drains traffic and leaves no warm capacity. Treat it
+as a destructive op even on non-prod-flavored apps; gate behind confirmation
+unless the operator explicitly passes `--no-confirm`.
+
+## VM presets
+
+Common presets (verify against `flyctl platform vm-sizes`):
+
+| Preset           | vCPU        | Memory | Use case                 |
+| ---------------- | ----------- | ------ | ------------------------ |
+| `shared-cpu-1x`  | 1 shared    | 256 MB | Small APIs, cron workers |
+| `shared-cpu-2x`  | 2 shared    | 512 MB | Medium APIs              |
+| `shared-cpu-4x`  | 4 shared    | 1 GB   | Larger Node/Go services  |
+| `performance-1x` | 1 dedicated | 2 GB   | Latency-sensitive        |
+| `performance-2x` | 2 dedicated | 4 GB   | CPU-bound services       |
+
+Override memory with `--memory`: `flyctl scale vm shared-cpu-1x --memory 512 -a $APP`.
+
+## Multi-region scale
+
+Fly Apps that span multiple regions: scale per-region with `--region`:
+
+```bash
+flyctl scale count 2 --region gru -a $APP
+flyctl scale count 1 --region cdg -a $APP
+flyctl scale show -a $APP  # confirm new layout
+```
+
+To list regions: `flyctl platform regions`.
+
+## `auto_stop` / `min_machines_running` interactions
+
+If `fly.toml` sets `min_machines_running = N`, `flyctl scale count` won't reduce
+below N (Fly enforces this server-side). To go lower, edit `fly.toml` first
+and `flyctl deploy` to apply, then `flyctl scale count` for the new floor.
+
+`auto_stop` and `auto_start` (typical default `true`) cause machines to stop
+between requests. This is independent of `scale count`: a `count 2` app with
+`auto_stop = true` may show one or zero machines in `started` state at any
+moment.
+
+## Memory ceiling
+
+A common cause of OOM-kills is undersized memory. Inspect Fly's metrics
+endpoint or watch `flyctl logs -a $APP` for `out of memory`. Bump with
+`flyctl scale memory <new-mb>` — the app restarts.
+
+## Verification
+
+After any scale change, confirm:
+
+```bash
+flyctl scale show -a $APP
+flyctl machines list -a $APP --json | jq '.[] | {id, state, region, size: .config.guest.cpus}'
+```

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/secrets.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/secrets.md
@@ -1,0 +1,70 @@
+# `/flyctl secrets`
+
+Manage Fly.io app secrets.
+
+## Verbs
+
+| Verb            | Command                                  | Triggers redeploy?          | Confirm on prod? |
+| --------------- | ---------------------------------------- | --------------------------- | ---------------- |
+| `list`          | `flyctl secrets list -a $APP`            | no                          | no               |
+| `set` (default) | `flyctl secrets set K=V -a $APP`         | **yes**                     | yes              |
+| `set --stage`   | `flyctl secrets set --stage K=V -a $APP` | no (applied on next deploy) | yes              |
+| `unset`         | `flyctl secrets unset K -a $APP`         | **yes**                     | yes              |
+
+## Batch updates → one restart
+
+`flyctl secrets set` accepts multiple `KEY=VALUE` pairs in a single invocation
+and triggers exactly one rolling restart. Always batch when setting more than
+one secret:
+
+```bash
+# Good — one restart
+flyctl secrets set DB_PASSWORD=...new... API_TOKEN=...new... -a $APP
+
+# Bad — two restarts, two windows of partial config
+flyctl secrets set DB_PASSWORD=...new... -a $APP
+flyctl secrets set API_TOKEN=...new... -a $APP
+```
+
+## Never echo secret values
+
+`flyctl secrets list` prints names only (and a digest), never values — that's by
+design. Mirror the same discipline in skill output:
+
+- Never paste a secret value into the chat to the operator
+- Never log the contents of `$VALUE` in audit output
+- When prompting for a secret, redirect the prompt and read silently:
+  `read -s -r VALUE && echo`
+- If the operator pastes a secret into chat, **do not** include it in any
+  subsequent assistant message or commit message
+
+## Rotation flow
+
+1. Obtain the new value from the external system (Neon dashboard, AWS Secrets
+   Manager, 1Password vault, etc.). The user must provide it; this skill does
+   not have access.
+2. `flyctl secrets set KEY="$NEW" -a $APP` (with confirmation if prod).
+3. Wait for the rolling restart to complete (~30 s for a small VM):
+   `flyctl status -a $APP` — confirm all machines are `started` on the new
+   release.
+4. Verify the specific functionality that uses the secret (a health endpoint,
+   a smoke query, etc.) — see [`health.md`](health.md).
+
+## `--stage` for atomic multi-secret + deploy
+
+Use `--stage` when you want to land multiple secrets AND a code change in a
+single deploy:
+
+```bash
+flyctl secrets set --stage DB_URL=... CACHE_URL=... -a $APP
+# no restart yet
+flyctl deploy -a $APP --image registry.fly.io/$APP:new-tag
+# secrets land in the new release
+```
+
+## Project-secret-manager indirection
+
+Many projects use an external secret manager (1Password, AWS Secrets Manager,
+Vault) as the source of truth, with Fly secrets as a runtime cache. If your
+project does, prefer the project's rotation tooling over direct `flyctl secrets
+set` — direct setting bypasses the project audit trail.

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/secrets.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/secrets.md
@@ -11,6 +11,24 @@ Manage Fly.io app secrets.
 | `set --stage`   | `flyctl secrets set --stage K=V -a $APP` | no (applied on next deploy) | yes              |
 | `unset`         | `flyctl secrets unset K -a $APP`         | **yes**                     | yes              |
 
+## Avoid secret values in argv
+
+`flyctl secrets set K=V` places values in the process argument list, where they
+appear in `ps`, `/proc/<pid>/cmdline`, and the skill's audit print. For sensitive
+values, pipe via stdin using `flyctl secrets import`:
+
+```bash
+# Preferred — values never appear in argv
+printf 'DB_PASSWORD=%s\nAPI_TOKEN=%s\n' "$DB_PASS" "$API_TOK" \
+  | flyctl secrets import -a $APP
+
+# Acceptable for low-sensitivity values
+flyctl secrets set PUBLIC_KEY=abc123 -a $APP
+```
+
+`flyctl secrets import` reads `KEY=VALUE` lines from stdin, batches them into
+one restart, and never exposes values on the command line.
+
 ## Batch updates → one restart
 
 `flyctl secrets set` accepts multiple `KEY=VALUE` pairs in a single invocation

--- a/plugins/dotbabel/templates/claude/skills/flyctl/references/ssh.md
+++ b/plugins/dotbabel/templates/claude/skills/flyctl/references/ssh.md
@@ -1,0 +1,50 @@
+# `/flyctl ssh`
+
+Open an interactive shell or file-transfer session inside a Fly Machine.
+
+## Subverbs
+
+| Form              | Command                                                 | Use case                        |
+| ----------------- | ------------------------------------------------------- | ------------------------------- |
+| Interactive shell | `flyctl ssh console -a $APP`                            | `printenv`, ad-hoc debugging    |
+| Pin to a machine  | `flyctl ssh console -a $APP -s <id>`                    | When one machine is misbehaving |
+| One-shot command  | `flyctl ssh console -a $APP -C "printenv DATABASE_URL"` | Scriptable inspection           |
+| File transfer     | `flyctl ssh sftp shell -a $APP`                         | `get` / `put` of small files    |
+| Issue SSH cert    | `flyctl ssh issue -a $APP`                              | When auth handshake fails       |
+
+## SSH cert refresh
+
+`flyctl` issues short-lived SSH certs automatically. If `flyctl ssh console`
+fails with an authentication error, refresh:
+
+```bash
+flyctl ssh issue -a $APP
+flyctl ssh console -a $APP
+```
+
+## Safety
+
+- SSH gives you a shell on the running machine. Be careful with commands that
+  modify state (DB writes, file overwrites, signal sending). Prefer read-only
+  inspection (`printenv`, `ls`, `cat`).
+- Never run interactive commands that don't terminate (`top`, `htop`) inside a
+  one-shot `-C` call — use `flyctl ssh console` interactively instead.
+- Don't `cat` secrets to the screen. If you need a value, redirect to a local
+  file with `flyctl ssh sftp` or set up a project-side audit log.
+
+## When the machine has no shell
+
+Slim runtime images (distroless, scratch) have no `/bin/sh`. `flyctl ssh
+console` will fail with "exec format error" or similar. Workarounds:
+
+- Add a debug shim to the Dockerfile (`COPY --from=busybox /bin/busybox /bin/sh`)
+- Use `flyctl logs` for runtime inspection instead
+- Open a temporary shell-bearing image with `flyctl deploy --image alpine`
+  (extreme — only in a non-prod app)
+
+## Confirmation rail
+
+SSH is interactive but read-shell from the skill's perspective; commands
+executed inside the SSH session are operator-driven. The skill does not gate
+`flyctl ssh console`. Inside the session, the operator is responsible for any
+mutations they perform.

--- a/plugins/dotbabel/templates/claude/skills/rollback-prod/references/fly.md
+++ b/plugins/dotbabel/templates/claude/skills/rollback-prod/references/fly.md
@@ -30,3 +30,8 @@ arguments.
   back databases or undo migrations.
 - If Fly rollback fails after another target succeeded, the helper reports the
   partial state and leaves follow-up action to the operator.
+
+## See also
+
+- `/flyctl` — ad-hoc fly ops (deploy, secrets, scale) when you don't need a full multi-target rollback.
+- `/deploy-status` — read-only SHA reporting across all deploy targets.

--- a/skills/deploy-status/references/fly.md
+++ b/skills/deploy-status/references/fly.md
@@ -38,3 +38,8 @@ target reports `unknown SHA` and exits `2` instead of guessing.
 - CLI not installed or not authenticated: target error, status exit `2`.
 - No successful releases: target error, status exit `2`.
 - Release metadata has no git SHA: target error, status exit `2`.
+
+## See also
+
+- `/flyctl` — fly-specific deploy, logs, secrets, scale, and machine ops outside the read-only status flow.
+- `/rollback-prod` — confirmation-gated rollback to the previous release.

--- a/skills/flyctl/SKILL.md
+++ b/skills/flyctl/SKILL.md
@@ -94,30 +94,42 @@ fi
 
 ## Subcommands
 
-| Sub                                      | Args                                     | Invocation                                                                                                                          | Confirm?                        | Reference                               |
-| ---------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------------------- |
-| `status`                                 | `[-a $APP]`                              | `flyctl status -a $APP`                                                                                                             | no                              | –                                       |
-| `logs`                                   | `[-a $APP] [-i ID] [--region R]`         | `flyctl logs -a $APP $EXTRA`                                                                                                        | no                              | [`logs.md`](references/logs.md)         |
-| `releases`                               | `[-a $APP] [--image]`                    | `flyctl releases -a $APP --json`                                                                                                    | no                              | [`releases.md`](references/releases.md) |
-| `deploy`                                 | `[-a $APP] [--image REF] [--strategy S]` | `flyctl deploy -a $APP --image $REF`                                                                                                | **YES if prod**                 | [`deploy.md`](references/deploy.md)     |
-| `secrets list`                           | `[-a $APP]`                              | `flyctl secrets list -a $APP`                                                                                                       | no                              | [`secrets.md`](references/secrets.md)   |
-| `secrets set`                            | `[-a $APP] [--stage] K=V...`             | `flyctl secrets set -a $APP $KV`                                                                                                    | **YES if prod**                 | [`secrets.md`](references/secrets.md)   |
-| `secrets unset`                          | `[-a $APP] K...`                         | `flyctl secrets unset -a $APP $K`                                                                                                   | **YES if prod**                 | [`secrets.md`](references/secrets.md)   |
-| `machines list`                          | `[-a $APP]`                              | `flyctl machines list -a $APP --json`                                                                                               | no                              | [`machines.md`](references/machines.md) |
-| `machines restart\|stop\|start\|destroy` | `<id> [-a $APP]`                         | `flyctl machines <op> $ID -a $APP`                                                                                                  | **YES if stop/destroy on prod** | [`machines.md`](references/machines.md) |
-| `scale show`                             | `[-a $APP]`                              | `flyctl scale show -a $APP`                                                                                                         | no                              | [`scale.md`](references/scale.md)       |
-| `scale count <n>`                        | `[-a $APP]`                              | `flyctl scale count $N -a $APP`                                                                                                     | **YES if prod or n=0**          | [`scale.md`](references/scale.md)       |
-| `scale vm <preset>`                      | `[-a $APP] [--memory MB]`                | `flyctl scale vm $P -a $APP`                                                                                                        | **YES if prod**                 | [`scale.md`](references/scale.md)       |
-| `ssh`                                    | `[console\|sftp] [-a $APP] [-s ID]`      | `flyctl ssh $SUB -a $APP`                                                                                                           | no                              | [`ssh.md`](references/ssh.md)           |
-| `proxy`                                  | `<local:remote> [-a $APP]`               | `flyctl proxy $P -a $APP`                                                                                                           | no                              | [`proxy.md`](references/proxy.md)       |
-| `health`                                 | `[-a $APP] [--path P]`                   | discover endpoints from `fly.toml`, proxy + curl                                                                                    | no                              | [`health.md`](references/health.md)     |
-| _any other_                              | –                                        | run `flyctl <cmd> --help`, classify the verb, **stop and prompt for explicit operator approval before executing any mutating verb** | per-op                          | –                                       |
+| Sub                     | Args                                     | Invocation                                                                                                                          | Confirm?               | Reference                               |
+| ----------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | --------------------------------------- |
+| `status`                | `[-a $APP]`                              | `flyctl status -a $APP`                                                                                                             | no                     | –                                       |
+| `logs`                  | `[-a $APP] [-i ID] [--region R]`         | `flyctl logs -a $APP $EXTRA`                                                                                                        | no                     | [`logs.md`](references/logs.md)         |
+| `releases`              | `[-a $APP] [--image]`                    | `flyctl releases -a $APP --json`                                                                                                    | no                     | [`releases.md`](references/releases.md) |
+| `deploy`                | `[-a $APP] [--image REF] [--strategy S]` | `flyctl deploy -a $APP --image $REF`                                                                                                | **YES if prod**        | [`deploy.md`](references/deploy.md)     |
+| `secrets list`          | `[-a $APP]`                              | `flyctl secrets list -a $APP`                                                                                                       | no                     | [`secrets.md`](references/secrets.md)   |
+| `secrets set`           | `[-a $APP] [--stage] K=V...`             | `flyctl secrets set -a $APP $KV`                                                                                                    | **YES if prod**        | [`secrets.md`](references/secrets.md)   |
+| `secrets unset`         | `[-a $APP] K...`                         | `flyctl secrets unset -a $APP $K`                                                                                                   | **YES if prod**        | [`secrets.md`](references/secrets.md)   |
+| `machines list`         | `[-a $APP]`                              | `flyctl machines list -a $APP --json`                                                                                               | no                     | [`machines.md`](references/machines.md) |
+| `machines restart <id>` | `[-a $APP]`                              | `flyctl machines restart $ID -a $APP`                                                                                               | no                     | [`machines.md`](references/machines.md) |
+| `machines stop <id>`    | `[-a $APP]`                              | `flyctl machines stop $ID -a $APP`                                                                                                  | **YES if prod**        | [`machines.md`](references/machines.md) |
+| `machines start <id>`   | `[-a $APP]`                              | `flyctl machines start $ID -a $APP`                                                                                                 | no                     | [`machines.md`](references/machines.md) |
+| `machines destroy <id>` | `[-a $APP]`                              | `flyctl machines destroy $ID --force -a $APP`                                                                                       | **YES if prod**        | [`machines.md`](references/machines.md) |
+| `scale show`            | `[-a $APP]`                              | `flyctl scale show -a $APP`                                                                                                         | no                     | [`scale.md`](references/scale.md)       |
+| `scale count <n>`       | `[-a $APP]`                              | `flyctl scale count $N -a $APP`                                                                                                     | **YES if prod or n=0** | [`scale.md`](references/scale.md)       |
+| `scale vm <preset>`     | `[-a $APP] [--memory MB]`                | `flyctl scale vm $P -a $APP`                                                                                                        | **YES if prod**        | [`scale.md`](references/scale.md)       |
+| `scale memory <mb>`     | `[-a $APP]`                              | `flyctl scale memory $MB -a $APP`                                                                                                   | **YES if prod**        | [`scale.md`](references/scale.md)       |
+| `ssh console`           | `[-a $APP] [-s ID]`                      | `flyctl ssh console -a $APP`                                                                                                        | no (interactive)       | [`ssh.md`](references/ssh.md)           |
+| `ssh console -C <cmd>`  | `[-a $APP] [-s ID]`                      | `flyctl ssh console -C "$CMD" -a $APP`                                                                                              | **YES if prod**        | [`ssh.md`](references/ssh.md)           |
+| `ssh sftp`              | `[-a $APP]`                              | `flyctl ssh sftp shell -a $APP`                                                                                                     | no                     | [`ssh.md`](references/ssh.md)           |
+| `proxy`                 | `<local:remote> [-a $APP]`               | `flyctl proxy $P -a $APP`                                                                                                           | no                     | [`proxy.md`](references/proxy.md)       |
+| `health`                | `[-a $APP] [--path P]`                   | discover endpoints from `fly.toml`, proxy + curl                                                                                    | no                     | [`health.md`](references/health.md)     |
+| _any other_             | –                                        | run `flyctl <cmd> --help`, classify the verb, **stop and prompt for explicit operator approval before executing any mutating verb** | per-op                 | –                                       |
 
 ## Confirmation Contract
 
 Destructive ops on prod-flavored apps require the operator to type the exact app
 name. The heuristic for "prod-flavored" is: app name does NOT match
 `*-staging*`, `*-preview*`, `*-pr-*`, `*-dev*`, or `*-test*`.
+
+> **Heuristic is best-effort.** App names that _contain_ these substrings but
+> are nonetheless prod (e.g. `my-developer-portal`, `payments-test-of-record`)
+> will silently skip the confirmation gate. Until v1.1 ships `confirm_always`
+> config, use `--no-confirm` deliberately for known non-prod apps with unusual
+> names, and add a comment in your runbook for prod apps that would false-match.
 
 ```bash
 # no_confirm_flag MUST be derived ONLY from an explicitly parsed --no-confirm
@@ -130,7 +142,7 @@ confirm_if_prod() {
     *-staging*|*-preview*|*-pr-*|*-dev*|*-test*) return 0 ;;
   esac
   printf 'About to run %s on PROD app %s.\nType the app name to confirm: ' "$op" "$app" >&2
-  read -r reply
+  read -r reply < /dev/tty || { echo "no interactive TTY; pass --no-confirm explicitly or run interactively" >&2; exit 2; }
   [ "$reply" = "$app" ] || { echo "confirmation failed" >&2; exit 1; }
 }
 
@@ -157,8 +169,8 @@ parsed CLI flag only — env vars cannot grant it.
 - Resolve CLI as `flyctl` first, `fly` second; never re-install.
 - Use existing CLI auth (`flyctl auth whoami`); never prompt for tokens.
 - Destructive ops on prod-flavored apps require typed confirmation matching the app name.
-- `--no-confirm` is honored only when passed explicitly; never via env or autonomous routing.
-- Print the exact `flyctl ...` command before executing (audit trail).
+- `--no-confirm` is honored only when passed explicitly as a deliberate operator flag; never via env, templates, or instructions that may reach automated invocations.
+- Print the exact `flyctl ...` command before executing (audit trail — terminal scrollback only, not durable).
 - Preserve flyctl native exit codes; remap only discovery/auth failures to `2`.
 - Multi-app monorepos: refuse to guess — operator must `cd` into the app dir or pass `-a <app>`.
 - Never echo secret values to chat — only names.
@@ -178,13 +190,24 @@ parsed CLI flag only — env vars cannot grant it.
 
 ## Optional Config
 
-This file is **not consumed by v1.0.0** — it documents the v1.1 config surface
+**This file is NOT consumed by v1.0.0.** It documents the v1.1 config surface
 so contributors can preview it. Operators whose prod apps don't match
 `*-staging*` / `*-preview*` / `*-pr-*` / `*-dev*` / `*-test*` will get
 typed-confirmation prompts on every mutating op until v1.1 wires `confirm_never`
 to override the heuristic; pass `--no-confirm` per-invocation until then.
 
 See [`examples/fly-targets.example.json`](examples/fly-targets.example.json).
+
+Planned v1.1 config schema (not yet wired — for preview only):
+
+| Key                     | Type       | Semantics                                                                                        |
+| ----------------------- | ---------- | ------------------------------------------------------------------------------------------------ |
+| `confirm_always`        | `string[]` | App names that always require typed confirmation, regardless of the prod-name heuristic.         |
+| `confirm_never`         | `string[]` | App names that never require typed confirmation (overrides heuristic for known non-prod apps).   |
+| `deploy.strategy`       | `string`   | Default `--strategy` value for `flyctl deploy` (e.g. `bluegreen`). Overridable per-invocation.   |
+| `deploy.require_digest` | `boolean`  | If `true`, reject `--image` refs without a `@sha256:` digest suffix (enforce immutable deploys). |
+
+When v1.1 wires this file, it will be read via `jq` from `.claude/flyctl.json` at skill startup.
 
 ## See also
 

--- a/skills/flyctl/SKILL.md
+++ b/skills/flyctl/SKILL.md
@@ -1,0 +1,195 @@
+---
+id: flyctl
+name: flyctl
+type: skill
+version: 1.0.0
+domain: [infra, devex, observability]
+platform: [flyio]
+task: [runtime-ops, diagnostics, incident-response]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-05-10
+updated: 2026-05-10
+description: >
+  Explicit-invocation Fly.io operations wrapper. Run `/flyctl <subcommand>` to
+  deploy (with --image), tail logs, manage secrets, inspect machines, scale,
+  SSH, proxy, check health, list releases, and show status. Auto-discovers
+  the app from fly.toml in the current directory. Side-effectful ops on
+  prod-flavored apps require typed confirmation matching the app name.
+  Rollback is delegated to /rollback-prod; cross-provider SHA reporting is
+  delegated to /deploy-status. For any subcommand not enumerated in
+  references/, run `flyctl <subcommand> --help` for canonical reference.
+argument-hint: "<subcommand> [-a <app>] [--no-confirm] [...]"
+tools: Bash, Read, Grep, Glob
+model: sonnet
+effort: medium
+disable-model-invocation: true
+user-invocable: true
+---
+
+# flyctl
+
+Portable Fly.io operations wrapper. Invoke as `/flyctl <subcommand>`.
+
+## When to Use
+
+This skill is **explicit-invocation only** (`disable-model-invocation: true`). The
+model will not auto-route phrases like "tail fly logs" or "fly deploy" to this
+skill — the operator must type `/flyctl <subcommand>` directly. This is the
+safe contract for a side-effectful skill (deploy, secrets-set, scale, machines
+destroy).
+
+Use `/flyctl` when you have an existing Fly.io app (its `fly.toml` is in the
+current directory) and you want to perform any of the operations enumerated in
+the Subcommands table below. The skill auto-discovers the app from `fly.toml`;
+all subcommands accept `-a <app>` to override.
+
+## Out of Scope
+
+This skill does **not** perform rollback or cross-provider release reporting.
+
+- For rollback to the previous release, use `/rollback-prod`.
+- For deployed git-SHA reporting across Vercel/Fly/AWS, use `/deploy-status`.
+- For app provisioning (`fly launch`, region setup), use the Fly UI or your IaC layer.
+- For any subcommand not enumerated above, run `flyctl <subcommand> --help` for
+  canonical reference. Read-only verbs (list, show, status, info, history,
+  version) may proceed without confirmation; mutating verbs (create, destroy,
+  delete, scale, restart, update, set, unset, deploy, suspend, resume,
+  regions add/remove, and any verb whose `--help` text mentions "destructive",
+  "irreversible", or "will redeploy") MUST be presented to the operator with
+  the exact command and require explicit y/N approval before executing.
+
+## Auto-Discovery
+
+Every subcommand begins by resolving the CLI binary and the target app. The
+operator may override the app with `-a <app>`; otherwise the skill reads the
+root `fly.toml` in the current working directory. Multi-app monorepos require
+the operator to `cd` into the per-app directory first — this skill refuses to
+guess across nested `fly.toml` files.
+
+```bash
+# CLI: prefer flyctl, fall back to fly
+FLY="$(command -v flyctl || command -v fly)" \
+  || { echo "flyctl/fly not on PATH; see https://fly.io/docs/flyctl/install/" >&2; exit 2; }
+
+# App: -a flag wins; otherwise parse root fly.toml only.
+# Mirrors parseFlyApp() in deploy-ops.mjs — supports leading whitespace
+# around the key, optional whitespace around '=', and BOTH double- and
+# single-quoted values.
+APP="${ARG_APP:-}"
+if [ -z "$APP" ]; then
+  if [ ! -f fly.toml ]; then
+    echo "no fly.toml in $(pwd); pass -a <app> or cd into the app directory" >&2
+    exit 2
+  fi
+  # Try double-quoted form first, then single-quoted as fallback.
+  APP="$(awk -F'"' '/^[[:space:]]*app[[:space:]]*=[[:space:]]*"/{print $2; exit}' fly.toml)"
+  if [ -z "$APP" ]; then
+    APP="$(awk -F"'" '/^[[:space:]]*app[[:space:]]*=[[:space:]]*'"'"'/{print $2; exit}' fly.toml)"
+  fi
+fi
+[ -z "$APP" ] && { echo "could not resolve app name from fly.toml; pass -a <app>" >&2; exit 2; }
+
+# Auth: existing CLI session only — never prompt
+"$FLY" auth whoami >/dev/null 2>&1 \
+  || { echo "not authenticated; run: $FLY auth login" >&2; exit 2; }
+```
+
+## Subcommands
+
+| Sub                                      | Args                                     | Invocation                                                                                                                          | Confirm?                        | Reference                               |
+| ---------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------------------- |
+| `status`                                 | `[-a $APP]`                              | `flyctl status -a $APP`                                                                                                             | no                              | –                                       |
+| `logs`                                   | `[-a $APP] [-i ID] [--region R]`         | `flyctl logs -a $APP $EXTRA`                                                                                                        | no                              | [`logs.md`](references/logs.md)         |
+| `releases`                               | `[-a $APP] [--image]`                    | `flyctl releases -a $APP --json`                                                                                                    | no                              | [`releases.md`](references/releases.md) |
+| `deploy`                                 | `[-a $APP] [--image REF] [--strategy S]` | `flyctl deploy -a $APP --image $REF`                                                                                                | **YES if prod**                 | [`deploy.md`](references/deploy.md)     |
+| `secrets list`                           | `[-a $APP]`                              | `flyctl secrets list -a $APP`                                                                                                       | no                              | [`secrets.md`](references/secrets.md)   |
+| `secrets set`                            | `[-a $APP] [--stage] K=V...`             | `flyctl secrets set -a $APP $KV`                                                                                                    | **YES if prod**                 | [`secrets.md`](references/secrets.md)   |
+| `secrets unset`                          | `[-a $APP] K...`                         | `flyctl secrets unset -a $APP $K`                                                                                                   | **YES if prod**                 | [`secrets.md`](references/secrets.md)   |
+| `machines list`                          | `[-a $APP]`                              | `flyctl machines list -a $APP --json`                                                                                               | no                              | [`machines.md`](references/machines.md) |
+| `machines restart\|stop\|start\|destroy` | `<id> [-a $APP]`                         | `flyctl machines <op> $ID -a $APP`                                                                                                  | **YES if stop/destroy on prod** | [`machines.md`](references/machines.md) |
+| `scale show`                             | `[-a $APP]`                              | `flyctl scale show -a $APP`                                                                                                         | no                              | [`scale.md`](references/scale.md)       |
+| `scale count <n>`                        | `[-a $APP]`                              | `flyctl scale count $N -a $APP`                                                                                                     | **YES if prod or n=0**          | [`scale.md`](references/scale.md)       |
+| `scale vm <preset>`                      | `[-a $APP] [--memory MB]`                | `flyctl scale vm $P -a $APP`                                                                                                        | **YES if prod**                 | [`scale.md`](references/scale.md)       |
+| `ssh`                                    | `[console\|sftp] [-a $APP] [-s ID]`      | `flyctl ssh $SUB -a $APP`                                                                                                           | no                              | [`ssh.md`](references/ssh.md)           |
+| `proxy`                                  | `<local:remote> [-a $APP]`               | `flyctl proxy $P -a $APP`                                                                                                           | no                              | [`proxy.md`](references/proxy.md)       |
+| `health`                                 | `[-a $APP] [--path P]`                   | discover endpoints from `fly.toml`, proxy + curl                                                                                    | no                              | [`health.md`](references/health.md)     |
+| _any other_                              | –                                        | run `flyctl <cmd> --help`, classify the verb, **stop and prompt for explicit operator approval before executing any mutating verb** | per-op                          | –                                       |
+
+## Confirmation Contract
+
+Destructive ops on prod-flavored apps require the operator to type the exact app
+name. The heuristic for "prod-flavored" is: app name does NOT match
+`*-staging*`, `*-preview*`, `*-pr-*`, `*-dev*`, or `*-test*`.
+
+```bash
+# no_confirm_flag MUST be derived ONLY from an explicitly parsed --no-confirm
+# flag in $@. The skill never reads any environment variable (e.g. NO_CONFIRM)
+# as a bypass — operator intent must be on the command line for each invocation.
+confirm_if_prod() {
+  local app="$1" op="$2" no_confirm_flag="$3"
+  [ "$no_confirm_flag" = "1" ] && return 0
+  case "$app" in
+    *-staging*|*-preview*|*-pr-*|*-dev*|*-test*) return 0 ;;
+  esac
+  printf 'About to run %s on PROD app %s.\nType the app name to confirm: ' "$op" "$app" >&2
+  read -r reply
+  [ "$reply" = "$app" ] || { echo "confirmation failed" >&2; exit 1; }
+}
+
+# Argument-parsing stub the skill MUST follow before calling confirm_if_prod:
+no_confirm_flag=0
+parsed=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-confirm) no_confirm_flag=1 ;;
+    *) parsed+=("$arg") ;;
+  esac
+done
+set -- "${parsed[@]}"
+```
+
+Lighter than `/rollback-prod`'s `ROLLBACK PROD` literal because deploy/scale are
+less catastrophic than rollback; typing the app name is harder to muscle-memory
+than a fixed string and is context-aware. Confirmation bypass derives from the
+parsed CLI flag only — env vars cannot grant it.
+
+## Rules
+
+- Auto-discover `app` from root `fly.toml`; never hardcode names, regions, VM presets, or secret names.
+- Resolve CLI as `flyctl` first, `fly` second; never re-install.
+- Use existing CLI auth (`flyctl auth whoami`); never prompt for tokens.
+- Destructive ops on prod-flavored apps require typed confirmation matching the app name.
+- `--no-confirm` is honored only when passed explicitly; never via env or autonomous routing.
+- Print the exact `flyctl ...` command before executing (audit trail).
+- Preserve flyctl native exit codes; remap only discovery/auth failures to `2`.
+- Multi-app monorepos: refuse to guess — operator must `cd` into the app dir or pass `-a <app>`.
+- Never echo secret values to chat — only names.
+- For unlisted subcommands: run `flyctl <subcommand> --help` first, classify mutability from the verb and the help text, and **require explicit operator y/N approval before executing any mutating op**. Read-only verbs (`list`, `show`, `status`, `info`, `history`, `version`) may run without prompting.
+
+## Failure Modes
+
+| Condition                                | Exit | Behavior                                                                      |
+| ---------------------------------------- | ---- | ----------------------------------------------------------------------------- |
+| Success                                  | `0`  | preserve flyctl exit                                                          |
+| Confirmation declined / flyctl exit 1    | `1`  | preserve                                                                      |
+| No `fly.toml` in cwd and no `-a`         | `2`  | print: "no fly.toml in `<pwd>`; pass -a `<app>` or cd into the app directory" |
+| `flyctl`/`fly` not on PATH               | `2`  | print install URL                                                             |
+| `auth whoami` fails                      | `2`  | print `flyctl auth login`                                                     |
+| `fly.toml` exists but `app` line missing | `2`  | print: "could not resolve app name from fly.toml; pass -a `<app>`"            |
+| Invalid `--image` ref (pre-flight regex) | `2`  | print expected format                                                         |
+
+## Optional Config
+
+This file is **not consumed by v1.0.0** — it documents the v1.1 config surface
+so contributors can preview it. Operators whose prod apps don't match
+`*-staging*` / `*-preview*` / `*-pr-*` / `*-dev*` / `*-test*` will get
+typed-confirmation prompts on every mutating op until v1.1 wires `confirm_never`
+to override the heuristic; pass `--no-confirm` per-invocation until then.
+
+See [`examples/fly-targets.example.json`](examples/fly-targets.example.json).
+
+## See also
+
+- [`/deploy-status`](../deploy-status/SKILL.md) — read-only SHA / release status across all configured deploy targets (use this when you want a snapshot, not an action).
+- [`/rollback-prod`](../rollback-prod/SKILL.md) — confirmation-gated rollback across all targets (use this for incident response; `/flyctl` is for non-incident, fly-only ops).

--- a/skills/flyctl/SKILL.md
+++ b/skills/flyctl/SKILL.md
@@ -17,8 +17,8 @@ description: >
   the app from fly.toml in the current directory. Side-effectful ops on
   prod-flavored apps require typed confirmation matching the app name.
   Rollback is delegated to /rollback-prod; cross-provider SHA reporting is
-  delegated to /deploy-status. For any subcommand not enumerated in
-  references/, run `flyctl <subcommand> --help` for canonical reference.
+  delegated to /deploy-status. Unlisted subcommands require
+  `flyctl <subcommand> --help` first.
 argument-hint: "<subcommand> [-a <app>] [--no-confirm] [...]"
 tools: Bash, Read, Grep, Glob
 model: sonnet
@@ -33,16 +33,13 @@ Portable Fly.io operations wrapper. Invoke as `/flyctl <subcommand>`.
 
 ## When to Use
 
-This skill is **explicit-invocation only** (`disable-model-invocation: true`). The
-model will not auto-route phrases like "tail fly logs" or "fly deploy" to this
-skill — the operator must type `/flyctl <subcommand>` directly. This is the
-safe contract for a side-effectful skill (deploy, secrets-set, scale, machines
-destroy).
+This skill is **explicit-invocation only** (`disable-model-invocation: true`).
+The operator must type `/flyctl <subcommand>` directly; the model must not
+auto-route phrases like "tail fly logs" or "fly deploy" to this side-effectful
+skill.
 
-Use `/flyctl` when you have an existing Fly.io app (its `fly.toml` is in the
-current directory) and you want to perform any of the operations enumerated in
-the Subcommands table below. The skill auto-discovers the app from `fly.toml`;
-all subcommands accept `-a <app>` to override.
+Use `/flyctl` from a Fly.io app directory containing `fly.toml`, or pass
+`-a <app>` to override auto-discovery.
 
 ## Out of Scope
 
@@ -51,13 +48,14 @@ This skill does **not** perform rollback or cross-provider release reporting.
 - For rollback to the previous release, use `/rollback-prod`.
 - For deployed git-SHA reporting across Vercel/Fly/AWS, use `/deploy-status`.
 - For app provisioning (`fly launch`, region setup), use the Fly UI or your IaC layer.
-- For any subcommand not enumerated above, run `flyctl <subcommand> --help` for
-  canonical reference. Read-only verbs (list, show, status, info, history,
-  version) may proceed without confirmation; mutating verbs (create, destroy,
-  delete, scale, restart, update, set, unset, deploy, suspend, resume,
-  regions add/remove, and any verb whose `--help` text mentions "destructive",
-  "irreversible", or "will redeploy") MUST be presented to the operator with
-  the exact command and require explicit y/N approval before executing.
+- For any subcommand not listed in the table or reference files, run
+  `flyctl <subcommand> --help` for canonical reference. Read-only verbs (list,
+  show, status, info, history, version) may proceed without confirmation;
+  mutating verbs (create, destroy, delete, scale, restart, update, set, unset,
+  deploy, suspend, resume, regions add/remove, and any verb whose `--help` text
+  mentions "destructive", "irreversible", or "will redeploy") MUST be presented
+  to the operator with the exact command and require explicit y/N approval before
+  executing.
 
 ## Auto-Discovery
 
@@ -69,8 +67,11 @@ guess across nested `fly.toml` files.
 
 ```bash
 # CLI: prefer flyctl, fall back to fly
-FLY="$(command -v flyctl || command -v fly)" \
-  || { echo "flyctl/fly not on PATH; see https://fly.io/docs/flyctl/install/" >&2; exit 2; }
+FLY="$(command -v flyctl || command -v fly || true)"
+if [ -z "$FLY" ]; then
+  echo "flyctl/fly not on PATH; see https://fly.io/docs/flyctl/install/" >&2
+  exit 2
+fi
 
 # App: -a flag wins; otherwise parse root fly.toml only.
 # Mirrors parseFlyApp() in deploy-ops.mjs — supports leading whitespace
@@ -82,11 +83,7 @@ if [ -z "$APP" ]; then
     echo "no fly.toml in $(pwd); pass -a <app> or cd into the app directory" >&2
     exit 2
   fi
-  # Try double-quoted form first, then single-quoted as fallback.
-  APP="$(awk -F'"' '/^[[:space:]]*app[[:space:]]*=[[:space:]]*"/{print $2; exit}' fly.toml)"
-  if [ -z "$APP" ]; then
-    APP="$(awk -F"'" '/^[[:space:]]*app[[:space:]]*=[[:space:]]*'"'"'/{print $2; exit}' fly.toml)"
-  fi
+  APP="$(sed -nE "s/^[[:space:]]*app[[:space:]]*=[[:space:]]*['\"]([^'\"]+)['\"].*/\1/p" fly.toml | head -n 1)"
 fi
 [ -z "$APP" ] && { echo "could not resolve app name from fly.toml; pass -a <app>" >&2; exit 2; }
 

--- a/skills/flyctl/examples/fly-targets.example.json
+++ b/skills/flyctl/examples/fly-targets.example.json
@@ -1,0 +1,14 @@
+{
+  "default_app": "my-api",
+  "environments": {
+    "prod": "my-api",
+    "staging": "my-api-staging",
+    "preview": "my-api-pr-{N}"
+  },
+  "deploy": {
+    "strategy": "bluegreen",
+    "require_digest": true
+  },
+  "confirm_always": ["my-api", "my-api-db"],
+  "confirm_never": ["my-api-dev"]
+}

--- a/skills/flyctl/references/deploy.md
+++ b/skills/flyctl/references/deploy.md
@@ -1,0 +1,101 @@
+# `/flyctl deploy`
+
+Deploy a Fly.io app from source or from a pre-built container image.
+
+## Pre-flight: validate `--image` reference
+
+Before invoking `flyctl deploy --image`, validate the image reference matches the
+expected format. Reject anything that doesn't match:
+
+```bash
+IMAGE_RE='^[a-z0-9._/-]+(:[A-Za-z0-9._-]+)?(@sha256:[a-f0-9]{64})?$'
+if ! echo "$IMAGE" | grep -Eq "$IMAGE_RE"; then
+  echo "invalid image ref: $IMAGE" >&2
+  echo "expected: <registry>/<repo>[:tag][@sha256:<digest>]" >&2
+  exit 2
+fi
+```
+
+**Strongly recommend digest pinning** (`@sha256:...`) for production deploys. A
+mutable `:tag` reference is resolved by Fly's builder at deploy time and
+introduces ambiguity if the registry is repushed mid-deploy.
+
+If `--image` is missing the digest, warn but do not block:
+
+```bash
+case "$IMAGE" in
+  *@sha256:*) ;;
+  *) echo "warning: deploying mutable tag $IMAGE — recommend digest pinning" >&2 ;;
+esac
+```
+
+## Source vs image deploys
+
+| Form                   | Command                                                   | When to use                                               |
+| ---------------------- | --------------------------------------------------------- | --------------------------------------------------------- |
+| Source build (default) | `flyctl deploy -a $APP`                                   | Local source + Dockerfile, builder runs on Fly            |
+| Source, remote builder | `flyctl deploy -a $APP --remote-only`                     | No local Docker; offload to Fly's remote builder          |
+| Source, local builder  | `flyctl deploy -a $APP --local-only`                      | Force local Docker (faster iteration on big images)       |
+| Pre-built image        | `flyctl deploy -a $APP --image $REF`                      | CI built the image and pushed to a registry; just promote |
+| Pre-built, no fly.toml | `flyctl deploy -a $APP --image $REF --strategy bluegreen` | Need explicit strategy override                           |
+
+## `--strategy` semantics
+
+| Strategy            | Behavior                                                   | Use when                                                |
+| ------------------- | ---------------------------------------------------------- | ------------------------------------------------------- |
+| `immediate`         | All machines updated at once; brief outage                 | Single-machine dev/preview apps                         |
+| `rolling` (default) | One machine at a time                                      | Most multi-machine apps                                 |
+| `bluegreen`         | Spin up new machines alongside old, swap traffic           | Zero-downtime prod deploys; doubles cost during rollout |
+| `canary`            | Deploy to one machine, hold for health check, then proceed | High-risk releases                                      |
+
+Read the value from `fly.toml` `deploy.strategy` first; honor an explicit
+`--strategy` override only when the operator passes it.
+
+## `--build-arg` and `--build-secret`
+
+Repeatable. Form: `--build-arg KEY=VALUE`. Build secrets are not persisted in
+the image (Docker buildkit secret-mount semantics):
+
+```bash
+flyctl deploy -a $APP --build-arg NODE_ENV=production --build-secret npmrc="$(cat .npmrc)"
+```
+
+Never paste secret values into chat. If a build secret is needed, prompt the
+operator for the source.
+
+## `release_command` failure
+
+If `fly.toml` defines `[deploy].release_command`, Fly runs it in a one-shot
+machine after the build and before swapping traffic. A non-zero exit aborts the
+deploy. Common causes:
+
+- Database migration failure — check `flyctl logs -a $APP` for the one-shot
+  machine output
+- Missing env/secret in the new release — check the secrets diff against the
+  previous release with `flyctl releases -a $APP --json | jq '.[0:2]'`
+
+Recovery: roll back via `/rollback-prod` (this skill does NOT do rollback).
+
+## Confirmation rail
+
+For prod-flavored apps, always run `confirm_if_prod "$APP" deploy "$no_confirm_flag"`
+before invoking `flyctl deploy`. The operator must type the exact app name to
+proceed. `--no-confirm` is only honored when passed explicitly on the command
+line.
+
+## Post-deploy verification
+
+After `flyctl deploy` returns 0, verify the new release is healthy:
+
+```bash
+flyctl status -a "$APP"
+flyctl releases -a "$APP" --json | jq '.[0]'
+```
+
+For end-to-end health, see [`health.md`](health.md) for the `flyctl proxy` + curl
+pattern.
+
+## See also
+
+- [`/rollback-prod`](../../rollback-prod/SKILL.md) — rollback the release this deploy created.
+- [`/deploy-status`](../../deploy-status/SKILL.md) — confirm the new SHA matches `origin/main`.

--- a/skills/flyctl/references/deploy.md
+++ b/skills/flyctl/references/deploy.md
@@ -9,7 +9,7 @@ expected format. Reject anything that doesn't match:
 
 ```bash
 IMAGE_RE='^[a-z0-9._/-]+(:[A-Za-z0-9._-]+)?(@sha256:[a-f0-9]{64})?$'
-if ! echo "$IMAGE" | grep -Eq "$IMAGE_RE"; then
+if ! printf '%s\n' "$IMAGE" | grep -Eq "$IMAGE_RE"; then
   echo "invalid image ref: $IMAGE" >&2
   echo "expected: <registry>/<repo>[:tag][@sha256:<digest>]" >&2
   exit 2
@@ -57,7 +57,9 @@ Repeatable. Form: `--build-arg KEY=VALUE`. Build secrets are not persisted in
 the image (Docker buildkit secret-mount semantics):
 
 ```bash
-flyctl deploy -a $APP --build-arg NODE_ENV=production --build-secret npmrc="$(cat .npmrc)"
+flyctl deploy -a $APP \
+  --build-arg NODE_ENV=production \
+  --build-secret npmrc="$(cat .npmrc)"
 ```
 
 Never paste secret values into chat. If a build secret is needed, prompt the
@@ -78,10 +80,10 @@ Recovery: roll back via `/rollback-prod` (this skill does NOT do rollback).
 
 ## Confirmation rail
 
-For prod-flavored apps, always run `confirm_if_prod "$APP" deploy "$no_confirm_flag"`
-before invoking `flyctl deploy`. The operator must type the exact app name to
-proceed. `--no-confirm` is only honored when passed explicitly on the command
-line.
+For prod-flavored apps, run
+`confirm_if_prod "$APP" deploy "$no_confirm_flag"` before invoking
+`flyctl deploy`; the shared confirmation contract handles app-name confirmation
+and CLI-only `--no-confirm`.
 
 ## Post-deploy verification
 

--- a/skills/flyctl/references/deploy.md
+++ b/skills/flyctl/references/deploy.md
@@ -59,8 +59,13 @@ the image (Docker buildkit secret-mount semantics):
 ```bash
 flyctl deploy -a $APP \
   --build-arg NODE_ENV=production \
-  --build-secret npmrc="$(cat .npmrc)"
+  --build-secret npmrc=@.npmrc
 ```
+
+Use `name=@path` (file reference) rather than `name="$(cat ...)"` — the
+`$(cat ...)` substitution inlines the secret into argv, exposing it in `ps`
+output and the skill's audit print. Docker buildkit's secret-mount keeps the
+file contents out of the process argument list when the `@path` form is used.
 
 Never paste secret values into chat. If a build secret is needed, prompt the
 operator for the source.

--- a/skills/flyctl/references/health.md
+++ b/skills/flyctl/references/health.md
@@ -1,0 +1,94 @@
+# `/flyctl health`
+
+Run a quick health check against the app's HTTP endpoints via `flyctl proxy` and
+`curl`. Endpoints are **NOT universal** — every project picks its own
+(`/livez`, `/readyz`, `/healthz`, `/_health`, none-at-all). This skill never
+hardcodes paths; it discovers them from `fly.toml` or asks the operator.
+
+## Discovery strategy
+
+1. **Parse `fly.toml`** for health-check paths. Fly supports two main forms:
+
+   ```toml
+   # Form A (current)
+   [[http_service.checks]]
+   path = "/healthz"
+   interval = "10s"
+
+   # Form B (legacy v2 services)
+   [[services.http_checks]]
+   path = "/healthz"
+   ```
+
+   Extract paths:
+
+   ```bash
+   paths=$(grep -E '^[[:space:]]*path[[:space:]]*=' fly.toml | sed -E 's/.*path[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+   ```
+
+2. **Override via `--path`** if the operator passes a specific endpoint:
+
+   ```bash
+   /flyctl health --path /custom-health
+   ```
+
+3. **Fallback prompt** when no checks are configured AND no `--path` was given.
+   Ask the operator:
+
+   > No health-check paths found in `fly.toml`. Provide one (e.g. `/healthz`)
+   > or use `--path <p>`.
+
+   Do NOT guess `/livez` / `/readyz` / `/healthz` — many apps don't expose
+   those, and a 404 from a guessed path is worse than no check at all.
+
+## Probe via `flyctl proxy`
+
+```bash
+INTERNAL_PORT=$(awk -F'=' '/^[[:space:]]*internal_port[[:space:]]*=/{gsub(/[[:space:]]/,""); print $2; exit}' fly.toml)
+INTERNAL_PORT="${INTERNAL_PORT:-8080}"
+LOCAL_PORT=18080
+
+flyctl proxy "$LOCAL_PORT:$INTERNAL_PORT" -a "$APP" &
+PROXY_PID=$!
+sleep 2
+
+for p in $paths; do
+  echo "=== $p ==="
+  curl -sf -w 'HTTP %{http_code} in %{time_total}s\n' "http://localhost:$LOCAL_PORT$p" || echo "FAILED: $p"
+done
+
+kill $PROXY_PID 2>/dev/null
+wait $PROXY_PID 2>/dev/null || true
+```
+
+## Authenticated endpoints
+
+Some apps gate health endpoints behind a header (e.g. `X-Admin-Secret`). Don't
+auto-fetch the secret from `flyctl secrets` (values are not retrievable —
+secrets are write-only from outside the running app). Either:
+
+- The operator pastes the secret into the prompt (skill never logs it)
+- The operator runs the curl manually after the proxy is up
+- The app exposes a public, unauthenticated liveness path (recommended)
+
+## Multi-endpoint sequencing
+
+If `fly.toml` declares multiple checks (e.g., `/livez` + `/readyz`), probe both
+in order. Stop on the first failure and surface that endpoint's response body
+to the operator for triage.
+
+## Interpretation
+
+| Outcome                     | Meaning                                                                       |
+| --------------------------- | ----------------------------------------------------------------------------- |
+| All paths 2xx               | App is responding                                                             |
+| Liveness 2xx, readiness 5xx | Process is up but dependencies (DB, cache) are unhealthy                      |
+| All paths timeout           | Machine likely stopped or unreachable — check `flyctl status`                 |
+| 404 on a documented path    | Path mismatch — verify the path against the running code, not just `fly.toml` |
+
+## Project-specific health workflows
+
+This reference covers generic discovery. Project-specific multi-step health
+playbooks (e.g., "after deploy, check `/livez`, `/readyz`, `/api/data-health`,
+then Sentry") belong in a project-scoped slash command that calls `/flyctl
+health` plus any project-specific endpoints.

--- a/skills/flyctl/references/health.md
+++ b/skills/flyctl/references/health.md
@@ -23,7 +23,7 @@ hardcodes paths; it discovers them from `fly.toml` or asks the operator.
    Extract paths:
 
    ```bash
-   paths=$(grep -E '^[[:space:]]*path[[:space:]]*=' fly.toml | sed -E 's/.*path[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+   paths=$(sed -nE "s/^[[:space:]]*path[[:space:]]*=[[:space:]]*['\"]([^'\"]+)['\"].*/\1/p" fly.toml)
    ```
 
 2. **Override via `--path`** if the operator passes a specific endpoint:
@@ -52,13 +52,14 @@ flyctl proxy "$LOCAL_PORT:$INTERNAL_PORT" -a "$APP" &
 PROXY_PID=$!
 sleep 2
 
-for p in $paths; do
-  echo "=== $p ==="
-  curl -sf -w 'HTTP %{http_code} in %{time_total}s\n' "http://localhost:$LOCAL_PORT$p" || echo "FAILED: $p"
+for health_path in $paths; do
+  echo "=== $health_path ==="
+  curl -sf -w 'HTTP %{http_code} in %{time_total}s\n' "http://localhost:$LOCAL_PORT$health_path" \
+    || echo "FAILED: $health_path"
 done
 
-kill $PROXY_PID 2>/dev/null
-wait $PROXY_PID 2>/dev/null || true
+kill "$PROXY_PID" 2>/dev/null
+wait "$PROXY_PID" 2>/dev/null || true
 ```
 
 ## Authenticated endpoints

--- a/skills/flyctl/references/logs.md
+++ b/skills/flyctl/references/logs.md
@@ -1,0 +1,54 @@
+# `/flyctl logs`
+
+Tail or one-shot fetch logs from a Fly.io app.
+
+## Forms
+
+| Goal                     | Command                                     |
+| ------------------------ | ------------------------------------------- |
+| Live tail                | `flyctl logs -a $APP`                       |
+| One-shot, last ~50 lines | `flyctl logs -a $APP --no-tail \| tail -50` |
+| Filter to one machine    | `flyctl logs -a $APP -i <machine-id>`       |
+| Filter to one region     | `flyctl logs -a $APP --region gru`          |
+| JSON output for piping   | `flyctl logs -a $APP --json`                |
+
+`-i` machine IDs are volatile — re-run `flyctl machines list -a $APP --json` to
+get the current set before targeting.
+
+## Common grep patterns
+
+```bash
+# Errors, fatals, panics
+flyctl logs -a $APP --no-tail 2>&1 | grep -E "FTL|ERR|panic|fatal"
+
+# Specific request-id (when the app logs structured fields)
+flyctl logs -a $APP --json | jq -r 'select(.attributes.request_id=="<id>")'
+
+# Timeouts and connection failures
+flyctl logs -a $APP --no-tail 2>&1 | grep -Ei "timeout|connection refused|EOF"
+
+# Database-flavored errors
+flyctl logs -a $APP --no-tail 2>&1 | grep -Ei "postgres|database|pgx|sqlx"
+```
+
+## When the app logs are quiet
+
+If `flyctl logs` returns nothing recent, check that the app is actually
+receiving traffic:
+
+```bash
+flyctl status -a $APP            # machines running?
+flyctl checks list -a $APP       # health checks passing?
+```
+
+A machine in `stopped` state with `auto_stop: true` is expected when there's
+been no traffic — logs will resume on the next request that wakes the machine.
+
+## Triage workflow
+
+For a structured incident-triage flow (1: confirm the problem, 2: find the
+error in logs, 3: classify, 4: correlate with the latest deploy, 5: check
+resource pressure, 6: check Sentry / external monitoring), this skill does NOT
+encode the project-specific playbook. Author it in your project's
+`.claude/commands/` directory, calling `/flyctl logs` and `/flyctl releases`
+from within it.

--- a/skills/flyctl/references/machines.md
+++ b/skills/flyctl/references/machines.md
@@ -1,0 +1,67 @@
+# `/flyctl machines`
+
+Inspect and manipulate individual Fly Machines under an app.
+
+## Verbs
+
+| Verb           | Command                                        | Confirm on prod? |
+| -------------- | ---------------------------------------------- | ---------------- |
+| `list`         | `flyctl machines list -a $APP --json`          | no               |
+| `status <id>`  | `flyctl machines status <id> -a $APP`          | no               |
+| `restart <id>` | `flyctl machines restart <id> -a $APP`         | no (transient)   |
+| `stop <id>`    | `flyctl machines stop <id> -a $APP`            | **yes**          |
+| `start <id>`   | `flyctl machines start <id> -a $APP`           | no               |
+| `destroy <id>` | `flyctl machines destroy <id> --force -a $APP` | **yes**          |
+
+## List with JSON for scripting
+
+```bash
+flyctl machines list -a $APP --json | jq '.[] | {id, name, state, checks: .checks[]?.status}'
+```
+
+State values: `created`, `started`, `stopped`, `suspended`, `replacing`,
+`destroyed`, `destroying`.
+
+## Machine IDs are volatile
+
+After `flyctl scale count`, `flyctl machines destroy`, or `flyctl deploy
+--strategy bluegreen`, the set of machine IDs changes. Always re-query before
+targeting:
+
+```bash
+ids=$(flyctl machines list -a $APP --json | jq -r '.[].id')
+```
+
+## `stop` vs `apps suspend`
+
+| Action                         | Scope                            | Reversible?                          |
+| ------------------------------ | -------------------------------- | ------------------------------------ |
+| `flyctl machines stop <id>`    | One machine                      | yes — `flyctl machines start <id>`   |
+| `flyctl scale count 0 -a $APP` | All machines, app stays          | yes — scale back up                  |
+| `flyctl apps suspend -a $APP`  | Whole app, traffic blocked       | yes — `flyctl apps resume -a $APP`   |
+| `flyctl apps destroy -a $APP`  | App + machines + volumes deleted | **no** — out of scope for this skill |
+
+## Stuck `stopped` machines
+
+With `auto_stop = true` in `fly.toml`, a machine in `stopped` state is normal
+behavior between requests. Only intervene if:
+
+- ALL machines are stopped AND traffic should be active
+- A machine has been stopped for > 5 minutes AND health checks were failing
+  before it stopped (suggests OOM-kill or panic)
+
+To force-wake one:
+
+```bash
+ID=$(flyctl machines list -a $APP --json | jq -r '.[] | select(.state=="stopped") | .id' | head -1)
+flyctl machines start "$ID" -a $APP
+```
+
+## Destroy
+
+`flyctl machines destroy <id> --force` is irreversible from this skill's
+perspective. Always confirm on prod. After destruction, a `flyctl deploy` will
+recreate machines from the latest release.
+
+For full app destruction (`flyctl apps destroy`), this skill refuses — use the
+Fly UI explicitly.

--- a/skills/flyctl/references/proxy.md
+++ b/skills/flyctl/references/proxy.md
@@ -1,0 +1,59 @@
+# `/flyctl proxy`
+
+Forward a local port to an internal Fly service.
+
+## Form
+
+```bash
+flyctl proxy <local-port>[:<remote-port>] [-a $APP]
+```
+
+If `<remote-port>` is omitted, Fly uses the app's primary internal port (read
+from `fly.toml` `[services]` or `[http_service]`).
+
+## Common use cases
+
+| Goal                      | Command                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------- |
+| Hit `/healthz` on prod    | `flyctl proxy 8080 -a $APP` → `curl http://localhost:8080/healthz`                                |
+| Connect to Fly Postgres   | `flyctl proxy 5432 -a $APP-db` → `psql postgres://...@localhost:5432/...`                         |
+| Connect to internal Redis | `flyctl proxy 6379 -a $APP-redis` → `redis-cli -p 6379`                                           |
+| Hit admin endpoint        | `flyctl proxy 8080 -a $APP` → `curl -H "X-Admin-Secret: $SECRET" http://localhost:8080/admin/...` |
+
+## `.flycast` internal hostnames
+
+Fly's internal networking exposes apps to each other via `.flycast` and
+`.internal` hostnames. `flyctl proxy` is the bridge that brings these into the
+operator's local machine. The proxy listens on `127.0.0.1` by default; bind to
+all interfaces with `--bind-addr 0.0.0.0:<port>` if you need WSL/host access
+(rarely needed).
+
+## Lifecycle
+
+`flyctl proxy` runs in the foreground until killed. Common pattern in scripts:
+
+```bash
+flyctl proxy 8080 -a $APP &
+PROXY_PID=$!
+sleep 2
+curl -sf http://localhost:8080/healthz
+kill $PROXY_PID 2>/dev/null
+wait $PROXY_PID 2>/dev/null || true
+```
+
+Always clean up the proxy PID — leaving it running blocks the port for the next
+invocation.
+
+## Authentication
+
+The proxy inherits `flyctl auth` state. If the proxy fails to connect, run
+`flyctl auth whoami` to verify the session is valid for the app's org.
+
+## Limitations
+
+- One port per `flyctl proxy` invocation. Multiple internal services require
+  multiple background proxies on different local ports.
+- TCP only. WebSocket and HTTP/2 work because they ride on TCP, but UDP services
+  are not supported.
+- Long-running proxies survive flyctl auth refresh; if auth expires mid-session,
+  the proxy reports broken pipe and exits.

--- a/skills/flyctl/references/proxy.md
+++ b/skills/flyctl/references/proxy.md
@@ -37,8 +37,8 @@ flyctl proxy 8080 -a $APP &
 PROXY_PID=$!
 sleep 2
 curl -sf http://localhost:8080/healthz
-kill $PROXY_PID 2>/dev/null
-wait $PROXY_PID 2>/dev/null || true
+kill "$PROXY_PID" 2>/dev/null
+wait "$PROXY_PID" 2>/dev/null || true
 ```
 
 Always clean up the proxy PID — leaving it running blocks the port for the next

--- a/skills/flyctl/references/releases.md
+++ b/skills/flyctl/references/releases.md
@@ -1,0 +1,72 @@
+# `/flyctl releases`
+
+List Fly.io app releases — version, status, image, deployer, timestamp.
+
+## Forms
+
+```bash
+flyctl releases -a $APP                  # human-readable table
+flyctl releases -a $APP --json           # structured output for piping
+flyctl releases -a $APP --image          # include image refs (some older flyctl versions)
+```
+
+## Columns (JSON)
+
+Per release object:
+
+| Field                 | Meaning                                             |
+| --------------------- | --------------------------------------------------- |
+| `version`             | Monotonic release number (v1, v2, ...)              |
+| `status`              | `succeeded`, `failed`, `pending`, `running`         |
+| `image_ref` / `image` | Container image reference deployed (when available) |
+| `deployer`            | User or bot that triggered the deploy               |
+| `created_at`          | ISO 8601 timestamp                                  |
+| `description`         | Deploy reason or release-command summary            |
+
+## Common queries
+
+```bash
+# Most recent successful release
+flyctl releases -a $APP --json \
+  | jq -r '[.[] | select(.status=="succeeded")][0]'
+
+# Diff the two most recent releases' image refs
+flyctl releases -a $APP --json \
+  | jq -r '.[0:2] | map(.image_ref // .image) | @tsv'
+
+# Find releases by a specific deployer
+flyctl releases -a $APP --json \
+  | jq '.[] | select(.deployer=="github-actions[bot]")'
+```
+
+## Cross-reference with deploy status
+
+`/flyctl releases` shows the release sequence; `/deploy-status` resolves the
+deployed git SHA and compares against `origin/main`. Together:
+
+```bash
+# Latest release
+flyctl releases -a $APP --json | jq -r '.[0] | {version, image_ref, created_at}'
+
+# Compare against main (cross-provider, includes Vercel/AWS too)
+# /deploy-status
+```
+
+## Failed-release recovery
+
+If the most recent release shows `status: "failed"`, the previous successful
+release is still serving traffic. Roll forward (fix + redeploy) is usually the
+right answer, not roll back. For an explicit rollback to the previous
+succeeded release, use `/rollback-prod` (this skill does not roll back).
+
+To inspect why a release failed:
+
+```bash
+flyctl logs -a $APP --no-tail 2>&1 | head -100   # release_command output is in logs
+flyctl releases -a $APP --json | jq '.[0].description'
+```
+
+## See also
+
+- [`/deploy-status`](../../deploy-status/SKILL.md) — read-only SHA reconciliation.
+- [`/rollback-prod`](../../rollback-prod/SKILL.md) — gated rollback to previous release.

--- a/skills/flyctl/references/scale.md
+++ b/skills/flyctl/references/scale.md
@@ -1,0 +1,71 @@
+# `/flyctl scale`
+
+Adjust Fly Machines: how many, what VM size, how much memory, what regions.
+
+## Subverbs
+
+| Verb                     | Command                                     | Confirm on prod?       |
+| ------------------------ | ------------------------------------------- | ---------------------- |
+| `show`                   | `flyctl scale show -a $APP`                 | no                     |
+| `count <n>`              | `flyctl scale count $N -a $APP`             | **yes if prod or n=0** |
+| `count <n> --region <r>` | `flyctl scale count $N --region $R -a $APP` | **yes if prod or n=0** |
+| `vm <preset>`            | `flyctl scale vm $PRESET -a $APP`           | **yes if prod**        |
+| `memory <mb>`            | `flyctl scale memory $MB -a $APP`           | **yes if prod**        |
+
+## `scale count 0` is destructive on prod
+
+Scaling to zero machines drains traffic and leaves no warm capacity. Treat it
+as a destructive op even on non-prod-flavored apps; gate behind confirmation
+unless the operator explicitly passes `--no-confirm`.
+
+## VM presets
+
+Common presets (verify against `flyctl platform vm-sizes`):
+
+| Preset           | vCPU        | Memory | Use case                 |
+| ---------------- | ----------- | ------ | ------------------------ |
+| `shared-cpu-1x`  | 1 shared    | 256 MB | Small APIs, cron workers |
+| `shared-cpu-2x`  | 2 shared    | 512 MB | Medium APIs              |
+| `shared-cpu-4x`  | 4 shared    | 1 GB   | Larger Node/Go services  |
+| `performance-1x` | 1 dedicated | 2 GB   | Latency-sensitive        |
+| `performance-2x` | 2 dedicated | 4 GB   | CPU-bound services       |
+
+Override memory with `--memory`: `flyctl scale vm shared-cpu-1x --memory 512 -a $APP`.
+
+## Multi-region scale
+
+Fly Apps that span multiple regions: scale per-region with `--region`:
+
+```bash
+flyctl scale count 2 --region gru -a $APP
+flyctl scale count 1 --region cdg -a $APP
+flyctl scale show -a $APP  # confirm new layout
+```
+
+To list regions: `flyctl platform regions`.
+
+## `auto_stop` / `min_machines_running` interactions
+
+If `fly.toml` sets `min_machines_running = N`, `flyctl scale count` won't reduce
+below N (Fly enforces this server-side). To go lower, edit `fly.toml` first
+and `flyctl deploy` to apply, then `flyctl scale count` for the new floor.
+
+`auto_stop` and `auto_start` (typical default `true`) cause machines to stop
+between requests. This is independent of `scale count`: a `count 2` app with
+`auto_stop = true` may show one or zero machines in `started` state at any
+moment.
+
+## Memory ceiling
+
+A common cause of OOM-kills is undersized memory. Inspect Fly's metrics
+endpoint or watch `flyctl logs -a $APP` for `out of memory`. Bump with
+`flyctl scale memory <new-mb>` — the app restarts.
+
+## Verification
+
+After any scale change, confirm:
+
+```bash
+flyctl scale show -a $APP
+flyctl machines list -a $APP --json | jq '.[] | {id, state, region, size: .config.guest.cpus}'
+```

--- a/skills/flyctl/references/secrets.md
+++ b/skills/flyctl/references/secrets.md
@@ -1,0 +1,70 @@
+# `/flyctl secrets`
+
+Manage Fly.io app secrets.
+
+## Verbs
+
+| Verb            | Command                                  | Triggers redeploy?          | Confirm on prod? |
+| --------------- | ---------------------------------------- | --------------------------- | ---------------- |
+| `list`          | `flyctl secrets list -a $APP`            | no                          | no               |
+| `set` (default) | `flyctl secrets set K=V -a $APP`         | **yes**                     | yes              |
+| `set --stage`   | `flyctl secrets set --stage K=V -a $APP` | no (applied on next deploy) | yes              |
+| `unset`         | `flyctl secrets unset K -a $APP`         | **yes**                     | yes              |
+
+## Batch updates → one restart
+
+`flyctl secrets set` accepts multiple `KEY=VALUE` pairs in a single invocation
+and triggers exactly one rolling restart. Always batch when setting more than
+one secret:
+
+```bash
+# Good — one restart
+flyctl secrets set DB_PASSWORD=...new... API_TOKEN=...new... -a $APP
+
+# Bad — two restarts, two windows of partial config
+flyctl secrets set DB_PASSWORD=...new... -a $APP
+flyctl secrets set API_TOKEN=...new... -a $APP
+```
+
+## Never echo secret values
+
+`flyctl secrets list` prints names only (and a digest), never values — that's by
+design. Mirror the same discipline in skill output:
+
+- Never paste a secret value into the chat to the operator
+- Never log the contents of `$VALUE` in audit output
+- When prompting for a secret, redirect the prompt and read silently:
+  `read -s -r VALUE && echo`
+- If the operator pastes a secret into chat, **do not** include it in any
+  subsequent assistant message or commit message
+
+## Rotation flow
+
+1. Obtain the new value from the external system (Neon dashboard, AWS Secrets
+   Manager, 1Password vault, etc.). The user must provide it; this skill does
+   not have access.
+2. `flyctl secrets set KEY="$NEW" -a $APP` (with confirmation if prod).
+3. Wait for the rolling restart to complete (~30 s for a small VM):
+   `flyctl status -a $APP` — confirm all machines are `started` on the new
+   release.
+4. Verify the specific functionality that uses the secret (a health endpoint,
+   a smoke query, etc.) — see [`health.md`](health.md).
+
+## `--stage` for atomic multi-secret + deploy
+
+Use `--stage` when you want to land multiple secrets AND a code change in a
+single deploy:
+
+```bash
+flyctl secrets set --stage DB_URL=... CACHE_URL=... -a $APP
+# no restart yet
+flyctl deploy -a $APP --image registry.fly.io/$APP:new-tag
+# secrets land in the new release
+```
+
+## Project-secret-manager indirection
+
+Many projects use an external secret manager (1Password, AWS Secrets Manager,
+Vault) as the source of truth, with Fly secrets as a runtime cache. If your
+project does, prefer the project's rotation tooling over direct `flyctl secrets
+set` — direct setting bypasses the project audit trail.

--- a/skills/flyctl/references/secrets.md
+++ b/skills/flyctl/references/secrets.md
@@ -11,6 +11,24 @@ Manage Fly.io app secrets.
 | `set --stage`   | `flyctl secrets set --stage K=V -a $APP` | no (applied on next deploy) | yes              |
 | `unset`         | `flyctl secrets unset K -a $APP`         | **yes**                     | yes              |
 
+## Avoid secret values in argv
+
+`flyctl secrets set K=V` places values in the process argument list, where they
+appear in `ps`, `/proc/<pid>/cmdline`, and the skill's audit print. For sensitive
+values, pipe via stdin using `flyctl secrets import`:
+
+```bash
+# Preferred — values never appear in argv
+printf 'DB_PASSWORD=%s\nAPI_TOKEN=%s\n' "$DB_PASS" "$API_TOK" \
+  | flyctl secrets import -a $APP
+
+# Acceptable for low-sensitivity values
+flyctl secrets set PUBLIC_KEY=abc123 -a $APP
+```
+
+`flyctl secrets import` reads `KEY=VALUE` lines from stdin, batches them into
+one restart, and never exposes values on the command line.
+
 ## Batch updates → one restart
 
 `flyctl secrets set` accepts multiple `KEY=VALUE` pairs in a single invocation

--- a/skills/flyctl/references/ssh.md
+++ b/skills/flyctl/references/ssh.md
@@ -1,0 +1,50 @@
+# `/flyctl ssh`
+
+Open an interactive shell or file-transfer session inside a Fly Machine.
+
+## Subverbs
+
+| Form              | Command                                                 | Use case                        |
+| ----------------- | ------------------------------------------------------- | ------------------------------- |
+| Interactive shell | `flyctl ssh console -a $APP`                            | `printenv`, ad-hoc debugging    |
+| Pin to a machine  | `flyctl ssh console -a $APP -s <id>`                    | When one machine is misbehaving |
+| One-shot command  | `flyctl ssh console -a $APP -C "printenv DATABASE_URL"` | Scriptable inspection           |
+| File transfer     | `flyctl ssh sftp shell -a $APP`                         | `get` / `put` of small files    |
+| Issue SSH cert    | `flyctl ssh issue -a $APP`                              | When auth handshake fails       |
+
+## SSH cert refresh
+
+`flyctl` issues short-lived SSH certs automatically. If `flyctl ssh console`
+fails with an authentication error, refresh:
+
+```bash
+flyctl ssh issue -a $APP
+flyctl ssh console -a $APP
+```
+
+## Safety
+
+- SSH gives you a shell on the running machine. Be careful with commands that
+  modify state (DB writes, file overwrites, signal sending). Prefer read-only
+  inspection (`printenv`, `ls`, `cat`).
+- Never run interactive commands that don't terminate (`top`, `htop`) inside a
+  one-shot `-C` call — use `flyctl ssh console` interactively instead.
+- Don't `cat` secrets to the screen. If you need a value, redirect to a local
+  file with `flyctl ssh sftp` or set up a project-side audit log.
+
+## When the machine has no shell
+
+Slim runtime images (distroless, scratch) have no `/bin/sh`. `flyctl ssh
+console` will fail with "exec format error" or similar. Workarounds:
+
+- Add a debug shim to the Dockerfile (`COPY --from=busybox /bin/busybox /bin/sh`)
+- Use `flyctl logs` for runtime inspection instead
+- Open a temporary shell-bearing image with `flyctl deploy --image alpine`
+  (extreme — only in a non-prod app)
+
+## Confirmation rail
+
+SSH is interactive but read-shell from the skill's perspective; commands
+executed inside the SSH session are operator-driven. The skill does not gate
+`flyctl ssh console`. Inside the session, the operator is responsible for any
+mutations they perform.

--- a/skills/rollback-prod/references/fly.md
+++ b/skills/rollback-prod/references/fly.md
@@ -30,3 +30,8 @@ arguments.
   back databases or undo migrations.
 - If Fly rollback fails after another target succeeded, the helper reports the
   partial state and leaves follow-up action to the operator.
+
+## See also
+
+- `/flyctl` — ad-hoc fly ops (deploy, secrets, scale) when you don't need a full multi-target rollback.
+- `/deploy-status` — read-only SHA reporting across all deploy targets.


### PR DESCRIPTION
## Summary

- Add `/flyctl` umbrella skill at `skills/flyctl/` for Fly.io operations (deploy with `--image`, logs, secrets, machines, scale, ssh, proxy, health, releases, status). Auto-discovers app from root `fly.toml`; supports `-a <app>` override. No project-specific assumptions.
- Side-effectful subcommands gate behind typed confirmation matching the app name on prod-flavored apps (heuristic: name does NOT match `*-staging*` / `*-preview*` / `*-pr-*` / `*-dev*` / `*-test*`). `--no-confirm` is honored ONLY when passed explicitly as a CLI flag — never from env. `disable-model-invocation: true` per CLAUDE.md §Skills, Commands, and Discovery; explicit `/flyctl <subcommand>` only.
- Cross-link `/flyctl` from `/deploy-status` and `/rollback-prod` Fly references. Rollback and cross-provider SHA reporting remain delegated to those existing skills.

## Out of scope (explicit deferrals in SKILL.md)

- Rollback → `/rollback-prod` (typed `ROLLBACK PROD` confirmation)
- Cross-provider git-SHA reporting → `/deploy-status`
- App provisioning (`fly launch`, region setup) → Fly UI or IaC layer
- Unlisted subcommands → run `flyctl <subcommand> --help`, classify the verb; mutating verbs require explicit y/N approval

## Test plan

All commands run locally in this worktree. Last 10 lines pasted into the PR thread on request.

- [x] `node plugins/dotbabel/bin/dotbabel-validate-skills.mjs` — `✓ manifest valid (36 skills)`
- [x] `node plugins/dotbabel/bin/dotbabel-validate-specs.mjs` — `✓ 4 spec(s) valid`
- [x] `node plugins/dotbabel/bin/dotbabel-check-instruction-drift.mjs` — `✓ instruction files match repo facts`
- [x] `node plugins/dotbabel/bin/dotbabel-check-instructions-fresh.mjs` — `✓ generated instruction files are fresh`
- [x] `node plugins/dotbabel/bin/dotbabel-check-instruction-parity.mjs` — `✓ generated instruction headings have parity`
- [x] `node plugins/dotbabel/bin/dotbabel-check-spec-coverage.mjs` — `✓ spec coverage ok`
- [x] `node plugins/dotbabel/bin/dotbabel-doctor.mjs` — `✓ project-sync wiring ok (108 entries verified)`
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — `✓ index fresh (60 artifacts)`
- [x] `node scripts/build-plugin.mjs --check` — `✓ plugin templates fresh (153 files + manifest)`
- [x] `node scripts/stamp-doc-versions.mjs --check` — `✓ all 14 docs stamped with v2.7.0`
- [x] `npm run lint` — prettier clean + markdownlint 0 errors + jsdoc-coverage 100%
- [x] `npm test` — 709 / 709 vitest pass
- [x] `npx bats plugins/dotbabel/tests/bats/` — 451 / 451 pass
- [x] Discoverability: `dotbabel-list --type skill | grep flyctl`, `dotbabel-search fly`, `dotbabel-show flyctl --type skill` all surface the skill with the full description
- [x] Negative-case harness (9 / 9 pass): no `fly.toml`; nested-only `fly.toml`; auth failure via `env -i HOME=/tmp/empty PATH=$PATH` (no `flyctl auth logout`); CLI missing; invalid `--image` ref (pre-flight regex); confirmation declined → exit 1; `fly.toml` without `app =`; double-quoted parse; single-quoted parse

## Adoption checklist (draft → validated promotion)

- [ ] Used `/flyctl deploy --image` end-to-end on ≥ 2 real Fly-hosted projects
- [ ] Used `/flyctl logs`, `/flyctl secrets`, `/flyctl scale` flows at least once each
- [ ] No bug-fix PRs against `skills/flyctl/` for 30 days post-merge
- [ ] Squadranks port (separate follow-up PR) lands cleanly without `/flyctl` skill-side changes

## Follow-up PRs (out of scope here)

1. `CONTRIBUTING.md` skill-scaffolding section using `/flyctl` as the worked example (closes the first-time-contributor gap: skill file → `dotbabel-index.mjs` → `build-plugin.mjs` → project-sync → format).
2. Slim `kaiohenricunha/squadranks` `.claude/commands/fly-ops.md` to defer generic ops to `/flyctl`, keeping only project-specific bits (app names, region/VM defaults, secret-category inventory, incident playbooks). Validates `/flyctl` portability.
3. v1.1 wires `.claude/flyctl.json` config consumption via inline `jq` for `confirm_always` / `confirm_never` / `deploy.strategy` overrides. Triggered when an operator with non-conventional naming reports friction.

### Spec coverage rationale

This PR touches `plugins/dotbabel/templates/**` (regenerated by `scripts/build-plugin.mjs`), `plugins/dotbabel/templates/claude/skills-manifest.json`, and `index/**` — all protected paths governed by the `dotbabel-core` spec at `docs/specs/dotbabel-core/spec.json:6-30`. Skill-shipping work is in-scope for that spec's surface (the npm package's templated artifacts).

## Spec ID

dotbabel-core
