### PR TITLE
feat: add /release-conductor skill to gate release-please PR merges

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,272 +1,283 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-11T14:20:21.046Z",
+  "generatedAt": "2026-05-26T14:40:46.829Z",
   "skills": [
-    {
-      "name": "audit-and-fix",
-      "path": ".claude/skills/audit-and-fix/SKILL.md",
-      "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "code-simplifier",
-      "path": ".claude/skills/code-simplifier/SKILL.md",
-      "checksum": "sha256:e24c64485f950d93815f492de5673aaa3ff65abb0df91fb41e41a40b68017cff",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "changelog",
-      "path": ".claude/commands/changelog.md",
-      "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "create-assessment",
-      "path": ".claude/skills/create-assessment/SKILL.md",
-      "checksum": "sha256:b1125255b0c62ec88157ad4476b681e1dbaff200a8e8942f3eccf49cb873dbe4",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "create-audit",
-      "path": ".claude/skills/create-audit/SKILL.md",
-      "checksum": "sha256:babb4a5e281388eb5dcf59f1d563b1622cfd5062a269b421e1aab0a53272695a",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "dependabot-sweep",
-      "path": ".claude/commands/dependabot-sweep.md",
-      "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "detect-flaky",
-      "path": ".claude/skills/detect-flaky/SKILL.md",
-      "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "deploy-status",
-      "path": ".claude/skills/deploy-status/SKILL.md",
-      "checksum": "sha256:f9128b2d793a9878e4288b1c54cb539ac0dc2165f0ecb9cff4f85c97906fe5d4",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "fix-with-evidence",
-      "path": ".claude/skills/fix-with-evidence/SKILL.md",
-      "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "flyctl",
-      "path": ".claude/skills/flyctl/SKILL.md",
-      "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "git",
-      "path": ".claude/skills/git/SKILL.md",
-      "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "ground-first",
-      "path": ".claude/skills/ground-first/SKILL.md",
-      "checksum": "sha256:238437a50b202ee5e32981ea410fc8b5adb4a7ea5979630642f2678e266804a3",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "markdown",
-      "path": ".claude/commands/markdown.md",
-      "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "merge-pr",
-      "path": ".claude/commands/merge-pr.md",
-      "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "create-inspection",
-      "path": ".claude/skills/create-inspection/SKILL.md",
-      "checksum": "sha256:421141b2c143acb094809f6e700d8562e6dcbade940df0edd8365de7671ecfb1",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "review-pr",
-      "path": ".claude/skills/review-pr/SKILL.md",
-      "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "security-review",
-      "path": ".claude/skills/security-review/SKILL.md",
-      "checksum": "sha256:ea03f5bc029de3182ef8ec286a9f3c12b635ad4d36631c024ec2f5c990f5a176",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
     },
     {
-      "name": "spec",
-      "path": ".claude/skills/spec/SKILL.md",
-      "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
+      "name": "audit-and-fix",
+      "path": ".claude/skills/audit-and-fix/SKILL.md",
+      "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "validate-spec",
-      "path": ".claude/skills/validate-spec/SKILL.md",
-      "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "kubernetes-specialist",
-      "path": ".claude/skills/kubernetes-specialist/SKILL.md",
-      "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
     },
     {
-      "name": "gcp-specialist",
-      "path": ".claude/skills/gcp-specialist/SKILL.md",
-      "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
+      "name": "changelog",
+      "path": ".claude/commands/changelog.md",
+      "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
     },
     {
-      "name": "terraform-specialist",
-      "path": ".claude/skills/terraform-specialist/SKILL.md",
-      "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
+      "name": "code-simplifier",
+      "path": ".claude/skills/code-simplifier/SKILL.md",
+      "checksum": "sha256:e24c64485f950d93815f492de5673aaa3ff65abb0df91fb41e41a40b68017cff",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
     },
     {
-      "name": "terragrunt-specialist",
-      "path": ".claude/skills/terragrunt-specialist/SKILL.md",
-      "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
+      "name": "create-assessment",
+      "path": ".claude/skills/create-assessment/SKILL.md",
+      "checksum": "sha256:b1125255b0c62ec88157ad4476b681e1dbaff200a8e8942f3eccf49cb873dbe4",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
     },
     {
-      "name": "crossplane-specialist",
-      "path": ".claude/skills/crossplane-specialist/SKILL.md",
-      "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
+      "name": "create-audit",
+      "path": ".claude/skills/create-audit/SKILL.md",
+      "checksum": "sha256:babb4a5e281388eb5dcf59f1d563b1622cfd5062a269b421e1aab0a53272695a",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "pulumi-specialist",
-      "path": ".claude/skills/pulumi-specialist/SKILL.md",
-      "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "veracity-audit",
-      "path": ".claude/skills/veracity-audit/SKILL.md",
-      "checksum": "sha256:ca6a137a6d9316de931a26d8a9bf2126d8c1f5005e53a5abd2a722f745fb1080",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "handoff",
-      "path": ".claude/skills/handoff/SKILL.md",
-      "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "review-prs",
-      "path": ".claude/skills/review-prs/SKILL.md",
-      "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "rollback-prod",
-      "path": ".claude/skills/rollback-prod/SKILL.md",
-      "checksum": "sha256:32a58bb0feb413e7f44148347d62283332ba259273a6c8f6d4a514876cc484dd",
-      "dependencies": ["deploy-status"],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "plan-grader",
-      "path": ".claude/skills/plan-grader/SKILL.md",
-      "checksum": "sha256:803d919381f876d5c29c28e1ab19d74a55cd54d74bb5ee6158ca10e8481af2a0",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
-    },
-    {
-      "name": "local-attest",
-      "path": ".claude/skills/local-attest/SKILL.md",
-      "checksum": "sha256:a4fab149f1ea05770de853331d321fc2e8d4a745fcb52dcc1da1f76edbe4a995",
-      "dependencies": [],
-      "lastValidated": "2026-05-23"
-    },
-    {
-      "name": "pre-pr",
-      "path": ".claude/commands/pre-pr.md",
-      "checksum": "sha256:f920c63e4d70bd7490cc52ba07b9e4e01577631ef06025031d7d8404a39543e2",
-      "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
     },
     {
       "name": "create-experiment",
       "path": ".claude/skills/create-experiment/SKILL.md",
       "checksum": "sha256:0f304358b5ad1605e83c2cb60b37f166491088a74f7a274dbf61137c14e9b86f",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "create-inspection",
+      "path": ".claude/skills/create-inspection/SKILL.md",
+      "checksum": "sha256:421141b2c143acb094809f6e700d8562e6dcbade940df0edd8365de7671ecfb1",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "crossplane-specialist",
+      "path": ".claude/skills/crossplane-specialist/SKILL.md",
+      "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "dependabot-sweep",
+      "path": ".claude/commands/dependabot-sweep.md",
+      "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "deploy-status",
+      "path": ".claude/skills/deploy-status/SKILL.md",
+      "checksum": "sha256:f9128b2d793a9878e4288b1c54cb539ac0dc2165f0ecb9cff4f85c97906fe5d4",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "detect-flaky",
+      "path": ".claude/skills/detect-flaky/SKILL.md",
+      "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "fix-with-evidence",
+      "path": ".claude/skills/fix-with-evidence/SKILL.md",
+      "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "flyctl",
+      "path": ".claude/skills/flyctl/SKILL.md",
+      "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "gcp-specialist",
+      "path": ".claude/skills/gcp-specialist/SKILL.md",
+      "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "git",
+      "path": ".claude/skills/git/SKILL.md",
+      "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "ground-first",
+      "path": ".claude/skills/ground-first/SKILL.md",
+      "checksum": "sha256:238437a50b202ee5e32981ea410fc8b5adb4a7ea5979630642f2678e266804a3",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "handoff",
+      "path": ".claude/skills/handoff/SKILL.md",
+      "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "kubernetes-specialist",
+      "path": ".claude/skills/kubernetes-specialist/SKILL.md",
+      "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "local-attest",
+      "path": ".claude/skills/local-attest/SKILL.md",
+      "checksum": "sha256:a4fab149f1ea05770de853331d321fc2e8d4a745fcb52dcc1da1f76edbe4a995",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "markdown",
+      "path": ".claude/commands/markdown.md",
+      "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "merge-pr",
+      "path": ".claude/commands/merge-pr.md",
+      "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "plan-grader",
+      "path": ".claude/skills/plan-grader/SKILL.md",
+      "checksum": "sha256:803d919381f876d5c29c28e1ab19d74a55cd54d74bb5ee6158ca10e8481af2a0",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
     },
     {
       "name": "post-pr-review",
       "path": ".claude/skills/post-pr-review/SKILL.md",
       "checksum": "sha256:0565fc80dba6872c5da9569cff5e53d112fc3ea3a16b4905fdf38255754ec628",
-      "dependencies": ["review-pr"],
-      "lastValidated": "2026-05-11"
+      "dependencies": [
+        "review-pr"
+      ],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "pre-pr",
+      "path": ".claude/commands/pre-pr.md",
+      "checksum": "sha256:f920c63e4d70bd7490cc52ba07b9e4e01577631ef06025031d7d8404a39543e2",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
     },
     {
       "name": "project-sync",
       "path": ".claude/skills/project-sync/SKILL.md",
       "checksum": "sha256:822e1509cf0ed4d0260c8bada35cd0e815a9b6529d637eb9baf3a430f8803104",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "pulumi-specialist",
+      "path": ".claude/skills/pulumi-specialist/SKILL.md",
+      "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "release-conductor",
+      "path": ".claude/commands/release-conductor.md",
+      "checksum": "sha256:d7c9044d6b6d5407b4ec24eba962c9eb131a9d9093a22494ea50cafafc0a7e3e",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "review-pr",
+      "path": ".claude/skills/review-pr/SKILL.md",
+      "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "review-prs",
+      "path": ".claude/skills/review-prs/SKILL.md",
+      "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "rollback-prod",
+      "path": ".claude/skills/rollback-prod/SKILL.md",
+      "checksum": "sha256:32a58bb0feb413e7f44148347d62283332ba259273a6c8f6d4a514876cc484dd",
+      "dependencies": [
+        "deploy-status"
+      ],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "security-review",
+      "path": ".claude/skills/security-review/SKILL.md",
+      "checksum": "sha256:ea03f5bc029de3182ef8ec286a9f3c12b635ad4d36631c024ec2f5c990f5a176",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "spec",
+      "path": ".claude/skills/spec/SKILL.md",
+      "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "terraform-specialist",
+      "path": ".claude/skills/terraform-specialist/SKILL.md",
+      "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "terragrunt-specialist",
+      "path": ".claude/skills/terragrunt-specialist/SKILL.md",
+      "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "validate-spec",
+      "path": ".claude/skills/validate-spec/SKILL.md",
+      "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
+    },
+    {
+      "name": "veracity-audit",
+      "path": ".claude/skills/veracity-audit/SKILL.md",
+      "checksum": "sha256:ca6a137a6d9316de931a26d8a9bf2126d8c1f5005e53a5abd2a722f745fb1080",
+      "dependencies": [],
+      "lastValidated": "2026-05-26"
     }
   ]
 }

