### PR TITLE
feat: add portable /local-attest skill for local CI attestation

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -234,6 +234,13 @@
       "lastValidated": "2026-05-11"
     },
     {
+      "name": "local-attest",
+      "path": ".claude/skills/local-attest/SKILL.md",
+      "checksum": "sha256:86a499fcaa8958539361d464b33eca1ef97d2ce960100be459c169a26476b2ef",
+      "dependencies": [],
+      "lastValidated": "2026-05-23"
+    },
+    {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:f920c63e4d70bd7490cc52ba07b9e4e01577631ef06025031d7d8404a39543e2",

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -236,7 +236,7 @@
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
-      "checksum": "sha256:86a499fcaa8958539361d464b33eca1ef97d2ce960100be459c169a26476b2ef",
+      "checksum": "sha256:a4fab149f1ea05770de853331d321fc2e8d4a745fcb52dcc1da1f76edbe4a995",
       "dependencies": [],
       "lastValidated": "2026-05-23"
     },

--- a/.codex/skills/local-attest
+++ b/.codex/skills/local-attest
@@ -1,0 +1,1 @@
+../../.claude/skills/local-attest

--- a/.gemini/skills/local-attest
+++ b/.gemini/skills/local-attest
@@ -1,0 +1,1 @@
+../../.claude/skills/local-attest

--- a/.github/instructions/local-attest.instructions.md
+++ b/.github/instructions/local-attest.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/local-attest/SKILL.md

--- a/.local-attest.config.mjs
+++ b/.local-attest.config.mjs
@@ -1,0 +1,9 @@
+export default {
+  matrix: [
+    { name: "lint", mode: "hard", command: "npm run lint" },
+    { name: "test", mode: "hard", command: "npm test" },
+    { name: "dogfood", mode: "hard", command: "npm run dogfood" },
+    { name: "build-plugin --check", mode: "hard", command: "npm run build-plugin -- --check" },
+  ],
+  pushAfterAttest: true,
+};

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotbabel.dev/schemas/index.schema.json",
-  "generatedAt": "2026-05-11T14:25:10.859Z",
+  "generatedAt": "2026-05-23T18:53:16.983Z",
   "version": "2.7.0",
   "artifacts": [
     {
@@ -571,6 +571,21 @@
         "platform": ["kubernetes"],
         "task": ["debugging", "review"],
         "maturity": "validated"
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
+    },
+    {
+      "id": "local-attest",
+      "type": "skill",
+      "path": "skills/local-attest/SKILL.md",
+      "name": "local-attest",
+      "description": "Run the configured CI matrix locally and, on a clean pass, post a SHA-pinned OWNER-authored PR comment that gates downstream GitHub Actions jobs off for that exact commit. Skips the redundant remote run after a maintainer has already verified locally, saving runner minutes without weakening the gate. A new push changes the head SHA, the attestation stops matching, CI runs again. Side-effectful (posts a PR comment, applies a label, optionally pushes) and slow (10–15 min depending on matrix). Invoke only on explicit request.\n",
+      "facets": {
+        "domain": ["devex", "observability"],
+        "platform": ["github-actions"],
+        "task": ["testing", "runtime-ops"],
+        "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha"

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -22,6 +22,7 @@
       "git",
       "ground-first",
       "handoff",
+      "local-attest",
       "markdown",
       "merge-pr",
       "plan-grader",
@@ -74,7 +75,7 @@
       "security-review"
     ],
     "data": ["data-scientist"],
-    "observability": ["flyctl"],
+    "observability": ["flyctl", "local-attest"],
     "frontend": ["frontend-developer", "test-engineer"]
   },
   "platform": {
@@ -127,6 +128,7 @@
     "github-actions": [
       "dependabot-sweep",
       "devops-engineer",
+      "local-attest",
       "merge-pr",
       "post-pr-review",
       "review-pr",
@@ -255,11 +257,13 @@
       "deployment-engineer",
       "docker-engineer",
       "flyctl",
-      "kubernetes-specialist"
+      "kubernetes-specialist",
+      "local-attest"
     ],
     "testing": [
       "detect-flaky",
       "fix-with-evidence",
+      "local-attest",
       "merge-pr",
       "pre-pr",
       "test-engineer",
@@ -319,6 +323,7 @@
       "handoff",
       "iac-engineer",
       "kubernetes-specialist",
+      "local-attest",
       "plan-grader",
       "platform-engineer",
       "post-pr-review",

--- a/index/by-type.json
+++ b/index/by-type.json
@@ -45,6 +45,7 @@
     "ground-first",
     "handoff",
     "kubernetes-specialist",
+    "local-attest",
     "plan-grader",
     "post-pr-review",
     "project-sync",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotbabel-list": "./plugins/dotbabel/bin/dotbabel-list.mjs",
     "dotbabel-show": "./plugins/dotbabel/bin/dotbabel-show.mjs",
     "dotbabel-handoff": "./plugins/dotbabel/bin/dotbabel-handoff.mjs",
+    "dotbabel-local-attest": "./plugins/dotbabel/bin/dotbabel-local-attest.mjs",
     "dotbabel-project-sync": "./plugins/dotbabel/bin/dotbabel-project-sync.mjs",
     "dotbabel-project-init": "./plugins/dotbabel/bin/dotbabel-project-init.mjs",
     "dotbabel-check-project-sync": "./plugins/dotbabel/bin/dotbabel-check-project-sync.mjs"

--- a/plugins/dotbabel/bin/dotbabel-local-attest.mjs
+++ b/plugins/dotbabel/bin/dotbabel-local-attest.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * dotbabel-local-attest — local CI attestation skill.
+ *
+ * Run the configured CI matrix locally; on a clean pass, post a SHA-pinned
+ * OWNER-authored PR comment that gates the remote pipeline off for that
+ * exact commit. A new push changes the SHA, the attestation stops matching,
+ * and CI runs again. Saves the cost of double-running every check on
+ * GitHub-hosted runners after a maintainer has already verified locally.
+ *
+ * Usage:
+ *   dotbabel local-attest [--pr <N>] [--no-push] [--dry-run] [--config <path>]
+ *
+ *   --pr <N>           Target PR number. Defaults to the open PR for the current branch.
+ *   --no-push          Run the matrix + post comment + apply label, but do not `git push`.
+ *   --dry-run          Run the matrix, render the comment, print it. Post nothing, label
+ *                      nothing, push nothing. Use this to verify a new project's config.
+ *   --config <path>    Override the .local-attest config file location.
+ *
+ * Config discovery (when --config not given):
+ *   .local-attest.config.mjs > .local-attest.config.json > package.json#local-attest
+ *
+ * See skills/local-attest/SKILL.md for the full operator contract, and
+ * skills/local-attest/references/config.md for the config schema.
+ *
+ * Exits:
+ *   0   PASS or successful --dry-run
+ *   1   hard leg failed, precondition failed, or push failed (nothing posted)
+ *   2   environment error (config unreadable, gh missing, etc.)
+ *   64  bad CLI invocation (unknown flag, malformed --pr)
+ */
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
+import { parseArgs } from "../src/local-attest-lib.mjs";
+import { ConfigError, loadConfig } from "../src/local-attest-config.mjs";
+import { PreconditionError, execute, realDeps } from "../src/local-attest-runner.mjs";
+
+const HELP = `dotbabel-local-attest [--pr <N>] [--no-push] [--dry-run] [--config <path>]
+
+Run the configured CI matrix locally and, on a clean pass, post an attestation
+comment to the open PR so the remote pipeline skips itself for this commit.
+
+Options:
+  --pr <N>           Target PR number (defaults to the open PR for the branch)
+  --no-push          Do not run \`git push\` after attesting
+  --dry-run          Print the comment that would be posted; post nothing
+  --config <path>    Override the .local-attest config file location
+  --help, -h         Show this help
+  --version, -V      Show version
+
+Config discovery (in order, when --config not given):
+  .local-attest.config.mjs
+  .local-attest.config.json
+  package.json#local-attest
+
+Exit codes: 0 ok, 1 attestation failure, 2 env error, 64 usage error.`;
+
+function fail(code, msg) {
+  if (msg) process.stderr.write(`dotbabel-local-attest: ${msg}\n`);
+  process.exit(code);
+}
+
+async function main() {
+  const rawArgs = process.argv.slice(2);
+  if (rawArgs.includes("--version") || rawArgs.includes("-V")) {
+    const { version } = await import("../src/index.mjs");
+    process.stdout.write(`${version}\n`);
+    process.exit(EXIT_CODES.OK);
+  }
+
+  /** @type {ReturnType<typeof parseArgs>} */
+  let argv;
+  try {
+    argv = parseArgs(rawArgs);
+  } catch (err) {
+    const code = /** @type {any} */ (err).exitCode ?? EXIT_CODES.USAGE;
+    fail(code, err.message);
+    return;
+  }
+
+  if (argv.help) {
+    process.stdout.write(HELP + "\n");
+    process.exit(EXIT_CODES.OK);
+  }
+
+  /** @type {import("../src/local-attest-config.mjs").Config} */
+  let cfg;
+  try {
+    cfg = await loadConfig({ cwd: process.cwd(), override: argv.config });
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      const hint = /** @type {any} */ (err).hint;
+      fail(EXIT_CODES.ENV, hint ? `${err.message}\n  hint: ${hint}` : err.message);
+    } else {
+      fail(EXIT_CODES.ENV, `config load failed: ${err.message}`);
+    }
+    return;
+  }
+
+  const deps = realDeps();
+  try {
+    const result = execute(deps, cfg, {
+      prOverride: argv.pr,
+      push: argv.push,
+      dryRun: argv.dryRun,
+    });
+    process.exit(result.exitCode);
+  } catch (err) {
+    if (err instanceof PreconditionError) {
+      fail(1, err.message);
+    } else {
+      fail(2, err.message);
+    }
+  }
+}
+
+// Run only when invoked as a CLI, not when imported by tests.
+const invokedDirect =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirect) {
+  main().catch((err) => fail(2, err.message));
+}
+
+// Re-exports for unit tests that want to drive the binary's `main` without spawning.
+export { main, HELP };

--- a/plugins/dotbabel/bin/dotbabel.mjs
+++ b/plugins/dotbabel/bin/dotbabel.mjs
@@ -42,6 +42,7 @@ const SUBCOMMANDS = [
   "list",
   "show",
   "handoff",
+  "local-attest",
 ];
 
 function printUsage() {

--- a/plugins/dotbabel/src/local-attest-config.mjs
+++ b/plugins/dotbabel/src/local-attest-config.mjs
@@ -1,0 +1,218 @@
+/**
+ * local-attest-config — config discovery + validation for the local-attest skill.
+ *
+ * Each consuming repo owns its own matrix (the list of legs to run locally
+ * before posting an attestation). Everything else has sensible defaults so a
+ * one-line config (just `matrix: [...]`) is enough to get started.
+ *
+ * Discovery precedence:
+ *   1. --config <path>                       (CLI flag)
+ *   2. .local-attest.config.mjs              (project root)
+ *   3. .local-attest.config.json             (project root)
+ *   4. package.json#local-attest             (project root)
+ *
+ * @typedef {object} Leg
+ * @property {string} name
+ * @property {"hard"|"advisory"} mode
+ * @property {string} command
+ * @property {string} [cwd]
+ * @property {Record<string, string>} [env]
+ *
+ * @typedef {object} Config
+ * @property {Leg[]} matrix
+ * @property {string} label
+ * @property {string} auditLogPath
+ * @property {string[]} trustedAssociations
+ * @property {boolean} requireClean
+ * @property {boolean} requireDocker
+ * @property {boolean} pushAfterAttest
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve as resolvePath, isAbsolute } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** @type {Config} */
+export const DEFAULTS = Object.freeze({
+  matrix: [],
+  label: "ci/local-verified",
+  auditLogPath: ".local-attest-log.jsonl",
+  trustedAssociations: ["OWNER"],
+  requireClean: true,
+  requireDocker: false,
+  pushAfterAttest: true,
+});
+
+/**
+ * Thrown by {@link loadConfig} and {@link validateConfig} when discovery or
+ * validation fails. Carries an optional `hint` pointing at the schema doc so
+ * CLI callers can surface it verbatim.
+ */
+export class ConfigError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ hint?: string }} [opts]
+   */
+  constructor(message, { hint } = {}) {
+    super(message);
+    this.name = "ConfigError";
+    this.code = "LOCAL_ATTEST_CONFIG";
+    if (hint) this.hint = hint;
+  }
+}
+
+const HINT_MISSING =
+  "see skills/local-attest/references/config.md for the .local-attest.config.mjs schema and three example configs.";
+
+/**
+ * Discover and load a config from `cwd`. When `override` is set, only that
+ * exact path is honored (no fallback).
+ *
+ * @param {{ cwd: string, override?: string|null }} args
+ * @returns {Promise<Config>}
+ */
+export async function loadConfig({ cwd, override }) {
+  if (override) {
+    const abs = isAbsolute(override) ? override : resolvePath(cwd, override);
+    if (!existsSync(abs)) {
+      throw new ConfigError(`--config: file not found: ${abs}`, { hint: HINT_MISSING });
+    }
+    return validateConfig(await loadFile(abs));
+  }
+
+  const candidates = [
+    { path: resolvePath(cwd, ".local-attest.config.mjs"), kind: "mjs" },
+    { path: resolvePath(cwd, ".local-attest.config.json"), kind: "json" },
+    { path: resolvePath(cwd, "package.json"), kind: "package" },
+  ];
+  for (const c of candidates) {
+    if (!existsSync(c.path)) continue;
+    if (c.kind === "package") {
+      const raw = readFileSync(c.path, "utf8");
+      let pkg;
+      try {
+        pkg = JSON.parse(raw);
+      } catch (err) {
+        throw new ConfigError(`package.json: ${err.message}`);
+      }
+      if (pkg && typeof pkg === "object" && pkg["local-attest"]) {
+        return validateConfig(pkg["local-attest"]);
+      }
+      continue;
+    }
+    return validateConfig(await loadFile(c.path));
+  }
+
+  throw new ConfigError(
+    `no .local-attest config found in ${cwd} (looked for .local-attest.config.mjs, .local-attest.config.json, package.json#local-attest)`,
+    { hint: HINT_MISSING },
+  );
+}
+
+/** @param {string} abs */
+async function loadFile(abs) {
+  if (abs.endsWith(".json")) {
+    const raw = readFileSync(abs, "utf8");
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new ConfigError(`${abs}: ${err.message}`);
+    }
+  }
+  const url = pathToFileURL(abs).href;
+  try {
+    const mod = await import(url);
+    return mod.default ?? mod;
+  } catch (err) {
+    throw new ConfigError(`${abs}: ${err.message}`);
+  }
+}
+
+/**
+ * Merge user-supplied config onto DEFAULTS and validate every field. Any
+ * structural problem throws ConfigError with a hint pointing at the schema.
+ *
+ * @param {unknown} input
+ * @returns {Config}
+ */
+export function validateConfig(input) {
+  if (!input || typeof input !== "object") {
+    throw new ConfigError("config must be an object");
+  }
+  const user = /** @type {Record<string, unknown>} */ (input);
+  const merged = { ...DEFAULTS, ...user };
+
+  if (!Array.isArray(merged.matrix) || merged.matrix.length === 0) {
+    throw new ConfigError("config.matrix must be a non-empty array", { hint: HINT_MISSING });
+  }
+  /** @type {Leg[]} */
+  const matrix = [];
+  const seen = new Set();
+  merged.matrix.forEach((legRaw, i) => {
+    if (!legRaw || typeof legRaw !== "object") {
+      throw new ConfigError(`config.matrix[${i}] must be an object`);
+    }
+    const leg = /** @type {Record<string, unknown>} */ (legRaw);
+    const name = leg.name;
+    if (typeof name !== "string" || name === "") {
+      throw new ConfigError(`config.matrix[${i}].name must be a non-empty string`);
+    }
+    if (seen.has(name)) {
+      throw new ConfigError(`config.matrix[${i}].name "${name}" is duplicated`);
+    }
+    seen.add(name);
+    if (leg.mode !== "hard" && leg.mode !== "advisory") {
+      throw new ConfigError(
+        `config.matrix[${i}].mode must be "hard" or "advisory", got ${JSON.stringify(leg.mode)}`,
+      );
+    }
+    if (typeof leg.command !== "string" || leg.command === "") {
+      throw new ConfigError(`config.matrix[${i}].command must be a non-empty string`);
+    }
+    if (leg.cwd !== undefined && typeof leg.cwd !== "string") {
+      throw new ConfigError(`config.matrix[${i}].cwd must be a string`);
+    }
+    if (leg.env !== undefined && (leg.env === null || typeof leg.env !== "object")) {
+      throw new ConfigError(`config.matrix[${i}].env must be an object`);
+    }
+    matrix.push(/** @type {Leg} */ ({
+      name,
+      mode: leg.mode,
+      command: leg.command,
+      ...(leg.cwd !== undefined ? { cwd: leg.cwd } : {}),
+      ...(leg.env !== undefined ? { env: { .../** @type {object} */ (leg.env) } } : {}),
+    }));
+  });
+
+  if (typeof merged.label !== "string" || merged.label === "") {
+    throw new ConfigError("config.label must be a non-empty string");
+  }
+  if (typeof merged.auditLogPath !== "string" || merged.auditLogPath === "") {
+    throw new ConfigError("config.auditLogPath must be a non-empty string");
+  }
+  if (merged.auditLogPath.split("/").some((seg) => seg === "..")) {
+    throw new ConfigError("config.auditLogPath must not contain '..' segments");
+  }
+  if (
+    !Array.isArray(merged.trustedAssociations) ||
+    merged.trustedAssociations.length === 0 ||
+    !merged.trustedAssociations.every((t) => typeof t === "string" && t.length > 0)
+  ) {
+    throw new ConfigError("config.trustedAssociations must be a non-empty array of strings");
+  }
+  for (const flag of ["requireClean", "requireDocker", "pushAfterAttest"]) {
+    if (typeof merged[flag] !== "boolean") {
+      throw new ConfigError(`config.${flag} must be a boolean`);
+    }
+  }
+
+  return /** @type {Config} */ ({
+    matrix,
+    label: merged.label,
+    auditLogPath: merged.auditLogPath,
+    trustedAssociations: [...merged.trustedAssociations],
+    requireClean: merged.requireClean,
+    requireDocker: merged.requireDocker,
+    pushAfterAttest: merged.pushAfterAttest,
+  });
+}