--- a/.codex/skills/release-conductor/SKILL.md
+++ b/.codex/skills/release-conductor/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/release-conductor.md

--- a/.gemini/skills/release-conductor/SKILL.md
+++ b/.gemini/skills/release-conductor/SKILL.md
@@ -1,0 +1,1 @@
+../../../.claude/commands/release-conductor.md

--- a/.github/prompts/release-conductor.prompt.md
+++ b/.github/prompts/release-conductor.prompt.md
@@ -1,0 +1,1 @@
+../../.claude/commands/release-conductor.md

--- a/commands/release-conductor.md
+++ b/commands/release-conductor.md
@@ -1,0 +1,239 @@
+---
+id: release-conductor
+name: release-conductor
+type: command
+version: 1.0.0
+domain: [devex]
+platform: [github-actions]
+task: [review, runtime-ops]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-05-26
+updated: 2026-05-26
+description: >
+  Gate the open release-please PR before merging: verify CI green, feature PRs landed,
+  no release blockers, changelog reflects intent. One-word approval, then merge.
+  Reports the resulting release.yml run URL. release-please owns the changelog/bump/tag;
+  release.yml owns OIDC npm publish — this skill only gates the merge in between.
+argument-hint: "[verify <tag>]"
+model: sonnet
+headless_safe: false
+---
+
+Gate the open release-please PR before merging. release-please drafts the changelog and version bump; `release.yml` handles OIDC npm publish on tag push. This skill is the human-in-the-loop step between them: verifies the PR is safe to merge, then merges it.
+
+Trigger: when the user says "ship a release", "cut a release", "merge the release PR", "is the release ready", or invokes `/release-conductor`. Also `/release-conductor verify <tag>` for post-publish smoke test.
+
+Arguments: `$ARGUMENTS` — optional subcommand:
+
+- (empty) — full gate + merge flow on the currently open release-please PR.
+- `verify <tag>` — post-publish smoke test for a published tag (e.g. `verify v2.8.0`).
+
+**Lifecycle:**
+
+```
+feature PRs merged → release-please opens release PR → /release-conductor (gate + merge) → release.yml (OIDC publish) → /release-conductor verify <tag>
+```
+
+## Steps
+
+### 0. Branch on subcommand
+
+If `$ARGUMENTS` starts with `verify`, jump to the **`verify` subcommand** section below.
+
+Otherwise, continue with the gate + merge flow.
+
+### 1. Find the open release-please PR
+
+```bash
+gh pr list --state open --search "head:release-please--" \
+  --json number,title,headRefName,mergeable,mergeStateStatus,labels,body
+```
+
+- **Zero matches.** Check what's accumulated since the last tag:
+
+  ```bash
+  LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+  git log "$LAST_TAG"..origin/main --oneline --no-merges
+  ```
+
+  If the log contains `feat:` / `fix:` / `perf:` / `refactor:` commits but no PR is open, suggest:
+
+  ```bash
+  gh run list --workflow=release-please.yml --limit 3
+  ```
+
+  release-please may have failed or not run. STOP and surface the most recent run.
+
+  If the log contains only `chore:` / `style:` / `test:` / `build:` / `ci:` / `docs:` commits, report:
+  `no shippable changes — release-please correctly held off.` STOP.
+
+- **One match.** Record `RELEASE_PR=$pr_number` and continue.
+
+- **Multiple matches.** STOP and ask the user which to ship — this signals a release-please config issue (multi-package monorepo without `include-component-in-tag`, etc.).
+
+### 2. Show what's being shipped
+
+```bash
+gh pr view $RELEASE_PR --json title,body | jq -r '.title, .body'
+gh pr diff $RELEASE_PR -- CHANGELOG.md | head -120
+gh pr view $RELEASE_PR --json files --jq '.files[].path'
+```
+
+Report:
+
+- PR title (release-please format: `chore(main): release X.Y.Z`)
+- The changelog section being added (first ~120 lines of the diff)
+- Files changed by the PR (should be `CHANGELOG.md`, `package.json`, `.release-please-manifest.json`, and any post-bump regen — `index/`, `docs/` stamps)
+
+### 3. Verify CI on the release PR
+
+```bash
+gh pr checks $RELEASE_PR
+```
+
+- Any check `failing` → STOP. Print the failing check names; tell the user to address them before re-running.
+- Any check `pending` → STOP. Tell the user to wait for CI to finish.
+- All checks pass → continue.
+
+Sanity check on `main`:
+
+```bash
+gh run list --branch main --limit 5 --json conclusion,name,createdAt
+```
+
+If the most recent run on `main` is failing, surface as **WARNING** (not blocking) — release.yml will run against the tag, not `main`, so a stale main failure won't break publish, but it's worth knowing.
+
+### 4. Verify no release blockers and feature PRs landed
+
+```bash
+LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+LAST_TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
+
+# Feature PRs merged since last tag
+gh pr list --state merged --search "merged:>$LAST_TAG_DATE base:main" \
+  --limit 50 --json number,title,headRefName,labels
+
+# Open PRs flagged as blockers
+gh pr list --state open --search "label:release-blocker,do-not-release,wip" \
+  --json number,title,labels
+```
+
+- Report count of feature PRs merged since `$LAST_TAG`.
+- Any open PR with `release-blocker` or `do-not-release` label → STOP. Surface the PR numbers.
+- Any **merged** PR with those labels (mistakes happen) → surface as WARNING.
+
+### 5. Sanity-check the bump
+
+```bash
+PREV_VERSION=${LAST_TAG#v}
+NEW_VERSION=$(gh pr view $RELEASE_PR --json title --jq .title \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+echo "Bump: $PREV_VERSION → $NEW_VERSION"
+```
+
+Inspect conventional-commit types since last tag:
+
+```bash
+git log "$LAST_TAG"..origin/main --pretty=format:'%s%n%b' --no-merges \
+  | grep -E '^(feat|fix|perf|refactor|docs)(\(.+\))?!?:|BREAKING CHANGE:' \
+  | sort -u
+```
+
+Expected bump (post-1.0):
+
+- `feat!:` or `BREAKING CHANGE:` anywhere → **major**
+- `feat:` (no breaking) → **minor**
+- `fix:` / `perf:` / `refactor:` only → **patch**
+
+For pre-1.0 packages, read `release-please-config.json` — `bump-minor-pre-major` promotes major→minor; `bump-patch-for-minor-pre-major` promotes minor→patch.
+
+If release-please's bump diverges from expectation, surface as **WARNING** with the divergence (likely config). Do not block — release-please's config is the source of truth.
+
+### 6. Go/no-go summary
+
+```
+Release-conductor: PR #$RELEASE_PR — $PREV_VERSION → $NEW_VERSION
+
+  Step 2 — Files:           CHANGELOG.md, package.json, .release-please-manifest.json, …
+  Step 3 — CI release PR:   ✓ green
+                         |  ✗ failing: <names> (BLOCKED)
+                         |  ⏳ pending (BLOCKED — wait)
+  Step 3 — CI main:         ✓ green
+                         |  ⚠ recent failures (not blocking publish)
+  Step 4 — Blockers:        none
+                         |  ✗ open: PR #N (label) (BLOCKED)
+  Step 4 — Landed PRs:      N feature PRs since $LAST_TAG
+  Step 5 — Bump:            ✓ matches commit types
+                         |  ⚠ release-please chose $NEW_VERSION, expected $EXPECTED (<reason>)
+
+Status: READY — say "ship" to merge PR #$RELEASE_PR (squash) and trigger release.yml.
+     |  BLOCKED — <reason>. Fix and re-run /release-conductor.
+```
+
+### 7. Merge on explicit approval
+
+Wait for the user to say `ship`, `merge`, `go`, or `lgtm`. CI green alone is not authorization.
+
+On approval:
+
+```bash
+gh pr merge $RELEASE_PR --squash --delete-branch
+```
+
+If the repo overrides merge method (check `.github/settings.yml` or repo settings UI), follow the override and note it in the report.
+
+### 8. Report the publish pipeline run
+
+release-please's GitHub Action creates the `v$NEW_VERSION` tag immediately after merge; the tag push fires `release.yml`. Report the most recent runs so the user can track:
+
+```bash
+TAG="v$NEW_VERSION"
+gh run list --workflow=release.yml --limit 3 \
+  --json url,headBranch,status,conclusion,createdAt
+```
+
+Do not poll. Print:
+
+```
+Merged PR #$RELEASE_PR ($PREV_VERSION → $NEW_VERSION)
+Tag should appear shortly: $TAG
+Track release.yml above. Once it shows ✓ success:
+  /release-conductor verify $TAG
+```
+
+## `verify <tag>` subcommand
+
+Post-publish smoke test. No gating, no merge — just three checks.
+
+```bash
+TAG=$(echo "$ARGUMENTS" | awk '{print $2}')
+VERSION=${TAG#v}
+PKG=$(node -p "require('./package.json').name")
+
+# 1. release.yml conclusion for this tag
+gh run list --workflow=release.yml --branch "$TAG" --limit 1 \
+  --json conclusion,url,databaseId
+
+# 2. npm has the version
+npm view "$PKG@$VERSION" version dist.tarball
+
+# 3. GitHub release exists
+gh release view "$TAG" --json url,publishedAt,name
+```
+
+Report PASS / FAIL per check. Specifics:
+
+- **release.yml conclusion** — `success` = PASS. `in_progress` = "still running, retry in ~60s." `failure` = FAIL, print URL.
+- **npm view** — exit 0 = PASS. 404 = "not yet propagated (npm CDN lag, up to ~60s)." Other error = FAIL.
+- **gh release view** — exit 0 = PASS. `release not found` = FAIL.
+
+## Rules
+
+- **Never reimplement release-please.** This skill does not write CHANGELOG.md, bump versions, or create tags. release-please owns that; this skill only gates the merge of release-please's PR.
+- **Never publish to npm directly.** OIDC publish happens in `release.yml` on tag push. The skill stops at `gh pr merge`.
+- **Require explicit verbal approval.** `ship` / `merge` / `go` / `lgtm`. CI green alone is not authorization.
+- **One release PR at a time.** Multiple open `release-please--*` PRs → stop and ask. Likely a config issue.
+- **Squash merge by default.** Matches `/merge-pr` convention. Repo override (if any) wins, but record it.
+- **No polling.** Print the run URL and exit. Use `verify <tag>` later.
+- **Pre-1.0 bump checks read config.** Don't assume semver — `release-please-config.json` may have `bump-minor-pre-major` flags that alter the expected bump.

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotbabel.dev/schemas/index.schema.json",
-  "generatedAt": "2026-05-23T19:36:52.899Z",
+  "generatedAt": "2026-05-26T14:40:25.841Z",
   "version": "2.8.0",
   "artifacts": [
     {
@@ -721,6 +721,21 @@
         "platform": ["pulumi"],
         "task": ["debugging", "review"],
         "maturity": "validated"
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
+    },
+    {
+      "id": "release-conductor",
+      "type": "command",
+      "path": "commands/release-conductor.md",
+      "name": "release-conductor",
+      "description": "Gate the open release-please PR before merging: verify CI green, feature PRs landed, no release blockers, changelog reflects intent. One-word approval, then merge. Reports the resulting release.yml run URL. release-please owns the changelog/bump/tag; release.yml owns OIDC npm publish — this skill only gates the merge in between.\n",
+      "facets": {
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review", "runtime-ops"],
+        "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha"

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -30,6 +30,7 @@
       "post-pr-review",
       "pre-pr",
       "project-sync",
+      "release-conductor",
       "review-pr",
       "review-prs",
       "rollback-prod",
@@ -131,6 +132,7 @@
       "local-attest",
       "merge-pr",
       "post-pr-review",
+      "release-conductor",
       "review-pr",
       "review-prs"
     ],
@@ -201,6 +203,7 @@
       "post-pr-review",
       "pre-pr",
       "pulumi-specialist",
+      "release-conductor",
       "review-pr",
       "review-prs",
       "security-auditor",
@@ -258,7 +261,8 @@
       "docker-engineer",
       "flyctl",
       "kubernetes-specialist",
-      "local-attest"
+      "local-attest",
+      "release-conductor"
     ],
     "testing": [
       "detect-flaky",
@@ -330,6 +334,7 @@
       "pre-pr",
       "project-sync",
       "pulumi-engineer",
+      "release-conductor",
       "review-prs",
       "rollback-prod",
       "security-auditor",

--- a/index/by-type.json
+++ b/index/by-type.json
@@ -60,7 +60,14 @@
     "validate-spec",
     "veracity-audit"
   ],
-  "command": ["changelog", "dependabot-sweep", "markdown", "merge-pr", "pre-pr"],
+  "command": [
+    "changelog",
+    "dependabot-sweep",
+    "markdown",
+    "merge-pr",
+    "pre-pr",
+    "release-conductor"
+  ],
   "hook": [],
   "template": []
 }