--- a/plugins/dotbabel/src/local-attest-config.mjs
+++ b/plugins/dotbabel/src/local-attest-config.mjs
@@ -187,8 +187,16 @@ export function validateConfig(input) {
   if (typeof merged.label !== "string" || merged.label === "") {
     throw new ConfigError("config.label must be a non-empty string");
   }
+  if (!/^[A-Za-z0-9._/ -]+$/.test(merged.label)) {
+    throw new ConfigError(
+      "config.label must contain only letters, numbers, dots, underscores, hyphens, slashes, or spaces",
+    );
+  }
   if (typeof merged.auditLogPath !== "string" || merged.auditLogPath === "") {
     throw new ConfigError("config.auditLogPath must be a non-empty string");
+  }
+  if (isAbsolute(merged.auditLogPath)) {
+    throw new ConfigError("config.auditLogPath must be a relative path");
   }
   if (merged.auditLogPath.split("/").some((seg) => seg === "..")) {
     throw new ConfigError("config.auditLogPath must not contain '..' segments");
@@ -199,6 +207,17 @@ export function validateConfig(input) {
     !merged.trustedAssociations.every((t) => typeof t === "string" && t.length > 0)
   ) {
     throw new ConfigError("config.trustedAssociations must be a non-empty array of strings");
+  }
+  const VALID_ASSOCIATIONS = new Set([
+    "OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR",
+    "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MANNEQUIN", "NONE",
+  ]);
+  for (const assoc of merged.trustedAssociations) {
+    if (!VALID_ASSOCIATIONS.has(assoc)) {
+      throw new ConfigError(
+        `config.trustedAssociations contains unknown value "${assoc}" — must be one of: ${[...VALID_ASSOCIATIONS].join(", ")}`,
+      );
+    }
   }
   for (const flag of ["requireClean", "requireDocker", "pushAfterAttest"]) {
     if (typeof merged[flag] !== "boolean") {

--- a/plugins/dotbabel/src/local-attest-lib.mjs
+++ b/plugins/dotbabel/src/local-attest-lib.mjs
@@ -224,10 +224,7 @@ export function buildGateSnippet(opts = {}) {
   if (!Array.isArray(trusted) || trusted.length === 0) {
     throw new Error("buildGateSnippet: trustedAssociations must be a non-empty array");
   }
-  const select =
-    trusted.length === 1
-      ? `select(.author_association == "${trusted[0]}")`
-      : `select(${trusted.map((t) => `.author_association == "${t}"`).join(" or ")})`;
+  const select = `select(${trusted.map((t) => `.author_association == "${t}"`).join(" or ")})`;
   return [
     `      - name: Check for local attestation`,
     `        if: github.event_name == 'pull_request'`,
@@ -240,7 +237,7 @@ export function buildGateSnippet(opts = {}) {
     `          MARKER="<!-- local-attest verified-sha=\${HEAD_SHA} -->"`,
     `          if gh api "repos/\${REPO}/issues/\${PR_NUMBER}/comments" --paginate \\`,
     `               --jq '.[] | ${select} | .body | split("\\n")[0]' \\`,
-    `             | grep -qF "$MARKER"; then`,
+    `             | grep -qFx "$MARKER"; then`,
     `            echo "attested=true" >> "$GITHUB_OUTPUT"`,
     `          else`,
     `            echo "attested=false" >> "$GITHUB_OUTPUT"`,

--- a/plugins/dotbabel/src/local-attest-lib.mjs
+++ b/plugins/dotbabel/src/local-attest-lib.mjs
@@ -1,0 +1,249 @@
+/**
+ * local-attest-lib — pure helpers for the local CI attestation skill.
+ *
+ * Every export here is deterministic and free of I/O so the test suite can
+ * exercise them without stubs. The CI gate semantics depend on these helpers
+ * being byte-exact: the marker must appear on the first line of the rendered
+ * comment, and only OWNER-class authors are trusted by default.
+ *
+ * @typedef {object} Comment
+ * @property {number|string} [id]
+ * @property {string} author_association
+ * @property {string} body
+ *
+ * @typedef {"hard"|"advisory"} LegMode
+ *
+ * @typedef {object} LegResult
+ * @property {string} name
+ * @property {LegMode} mode
+ * @property {boolean} passed
+ * @property {number} durationS
+ * @property {string} tail
+ *
+ * @typedef {object} ParsedArgs
+ * @property {string|null} pr
+ * @property {boolean} push
+ * @property {boolean} dryRun
+ * @property {string|null} config
+ * @property {boolean} help
+ */
+
+export const ATTEST_MARKER_PREFIX = "<!-- local-attest verified-sha=";
+
+const SHA_RE = /^[0-9a-f]{7,40}$/i;
+
+/**
+ * Build the hidden marker the CI gate greps for. Throws on a non-SHA so a
+ * malformed value can never produce a marker that silently never matches.
+ *
+ * @param {string} sha
+ * @returns {string}
+ */
+export function buildAttestMarker(sha) {
+  if (typeof sha !== "string" || !SHA_RE.test(sha)) {
+    throw new Error(`invalid sha: ${JSON.stringify(sha)}`);
+  }
+  return `${ATTEST_MARKER_PREFIX}${sha} -->`;
+}
+
+/**
+ * True iff a comment from a trusted author attests this exact head SHA.
+ * Trust is determined by `trustedAssociations` (default `["OWNER"]`) — a
+ * non-trusted user cannot forge a skip by commenting the marker.
+ *
+ * @param {Comment[]} comments
+ * @param {string} headSha
+ * @param {{ trustedAssociations?: string[] }} [opts]
+ * @returns {boolean}
+ */
+export function isAttested(comments, headSha, opts = {}) {
+  if (!Array.isArray(comments) || typeof headSha !== "string" || headSha === "") {
+    return false;
+  }
+  let marker;
+  try {
+    marker = buildAttestMarker(headSha);
+  } catch {
+    return false;
+  }
+  const trusted = new Set(opts.trustedAssociations ?? ["OWNER"]);
+  return comments.some(
+    (c) =>
+      c &&
+      trusted.has(c.author_association) &&
+      typeof c.body === "string" &&
+      c.body.split("\n")[0] === marker,
+  );
+}
+
+/**
+ * Find any existing local-attest comment (any SHA, any author) so the
+ * caller can update it in place instead of posting a duplicate.
+ *
+ * @param {Comment[]} comments
+ * @returns {Comment|null}
+ */
+export function findAttestComment(comments) {
+  if (!Array.isArray(comments)) return null;
+  return (
+    comments.find(
+      (c) => c && typeof c.body === "string" && c.body.includes(ATTEST_MARKER_PREFIX),
+    ) ?? null
+  );
+}
+
+/**
+ * Parse CLI argv. Exits via `die` on usage errors so the caller can wrap
+ * with the harness exit codes.
+ *
+ * @param {string[]} argv
+ * @param {(code: number, msg: string) => void} [die]
+ * @returns {ParsedArgs}
+ */
+export function parseArgs(argv, die) {
+  const exit =
+    die ??
+    ((code, msg) => {
+      const err = new Error(msg);
+      /** @type {any} */ (err).code = "USAGE";
+      /** @type {any} */ (err).exitCode = code;
+      throw err;
+    });
+  /** @type {ParsedArgs} */
+  const args = { pr: null, push: true, dryRun: false, config: null, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--pr") {
+      const v = argv[++i];
+      if (!v || !/^\d+$/.test(v)) return exit(64, `--pr requires a number, got ${v ?? "(missing)"}`);
+      args.pr = v;
+    } else if (a === "--no-push") {
+      args.push = false;
+    } else if (a === "--dry-run") {
+      args.dryRun = true;
+    } else if (a === "--config") {
+      const v = argv[++i];
+      if (!v) return exit(64, "--config requires a path");
+      args.config = v;
+    } else if (a === "--help" || a === "-h") {
+      args.help = true;
+    } else {
+      return exit(64, `unknown argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+/**
+ * Return the last `n` lines of `text`, trimming trailing whitespace.
+ *
+ * @param {string} text
+ * @param {number} [n]
+ * @returns {string}
+ */
+export function tail(text, n = 10) {
+  const lines = String(text ?? "")
+    .replace(/\s+$/, "")
+    .split("\n");
+  return lines.slice(-n).join("\n");
+}
+
+/**
+ * Render the attestation comment body. The marker is guaranteed to be line 1 —
+ * the CI gate matches only the first line of each comment.
+ *
+ * @param {LegResult[]} results
+ * @param {{ headSha: string, hostname: string, now?: Date }} ctx
+ * @returns {string}
+ */
+export function renderComment(results, { headSha, hostname, now }) {
+  const marker = buildAttestMarker(headSha);
+  const ts = (now ?? new Date()).toISOString();
+  const rows = results
+    .map((r) => {
+      const status = r.passed ? "pass" : r.mode === "advisory" ? "fail (advisory)" : "FAIL";
+      return `| ${r.name} | ${r.mode} | ${status} | ${r.durationS}s |`;
+    })
+    .join("\n");
+  return [
+    marker,
+    "## Local Attestation",
+    "",
+    `The full CI check matrix ran locally and the hard legs passed for \`${headSha.slice(0, 8)}\`.`,
+    "Test and Preview will skip for this commit. A new push re-runs CI automatically.",
+    "",
+    "| Check | Mode | Result | Duration |",
+    "|---|---|---|---|",
+    rows,
+    "",
+    `- Host: \`${hostname}\``,
+    `- Attested at: \`${ts}\``,
+    `- Verified SHA: \`${headSha}\``,
+  ].join("\n");
+}
+
+/**
+ * Shape one JSONL line for the audit log.
+ *
+ * @param {{ pr: number|string, sha: string, hostname: string, advisoryFails: string[], now?: Date }} input
+ * @returns {{ ts: string, pr: number, sha: string, host: string, advisoryFails: string[] }}
+ */
+export function buildAuditEntry({ pr, sha, hostname, advisoryFails, now }) {
+  return {
+    ts: (now ?? new Date()).toISOString(),
+    pr: Number(pr),
+    sha,
+    host: hostname,
+    advisoryFails: [...advisoryFails],
+  };
+}
+
+/**
+ * Summarize a matrix run.
+ *
+ * @param {LegResult[]} results
+ * @returns {{ hardFails: LegResult[], advisoryFails: LegResult[], totalDurationS: number }}
+ */
+export function summarizeResults(results) {
+  const hardFails = results.filter((r) => r.mode === "hard" && !r.passed);
+  const advisoryFails = results.filter((r) => r.mode === "advisory" && !r.passed);
+  const totalDurationS = results.reduce((acc, r) => acc + (r.durationS ?? 0), 0);
+  return { hardFails, advisoryFails, totalDurationS };
+}
+
+/**
+ * Build the workflow gate snippet for `test.yml` / `preview.yml`. Substitutes
+ * the configured trust list into the jq `select(...)` clause so a project that
+ * trusts MEMBERs as well as OWNERs gets a snippet that matches its config.
+ *
+ * @param {{ trustedAssociations?: string[] }} [opts]
+ * @returns {string}
+ */
+export function buildGateSnippet(opts = {}) {
+  const trusted = opts.trustedAssociations ?? ["OWNER"];
+  if (!Array.isArray(trusted) || trusted.length === 0) {
+    throw new Error("buildGateSnippet: trustedAssociations must be a non-empty array");
+  }
+  const select =
+    trusted.length === 1
+      ? `select(.author_association == "${trusted[0]}")`
+      : `select(${trusted.map((t) => `.author_association == "${t}"`).join(" or ")})`;
+  return [
+    `      - name: Check for local attestation`,
+    `        if: github.event_name == 'pull_request'`,
+    `        env:`,
+    `          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}`,
+    `          REPO: \${{ github.repository }}`,
+    `          PR_NUMBER: \${{ github.event.pull_request.number }}`,
+    `          HEAD_SHA: \${{ github.event.pull_request.head.sha }}`,
+    `        run: |`,
+    `          MARKER="<!-- local-attest verified-sha=\${HEAD_SHA} -->"`,
+    `          if gh api "repos/\${REPO}/issues/\${PR_NUMBER}/comments" --paginate \\`,
+    `               --jq '.[] | ${select} | .body | split("\\n")[0]' \\`,
+    `             | grep -qF "$MARKER"; then`,
+    `            echo "attested=true" >> "$GITHUB_OUTPUT"`,
+    `          else`,
+    `            echo "attested=false" >> "$GITHUB_OUTPUT"`,
+    `          fi`,
+  ].join("\n");
+}

--- a/plugins/dotbabel/src/local-attest-runner.mjs
+++ b/plugins/dotbabel/src/local-attest-runner.mjs
@@ -1,0 +1,374 @@
+/**
+ * local-attest-runner — orchestration with injectable I/O.
+ *
+ * Every external call (shell, gh, fs) is routed through a `deps` object so
+ * the test suite can stub them without touching the real environment. The
+ * runner is otherwise a thin shell that wires `local-attest-lib` helpers
+ * together in the right order:
+ *
+ *   1. checkPreconditions — clean tree, branch, PR, head SHA, gh, docker
+ *   2. runMatrix          — execute each leg sequentially, capture tails
+ *   3. push (optional)    — only after hard legs pass; before posting
+ *   4. upsertComment      — PATCH existing attestation comment or POST a new one
+ *   5. applyLabel         — best-effort decoration
+ *   6. appendAuditLog     — best-effort jsonl line
+ *
+ * NEVER interpolate untrusted strings (PR titles, branch names, commit bodies)
+ * into a shell command. JSON payloads go through `--input -` (stdin) so shell
+ * quoting can never break a multiline markdown body.
+ *
+ * @typedef {object} Deps
+ * @property {(cmd: string, opts?: { cwd?: string, env?: Record<string,string>, capture?: boolean }) => { status: number, stdout: string, stderr: string }} run
+ * @property {(cmd: string, payload: object) => string} ghApiWithInput
+ * @property {(path: string, line: string) => void} appendLog
+ * @property {() => string} hostname
+ * @property {(msg: string) => void} log
+ * @property {(msg: string) => void} warn
+ *
+ * @typedef {import("./local-attest-config.mjs").Config} Config
+ * @typedef {import("./local-attest-config.mjs").Leg} Leg
+ * @typedef {import("./local-attest-lib.mjs").LegResult} LegResult
+ * @typedef {import("./local-attest-lib.mjs").Comment} Comment
+ *
+ * @typedef {object} Preconditions
+ * @property {string} branch
+ * @property {string} repo
+ * @property {string} pr
+ * @property {string} headSha
+ */
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import os from "node:os";
+
+import {
+  buildAuditEntry,
+  findAttestComment,
+  renderComment,
+  summarizeResults,
+  tail,
+} from "./local-attest-lib.mjs";
+
+/**
+ * Build a `Deps` bundle wired to the real environment. Tests construct their
+ * own with in-memory recorders instead.
+ *
+ * @returns {Deps}
+ */
+export function realDeps() {
+  return {
+    run(cmd, { cwd, env, capture = false } = {}) {
+      const r = spawnSync(cmd, {
+        shell: true,
+        cwd,
+        env: { ...process.env, ...env },
+        encoding: "utf8",
+        stdio: capture ? "pipe" : ["inherit", "pipe", "pipe"],
+        maxBuffer: 64 * 1024 * 1024,
+      });
+      return { status: r.status ?? 1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+    },
+    ghApiWithInput(cmd, payload) {
+      const r = spawnSync(cmd, {
+        shell: true,
+        input: JSON.stringify(payload),
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      if (r.status !== 0) {
+        throw new Error(`command failed (${r.status}): ${cmd}\n${r.stderr || ""}`);
+      }
+      return r.stdout;
+    },
+    appendLog(path, line) {
+      appendFileSync(path, line);
+    },
+    hostname() {
+      return os.hostname();
+    },
+    log(msg) {
+      process.stdout.write(msg + "\n");
+    },
+    warn(msg) {
+      process.stderr.write(msg + "\n");
+    },
+  };
+}
+
+/**
+ * Run a captured shell command; throws on non-zero with stderr in the message.
+ *
+ * @param {Deps} deps
+ * @param {string} cmd
+ * @returns {string}
+ */
+function capture(deps, cmd) {
+  const r = deps.run(cmd, { capture: true });
+  if (r.status !== 0) {
+    throw new Error(`command failed (${r.status}): ${cmd}\n${r.stderr || ""}`);
+  }
+  return (r.stdout || "").trim();
+}
+
+/**
+ * Thrown by {@link checkPreconditions} when the worktree, gh auth, PR
+ * resolution, head-SHA match, or Docker check fails. The CLI maps this to
+ * exit code 1 ("attestation failure") so callers can distinguish it from
+ * environment errors (exit 2).
+ */
+export class PreconditionError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = "PreconditionError";
+    this.code = "LOCAL_ATTEST_PRECONDITION";
+  }
+}
+
+/**
+ * @param {Deps} deps
+ * @param {Config} cfg
+ * @param {{ prOverride?: string|null }} [opts]
+ * @returns {Preconditions}
+ */
+export function checkPreconditions(deps, cfg, opts = {}) {
+  let branch;
+  try {
+    branch = capture(deps, "git rev-parse --abbrev-ref HEAD");
+  } catch {
+    throw new PreconditionError("not inside a git repository.");
+  }
+  if (branch === "HEAD") {
+    throw new PreconditionError("detached HEAD — check out the PR branch before attesting.");
+  }
+
+  if (cfg.requireClean) {
+    const dirty = capture(deps, "git status --porcelain");
+    if (dirty !== "") {
+      throw new PreconditionError(
+        "worktree is not clean — commit or stash your changes before attesting.\n" +
+          "The attestation must certify the exact tree that gets pushed.\n\n" +
+          dirty,
+      );
+    }
+  }
+
+  if (deps.run("gh auth status", { capture: true }).status !== 0) {
+    throw new PreconditionError("gh is not authenticated — run `gh auth login`.");
+  }
+
+  const repo = capture(deps, "gh repo view --json nameWithOwner --jq .nameWithOwner");
+
+  let pr = opts.prOverride ?? null;
+  if (!pr) {
+    try {
+      pr = capture(deps, "gh pr view --json number --jq .number");
+      if (!pr) throw new Error("no PR number");
+    } catch {
+      throw new PreconditionError(`no open PR for branch ${branch} — pass --pr <N> explicitly.`);
+    }
+  }
+
+  const headSha = capture(deps, "git rev-parse HEAD");
+  const prHeadSha = capture(deps, `gh pr view ${pr} --json headRefOid --jq .headRefOid`);
+  if (headSha !== prHeadSha) {
+    throw new PreconditionError(
+      `local HEAD (${headSha.slice(0, 8)}) differs from PR #${pr} head (${prHeadSha.slice(0, 8)}).\n` +
+        "Push or pull so they match before attesting.",
+    );
+  }
+
+  if (cfg.requireDocker && deps.run("docker info", { capture: true }).status !== 0) {
+    throw new PreconditionError(
+      "Docker is not available — config.requireDocker is true. Start Docker and retry.",
+    );
+  }
+
+  // Trust list mismatch is a warning, not a failure: a non-trusted user can
+  // still iterate; their attestation just won't skip CI. The skill prints
+  // the warning once at the start of the run so it's loud.
+  try {
+    const me = capture(deps, "gh api user --jq .login");
+    const ownerAssoc = capture(deps, `gh api repos/${repo}/collaborators/${me}/permission --jq .permission`).toUpperCase();
+    const mapped =
+      ownerAssoc === "ADMIN" ? "OWNER" :
+      ownerAssoc === "WRITE" ? "MEMBER" :
+      ownerAssoc === "READ" ? "COLLABORATOR" :
+      ownerAssoc;
+    if (!cfg.trustedAssociations.includes(mapped)) {
+      deps.warn(
+        `WARNING: you (${me}) have permission ${ownerAssoc} on ${repo}, which is not in the configured trust list (${cfg.trustedAssociations.join(", ")}). The CI gate will not honor this attestation.`,
+      );
+    }
+  } catch {
+    // Permission probe is a courtesy — never block on it.
+  }
+
+  return { branch, repo, pr, headSha };
+}
+
+/**
+ * Execute the matrix sequentially. Each leg runs to completion; output is
+ * tailed at 10 lines so large logs don't bloat the result struct.
+ *
+ * @param {Deps} deps
+ * @param {Leg[]} matrix
+ * @returns {LegResult[]}
+ */
+export function runMatrix(deps, matrix) {
+  /** @type {LegResult[]} */
+  const results = [];
+  for (const leg of matrix) {
+    deps.log(`\n=== ${leg.name} (${leg.mode}) ===`);
+    const started = Date.now();
+    const r = deps.run(leg.command, { cwd: leg.cwd, env: leg.env });
+    const durationS = Math.round((Date.now() - started) / 1000);
+    const passed = r.status === 0;
+    const output = tail(`${r.stdout || ""}\n${r.stderr || ""}`);
+    results.push({ name: leg.name, mode: leg.mode, passed, durationS, tail: output });
+    deps.log(`--- ${leg.name}: ${passed ? "PASS" : "FAIL"} (${durationS}s)`);
+    if (!passed) deps.log(output);
+  }
+  return results;
+}
+
+/**
+ * Insert or update the attestation comment. Always sends the body via stdin
+ * (`gh api --input -`) so multiline markdown can't be mangled by shell quoting.
+ *
+ * @param {Deps} deps
+ * @param {{ repo: string, pr: string|number, body: string }} args
+ * @returns {{ kind: "post"|"patch", commentId?: number|string }}
+ */
+export function upsertComment(deps, { repo, pr, body }) {
+  const raw = capture(deps, `gh api repos/${repo}/issues/${pr}/comments --paginate`);
+  /** @type {Comment[]} */
+  const comments = JSON.parse(raw || "[]");
+  const existing = findAttestComment(comments);
+  if (existing) {
+    deps.ghApiWithInput(
+      `gh api --method PATCH repos/${repo}/issues/comments/${existing.id} --input -`,
+      { body },
+    );
+    deps.log(`Updated existing attestation comment ${existing.id}.`);
+    return { kind: "patch", commentId: existing.id };
+  }
+  deps.ghApiWithInput(`gh api --method POST repos/${repo}/issues/${pr}/comments --input -`, {
+    body,
+  });
+  deps.log("Posted new attestation comment.");
+  return { kind: "post" };
+}
+
+/**
+ * Create the label if it does not exist, then attach it to the PR. Both
+ * sub-steps are best-effort: label-already-exists is ignored, and attach
+ * failure warns but does not abort.
+ *
+ * @param {Deps} deps
+ * @param {{ repo: string, pr: string|number, label: string }} args
+ */
+export function applyLabel(deps, { repo, pr, label }) {
+  deps.run(
+    `gh label create ${label} --repo ${repo} --color BFD4F2 ` +
+      `--description "Local CI attestation posted; remote CI jobs may skip"`,
+    { capture: true },
+  );
+  const r = deps.run(`gh pr edit ${pr} --add-label ${label}`, { capture: true });
+  if (r.status !== 0) {
+    deps.warn(`WARNING: could not apply ${label} label (non-fatal): ${r.stderr || ""}`);
+  } else {
+    deps.log(`Applied ${label} label.`);
+  }
+}
+
+/**
+ * Append one JSONL line to the audit log. Failures are swallowed.
+ *
+ * @param {Deps} deps
+ * @param {{ auditLogPath: string, pr: string|number, sha: string, advisoryFails: string[], hostname: string }} args
+ */
+export function appendAuditLog(deps, { auditLogPath, pr, sha, advisoryFails, hostname }) {
+  try {
+    const entry = buildAuditEntry({ pr, sha, hostname, advisoryFails });
+    deps.appendLog(auditLogPath, JSON.stringify(entry) + "\n");
+  } catch {
+    // Best-effort audit log; never block the run.
+  }
+}
+
+/**
+ * End-to-end orchestration: preconditions → matrix → push (optional) →
+ * comment → label → audit. Returns the rendered comment body so the CLI
+ * can print it in --dry-run mode.
+ *
+ * @param {Deps} deps
+ * @param {Config} cfg
+ * @param {{ prOverride?: string|null, push: boolean, dryRun: boolean }} flags
+ * @returns {{ ok: boolean, body: string, results: LegResult[], pre: Preconditions, exitCode: number }}
+ */
+export function execute(deps, cfg, flags) {
+  const pre = checkPreconditions(deps, cfg, { prOverride: flags.prOverride });
+  deps.log(`Attesting PR #${pre.pr} (${pre.repo}) at ${pre.headSha.slice(0, 8)}.`);
+
+  const results = runMatrix(deps, cfg.matrix);
+  const { hardFails, advisoryFails } = summarizeResults(results);
+
+  deps.log("\n========== Summary ==========");
+  for (const r of results) {
+    const m = r.passed ? "PASS" : r.mode === "advisory" ? "fail (advisory)" : "FAIL";
+    deps.log(`  ${r.name.padEnd(28)} ${m} (${r.durationS}s)`);
+  }
+
+  const body = renderComment(results, {
+    headSha: pre.headSha,
+    hostname: deps.hostname(),
+  });
+
+  if (hardFails.length > 0) {
+    deps.warn(
+      `\n${hardFails.length} hard leg(s) failed: ${hardFails.map((r) => r.name).join(", ")}.`,
+    );
+    deps.warn("No attestation posted, no label applied, nothing pushed.");
+    return { ok: false, body, results, pre, exitCode: 1 };
+  }
+  if (advisoryFails.length > 0) {
+    deps.log(
+      `\n${advisoryFails.length} advisory leg(s) failed (not blocking): ${advisoryFails.map((r) => r.name).join(", ")}.`,
+    );
+  }
+
+  if (flags.dryRun) {
+    deps.log("\n--dry-run: would post the comment below; not posting, not labeling, not pushing.\n");
+    deps.log(body);
+    return { ok: true, body, results, pre, exitCode: 0 };
+  }
+
+  if (flags.push && cfg.pushAfterAttest) {
+    deps.log("\nPushing...");
+    const pushResult = deps.run("git push");
+    if (pushResult.status !== 0) {
+      deps.warn("git push failed — no attestation posted. Fix the push and retry.");
+      return { ok: false, body, results, pre, exitCode: 1 };
+    }
+    deps.log("Pushed.");
+  }
+
+  upsertComment(deps, { repo: pre.repo, pr: pre.pr, body });
+  applyLabel(deps, { repo: pre.repo, pr: pre.pr, label: cfg.label });
+  appendAuditLog(deps, {
+    auditLogPath: cfg.auditLogPath,
+    pr: pre.pr,
+    sha: pre.headSha,
+    advisoryFails: advisoryFails.map((r) => r.name),
+    hostname: deps.hostname(),
+  });
+
+  if (flags.push && cfg.pushAfterAttest) {
+    deps.log("Remote CI jobs gated by the attestation comment will skip for this commit.");
+  } else {
+    deps.log("\nDid not push. Push manually to trigger the CI skip.");
+  }
+
+  return { ok: true, body, results, pre, exitCode: 0 };
+}

--- a/plugins/dotbabel/src/local-attest-runner.mjs
+++ b/plugins/dotbabel/src/local-attest-runner.mjs
@@ -190,11 +190,8 @@ export function checkPreconditions(deps, cfg, opts = {}) {
   try {
     const me = capture(deps, "gh api user --jq .login");
     const ownerAssoc = capture(deps, `gh api repos/${repo}/collaborators/${me}/permission --jq .permission`).toUpperCase();
-    const mapped =
-      ownerAssoc === "ADMIN" ? "OWNER" :
-      ownerAssoc === "WRITE" ? "MEMBER" :
-      ownerAssoc === "READ" ? "COLLABORATOR" :
-      ownerAssoc;
+    const PERM_TO_ASSOC = { ADMIN: "OWNER", WRITE: "MEMBER", READ: "COLLABORATOR", MAINTAIN: "MEMBER", TRIAGE: "COLLABORATOR" };
+    const mapped = PERM_TO_ASSOC[ownerAssoc] ?? ownerAssoc;
     if (!cfg.trustedAssociations.includes(mapped)) {
       deps.warn(
         `WARNING: you (${me}) have permission ${ownerAssoc} on ${repo}, which is not in the configured trust list (${cfg.trustedAssociations.join(", ")}). The CI gate will not honor this attestation.`,
@@ -235,23 +232,33 @@ export function runMatrix(deps, matrix) {
 /**
  * Insert or update the attestation comment. Always sends the body via stdin
  * (`gh api --input -`) so multiline markdown can't be mangled by shell quoting.
+ * Only PATCHes a comment whose original author is in `trustedAssociations` so
+ * the CI gate (which filters by author_association) sees the correct author.
  *
  * @param {Deps} deps
- * @param {{ repo: string, pr: string|number, body: string }} args
+ * @param {{ repo: string, pr: string|number, body: string, trustedAssociations?: string[] }} args
  * @returns {{ kind: "post"|"patch", commentId?: number|string }}
  */
-export function upsertComment(deps, { repo, pr, body }) {
+export function upsertComment(deps, { repo, pr, body, trustedAssociations }) {
   const raw = capture(deps, `gh api repos/${repo}/issues/${pr}/comments --paginate`);
   /** @type {Comment[]} */
   const comments = JSON.parse(raw || "[]");
-  const existing = findAttestComment(comments);
+  const trusted = trustedAssociations ? new Set(trustedAssociations) : null;
+  const candidates = trusted
+    ? comments.filter((c) => c && trusted.has(c.author_association))
+    : comments;
+  const existing = findAttestComment(candidates);
   if (existing) {
+    const id = Number(existing.id);
+    if (!Number.isFinite(id) || id <= 0) {
+      throw new Error(`unexpected comment id: ${existing.id}`);
+    }
     deps.ghApiWithInput(
-      `gh api --method PATCH repos/${repo}/issues/comments/${existing.id} --input -`,
+      `gh api --method PATCH repos/${repo}/issues/comments/${id} --input -`,
       { body },
     );
-    deps.log(`Updated existing attestation comment ${existing.id}.`);
-    return { kind: "patch", commentId: existing.id };
+    deps.log(`Updated existing attestation comment ${id}.`);
+    return { kind: "patch", commentId: id };
   }
   deps.ghApiWithInput(`gh api --method POST repos/${repo}/issues/${pr}/comments --input -`, {
     body,
@@ -292,8 +299,8 @@ export function appendAuditLog(deps, { auditLogPath, pr, sha, advisoryFails, hos
   try {
     const entry = buildAuditEntry({ pr, sha, hostname, advisoryFails });
     deps.appendLog(auditLogPath, JSON.stringify(entry) + "\n");
-  } catch {
-    // Best-effort audit log; never block the run.
+  } catch (err) {
+    deps.warn(`WARNING: audit log append failed (non-fatal): ${err.message || err}`);
   }
 }
 
@@ -316,7 +323,10 @@ export function execute(deps, cfg, flags) {
 
   deps.log("\n========== Summary ==========");
   for (const r of results) {
-    const m = r.passed ? "PASS" : r.mode === "advisory" ? "fail (advisory)" : "FAIL";
+    let m;
+    if (r.passed) m = "PASS";
+    else if (r.mode === "advisory") m = "fail (advisory)";
+    else m = "FAIL";
     deps.log(`  ${r.name.padEnd(28)} ${m} (${r.durationS}s)`);
   }
 
@@ -344,17 +354,24 @@ export function execute(deps, cfg, flags) {
     return { ok: true, body, results, pre, exitCode: 0 };
   }
 
+  // Post the attestation comment BEFORE pushing so it is visible when the
+  // push event fires GitHub Actions. The SHA embedded in the marker is the
+  // local HEAD, which is identical to what gets pushed.
+  upsertComment(deps, { repo: pre.repo, pr: pre.pr, body, trustedAssociations: cfg.trustedAssociations });
+
   if (flags.push && cfg.pushAfterAttest) {
     deps.log("\nPushing...");
     const pushResult = deps.run("git push");
     if (pushResult.status !== 0) {
-      deps.warn("git push failed — no attestation posted. Fix the push and retry.");
+      deps.warn(
+        "git push failed. The attestation comment was already posted but the branch was not pushed.\n" +
+          "Fix the push issue and retry — `git push` alone is enough; the comment is already in place.",
+      );
       return { ok: false, body, results, pre, exitCode: 1 };
     }
     deps.log("Pushed.");
   }
 
-  upsertComment(deps, { repo: pre.repo, pr: pre.pr, body });
   applyLabel(deps, { repo: pre.repo, pr: pre.pr, label: cfg.label });
   appendAuditLog(deps, {
     auditLogPath: cfg.auditLogPath,

--- a/plugins/dotbabel/templates/claude/skills-manifest.json
+++ b/plugins/dotbabel/templates/claude/skills-manifest.json
@@ -150,6 +150,13 @@
       "lastValidated": null
     },
     {
+      "name": "local-attest",
+      "path": ".claude/skills/local-attest/SKILL.md",
+      "checksum": "",
+      "dependencies": [],
+      "lastValidated": null
+    },
+    {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "",

--- a/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
@@ -1,0 +1,139 @@
+---
+id: local-attest
+name: local-attest
+type: skill
+version: 1.0.0
+domain: [devex, observability]
+platform: [github-actions]
+task: [testing, runtime-ops]
+maturity: draft
+description: >
+  Run the configured CI matrix locally and, on a clean pass, post a SHA-pinned
+  OWNER-authored PR comment that gates downstream GitHub Actions jobs off for
+  that exact commit. Skips the redundant remote run after a maintainer has
+  already verified locally, saving runner minutes without weakening the gate.
+  A new push changes the head SHA, the attestation stops matching, CI runs
+  again. Side-effectful (posts a PR comment, applies a label, optionally pushes)
+  and slow (10–15 min depending on matrix). Invoke only on explicit request.
+argument-hint: "[--pr <N>] [--no-push] [--dry-run] [--config <path>]"
+tools: Bash
+disable-model-invocation: true
+user-invocable: true
+---
+
+# /local-attest — Local CI attestation
+
+Run the project's configured CI matrix on your machine. On a clean pass, post
+a hidden marker comment to the open PR so the remote `Test` / `Preview` jobs
+read the marker and skip themselves for that exact commit.
+
+> **This skill is side-effectful and slow.** It runs every leg of your CI
+> matrix sequentially (typically 10–15 minutes), posts a PR comment, applies
+> a label, and pushes the current branch. Invoke only when you've decided to
+> attest a specific PR.
+
+## Quick start
+
+```bash
+# In a project root with a .local-attest.config.mjs
+dotbabel local-attest --pr 123
+
+# Try a config without posting anything:
+dotbabel local-attest --pr 123 --dry-run
+
+# Run + post + label, but do not git push (useful for offline review):
+dotbabel local-attest --pr 123 --no-push
+```
+
+## Prerequisites
+
+- **A `.local-attest` config** in the project root — see
+  [references/config.md](references/config.md) for the schema and three example
+  configs (Node-only, Node + Go monorepo, Python).
+- **A workflow gate** wired into your `.github/workflows/test.yml` (and any
+  other pipeline you want to skip). Paste the snippet from
+  [references/workflow-gate.yml.tmpl](references/workflow-gate.yml.tmpl). This
+  is a one-time manual setup — auto-injecting YAML across diverse CI layouts
+  is too risky to do for you.
+- **A clean worktree** — the skill aborts on any uncommitted change, because
+  the attestation must certify the exact tree that gets pushed. (Configurable
+  via `requireClean: false`, but generally not recommended.)
+- **Local HEAD must match the PR head** — the skill aborts if your local
+  branch tip differs from the remote PR head. Push any local commits first.
+- **`gh` authenticated** as a user whose `author_association` is in your
+  config's `trustedAssociations` list (default: `["OWNER"]`).
+- **Docker running** if your config sets `requireDocker: true`.
+
+## How the gate works
+
+The gate input is a PR comment authored by a trusted user (default: the repo
+OWNER) whose **first line** is exactly:
+
+```text
+<!-- local-attest verified-sha=<full-head-sha> -->
+```
+
+The CI workflow reads PR comments, applies a `jq select(.author_association == "OWNER")`
+filter, takes the first line of each, and `grep -qF`s for the marker that
+matches `github.event.pull_request.head.sha`. When it matches, every downstream
+job's `if:` evaluates false and skips at zero runner cost.
+
+Freshness is automatic: a new push changes the head SHA, the old comment no
+longer matches, CI runs again. Editing or deleting the comment does **not**
+re-trigger CI (the gate only re-evaluates on `push`/`synchronize`). If you
+need to revoke an attestation, push any new (even empty) commit.
+
+Full operator contract: [references/operator-guide.md](references/operator-guide.md).
+
+## What the skill does, in order
+
+1. **Preconditions.** Branch exists, worktree clean (if `requireClean`), local
+   HEAD == PR head, `gh` authed, Docker available (if `requireDocker`). Any
+   failure aborts before a single test runs. The skill also warns (does not
+   fail) if your current user's permission level is not in the trust list.
+2. **Run matrix.** Each leg from the config runs sequentially. Hard legs must
+   pass to attest; advisory legs are reported but never block. Stdout + stderr
+   are tailed at 10 lines per leg so the result table stays readable.
+3. **Hard-leg gate.** Any hard failure aborts: no comment, no label, no push.
+4. **Push first** (if `pushAfterAttest` and not `--no-push`). The attestation
+   must never describe a SHA the remote hasn't seen.
+5. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
+   place; otherwise a new one is POSTed. Body always goes via `gh api --input -`
+   so multiline markdown can't be mangled by shell quoting.
+6. **Apply label** (default `ci/local-verified`). Best-effort; failure warns
+   but does not abort.
+7. **Append audit log line** to the configured `auditLogPath` (default
+   `.local-attest-log.jsonl`). Best-effort.
+
+## Flags
+
+| Flag              | Effect                                                                                                                                       |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--pr <N>`        | Target PR number. Defaults to the open PR for the current branch.                                                                            |
+| `--no-push`       | Run matrix + post + label, but skip `git push`.                                                                                              |
+| `--dry-run`       | Run matrix, render the comment, print it. Post nothing, label nothing, push nothing. Use this to validate a new project's config end-to-end. |
+| `--config <path>` | Override config discovery.                                                                                                                   |
+
+## What this skill never does
+
+- **Auto-install the workflow gate.** Paste it manually using the template.
+- **Skip the Secret-scan job** (or any other gate you didn't put behind the
+  attestation `if:`). Configure each workflow's `if:` explicitly.
+- **Merge or deploy.** It only attests and pushes the current branch.
+- **Multiple comments per PR.** One attestation comment, upserted in place.
+- **Auto-unlabel on stale attestation.** A new push silently invalidates the
+  prior attestation by SHA mismatch; the label stays as audit decoration.
+
+## Trust model
+
+Default `trustedAssociations: ["OWNER"]`. Only comments from the repo OWNER
+will gate CI. A non-trusted user's comment will post (and the label may apply)
+but CI will still run. Widen the trust list in your config for multi-maintainer
+repos:
+
+```js
+trustedAssociations: ["OWNER", "MEMBER", "COLLABORATOR"];
+```
+
+The generated workflow gate snippet ([references/workflow-gate.yml.tmpl](references/workflow-gate.yml.tmpl))
+automatically matches the configured list.

--- a/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
@@ -49,7 +49,8 @@ dotbabel local-attest --pr 123 --no-push
 
 - **A `.local-attest` config** in the project root — see
   [references/config.md](references/config.md) for the schema and three example
-  configs (Node-only, Node + Go monorepo, Python).
+  configs (Node-only, Node + Go monorepo, Python). Discovery order:
+  `.local-attest.config.mjs` → `.local-attest.config.json` → `package.json#local-attest`.
 - **A workflow gate** wired into your `.github/workflows/test.yml` (and any
   other pipeline you want to skip). Paste the snippet from
   [references/workflow-gate.yml.tmpl](references/workflow-gate.yml.tmpl). This
@@ -74,8 +75,8 @@ OWNER) whose **first line** is exactly:
 ```
 
 The CI workflow reads PR comments, applies a `jq select(.author_association == "OWNER")`
-filter, takes the first line of each, and `grep -qF`s for the marker that
-matches `github.event.pull_request.head.sha`. When it matches, every downstream
+filter, takes the first line of each, and `grep -qFx`s (exact-line match)
+for the marker that matches `github.event.pull_request.head.sha`. When it matches, every downstream
 job's `if:` evaluates false and skips at zero runner cost.
 
 Freshness is automatic: a new push changes the head SHA, the old comment no
@@ -90,7 +91,9 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
 1. **Preconditions.** Branch exists, worktree clean (if `requireClean`), local
    HEAD == PR head, `gh` authed, Docker available (if `requireDocker`). Any
    failure aborts before a single test runs. The skill also warns (does not
-   fail) if your current user's permission level is not in the trust list.
+   fail) if your GitHub `author_association` on the repo (OWNER / MEMBER /
+   COLLABORATOR, etc.) is not in the config's `trustedAssociations` list — the
+   attestation will post but CI will ignore it.
 2. **Run matrix.** Each leg from the config runs sequentially. Hard legs must
    pass to attest; advisory legs are reported but never block. Stdout + stderr
    are tailed at 10 lines per leg so the result table stays readable.

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
@@ -4,9 +4,9 @@ Every consuming project supplies its own CI matrix. The skill discovers config
 in this order (first match wins):
 
 1. `--config <path>` (CLI flag)
-2. `./.local-attest.config.mjs`
-3. `./.local-attest.config.json`
-4. `./package.json` → `local-attest` key
+2. `.local-attest.config.mjs`
+3. `.local-attest.config.json`
+4. `package.json` → `local-attest` key
 
 ## Schema
 

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
@@ -1,0 +1,120 @@
+# `.local-attest` configuration
+
+Every consuming project supplies its own CI matrix. The skill discovers config
+in this order (first match wins):
+
+1. `--config <path>` (CLI flag)
+2. `./.local-attest.config.mjs`
+3. `./.local-attest.config.json`
+4. `./package.json` → `local-attest` key
+
+## Schema
+
+```ts
+type Config = {
+  // REQUIRED — the list of checks to run locally. Order is preserved.
+  matrix: Array<{
+    name: string; // unique within the matrix; appears in the result table
+    mode:
+      | "hard" // "hard" legs must pass to attest
+      | "advisory"; // "advisory" legs report but never block
+    command: string; // shell command (runs under `bash -c`)
+    cwd?: string; // working dir relative to project root
+    env?: Record<string, string>; // extra env vars for this leg only
+  }>;
+
+  label?: string; // PR label to apply on attest (default: "ci/local-verified")
+  auditLogPath?: string; // jsonl audit trail (default: ".local-attest-log.jsonl")
+  trustedAssociations?: string[]; // gh author_association values that gate CI (default: ["OWNER"])
+  requireClean?: boolean; // abort on dirty worktree (default: true)
+  requireDocker?: boolean; // abort if `docker info` fails (default: false)
+  pushAfterAttest?: boolean; // git push after attest, before posting (default: true)
+};
+```
+
+The matrix is the only required field; everything else has sensible defaults.
+
+## Example 1 — minimal Node app
+
+```js
+// .local-attest.config.mjs
+export default {
+  matrix: [
+    { name: "npm ci", mode: "hard", command: "npm ci" },
+    { name: "lint", mode: "hard", command: "npm run lint" },
+    { name: "tests", mode: "hard", command: "npm test" },
+    { name: "build", mode: "hard", command: "npm run build" },
+    { name: "audit", mode: "advisory", command: "npm audit --omit=dev --audit-level=high" },
+  ],
+};
+```
+
+## Example 2 — Node frontend + Go backend monorepo
+
+```js
+// .local-attest.config.mjs
+export default {
+  matrix: [
+    { name: "npm ci", mode: "hard", command: "npm ci" },
+    { name: "frontend lint", mode: "hard", command: "npm run lint" },
+    { name: "frontend tests", mode: "hard", command: "npm run test:coverage" },
+    { name: "frontend build", mode: "hard", command: "npm run build" },
+    { name: "knip", mode: "advisory", command: "npm run knip" },
+    {
+      name: "e2e",
+      mode: "hard",
+      command: "npx playwright install chromium && npm run test:e2e",
+      env: { CI: "1" },
+    },
+    { name: "backend tests", mode: "hard", command: "go test -race -count=1 ./...", cwd: "api" },
+    {
+      name: "backend vuln",
+      mode: "hard",
+      command: "go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...",
+      cwd: "api",
+    },
+    {
+      name: "golangci-lint",
+      mode: "advisory",
+      command: "go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run",
+      cwd: "api",
+    },
+  ],
+  requireDocker: true, // testcontainers-based integration tests
+  trustedAssociations: ["OWNER"],
+};
+```
+
+## Example 3 — Python (uv + pytest)
+
+```json
+{
+  "matrix": [
+    { "name": "uv sync", "mode": "hard", "command": "uv sync --frozen" },
+    { "name": "ruff", "mode": "hard", "command": "uv run ruff check ." },
+    { "name": "mypy", "mode": "hard", "command": "uv run mypy ." },
+    { "name": "pytest", "mode": "hard", "command": "uv run pytest -q" },
+    {
+      "name": "coverage",
+      "mode": "advisory",
+      "command": "uv run pytest --cov=src --cov-fail-under=80"
+    }
+  ],
+  "trustedAssociations": ["OWNER", "MEMBER"]
+}
+```
+
+## Validation rules
+
+- `matrix` must be a non-empty array.
+- Every leg must have a non-empty `name`, a `mode` of `"hard"` or `"advisory"`,
+  and a non-empty `command`.
+- Leg `name`s must be unique within the matrix.
+- `auditLogPath` must not contain `..` segments (path-traversal guard).
+- `trustedAssociations` must be a non-empty array of strings.
+- Unknown top-level keys are ignored. Defaults are merged from
+  `plugins/dotbabel/src/local-attest-config.mjs:DEFAULTS`.
+
+`dotbabel local-attest --dry-run --pr <N>` runs the matrix and prints the
+comment it would post without touching the PR — use it to validate a new
+config end-to-end.

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/operator-guide.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/operator-guide.md
@@ -1,0 +1,134 @@
+# Operator guide — CI skip via local attestation
+
+CI minutes are billed; running the same matrix on GitHub-hosted runners after
+a maintainer has already verified the change locally is duplicated spend. The
+`/local-attest` skill lets a trusted user trade ~10–15 minutes of local
+runtime for a clean skip of the equivalent remote pipeline.
+
+This guide is the operator contract for using the skill safely.
+
+## How the gate works
+
+The gate input is a **PR comment authored by a trusted user** (default: the
+repo OWNER) whose first line is exactly the marker:
+
+```text
+<!-- local-attest verified-sha=<full-head-sha> -->
+```
+
+The workflow gate (template at
+[`workflow-gate.yml.tmpl`](workflow-gate.yml.tmpl)) reads the PR comments,
+filters by `author_association`, takes the first line of each, and
+`grep -qF`s for the marker matching `github.event.pull_request.head.sha`.
+
+When the marker matches, downstream jobs whose `if:` consumes
+`needs.classify.outputs.attested` skip at zero runner cost.
+
+### Freshness is automatic
+
+A new push changes the head SHA, the old marker no longer matches, and CI
+runs again. There is no auto-unlabel workflow; the label is decoration only.
+
+### Editing/deleting the comment does NOT re-trigger CI
+
+GitHub Actions only re-evaluates workflow gates on `push` / `synchronize`
+events, not on comment events. If you need to revoke an attestation, **push
+a new (even empty) commit** — that's the documented contract.
+
+### Always run, never gate
+
+Some jobs should always run regardless of attestation:
+
+- **Secret scanning** (gitleaks, trufflehog) — never gate.
+- **License / SBOM publishing** — always run on push.
+- **Required status checks** specified in branch protection — if you gate
+  them, make sure your downstream `if:` produces a green check anyway. The
+  common shape is "always emit `success` from a downstream summary job, but
+  let the upstream attested jobs skip."
+
+## Producing an attestation
+
+From the PR branch in your local checkout:
+
+```bash
+dotbabel local-attest --pr 123
+```
+
+The skill runs every leg of your `.local-attest` matrix, prints a result
+table, pushes (if `pushAfterAttest`), posts/PATCHes the attestation comment,
+applies the label, and appends a line to the audit log.
+
+`--dry-run` runs the matrix and prints the comment without posting anything.
+Use it to validate a new config end-to-end.
+
+`--no-push` skips the `git push` step but still posts the comment + label.
+Use it when you've pushed manually and just want to attest.
+
+## Trust model
+
+Default `trustedAssociations: ["OWNER"]`. Only comments from a user with
+`author_association == "OWNER"` will gate CI. A non-trusted user's comment
+will post, but CI will still run.
+
+Multi-maintainer repos widen the trust list:
+
+```js
+// .local-attest.config.mjs
+trustedAssociations: ["OWNER", "MEMBER", "COLLABORATOR"];
+```
+
+The workflow gate template uses `{{TRUSTED_SELECT}}` as a placeholder for
+the matching jq filter. Substitute it manually for now.
+
+## Caveats
+
+### Branch protection unconditional checks
+
+If branch protection requires a specific status check (e.g.
+`Test / backend tests`) and you gate that job off via attestation, the check
+will be reported as skipped, which counts as missing for protection.
+
+**Fix**: introduce an always-run summary job that aggregates the attested
+jobs' results and reports a single status check. Make that summary job the
+one required by branch protection.
+
+### Drift between local and remote matrix
+
+The skill runs whatever your `.local-attest.config.mjs` says. If it drifts
+from what `.github/workflows/test.yml` actually runs, the attestation
+certifies a different (probably smaller) set of checks. Treat the config
+file as documentation that has to track the workflow.
+
+A simple drift check is to put both lists in a single source (e.g. a JSON
+manifest both sides import) — but most projects find it cheaper to review
+the diff manually whenever either side changes.
+
+### Long-running matrices
+
+Attestation runs sequentially. 10–15 minutes is typical; pathologically
+slow matrices (heavy e2e + multiple language runtimes) can hit 30+. That's
+the deliberate cost of skipping the remote run.
+
+### Audit
+
+The label `ci/local-verified` is decoration for visibility:
+
+```bash
+gh pr list --label ci/local-verified --state all
+```
+
+The audit log (`.local-attest-log.jsonl` by default) records one JSONL line
+per attestation:
+
+```json
+{
+  "ts": "2026-05-23T16:00:00.000Z",
+  "pr": 123,
+  "sha": "abc1234...",
+  "host": "wsl-laptop",
+  "advisoryFails": ["knip"]
+}
+```
+
+Add the audit log to `.gitignore` if you don't want it in version control;
+the contract is single-line JSONL so any log shipper handles it natively.

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/operator-guide.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/operator-guide.md
@@ -19,7 +19,8 @@ repo OWNER) whose first line is exactly the marker:
 The workflow gate (template at
 [`workflow-gate.yml.tmpl`](workflow-gate.yml.tmpl)) reads the PR comments,
 filters by `author_association`, takes the first line of each, and
-`grep -qF`s for the marker matching `github.event.pull_request.head.sha`.
+`grep -qFx`s (exact-line match) for the marker matching
+`github.event.pull_request.head.sha`.
 
 When the marker matches, downstream jobs whose `if:` consumes
 `needs.classify.outputs.attested` skip at zero runner cost.
@@ -77,8 +78,11 @@ Multi-maintainer repos widen the trust list:
 trustedAssociations: ["OWNER", "MEMBER", "COLLABORATOR"];
 ```
 
-The workflow gate template uses `{{TRUSTED_SELECT}}` as a placeholder for
-the matching jq filter. Substitute it manually for now.
+The workflow gate template is pre-substituted for the default single-OWNER
+config. If you widen `trustedAssociations`, update the `select(...)` clause in
+your workflow gate file and commit both changes together — they must stay in sync
+or attestations from the newly-trusted association will be posted but never
+honored by CI.
 
 ## Caveats
 
@@ -90,7 +94,26 @@ will be reported as skipped, which counts as missing for protection.
 
 **Fix**: introduce an always-run summary job that aggregates the attested
 jobs' results and reports a single status check. Make that summary job the
-one required by branch protection.
+one required by branch protection. Example:
+
+```yaml
+attested-or-passed:
+  needs: [test, preview] # jobs gated by local-attest
+  if: always()
+  runs-on: ubuntu-latest
+  steps:
+    - run: |
+        if [[ "${{ needs.test.result }}" == "skipped" && \
+              "${{ needs.preview.result }}" == "skipped" ]]; then
+          echo "All CI jobs skipped via local attestation"
+        elif [[ "${{ needs.test.result }}" != "success" || \
+                "${{ needs.preview.result }}" != "success" ]]; then
+          exit 1
+        fi
+```
+
+Point branch protection's required status check at `attested-or-passed` instead
+of the individual jobs.
 
 ### Drift between local and remote matrix
 

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/workflow-gate.yml.tmpl
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/workflow-gate.yml.tmpl
@@ -1,0 +1,66 @@
+# Local-attest workflow gate template
+#
+# Paste this into your `.github/workflows/test.yml` (and any other workflow
+# you want to gate, e.g. `preview.yml`) per the operator-guide.md walkthrough.
+#
+# Substitute `{{TRUSTED_SELECT}}` for the jq filter matching your config's
+# `trustedAssociations`. The default config (OWNER only) produces:
+#
+#   select(.author_association == "OWNER")
+#
+# A multi-trust config like `trustedAssociations: ["OWNER", "MEMBER"]` produces:
+#
+#   select(.author_association == "OWNER" or .author_association == "MEMBER")
+#
+# `dotbabel local-attest --print-gate` (planned, post-1.0) will emit the
+# already-substituted snippet for the current config.
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      attested: ${{ steps.attest.outputs.attested }}
+    steps:
+      - name: Check for local attestation
+        id: attest
+        # A local-attestation comment lets a maintainer skip the redundant
+        # remote CI run after running the full check matrix locally. The
+        # gate is a PR comment authored by a trusted user (default OWNER)
+        # carrying the marker:
+        #   <!-- local-attest verified-sha=<HEAD_SHA> -->
+        # Only the first line of each comment is matched, so a quote-reply
+        # that happens to contain the marker in a quoted block cannot forge
+        # a skip. The head SHA is embedded in the marker, so a new push (new
+        # SHA) automatically invalidates a stale attestation.
+        # Fail-closed: if the gh api call fails, grep exits non-zero →
+        # attested=false → CI runs.
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          MARKER="<!-- local-attest verified-sha=${HEAD_SHA} -->"
+          if gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+               --jq '.[] | {{TRUSTED_SELECT}} | .body | split("\n")[0]' \
+             | grep -qF "$MARKER"; then
+            echo "Local attestation found for ${HEAD_SHA} — remote CI jobs will skip."
+            echo "attested=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No local attestation for ${HEAD_SHA} — remote CI jobs will run."
+            echo "attested=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Every downstream job gates off `classify.outputs.attested`. Example:
+  test:
+    needs: classify
+    if: needs.classify.outputs.attested != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # ... your real test steps ...
+      - run: echo "running tests"
+
+  # The Secret-scan job is intentionally NOT gated. Run it on every push.
+  # Add other always-run jobs (license check, SBOM publish, etc.) without
+  # the `needs: classify` line.

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/workflow-gate.yml.tmpl
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/workflow-gate.yml.tmpl
@@ -3,17 +3,17 @@
 # Paste this into your `.github/workflows/test.yml` (and any other workflow
 # you want to gate, e.g. `preview.yml`) per the operator-guide.md walkthrough.
 #
-# Substitute `{{TRUSTED_SELECT}}` for the jq filter matching your config's
-# `trustedAssociations`. The default config (OWNER only) produces:
-#
-#   select(.author_association == "OWNER")
-#
-# A multi-trust config like `trustedAssociations: ["OWNER", "MEMBER"]` produces:
+# This template is pre-substituted for the default single-OWNER config.
+# If your config uses a wider trust list (e.g. `trustedAssociations: ["OWNER","MEMBER"]`),
+# replace the jq `select(...)` clause on the `--jq` line below with:
 #
 #   select(.author_association == "OWNER" or .author_association == "MEMBER")
 #
+# Whenever you change `trustedAssociations` in your config, update the
+# `select(...)` clause here and commit both changes in the same PR.
+#
 # `dotbabel local-attest --print-gate` (planned, post-1.0) will emit the
-# already-substituted snippet for the current config.
+# correctly-substituted snippet for the current config automatically.
 
 jobs:
   classify:
@@ -43,8 +43,8 @@ jobs:
         run: |
           MARKER="<!-- local-attest verified-sha=${HEAD_SHA} -->"
           if gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-               --jq '.[] | {{TRUSTED_SELECT}} | .body | split("\n")[0]' \
-             | grep -qF "$MARKER"; then
+               --jq '.[] | select(.author_association == "OWNER") | .body | split("\n")[0]' \
+             | grep -qFx "$MARKER"; then
             echo "Local attestation found for ${HEAD_SHA} — remote CI jobs will skip."
             echo "attested=true" >> "$GITHUB_OUTPUT"
           else

--- a/plugins/dotbabel/tests/fixtures/local-attest/duplicate-leg.config.mjs
+++ b/plugins/dotbabel/tests/fixtures/local-attest/duplicate-leg.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  matrix: [
+    { name: "lint", mode: "hard", command: "true" },
+    { name: "lint", mode: "hard", command: "true" },
+  ],
+};

--- a/plugins/dotbabel/tests/fixtures/local-attest/missing-name.config.mjs
+++ b/plugins/dotbabel/tests/fixtures/local-attest/missing-name.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  matrix: [{ mode: "hard", command: "true" }],
+};

--- a/plugins/dotbabel/tests/fixtures/local-attest/valid.config.mjs
+++ b/plugins/dotbabel/tests/fixtures/local-attest/valid.config.mjs
@@ -1,0 +1,8 @@
+export default {
+  matrix: [
+    { name: "deps", mode: "hard", command: "true" },
+    { name: "lint", mode: "hard", command: "true" },
+    { name: "test", mode: "hard", command: "true" },
+    { name: "knip", mode: "advisory", command: "true" },
+  ],
+};

--- a/plugins/dotbabel/tests/local-attest-config.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-config.test.mjs
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  ConfigError,
+  DEFAULTS,
+  loadConfig,
+  validateConfig,
+} from "../src/local-attest-config.mjs";
+
+const FIXTURES = resolve(import.meta.dirname ?? new URL(".", import.meta.url).pathname, "fixtures", "local-attest");
+
+function makeTmpDir() {
+  const dir = mkdtempSync(join(tmpdir(), "local-attest-cfg-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("loadConfig", () => {
+  it("honors --config override", async () => {
+    const cfg = await loadConfig({
+      cwd: "/nowhere",
+      override: join(FIXTURES, "valid.config.mjs"),
+    });
+    expect(cfg.matrix).toHaveLength(4);
+    expect(cfg.label).toBe(DEFAULTS.label);
+  });
+
+  it("throws ConfigError with a hint when override file is missing", async () => {
+    await expect(
+      loadConfig({ cwd: "/nowhere", override: "/nope/missing.mjs" }),
+    ).rejects.toMatchObject({
+      name: "ConfigError",
+      message: expect.stringContaining("not found"),
+      hint: expect.stringContaining("references/config.md"),
+    });
+  });
+
+  it("discovers .local-attest.config.mjs in cwd", async () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(
+        join(dir, ".local-attest.config.mjs"),
+        `export default { matrix: [{ name: "x", mode: "hard", command: "true" }] };\n`,
+      );
+      const cfg = await loadConfig({ cwd: dir });
+      expect(cfg.matrix[0].name).toBe("x");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("discovers .local-attest.config.json when .mjs is absent", async () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(
+        join(dir, ".local-attest.config.json"),
+        JSON.stringify({ matrix: [{ name: "j", mode: "hard", command: "true" }] }),
+      );
+      const cfg = await loadConfig({ cwd: dir });
+      expect(cfg.matrix[0].name).toBe("j");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("reads from package.json#local-attest as last fallback", async () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({
+          name: "x",
+          "local-attest": {
+            matrix: [{ name: "p", mode: "advisory", command: "true" }],
+          },
+        }),
+      );
+      const cfg = await loadConfig({ cwd: dir });
+      expect(cfg.matrix[0]).toMatchObject({ name: "p", mode: "advisory" });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("errors with a hint when no config exists anywhere", async () => {
+    const { dir, cleanup } = makeTmpDir();
+    try {
+      await expect(loadConfig({ cwd: dir })).rejects.toMatchObject({
+        name: "ConfigError",
+        message: expect.stringContaining("no .local-attest config found"),
+        hint: expect.stringContaining("references/config.md"),
+      });
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("validateConfig", () => {
+  function base() {
+    return {
+      matrix: [
+        { name: "a", mode: "hard", command: "true" },
+        { name: "b", mode: "advisory", command: "true" },
+      ],
+    };
+  }
+
+  it("returns merged defaults for a minimal config", () => {
+    const cfg = validateConfig(base());
+    expect(cfg.label).toBe("ci/local-verified");
+    expect(cfg.auditLogPath).toBe(".local-attest-log.jsonl");
+    expect(cfg.trustedAssociations).toEqual(["OWNER"]);
+    expect(cfg.requireClean).toBe(true);
+    expect(cfg.requireDocker).toBe(false);
+    expect(cfg.pushAfterAttest).toBe(true);
+  });
+
+  it("rejects non-object input", () => {
+    expect(() => validateConfig(null)).toThrow(ConfigError);
+    expect(() => validateConfig("hi")).toThrow(ConfigError);
+  });
+
+  it("rejects empty matrix", () => {
+    expect(() => validateConfig({ matrix: [] })).toThrow(/non-empty array/);
+  });
+
+  it("rejects matrix leg missing name", () => {
+    expect(() => validateConfig({ matrix: [{ mode: "hard", command: "true" }] })).toThrow(
+      /matrix\[0\]\.name/,
+    );
+  });
+
+  it("rejects unknown mode", () => {
+    expect(() =>
+      validateConfig({ matrix: [{ name: "a", mode: "soft", command: "true" }] }),
+    ).toThrow(/mode/);
+  });
+
+  it("rejects empty command", () => {
+    expect(() => validateConfig({ matrix: [{ name: "a", mode: "hard", command: "" }] })).toThrow(
+      /command/,
+    );
+  });
+
+  it("rejects duplicate leg names", () => {
+    const cfg = {
+      matrix: [
+        { name: "x", mode: "hard", command: "true" },
+        { name: "x", mode: "hard", command: "true" },
+      ],
+    };
+    expect(() => validateConfig(cfg)).toThrow(/duplicated/);
+  });
+
+  it("rejects auditLogPath with .. segments", () => {
+    expect(() =>
+      validateConfig({ ...base(), auditLogPath: "../escape.jsonl" }),
+    ).toThrow(/\.\./);
+  });
+
+  it("rejects empty trustedAssociations", () => {
+    expect(() => validateConfig({ ...base(), trustedAssociations: [] })).toThrow(
+      /trustedAssociations/,
+    );
+  });
+
+  it("rejects non-string trustedAssociations entries", () => {
+    expect(() =>
+      validateConfig({ ...base(), trustedAssociations: ["OWNER", 42] }),
+    ).toThrow(/trustedAssociations/);
+  });
+
+  it("rejects non-boolean requireClean", () => {
+    expect(() =>
+      validateConfig({ ...base(), requireClean: "yes" }),
+    ).toThrow(/requireClean/);
+  });
+
+  it("preserves matrix order", () => {
+    const cfg = validateConfig({
+      matrix: [
+        { name: "z", mode: "hard", command: "true" },
+        { name: "a", mode: "hard", command: "true" },
+        { name: "m", mode: "advisory", command: "true" },
+      ],
+    });
+    expect(cfg.matrix.map((l) => l.name)).toEqual(["z", "a", "m"]);
+  });
+});

--- a/plugins/dotbabel/tests/local-attest-lib.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-lib.test.mjs
@@ -1,0 +1,303 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  ATTEST_MARKER_PREFIX,
+  buildAttestMarker,
+  buildAuditEntry,
+  buildGateSnippet,
+  findAttestComment,
+  isAttested,
+  parseArgs,
+  renderComment,
+  summarizeResults,
+  tail,
+} from "../src/local-attest-lib.mjs";
+
+describe("buildAttestMarker", () => {
+  it("accepts a full 40-char SHA", () => {
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    expect(buildAttestMarker(sha)).toBe(`${ATTEST_MARKER_PREFIX}${sha} -->`);
+  });
+
+  it("accepts a short SHA (7+ chars)", () => {
+    expect(buildAttestMarker("0123456")).toBe(`${ATTEST_MARKER_PREFIX}0123456 -->`);
+  });
+
+  it("accepts uppercase hex", () => {
+    expect(buildAttestMarker("ABCDEF0")).toContain("ABCDEF0");
+  });
+
+  it("rejects empty string", () => {
+    expect(() => buildAttestMarker("")).toThrow(/invalid sha/);
+  });
+
+  it("rejects non-hex characters", () => {
+    expect(() => buildAttestMarker("zxywvut")).toThrow(/invalid sha/);
+  });
+
+  it("rejects too-short input (<7 chars)", () => {
+    expect(() => buildAttestMarker("abc123")).toThrow(/invalid sha/);
+  });
+
+  it("rejects non-string input", () => {
+    expect(() => buildAttestMarker(/** @type {any} */ (null))).toThrow(/invalid sha/);
+    expect(() => buildAttestMarker(/** @type {any} */ (42))).toThrow(/invalid sha/);
+  });
+});
+
+describe("isAttested", () => {
+  const SHA = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+  const marker = `${ATTEST_MARKER_PREFIX}${SHA} -->`;
+
+  it("returns true for an OWNER comment matching the SHA", () => {
+    const comments = [
+      { author_association: "OWNER", body: `${marker}\nbody text here` },
+    ];
+    expect(isAttested(comments, SHA)).toBe(true);
+  });
+
+  it("returns false for a stale SHA", () => {
+    const staleMarker = `${ATTEST_MARKER_PREFIX}aaaaaaa -->`;
+    const comments = [{ author_association: "OWNER", body: staleMarker }];
+    expect(isAttested(comments, SHA)).toBe(false);
+  });
+
+  it("rejects non-OWNER authors by default", () => {
+    const comments = [{ author_association: "CONTRIBUTOR", body: marker }];
+    expect(isAttested(comments, SHA)).toBe(false);
+  });
+
+  it("accepts MEMBER when trust list widened", () => {
+    const comments = [{ author_association: "MEMBER", body: marker }];
+    expect(isAttested(comments, SHA, { trustedAssociations: ["OWNER", "MEMBER"] })).toBe(true);
+  });
+
+  it("returns false when marker missing", () => {
+    const comments = [{ author_association: "OWNER", body: "just a normal comment" }];
+    expect(isAttested(comments, SHA)).toBe(false);
+  });
+
+  it("returns false when marker is malformed (e.g. on line 2 only)", () => {
+    const comments = [{ author_association: "OWNER", body: `> quoted reply\n${marker}` }];
+    expect(isAttested(comments, SHA)).toBe(false);
+  });
+
+  it("returns false on non-array input", () => {
+    expect(isAttested(/** @type {any} */ (null), SHA)).toBe(false);
+    expect(isAttested(/** @type {any} */ ("[]"), SHA)).toBe(false);
+  });
+
+  it("returns false on empty headSha", () => {
+    expect(isAttested([], "")).toBe(false);
+  });
+
+  it("finds a matching comment among several non-matching ones", () => {
+    const comments = [
+      { author_association: "CONTRIBUTOR", body: marker },
+      { author_association: "OWNER", body: "just chat" },
+      { author_association: "OWNER", body: `${marker}\nokay attestation` },
+    ];
+    expect(isAttested(comments, SHA)).toBe(true);
+  });
+});
+
+describe("findAttestComment", () => {
+  it("returns the first comment whose body contains the marker prefix", () => {
+    const target = { author_association: "OWNER", body: `${ATTEST_MARKER_PREFIX}abc1234 -->` };
+    expect(findAttestComment([{ body: "noise" }, target, { body: "more" }])).toBe(target);
+  });
+
+  it("returns null when no comment carries the prefix", () => {
+    expect(findAttestComment([{ body: "x" }, { body: "y" }])).toBe(null);
+  });
+
+  it("returns null on non-array input", () => {
+    expect(findAttestComment(/** @type {any} */ (null))).toBe(null);
+  });
+});
+
+describe("parseArgs", () => {
+  it("returns defaults when argv is empty", () => {
+    expect(parseArgs([])).toEqual({
+      pr: null,
+      push: true,
+      dryRun: false,
+      config: null,
+      help: false,
+    });
+  });
+
+  it("parses --pr <N>", () => {
+    expect(parseArgs(["--pr", "123"]).pr).toBe("123");
+  });
+
+  it("toggles --no-push", () => {
+    expect(parseArgs(["--no-push"]).push).toBe(false);
+  });
+
+  it("toggles --dry-run", () => {
+    expect(parseArgs(["--dry-run"]).dryRun).toBe(true);
+  });
+
+  it("captures --config <path>", () => {
+    expect(parseArgs(["--config", "/tmp/cfg.mjs"]).config).toBe("/tmp/cfg.mjs");
+  });
+
+  it("sets help on --help / -h", () => {
+    expect(parseArgs(["--help"]).help).toBe(true);
+    expect(parseArgs(["-h"]).help).toBe(true);
+  });
+
+  it("rejects non-numeric --pr", () => {
+    const die = (code, msg) => ({ code, msg });
+    expect(parseArgs(["--pr", "abc"], die)).toEqual({ code: 64, msg: expect.stringContaining("--pr") });
+  });
+
+  it("rejects unknown flags", () => {
+    const die = (code, msg) => ({ code, msg });
+    expect(parseArgs(["--bogus"], die)).toEqual({ code: 64, msg: expect.stringContaining("unknown") });
+  });
+
+  it("rejects --config with no value", () => {
+    const die = (code, msg) => ({ code, msg });
+    expect(parseArgs(["--config"], die)).toEqual({ code: 64, msg: expect.stringContaining("--config") });
+  });
+});
+
+describe("tail", () => {
+  it("returns empty string for empty input", () => {
+    expect(tail("")).toBe("");
+  });
+
+  it("returns all lines when fewer than n", () => {
+    expect(tail("a\nb", 5)).toBe("a\nb");
+  });
+
+  it("returns exactly the last n lines when more available", () => {
+    const input = Array.from({ length: 20 }, (_, i) => `L${i + 1}`).join("\n");
+    expect(tail(input, 3)).toBe("L18\nL19\nL20");
+  });
+
+  it("strips trailing whitespace before splitting", () => {
+    expect(tail("a\nb\n\n  \n", 5)).toBe("a\nb");
+  });
+});
+
+describe("renderComment", () => {
+  const SHA = "0123456789abcdef0123456789abcdef01234567";
+  const results = [
+    { name: "lint", mode: "hard", passed: true, durationS: 3, tail: "" },
+    { name: "test", mode: "hard", passed: true, durationS: 12, tail: "" },
+    { name: "knip", mode: "advisory", passed: false, durationS: 1, tail: "noise" },
+  ];
+
+  it("places the marker on line 1 (CI-gate invariant)", () => {
+    const body = renderComment(results, {
+      headSha: SHA,
+      hostname: "host",
+      now: new Date("2026-01-01T00:00:00Z"),
+    });
+    expect(body.split("\n")[0]).toBe(buildAttestMarker(SHA));
+  });
+
+  it("includes one row per leg with mode + status", () => {
+    const body = renderComment(results, {
+      headSha: SHA,
+      hostname: "host",
+      now: new Date("2026-01-01T00:00:00Z"),
+    });
+    expect(body).toContain("| lint | hard | pass | 3s |");
+    expect(body).toContain("| test | hard | pass | 12s |");
+    expect(body).toContain("| knip | advisory | fail (advisory) | 1s |");
+  });
+
+  it("uses 'FAIL' (uppercase) for hard failures", () => {
+    const failed = [{ name: "lint", mode: "hard", passed: false, durationS: 4, tail: "" }];
+    const body = renderComment(failed, {
+      headSha: SHA,
+      hostname: "h",
+      now: new Date("2026-01-01T00:00:00Z"),
+    });
+    expect(body).toContain("| lint | hard | FAIL | 4s |");
+  });
+
+  it("includes host, timestamp, and SHA footer", () => {
+    const body = renderComment(results, {
+      headSha: SHA,
+      hostname: "ci-laptop",
+      now: new Date("2026-01-01T12:34:56Z"),
+    });
+    expect(body).toContain("- Host: `ci-laptop`");
+    expect(body).toContain("- Attested at: `2026-01-01T12:34:56.000Z`");
+    expect(body).toContain(`- Verified SHA: \`${SHA}\``);
+  });
+});
+
+describe("buildAuditEntry", () => {
+  it("produces the documented .local-attest-log.jsonl shape", () => {
+    const e = buildAuditEntry({
+      pr: "123",
+      sha: "abc1234",
+      hostname: "host",
+      advisoryFails: ["knip"],
+      now: new Date("2026-01-01T00:00:00Z"),
+    });
+    expect(e).toEqual({
+      ts: "2026-01-01T00:00:00.000Z",
+      pr: 123,
+      sha: "abc1234",
+      host: "host",
+      advisoryFails: ["knip"],
+    });
+  });
+
+  it("copies the advisoryFails array (no shared reference)", () => {
+    const src = ["a"];
+    const e = buildAuditEntry({
+      pr: 1,
+      sha: "abc1234",
+      hostname: "h",
+      advisoryFails: src,
+      now: new Date(),
+    });
+    src.push("b");
+    expect(e.advisoryFails).toEqual(["a"]);
+  });
+});
+
+describe("summarizeResults", () => {
+  it("partitions hard fails, advisory fails, and totals durations", () => {
+    const results = [
+      { name: "a", mode: "hard", passed: true, durationS: 1, tail: "" },
+      { name: "b", mode: "hard", passed: false, durationS: 2, tail: "" },
+      { name: "c", mode: "advisory", passed: false, durationS: 3, tail: "" },
+      { name: "d", mode: "advisory", passed: true, durationS: 4, tail: "" },
+    ];
+    const s = summarizeResults(results);
+    expect(s.hardFails.map((r) => r.name)).toEqual(["b"]);
+    expect(s.advisoryFails.map((r) => r.name)).toEqual(["c"]);
+    expect(s.totalDurationS).toBe(10);
+  });
+});
+
+describe("buildGateSnippet", () => {
+  it("emits a single OWNER select for the default trust list", () => {
+    const snippet = buildGateSnippet();
+    expect(snippet).toContain('select(.author_association == "OWNER")');
+    expect(snippet).toContain("MARKER=");
+  });
+
+  it("emits a multi-trust select for widened trust", () => {
+    const snippet = buildGateSnippet({ trustedAssociations: ["OWNER", "MEMBER"] });
+    expect(snippet).toContain(
+      'select(.author_association == "OWNER" or .author_association == "MEMBER")',
+    );
+  });
+
+  it("rejects empty or non-array trustedAssociations", () => {
+    expect(() => buildGateSnippet({ trustedAssociations: [] })).toThrow(/non-empty array/);
+    expect(() =>
+      buildGateSnippet({ trustedAssociations: /** @type {any} */ ("OWNER") }),
+    ).toThrow(/non-empty array/);
+  });
+});

--- a/plugins/dotbabel/tests/local-attest-runner.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-runner.test.mjs
@@ -1,0 +1,357 @@
+import { describe, it, expect } from "vitest";
+
+import { validateConfig } from "../src/local-attest-config.mjs";
+import {
+  PreconditionError,
+  appendAuditLog,
+  applyLabel,
+  checkPreconditions,
+  execute,
+  runMatrix,
+  upsertComment,
+} from "../src/local-attest-runner.mjs";
+
+/**
+ * Build a `deps` stub whose `run`/`ghApiWithInput`/`appendLog` record every
+ * invocation. The `runReplies` parameter is a regex-keyed table mapping a
+ * command-substring pattern to its mocked result.
+ */
+function makeDeps({ runReplies = [], hostname = "stub-host" } = {}) {
+  const calls = { run: [], gh: [], log: [], warn: [], appendLog: [] };
+
+  const run = (cmd, opts = {}) => {
+    calls.run.push({ cmd, opts });
+    for (const [pattern, result] of runReplies) {
+      if (pattern.test(cmd)) {
+        return { status: 0, stdout: "", stderr: "", ...result };
+      }
+    }
+    return { status: 0, stdout: "", stderr: "" };
+  };
+
+  return {
+    deps: {
+      run,
+      ghApiWithInput(cmd, payload) {
+        calls.gh.push({ cmd, payload });
+        return "";
+      },
+      appendLog(path, line) {
+        calls.appendLog.push({ path, line });
+      },
+      hostname() {
+        return hostname;
+      },
+      log(msg) {
+        calls.log.push(msg);
+      },
+      warn(msg) {
+        calls.warn.push(msg);
+      },
+    },
+    calls,
+  };
+}
+
+function baseConfig(overrides = {}) {
+  return validateConfig({
+    matrix: [
+      { name: "lint", mode: "hard", command: "echo lint" },
+      { name: "test", mode: "hard", command: "echo test" },
+      { name: "knip", mode: "advisory", command: "echo knip" },
+    ],
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// checkPreconditions
+// ---------------------------------------------------------------------------
+
+describe("checkPreconditions", () => {
+  const HAPPY_REPLIES = [
+    [/git rev-parse --abbrev-ref HEAD/, { stdout: "feature-x\n" }],
+    [/git status --porcelain/, { stdout: "" }],
+    [/gh auth status/, { status: 0 }],
+    [/gh repo view --json nameWithOwner/, { stdout: "kaio/repo\n" }],
+    [/gh pr view --json number/, { stdout: "42\n" }],
+    [/git rev-parse HEAD/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh pr view 42 --json headRefOid/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh api user --jq \.login/, { stdout: "kaio\n" }],
+    [/gh api repos\/.*\/collaborators\/.*\/permission/, { stdout: "ADMIN\n" }],
+  ];
+
+  it("succeeds on the happy path", () => {
+    const { deps } = makeDeps({ runReplies: HAPPY_REPLIES });
+    const pre = checkPreconditions(deps, baseConfig());
+    expect(pre.branch).toBe("feature-x");
+    expect(pre.repo).toBe("kaio/repo");
+    expect(pre.pr).toBe("42");
+  });
+
+  it("fails when not inside a git repo", () => {
+    const { deps } = makeDeps({ runReplies: [[/git rev-parse --abbrev-ref HEAD/, { status: 1, stderr: "fatal" }]] });
+    expect(() => checkPreconditions(deps, baseConfig())).toThrow(PreconditionError);
+  });
+
+  it("fails on detached HEAD", () => {
+    const { deps } = makeDeps({
+      runReplies: [[/git rev-parse --abbrev-ref HEAD/, { stdout: "HEAD\n" }]],
+    });
+    expect(() => checkPreconditions(deps, baseConfig())).toThrow(/detached HEAD/);
+  });
+
+  it("fails when worktree is dirty and requireClean is true", () => {
+    const replies = HAPPY_REPLIES.map((p) =>
+      p[0].source.includes("git status") ? [p[0], { stdout: " M file.txt\n" }] : p,
+    );
+    const { deps } = makeDeps({ runReplies: replies });
+    expect(() => checkPreconditions(deps, baseConfig())).toThrow(/worktree is not clean/);
+  });
+
+  it("skips the dirty check when requireClean is false", () => {
+    const replies = HAPPY_REPLIES.map((p) =>
+      p[0].source.includes("git status") ? [p[0], { stdout: " M file.txt\n" }] : p,
+    );
+    const { deps } = makeDeps({ runReplies: replies });
+    expect(() => checkPreconditions(deps, baseConfig({ requireClean: false }))).not.toThrow();
+  });
+
+  it("fails when gh is not authenticated", () => {
+    const replies = HAPPY_REPLIES.map((p) =>
+      p[0].source.includes("gh auth status") ? [p[0], { status: 1, stderr: "not logged in" }] : p,
+    );
+    const { deps } = makeDeps({ runReplies: replies });
+    expect(() => checkPreconditions(deps, baseConfig())).toThrow(/gh is not authenticated/);
+  });
+
+  it("fails when no PR for the branch and no --pr passed", () => {
+    const replies = HAPPY_REPLIES.map((p) =>
+      p[0].source.includes("gh pr view --json number") ? [p[0], { status: 1, stderr: "no pr" }] : p,
+    );
+    const { deps } = makeDeps({ runReplies: replies });
+    expect(() => checkPreconditions(deps, baseConfig())).toThrow(/no open PR/);
+  });
+
+  it("fails when local HEAD != PR head", () => {
+    const replies = HAPPY_REPLIES.map((p) =>
+      p[0].source.includes("git rev-parse HEAD")
+        ? [p[0], { stdout: "ffffffffffffffffffffffffffffffffffffffff\n" }]
+        : p,
+    );
+    const { deps } = makeDeps({ runReplies: replies });
+    expect(() => checkPreconditions(deps, baseConfig())).toThrow(/differs from PR/);
+  });
+
+  it("fails when requireDocker is true and docker is unavailable", () => {
+    const replies = [...HAPPY_REPLIES, [/docker info/, { status: 1 }]];
+    const { deps } = makeDeps({ runReplies: replies });
+    expect(() => checkPreconditions(deps, baseConfig({ requireDocker: true }))).toThrow(
+      /Docker is not available/,
+    );
+  });
+
+  it("warns but does not fail when permission level is outside the trust list", () => {
+    const replies = HAPPY_REPLIES.map((p) =>
+      p[0].source.includes("collaborators") ? [p[0], { stdout: "READ\n" }] : p,
+    );
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    expect(() => checkPreconditions(deps, baseConfig())).not.toThrow();
+    expect(calls.warn.some((w) => /not in the configured trust list/.test(w))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runMatrix
+// ---------------------------------------------------------------------------
+
+describe("runMatrix", () => {
+  it("runs every leg in order and records pass/fail", () => {
+    const { deps, calls } = makeDeps({
+      runReplies: [
+        [/echo test/, { status: 1, stderr: "boom" }],
+      ],
+    });
+    const results = runMatrix(deps, baseConfig().matrix);
+    expect(results.map((r) => r.name)).toEqual(["lint", "test", "knip"]);
+    expect(results[0].passed).toBe(true);
+    expect(results[1].passed).toBe(false);
+    expect(results[2].passed).toBe(true);
+    // Stub run() was invoked once per leg.
+    expect(calls.run.filter((c) => /^echo /.test(c.cmd))).toHaveLength(3);
+  });
+
+  it("captures tail output for failures", () => {
+    const longErr = Array.from({ length: 30 }, (_, i) => `line${i}`).join("\n");
+    const { deps } = makeDeps({
+      runReplies: [[/echo lint/, { status: 1, stderr: longErr }]],
+    });
+    const [lint] = runMatrix(deps, baseConfig().matrix);
+    expect(lint.tail.split("\n").length).toBeLessThanOrEqual(10);
+    expect(lint.tail).toContain("line29");
+  });
+
+  it("forwards cwd and env per leg", () => {
+    const cfg = validateConfig({
+      matrix: [{ name: "scoped", mode: "hard", command: "echo x", cwd: "api", env: { K: "v" } }],
+    });
+    const { deps, calls } = makeDeps();
+    runMatrix(deps, cfg.matrix);
+    expect(calls.run[0].opts).toMatchObject({ cwd: "api", env: { K: "v" } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertComment / applyLabel / appendAuditLog
+// ---------------------------------------------------------------------------
+
+describe("upsertComment", () => {
+  it("POSTs when no existing attestation comment", () => {
+    const { deps, calls } = makeDeps({
+      runReplies: [[/gh api repos.*\/comments/, { stdout: "[]" }]],
+    });
+    const r = upsertComment(deps, { repo: "kaio/repo", pr: 1, body: "hi" });
+    expect(r.kind).toBe("post");
+    expect(calls.gh).toHaveLength(1);
+    expect(calls.gh[0].cmd).toMatch(/--method POST/);
+    expect(calls.gh[0].payload).toEqual({ body: "hi" });
+  });
+
+  it("PATCHes the existing attestation comment in place", () => {
+    const existing = [
+      { id: 999, author_association: "OWNER", body: `<!-- local-attest verified-sha=abc1234 -->` },
+    ];
+    const { deps, calls } = makeDeps({
+      runReplies: [[/gh api repos.*\/comments/, { stdout: JSON.stringify(existing) }]],
+    });
+    const r = upsertComment(deps, { repo: "kaio/repo", pr: 1, body: "new" });
+    expect(r.kind).toBe("patch");
+    expect(r.commentId).toBe(999);
+    expect(calls.gh[0].cmd).toMatch(/--method PATCH .*comments\/999/);
+  });
+
+  it("always sends body via stdin (--input -), never shell-interpolated", () => {
+    const { deps, calls } = makeDeps({
+      runReplies: [[/gh api repos.*\/comments/, { stdout: "[]" }]],
+    });
+    upsertComment(deps, { repo: "kaio/repo", pr: 1, body: "line1\nline2 `backticks` $vars" });
+    expect(calls.gh[0].cmd).toContain("--input -");
+    expect(calls.gh[0].cmd).not.toContain("line1");
+  });
+});
+
+describe("applyLabel", () => {
+  it("creates the label (ignores already-exists) then attaches it", () => {
+    const { deps, calls } = makeDeps();
+    applyLabel(deps, { repo: "kaio/repo", pr: 1, label: "ci/local-verified" });
+    const cmds = calls.run.map((c) => c.cmd);
+    expect(cmds.some((c) => /gh label create ci\/local-verified/.test(c))).toBe(true);
+    expect(cmds.some((c) => /gh pr edit 1 --add-label ci\/local-verified/.test(c))).toBe(true);
+  });
+
+  it("warns but does not throw when label attach fails", () => {
+    const { deps, calls } = makeDeps({
+      runReplies: [[/gh pr edit/, { status: 1, stderr: "no perms" }]],
+    });
+    expect(() => applyLabel(deps, { repo: "kaio/repo", pr: 1, label: "x" })).not.toThrow();
+    expect(calls.warn.some((w) => /could not apply/.test(w))).toBe(true);
+  });
+});
+
+describe("appendAuditLog", () => {
+  it("writes one JSONL line with the documented shape", () => {
+    const { deps, calls } = makeDeps();
+    appendAuditLog(deps, {
+      auditLogPath: "/tmp/x.jsonl",
+      pr: "7",
+      sha: "abc1234",
+      advisoryFails: ["knip"],
+      hostname: "h",
+    });
+    expect(calls.appendLog).toHaveLength(1);
+    const { path, line } = calls.appendLog[0];
+    expect(path).toBe("/tmp/x.jsonl");
+    const obj = JSON.parse(line);
+    expect(obj).toMatchObject({ pr: 7, sha: "abc1234", host: "h", advisoryFails: ["knip"] });
+    expect(typeof obj.ts).toBe("string");
+  });
+
+  it("swallows fs errors (best-effort)", () => {
+    const { deps } = makeDeps();
+    deps.appendLog = () => {
+      throw new Error("disk full");
+    };
+    expect(() =>
+      appendAuditLog(deps, {
+        auditLogPath: "/tmp/x.jsonl",
+        pr: 1,
+        sha: "abc1234",
+        advisoryFails: [],
+        hostname: "h",
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// execute (orchestration)
+// ---------------------------------------------------------------------------
+
+describe("execute (orchestration)", () => {
+  const happy = [
+    [/git rev-parse --abbrev-ref HEAD/, { stdout: "feature\n" }],
+    [/git status --porcelain/, { stdout: "" }],
+    [/gh auth status/, { status: 0 }],
+    [/gh repo view --json nameWithOwner/, { stdout: "k/r\n" }],
+    [/gh pr view --json number/, { stdout: "42\n" }],
+    [/git rev-parse HEAD/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh pr view 42 --json headRefOid/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh api user --jq \.login/, { stdout: "k\n" }],
+    [/gh api repos\/.*\/collaborators\/.*\/permission/, { stdout: "ADMIN\n" }],
+  ];
+
+  it("dry-run prints the body but never calls gh comments / label / push", () => {
+    const cfg = baseConfig();
+    const { deps, calls } = makeDeps({ runReplies: happy });
+    const r = execute(deps, cfg, { prOverride: null, push: true, dryRun: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.ok).toBe(true);
+    expect(calls.gh).toHaveLength(0);
+    expect(calls.appendLog).toHaveLength(0);
+    expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
+    expect(calls.run.some((c) => /gh label create/.test(c.cmd))).toBe(false);
+    expect(r.body.split("\n")[0]).toMatch(/^<!-- local-attest verified-sha=[0-9a-f]{7,40} -->$/);
+  });
+
+  it("exits 1 when a hard leg fails and posts nothing", () => {
+    const cfg = baseConfig();
+    const replies = [
+      ...happy,
+      [/echo test/, { status: 1, stderr: "boom" }],
+    ];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const r = execute(deps, cfg, { prOverride: null, push: true, dryRun: false });
+    expect(r.exitCode).toBe(1);
+    expect(r.ok).toBe(false);
+    expect(calls.gh).toHaveLength(0);
+    expect(calls.appendLog).toHaveLength(0);
+  });
+
+  it("posts + labels + audits on full pass (no dry-run)", () => {
+    const cfg = baseConfig();
+    const replies = [
+      ...happy,
+      [/gh api repos.*\/comments/, { stdout: "[]" }],
+    ];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const r = execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    expect(r.exitCode).toBe(0);
+    // 1 gh comment upsert
+    expect(calls.gh).toHaveLength(1);
+    // 1 audit log line
+    expect(calls.appendLog).toHaveLength(1);
+    // label create + label attach
+    expect(calls.run.some((c) => /gh label create/.test(c.cmd))).toBe(true);
+    expect(calls.run.some((c) => /gh pr edit 42 --add-label/.test(c.cmd))).toBe(true);
+  });
+});

--- a/plugins/dotbabel/tests/local-attest-smoke.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-smoke.test.mjs
@@ -1,0 +1,195 @@
+/**
+ * Synthetic end-to-end smoke test.
+ *
+ * Drives `execute()` with a fully stubbed `deps` object whose `run` recorder
+ * returns the responses the real gh/git would for a clean run. The config
+ * mirrors a squadranks-shaped matrix (Node + Go monorepo) so the snapshot
+ * doubles as an equivalence check — it should produce a comment body the
+ * squadranks CI gate would accept verbatim.
+ *
+ * No subprocess executes; no file is written; no network call is made. The
+ * recorder asserts at the end that nothing escaped the stubs.
+ */
+import { describe, it, expect } from "vitest";
+
+import { validateConfig } from "../src/local-attest-config.mjs";
+import { execute } from "../src/local-attest-runner.mjs";
+import { buildAttestMarker } from "../src/local-attest-lib.mjs";
+
+const HEAD = "abc1234abc1234abc1234abc1234abc1234abc12";
+
+function squadranksShapedConfig() {
+  return validateConfig({
+    matrix: [
+      { name: "npm ci", mode: "hard", command: "true" },
+      { name: "actionlint", mode: "hard", command: "true" },
+      { name: "eslint", mode: "hard", command: "true" },
+      { name: "prettier", mode: "hard", command: "true" },
+      { name: "knip", mode: "advisory", command: "true" },
+      { name: "npm audit (prod, high+)", mode: "hard", command: "true" },
+      { name: "verify:repo:harness", mode: "hard", command: "true" },
+      { name: "ranking sanity", mode: "hard", command: "true" },
+      { name: "frontend unit tests", mode: "hard", command: "true" },
+      { name: "build", mode: "hard", command: "true" },
+      { name: "bundle size (<=500KB gz)", mode: "hard", command: "true" },
+      { name: "e2e (playwright)", mode: "hard", command: "true" },
+      { name: "backend tests + coverage", mode: "hard", command: "true", cwd: "api" },
+      { name: "backend integration", mode: "hard", command: "true", cwd: "api" },
+      { name: "govulncheck", mode: "hard", command: "true", cwd: "api" },
+      { name: "golangci-lint", mode: "advisory", command: "true", cwd: "api" },
+    ],
+    requireDocker: false,
+    pushAfterAttest: false,
+  });
+}
+
+function happyDeps() {
+  const calls = { run: [], gh: [], appendLog: [], log: [], warn: [] };
+  const REPLIES = [
+    [/git rev-parse --abbrev-ref HEAD/, { stdout: "feature\n" }],
+    [/git status --porcelain/, { stdout: "" }],
+    [/gh auth status/, { status: 0 }],
+    [/gh repo view --json nameWithOwner/, { stdout: "kaio/squadranks\n" }],
+    [/gh pr view --json number/, { stdout: "42\n" }],
+    [/git rev-parse HEAD/, { stdout: `${HEAD}\n` }],
+    [/gh pr view 42 --json headRefOid/, { stdout: `${HEAD}\n` }],
+    [/gh api user --jq \.login/, { stdout: "kaio\n" }],
+    [/gh api repos\/.*\/collaborators\/.*\/permission/, { stdout: "ADMIN\n" }],
+    [/git push/, { status: 0 }],
+    [/gh api repos.*\/comments/, { stdout: "[]" }],
+  ];
+  const run = (cmd, opts = {}) => {
+    calls.run.push({ cmd, opts });
+    for (const [pat, result] of REPLIES) {
+      if (pat.test(cmd)) return { status: 0, stdout: "", stderr: "", ...result };
+    }
+    return { status: 0, stdout: "", stderr: "" };
+  };
+  return {
+    calls,
+    deps: {
+      run,
+      ghApiWithInput(cmd, payload) {
+        calls.gh.push({ cmd, payload });
+        return "";
+      },
+      appendLog(path, line) {
+        calls.appendLog.push({ path, line });
+      },
+      hostname() {
+        return "ci-stub";
+      },
+      log(msg) {
+        calls.log.push(msg);
+      },
+      warn(msg) {
+        calls.warn.push(msg);
+      },
+    },
+  };
+}
+
+describe("local-attest end-to-end smoke (synthetic, no real I/O)", () => {
+  it("marker invariant: rendered comment line 1 is exactly the marker", () => {
+    const { deps } = happyDeps();
+    const r = execute(deps, squadranksShapedConfig(), {
+      prOverride: null,
+      push: false,
+      dryRun: true,
+    });
+    const firstLine = r.body.split("\n")[0];
+    expect(firstLine).toBe(buildAttestMarker(HEAD));
+    expect(firstLine).toMatch(/^<!-- local-attest verified-sha=[0-9a-f]{7,40} -->$/);
+  });
+
+  it("table fidelity: every leg appears once, in order, with correct mode + status", () => {
+    const { deps } = happyDeps();
+    const r = execute(deps, squadranksShapedConfig(), {
+      prOverride: null,
+      push: false,
+      dryRun: true,
+    });
+    const expected = squadranksShapedConfig().matrix;
+    const rows = r.body.split("\n").filter((l) => /^\| .+ \| (hard|advisory) \| /.test(l));
+    expect(rows).toHaveLength(expected.length);
+    expected.forEach((leg, i) => {
+      expect(rows[i]).toContain(`| ${leg.name} | ${leg.mode} | pass |`);
+    });
+  });
+
+  it("I/O containment: dry-run never POSTs/PATCHes, never pushes, never writes audit log", () => {
+    const { deps, calls } = happyDeps();
+    execute(deps, squadranksShapedConfig(), { prOverride: null, push: true, dryRun: true });
+    expect(calls.gh).toHaveLength(0);
+    expect(calls.appendLog).toHaveLength(0);
+    expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
+    expect(calls.run.some((c) => /gh label create/.test(c.cmd))).toBe(false);
+    expect(calls.run.some((c) => /gh pr edit/.test(c.cmd))).toBe(false);
+  });
+
+  it("snapshot: rendered comment body (timestamp redacted) is stable", () => {
+    const { deps } = happyDeps();
+    const r = execute(deps, squadranksShapedConfig(), {
+      prOverride: null,
+      push: false,
+      dryRun: true,
+    });
+    const redacted = r.body.replace(/`\d{4}-\d{2}-\d{2}T[^`]+`/g, "`<TS>`");
+    expect(redacted).toMatchInlineSnapshot(`
+      "<!-- local-attest verified-sha=abc1234abc1234abc1234abc1234abc1234abc12 -->
+      ## Local Attestation
+
+      The full CI check matrix ran locally and the hard legs passed for \`abc1234a\`.
+      Test and Preview will skip for this commit. A new push re-runs CI automatically.
+
+      | Check | Mode | Result | Duration |
+      |---|---|---|---|
+      | npm ci | hard | pass | 0s |
+      | actionlint | hard | pass | 0s |
+      | eslint | hard | pass | 0s |
+      | prettier | hard | pass | 0s |
+      | knip | advisory | pass | 0s |
+      | npm audit (prod, high+) | hard | pass | 0s |
+      | verify:repo:harness | hard | pass | 0s |
+      | ranking sanity | hard | pass | 0s |
+      | frontend unit tests | hard | pass | 0s |
+      | build | hard | pass | 0s |
+      | bundle size (<=500KB gz) | hard | pass | 0s |
+      | e2e (playwright) | hard | pass | 0s |
+      | backend tests + coverage | hard | pass | 0s |
+      | backend integration | hard | pass | 0s |
+      | govulncheck | hard | pass | 0s |
+      | golangci-lint | advisory | pass | 0s |
+
+      - Host: \`ci-stub\`
+      - Attested at: \`<TS>\`
+      - Verified SHA: \`abc1234abc1234abc1234abc1234abc1234abc12\`"
+    `);
+  });
+
+  it("squadranks-shape compatibility: marker, default label, and audit shape match the gate's expectations", () => {
+    // Full run (not dry-run) so upsert + label + audit fire.
+    const { deps, calls } = happyDeps();
+    execute(deps, squadranksShapedConfig(), { prOverride: null, push: false, dryRun: false });
+
+    // 1) Comment posted via stdin payload, body line 1 is the marker.
+    expect(calls.gh).toHaveLength(1);
+    const payloadBody = calls.gh[0].payload.body;
+    expect(payloadBody.split("\n")[0]).toBe(buildAttestMarker(HEAD));
+
+    // 2) Label is the documented default the gate's audit query relies on.
+    const labelCreate = calls.run.find((c) => /gh label create/.test(c.cmd));
+    expect(labelCreate.cmd).toContain("ci/local-verified");
+
+    // 3) Audit log line shape matches the documented JSONL schema.
+    expect(calls.appendLog).toHaveLength(1);
+    const audit = JSON.parse(calls.appendLog[0].line);
+    expect(audit).toMatchObject({
+      pr: 42,
+      sha: HEAD,
+      host: "ci-stub",
+      advisoryFails: [],
+    });
+    expect(typeof audit.ts).toBe("string");
+  });
+});

--- a/skills/local-attest/SKILL.md
+++ b/skills/local-attest/SKILL.md
@@ -1,0 +1,142 @@
+---
+id: local-attest
+name: local-attest
+type: skill
+version: 1.0.0
+domain: [devex, observability]
+platform: [github-actions]
+task: [testing, runtime-ops]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-05-23
+updated: 2026-05-23
+description: >
+  Run the configured CI matrix locally and, on a clean pass, post a SHA-pinned
+  OWNER-authored PR comment that gates downstream GitHub Actions jobs off for
+  that exact commit. Skips the redundant remote run after a maintainer has
+  already verified locally, saving runner minutes without weakening the gate.
+  A new push changes the head SHA, the attestation stops matching, CI runs
+  again. Side-effectful (posts a PR comment, applies a label, optionally pushes)
+  and slow (10–15 min depending on matrix). Invoke only on explicit request.
+argument-hint: "[--pr <N>] [--no-push] [--dry-run] [--config <path>]"
+tools: Bash
+disable-model-invocation: true
+user-invocable: true
+---
+
+# /local-attest — Local CI attestation
+
+Run the project's configured CI matrix on your machine. On a clean pass, post
+a hidden marker comment to the open PR so the remote `Test` / `Preview` jobs
+read the marker and skip themselves for that exact commit.
+
+> **This skill is side-effectful and slow.** It runs every leg of your CI
+> matrix sequentially (typically 10–15 minutes), posts a PR comment, applies
+> a label, and pushes the current branch. Invoke only when you've decided to
+> attest a specific PR.
+
+## Quick start
+
+```bash
+# In a project root with a .local-attest.config.mjs
+dotbabel local-attest --pr 123
+
+# Try a config without posting anything:
+dotbabel local-attest --pr 123 --dry-run
+
+# Run + post + label, but do not git push (useful for offline review):
+dotbabel local-attest --pr 123 --no-push
+```
+
+## Prerequisites
+
+- **A `.local-attest` config** in the project root — see
+  [references/config.md](references/config.md) for the schema and three example
+  configs (Node-only, Node + Go monorepo, Python).
+- **A workflow gate** wired into your `.github/workflows/test.yml` (and any
+  other pipeline you want to skip). Paste the snippet from
+  [references/workflow-gate.yml.tmpl](references/workflow-gate.yml.tmpl). This
+  is a one-time manual setup — auto-injecting YAML across diverse CI layouts
+  is too risky to do for you.
+- **A clean worktree** — the skill aborts on any uncommitted change, because
+  the attestation must certify the exact tree that gets pushed. (Configurable
+  via `requireClean: false`, but generally not recommended.)
+- **Local HEAD must match the PR head** — the skill aborts if your local
+  branch tip differs from the remote PR head. Push any local commits first.
+- **`gh` authenticated** as a user whose `author_association` is in your
+  config's `trustedAssociations` list (default: `["OWNER"]`).
+- **Docker running** if your config sets `requireDocker: true`.
+
+## How the gate works
+
+The gate input is a PR comment authored by a trusted user (default: the repo
+OWNER) whose **first line** is exactly:
+
+```text
+<!-- local-attest verified-sha=<full-head-sha> -->
+```
+
+The CI workflow reads PR comments, applies a `jq select(.author_association == "OWNER")`
+filter, takes the first line of each, and `grep -qF`s for the marker that
+matches `github.event.pull_request.head.sha`. When it matches, every downstream
+job's `if:` evaluates false and skips at zero runner cost.
+
+Freshness is automatic: a new push changes the head SHA, the old comment no
+longer matches, CI runs again. Editing or deleting the comment does **not**
+re-trigger CI (the gate only re-evaluates on `push`/`synchronize`). If you
+need to revoke an attestation, push any new (even empty) commit.
+
+Full operator contract: [references/operator-guide.md](references/operator-guide.md).
+
+## What the skill does, in order
+
+1. **Preconditions.** Branch exists, worktree clean (if `requireClean`), local
+   HEAD == PR head, `gh` authed, Docker available (if `requireDocker`). Any
+   failure aborts before a single test runs. The skill also warns (does not
+   fail) if your current user's permission level is not in the trust list.
+2. **Run matrix.** Each leg from the config runs sequentially. Hard legs must
+   pass to attest; advisory legs are reported but never block. Stdout + stderr
+   are tailed at 10 lines per leg so the result table stays readable.
+3. **Hard-leg gate.** Any hard failure aborts: no comment, no label, no push.
+4. **Push first** (if `pushAfterAttest` and not `--no-push`). The attestation
+   must never describe a SHA the remote hasn't seen.
+5. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
+   place; otherwise a new one is POSTed. Body always goes via `gh api --input -`
+   so multiline markdown can't be mangled by shell quoting.
+6. **Apply label** (default `ci/local-verified`). Best-effort; failure warns
+   but does not abort.
+7. **Append audit log line** to the configured `auditLogPath` (default
+   `.local-attest-log.jsonl`). Best-effort.
+
+## Flags
+
+| Flag              | Effect                                                                                                                                       |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--pr <N>`        | Target PR number. Defaults to the open PR for the current branch.                                                                            |
+| `--no-push`       | Run matrix + post + label, but skip `git push`.                                                                                              |
+| `--dry-run`       | Run matrix, render the comment, print it. Post nothing, label nothing, push nothing. Use this to validate a new project's config end-to-end. |
+| `--config <path>` | Override config discovery.                                                                                                                   |
+
+## What this skill never does
+
+- **Auto-install the workflow gate.** Paste it manually using the template.
+- **Skip the Secret-scan job** (or any other gate you didn't put behind the
+  attestation `if:`). Configure each workflow's `if:` explicitly.
+- **Merge or deploy.** It only attests and pushes the current branch.
+- **Multiple comments per PR.** One attestation comment, upserted in place.
+- **Auto-unlabel on stale attestation.** A new push silently invalidates the
+  prior attestation by SHA mismatch; the label stays as audit decoration.
+
+## Trust model
+
+Default `trustedAssociations: ["OWNER"]`. Only comments from the repo OWNER
+will gate CI. A non-trusted user's comment will post (and the label may apply)
+but CI will still run. Widen the trust list in your config for multi-maintainer
+repos:
+
+```js
+trustedAssociations: ["OWNER", "MEMBER", "COLLABORATOR"];
+```
+
+The generated workflow gate snippet ([references/workflow-gate.yml.tmpl](references/workflow-gate.yml.tmpl))
+automatically matches the configured list.

--- a/skills/local-attest/SKILL.md
+++ b/skills/local-attest/SKILL.md
@@ -52,7 +52,8 @@ dotbabel local-attest --pr 123 --no-push
 
 - **A `.local-attest` config** in the project root — see
   [references/config.md](references/config.md) for the schema and three example
-  configs (Node-only, Node + Go monorepo, Python).
+  configs (Node-only, Node + Go monorepo, Python). Discovery order:
+  `.local-attest.config.mjs` → `.local-attest.config.json` → `package.json#local-attest`.
 - **A workflow gate** wired into your `.github/workflows/test.yml` (and any
   other pipeline you want to skip). Paste the snippet from
   [references/workflow-gate.yml.tmpl](references/workflow-gate.yml.tmpl). This
@@ -77,8 +78,8 @@ OWNER) whose **first line** is exactly:
 ```
 
 The CI workflow reads PR comments, applies a `jq select(.author_association == "OWNER")`
-filter, takes the first line of each, and `grep -qF`s for the marker that
-matches `github.event.pull_request.head.sha`. When it matches, every downstream
+filter, takes the first line of each, and `grep -qFx`s (exact-line match)
+for the marker that matches `github.event.pull_request.head.sha`. When it matches, every downstream
 job's `if:` evaluates false and skips at zero runner cost.
 
 Freshness is automatic: a new push changes the head SHA, the old comment no
@@ -93,7 +94,9 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
 1. **Preconditions.** Branch exists, worktree clean (if `requireClean`), local
    HEAD == PR head, `gh` authed, Docker available (if `requireDocker`). Any
    failure aborts before a single test runs. The skill also warns (does not
-   fail) if your current user's permission level is not in the trust list.
+   fail) if your GitHub `author_association` on the repo (OWNER / MEMBER /
+   COLLABORATOR, etc.) is not in the config's `trustedAssociations` list — the
+   attestation will post but CI will ignore it.
 2. **Run matrix.** Each leg from the config runs sequentially. Hard legs must
    pass to attest; advisory legs are reported but never block. Stdout + stderr
    are tailed at 10 lines per leg so the result table stays readable.

--- a/skills/local-attest/references/config.md
+++ b/skills/local-attest/references/config.md
@@ -4,9 +4,9 @@ Every consuming project supplies its own CI matrix. The skill discovers config
 in this order (first match wins):
 
 1. `--config <path>` (CLI flag)
-2. `./.local-attest.config.mjs`
-3. `./.local-attest.config.json`
-4. `./package.json` → `local-attest` key
+2. `.local-attest.config.mjs`
+3. `.local-attest.config.json`
+4. `package.json` → `local-attest` key
 
 ## Schema
 

--- a/skills/local-attest/references/config.md
+++ b/skills/local-attest/references/config.md
@@ -1,0 +1,120 @@
+# `.local-attest` configuration
+
+Every consuming project supplies its own CI matrix. The skill discovers config
+in this order (first match wins):
+
+1. `--config <path>` (CLI flag)
+2. `./.local-attest.config.mjs`
+3. `./.local-attest.config.json`
+4. `./package.json` → `local-attest` key
+
+## Schema
+
+```ts
+type Config = {
+  // REQUIRED — the list of checks to run locally. Order is preserved.
+  matrix: Array<{
+    name: string; // unique within the matrix; appears in the result table
+    mode:
+      | "hard" // "hard" legs must pass to attest
+      | "advisory"; // "advisory" legs report but never block
+    command: string; // shell command (runs under `bash -c`)
+    cwd?: string; // working dir relative to project root
+    env?: Record<string, string>; // extra env vars for this leg only
+  }>;
+
+  label?: string; // PR label to apply on attest (default: "ci/local-verified")
+  auditLogPath?: string; // jsonl audit trail (default: ".local-attest-log.jsonl")
+  trustedAssociations?: string[]; // gh author_association values that gate CI (default: ["OWNER"])
+  requireClean?: boolean; // abort on dirty worktree (default: true)
+  requireDocker?: boolean; // abort if `docker info` fails (default: false)
+  pushAfterAttest?: boolean; // git push after attest, before posting (default: true)
+};
+```
+
+The matrix is the only required field; everything else has sensible defaults.
+
+## Example 1 — minimal Node app
+
+```js
+// .local-attest.config.mjs
+export default {
+  matrix: [
+    { name: "npm ci", mode: "hard", command: "npm ci" },
+    { name: "lint", mode: "hard", command: "npm run lint" },
+    { name: "tests", mode: "hard", command: "npm test" },
+    { name: "build", mode: "hard", command: "npm run build" },
+    { name: "audit", mode: "advisory", command: "npm audit --omit=dev --audit-level=high" },
+  ],
+};
+```
+
+## Example 2 — Node frontend + Go backend monorepo
+
+```js
+// .local-attest.config.mjs
+export default {
+  matrix: [
+    { name: "npm ci", mode: "hard", command: "npm ci" },
+    { name: "frontend lint", mode: "hard", command: "npm run lint" },
+    { name: "frontend tests", mode: "hard", command: "npm run test:coverage" },
+    { name: "frontend build", mode: "hard", command: "npm run build" },
+    { name: "knip", mode: "advisory", command: "npm run knip" },
+    {
+      name: "e2e",
+      mode: "hard",
+      command: "npx playwright install chromium && npm run test:e2e",
+      env: { CI: "1" },
+    },
+    { name: "backend tests", mode: "hard", command: "go test -race -count=1 ./...", cwd: "api" },
+    {
+      name: "backend vuln",
+      mode: "hard",
+      command: "go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...",
+      cwd: "api",
+    },
+    {
+      name: "golangci-lint",
+      mode: "advisory",
+      command: "go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run",
+      cwd: "api",
+    },
+  ],
+  requireDocker: true, // testcontainers-based integration tests
+  trustedAssociations: ["OWNER"],
+};
+```
+
+## Example 3 — Python (uv + pytest)
+
+```json
+{
+  "matrix": [
+    { "name": "uv sync", "mode": "hard", "command": "uv sync --frozen" },
+    { "name": "ruff", "mode": "hard", "command": "uv run ruff check ." },
+    { "name": "mypy", "mode": "hard", "command": "uv run mypy ." },
+    { "name": "pytest", "mode": "hard", "command": "uv run pytest -q" },
+    {
+      "name": "coverage",
+      "mode": "advisory",
+      "command": "uv run pytest --cov=src --cov-fail-under=80"
+    }
+  ],
+  "trustedAssociations": ["OWNER", "MEMBER"]
+}
+```
+
+## Validation rules
+
+- `matrix` must be a non-empty array.
+- Every leg must have a non-empty `name`, a `mode` of `"hard"` or `"advisory"`,
+  and a non-empty `command`.
+- Leg `name`s must be unique within the matrix.
+- `auditLogPath` must not contain `..` segments (path-traversal guard).
+- `trustedAssociations` must be a non-empty array of strings.
+- Unknown top-level keys are ignored. Defaults are merged from
+  `plugins/dotbabel/src/local-attest-config.mjs:DEFAULTS`.
+
+`dotbabel local-attest --dry-run --pr <N>` runs the matrix and prints the
+comment it would post without touching the PR — use it to validate a new
+config end-to-end.

--- a/skills/local-attest/references/operator-guide.md
+++ b/skills/local-attest/references/operator-guide.md
@@ -1,0 +1,134 @@
+# Operator guide — CI skip via local attestation
+
+CI minutes are billed; running the same matrix on GitHub-hosted runners after
+a maintainer has already verified the change locally is duplicated spend. The
+`/local-attest` skill lets a trusted user trade ~10–15 minutes of local
+runtime for a clean skip of the equivalent remote pipeline.
+
+This guide is the operator contract for using the skill safely.
+
+## How the gate works
+
+The gate input is a **PR comment authored by a trusted user** (default: the
+repo OWNER) whose first line is exactly the marker:
+
+```text
+<!-- local-attest verified-sha=<full-head-sha> -->
+```
+
+The workflow gate (template at
+[`workflow-gate.yml.tmpl`](workflow-gate.yml.tmpl)) reads the PR comments,
+filters by `author_association`, takes the first line of each, and
+`grep -qF`s for the marker matching `github.event.pull_request.head.sha`.
+
+When the marker matches, downstream jobs whose `if:` consumes
+`needs.classify.outputs.attested` skip at zero runner cost.
+
+### Freshness is automatic
+
+A new push changes the head SHA, the old marker no longer matches, and CI
+runs again. There is no auto-unlabel workflow; the label is decoration only.
+
+### Editing/deleting the comment does NOT re-trigger CI
+
+GitHub Actions only re-evaluates workflow gates on `push` / `synchronize`
+events, not on comment events. If you need to revoke an attestation, **push
+a new (even empty) commit** — that's the documented contract.
+
+### Always run, never gate
+
+Some jobs should always run regardless of attestation:
+
+- **Secret scanning** (gitleaks, trufflehog) — never gate.
+- **License / SBOM publishing** — always run on push.
+- **Required status checks** specified in branch protection — if you gate
+  them, make sure your downstream `if:` produces a green check anyway. The
+  common shape is "always emit `success` from a downstream summary job, but
+  let the upstream attested jobs skip."
+
+## Producing an attestation
+
+From the PR branch in your local checkout:
+
+```bash
+dotbabel local-attest --pr 123
+```
+
+The skill runs every leg of your `.local-attest` matrix, prints a result
+table, pushes (if `pushAfterAttest`), posts/PATCHes the attestation comment,
+applies the label, and appends a line to the audit log.
+
+`--dry-run` runs the matrix and prints the comment without posting anything.
+Use it to validate a new config end-to-end.
+
+`--no-push` skips the `git push` step but still posts the comment + label.
+Use it when you've pushed manually and just want to attest.
+
+## Trust model
+
+Default `trustedAssociations: ["OWNER"]`. Only comments from a user with
+`author_association == "OWNER"` will gate CI. A non-trusted user's comment
+will post, but CI will still run.
+
+Multi-maintainer repos widen the trust list:
+
+```js
+// .local-attest.config.mjs
+trustedAssociations: ["OWNER", "MEMBER", "COLLABORATOR"];
+```
+
+The workflow gate template uses `{{TRUSTED_SELECT}}` as a placeholder for
+the matching jq filter. Substitute it manually for now.
+
+## Caveats
+
+### Branch protection unconditional checks
+
+If branch protection requires a specific status check (e.g.
+`Test / backend tests`) and you gate that job off via attestation, the check
+will be reported as skipped, which counts as missing for protection.
+
+**Fix**: introduce an always-run summary job that aggregates the attested
+jobs' results and reports a single status check. Make that summary job the
+one required by branch protection.
+
+### Drift between local and remote matrix
+
+The skill runs whatever your `.local-attest.config.mjs` says. If it drifts
+from what `.github/workflows/test.yml` actually runs, the attestation
+certifies a different (probably smaller) set of checks. Treat the config
+file as documentation that has to track the workflow.
+
+A simple drift check is to put both lists in a single source (e.g. a JSON
+manifest both sides import) — but most projects find it cheaper to review
+the diff manually whenever either side changes.
+
+### Long-running matrices
+
+Attestation runs sequentially. 10–15 minutes is typical; pathologically
+slow matrices (heavy e2e + multiple language runtimes) can hit 30+. That's
+the deliberate cost of skipping the remote run.
+
+### Audit
+
+The label `ci/local-verified` is decoration for visibility:
+
+```bash
+gh pr list --label ci/local-verified --state all
+```
+
+The audit log (`.local-attest-log.jsonl` by default) records one JSONL line
+per attestation:
+
+```json
+{
+  "ts": "2026-05-23T16:00:00.000Z",
+  "pr": 123,
+  "sha": "abc1234...",
+  "host": "wsl-laptop",
+  "advisoryFails": ["knip"]
+}
+```
+
+Add the audit log to `.gitignore` if you don't want it in version control;
+the contract is single-line JSONL so any log shipper handles it natively.

--- a/skills/local-attest/references/operator-guide.md
+++ b/skills/local-attest/references/operator-guide.md
@@ -19,7 +19,8 @@ repo OWNER) whose first line is exactly the marker:
 The workflow gate (template at
 [`workflow-gate.yml.tmpl`](workflow-gate.yml.tmpl)) reads the PR comments,
 filters by `author_association`, takes the first line of each, and
-`grep -qF`s for the marker matching `github.event.pull_request.head.sha`.
+`grep -qFx`s (exact-line match) for the marker matching
+`github.event.pull_request.head.sha`.
 
 When the marker matches, downstream jobs whose `if:` consumes
 `needs.classify.outputs.attested` skip at zero runner cost.
@@ -77,8 +78,11 @@ Multi-maintainer repos widen the trust list:
 trustedAssociations: ["OWNER", "MEMBER", "COLLABORATOR"];
 ```
 
-The workflow gate template uses `{{TRUSTED_SELECT}}` as a placeholder for
-the matching jq filter. Substitute it manually for now.
+The workflow gate template is pre-substituted for the default single-OWNER
+config. If you widen `trustedAssociations`, update the `select(...)` clause in
+your workflow gate file and commit both changes together — they must stay in sync
+or attestations from the newly-trusted association will be posted but never
+honored by CI.
 
 ## Caveats
 
@@ -90,7 +94,26 @@ will be reported as skipped, which counts as missing for protection.
 
 **Fix**: introduce an always-run summary job that aggregates the attested
 jobs' results and reports a single status check. Make that summary job the
-one required by branch protection.
+one required by branch protection. Example:
+
+```yaml
+attested-or-passed:
+  needs: [test, preview] # jobs gated by local-attest
+  if: always()
+  runs-on: ubuntu-latest
+  steps:
+    - run: |
+        if [[ "${{ needs.test.result }}" == "skipped" && \
+              "${{ needs.preview.result }}" == "skipped" ]]; then
+          echo "All CI jobs skipped via local attestation"
+        elif [[ "${{ needs.test.result }}" != "success" || \
+                "${{ needs.preview.result }}" != "success" ]]; then
+          exit 1
+        fi
+```
+
+Point branch protection's required status check at `attested-or-passed` instead
+of the individual jobs.
 
 ### Drift between local and remote matrix
 

--- a/skills/local-attest/references/workflow-gate.yml.tmpl
+++ b/skills/local-attest/references/workflow-gate.yml.tmpl
@@ -1,0 +1,66 @@
+# Local-attest workflow gate template
+#
+# Paste this into your `.github/workflows/test.yml` (and any other workflow
+# you want to gate, e.g. `preview.yml`) per the operator-guide.md walkthrough.
+#
+# Substitute `{{TRUSTED_SELECT}}` for the jq filter matching your config's
+# `trustedAssociations`. The default config (OWNER only) produces:
+#
+#   select(.author_association == "OWNER")
+#
+# A multi-trust config like `trustedAssociations: ["OWNER", "MEMBER"]` produces:
+#
+#   select(.author_association == "OWNER" or .author_association == "MEMBER")
+#
+# `dotbabel local-attest --print-gate` (planned, post-1.0) will emit the
+# already-substituted snippet for the current config.
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      attested: ${{ steps.attest.outputs.attested }}
+    steps:
+      - name: Check for local attestation
+        id: attest
+        # A local-attestation comment lets a maintainer skip the redundant
+        # remote CI run after running the full check matrix locally. The
+        # gate is a PR comment authored by a trusted user (default OWNER)
+        # carrying the marker:
+        #   <!-- local-attest verified-sha=<HEAD_SHA> -->
+        # Only the first line of each comment is matched, so a quote-reply
+        # that happens to contain the marker in a quoted block cannot forge
+        # a skip. The head SHA is embedded in the marker, so a new push (new
+        # SHA) automatically invalidates a stale attestation.
+        # Fail-closed: if the gh api call fails, grep exits non-zero →
+        # attested=false → CI runs.
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          MARKER="<!-- local-attest verified-sha=${HEAD_SHA} -->"
+          if gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+               --jq '.[] | {{TRUSTED_SELECT}} | .body | split("\n")[0]' \
+             | grep -qF "$MARKER"; then
+            echo "Local attestation found for ${HEAD_SHA} — remote CI jobs will skip."
+            echo "attested=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No local attestation for ${HEAD_SHA} — remote CI jobs will run."
+            echo "attested=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Every downstream job gates off `classify.outputs.attested`. Example:
+  test:
+    needs: classify
+    if: needs.classify.outputs.attested != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # ... your real test steps ...
+      - run: echo "running tests"
+
+  # The Secret-scan job is intentionally NOT gated. Run it on every push.
+  # Add other always-run jobs (license check, SBOM publish, etc.) without
+  # the `needs: classify` line.

--- a/skills/local-attest/references/workflow-gate.yml.tmpl
+++ b/skills/local-attest/references/workflow-gate.yml.tmpl
@@ -3,17 +3,17 @@
 # Paste this into your `.github/workflows/test.yml` (and any other workflow
 # you want to gate, e.g. `preview.yml`) per the operator-guide.md walkthrough.
 #
-# Substitute `{{TRUSTED_SELECT}}` for the jq filter matching your config's
-# `trustedAssociations`. The default config (OWNER only) produces:
-#
-#   select(.author_association == "OWNER")
-#
-# A multi-trust config like `trustedAssociations: ["OWNER", "MEMBER"]` produces:
+# This template is pre-substituted for the default single-OWNER config.
+# If your config uses a wider trust list (e.g. `trustedAssociations: ["OWNER","MEMBER"]`),
+# replace the jq `select(...)` clause on the `--jq` line below with:
 #
 #   select(.author_association == "OWNER" or .author_association == "MEMBER")
 #
+# Whenever you change `trustedAssociations` in your config, update the
+# `select(...)` clause here and commit both changes in the same PR.
+#
 # `dotbabel local-attest --print-gate` (planned, post-1.0) will emit the
-# already-substituted snippet for the current config.
+# correctly-substituted snippet for the current config automatically.
 
 jobs:
   classify:
@@ -43,8 +43,8 @@ jobs:
         run: |
           MARKER="<!-- local-attest verified-sha=${HEAD_SHA} -->"
           if gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-               --jq '.[] | {{TRUSTED_SELECT}} | .body | split("\n")[0]' \
-             | grep -qF "$MARKER"; then
+               --jq '.[] | select(.author_association == "OWNER") | .body | split("\n")[0]' \
+             | grep -qFx "$MARKER"; then
             echo "Local attestation found for ${HEAD_SHA} — remote CI jobs will skip."
             echo "attested=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

- New universal `/local-attest` skill that runs a configurable CI matrix locally and posts a SHA-pinned OWNER-authored PR comment to gate downstream GitHub Actions jobs off for that exact commit. Trades ~10–15 min of local runtime for a clean skip of the equivalent remote pipeline.
- Engine in `plugins/dotbabel/src` (pure helpers + config loader/validator + injectable-I/O runner); standalone bin + dotbabel subcommand. Project-side config in `.local-attest.config.mjs` declares the matrix; everything else has sensible defaults (label, audit log path, trust list, push/clean/docker requirements).
- Ships skill markdown, three references (config schema with examples, parameterized workflow-gate template, operator guide), 88 vitest cases across 4 files (lib, config, runner with stubbed deps, end-to-end synthetic smoke that asserts the CI-gate invariants).

Ported from the squadranks `preflight-bypass` worktree's `scripts/local-attest.mjs`. The 16 hardcoded squadranks specifics (`api/` cwd, 74% coverage floor, 500KB bundle ceiling, `npm run check:ranking-sanity`, etc.) move into per-project config; the trust model, marker, idempotent comment upsert, label, audit, and push ordering are now generic. Squadranks can adopt this skill in a follow-up by writing its own config and deleting the private copy.

## Test plan

- [x] `npx vitest run plugins/dotbabel/tests/local-attest-*.test.mjs` → 4 files, 88 tests pass
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs` → 62 artifacts, 0 warnings
- [x] `npm run build-plugin` → 158 files + manifest written
- [x] `npm run build-plugin -- --check` → fresh
- [x] `npm run lint` → prettier clean, markdownlint 0 errors, JSDoc coverage ok (31 files)
- [x] `npm test` → 51 files, 797 tests pass (no regressions)
- [x] `npm run dogfood` → manifest valid (38 skills), specs valid, drift clean, coverage ok
- [x] `node plugins/dotbabel/bin/dotbabel-doctor.mjs` → 17/17 pass
- [x] `node plugins/dotbabel/bin/dotbabel-local-attest.mjs --help` → renders correctly
- [x] Synthetic smoke test asserts (i) marker is line 1, (ii) every config leg appears in order with correct mode/status, (iii) dry-run never POSTs/PATCHes/pushes/audits, (iv) snapshot-stable rendered body (timestamp redacted), (v) squadranks-shape compatibility (default label `ci/local-verified`, audit JSONL schema, marker matches CI gate's grep)

## No-spec rationale

This change touches several protected paths (`.claude/**`, `plugins/dotbabel/src/**`, `plugins/dotbabel/bin/**`, `plugins/dotbabel/templates/**`) but adds a new skill rather than altering dotbabel-core's product surface. The skill's operator contract lives in `skills/local-attest/references/operator-guide.md`, its config schema in `skills/local-attest/references/config.md`, and its workflow-gate contract in `skills/local-attest/references/workflow-gate.yml.tmpl` — all per-skill documentation rather than top-level spec material. The harness primitives reused (`plugins/dotbabel/src/lib/{argv,output,exit-codes}.mjs`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