### PR DESCRIPTION
## Summary

- Adds `/release-conductor` command — gates the open release-please PR before merging, then `release.yml` (OIDC npm publish) takes over on tag push. Closes the manual-coordination gap between the two existing pieces.
- Flow: find release-please PR → show CHANGELOG diff + bump → verify CI green → check no `release-blocker` labels → sanity-check bump vs commit types → wait for one-word approval → squash-merge → report the resulting `release.yml` run URL.
- Includes `verify <tag>` subcommand for post-publish smoke test (release.yml success, npm propagation, GitHub release exists).
- Does NOT reimplement release-please (no changelog drafting, version bumping, or tag creation) and does NOT publish to npm directly. release.yml owns the OIDC publish.

## Test plan

- [x] `node plugins/dotbabel/bin/dotbabel-validate-skills.mjs` — manifest valid (39 skills)
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — index fresh (63 artifacts)
- [x] `npx --yes prettier@3 --check commands/release-conductor.md` — clean
- [x] `npx --yes markdownlint-cli2 commands/release-conductor.md` — 0 errors (path is in lint exclusions; no regressions)
- [x] `node plugins/dotbabel/bin/dotbabel-doctor.mjs` — all green after `dotbabel-project-sync`
- [x] `node plugins/dotbabel/bin/dotbabel-check-spec-coverage.mjs` — 1 protected file changed, coverage ok
- [x] `node plugins/dotbabel/bin/dotbabel-project-sync.mjs` — codex/gemini/copilot fan-out generated (separate commit)
- [ ] Manual: run `/release-conductor` against the next release-please PR and confirm the gate report is accurate before merging

## No-spec rationale

Adds a new command artifact rather than altering dotbabel-core's product surface. Protected paths touched: `.claude/skills-manifest.json` (mechanical manifest entry for the new artifact) and `index/*.json` (regenerated by `dotbabel-index`). All harness primitives (`plugins/dotbabel/src/**`, `plugins/dotbabel/bin/**`, `plugins/dotbabel/templates/**`) are unchanged. The skill's contract lives inline in `commands/release-conductor.md`. Follows the precedent of #236 (local-attest) and #231 (flyctl) which used the same rationale for new-skill PRs touching `.claude/**`.
