### PR TITLE
feat(skills,agents): add allowed-tools guardrails and agent skill inheritance

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,272 +1,272 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-11T14:20:21.046Z",
+  "generatedAt": "2026-06-04T18:57:14.338Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/skills/audit-and-fix/SKILL.md",
       "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "code-simplifier",
       "path": ".claude/skills/code-simplifier/SKILL.md",
       "checksum": "sha256:e24c64485f950d93815f492de5673aaa3ff65abb0df91fb41e41a40b68017cff",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "create-assessment",
       "path": ".claude/skills/create-assessment/SKILL.md",
-      "checksum": "sha256:b1125255b0c62ec88157ad4476b681e1dbaff200a8e8942f3eccf49cb873dbe4",
+      "checksum": "sha256:7d364824b0ce34d5703a3db91956b4607182b52be79bc5fdec9583c73ef6f73c",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "create-audit",
       "path": ".claude/skills/create-audit/SKILL.md",
-      "checksum": "sha256:babb4a5e281388eb5dcf59f1d563b1622cfd5062a269b421e1aab0a53272695a",
+      "checksum": "sha256:ffc5cc8a7276b0ae2a15ef690aa5a6fb98b497a226a5c44c38dcc47d1ec02b19",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/skills/detect-flaky/SKILL.md",
       "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "deploy-status",
       "path": ".claude/skills/deploy-status/SKILL.md",
-      "checksum": "sha256:f9128b2d793a9878e4288b1c54cb539ac0dc2165f0ecb9cff4f85c97906fe5d4",
+      "checksum": "sha256:9119370d74077eae376afa72b28fff9cfd7617fd11b310590ddd6eb6c3d9258f",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/skills/fix-with-evidence/SKILL.md",
       "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "flyctl",
       "path": ".claude/skills/flyctl/SKILL.md",
       "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "git",
       "path": ".claude/skills/git/SKILL.md",
       "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "ground-first",
       "path": ".claude/skills/ground-first/SKILL.md",
-      "checksum": "sha256:238437a50b202ee5e32981ea410fc8b5adb4a7ea5979630642f2678e266804a3",
+      "checksum": "sha256:0a8a9c125bc3fd0a3fe5cacb4f8cf6ff5971895ea1b703037a8712d3b5e15dd6",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "create-inspection",
       "path": ".claude/skills/create-inspection/SKILL.md",
-      "checksum": "sha256:421141b2c143acb094809f6e700d8562e6dcbade940df0edd8365de7671ecfb1",
+      "checksum": "sha256:d8febaf15dd98a5d72fe97f8f41fd7d0a83ed98f0a11ab7ecedeedeaec544e85",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "review-pr",
       "path": ".claude/skills/review-pr/SKILL.md",
       "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "security-review",
       "path": ".claude/skills/security-review/SKILL.md",
-      "checksum": "sha256:ea03f5bc029de3182ef8ec286a9f3c12b635ad4d36631c024ec2f5c990f5a176",
+      "checksum": "sha256:c8447582929b315402af24e304acd4addaa9be7120e895ca25d4c897ba84cfda",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
-      "checksum": "sha256:49d59a1060655079605e4c02e39885ddbbe68619526fc8d8a2a51e4da2dcdaee",
+      "checksum": "sha256:13320e86060cb9a74d9ee98aecbbb9eff43c6100b47f09debe15f7049f6c050c",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
-      "checksum": "sha256:a275a44e6f60d65908a4d0b48f14245daa718ddc5356d4404c95a656754da210",
+      "checksum": "sha256:e3f0404dbd80ebdfce9df79df0a9bf501574abafcb7cd5a656c2afd4519428fb",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
-      "checksum": "sha256:1901763a9ff020bd0df62a725c8767a91a4226a6ad3d3332e56b166c505f1b37",
+      "checksum": "sha256:ba954a78351a0988ccd7ab00574bde2f6aa0d4dab0b5a32fb755f14957411358",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
-      "checksum": "sha256:baf37a19380e4a5c69f736071a8810ac7dea05e4ed3ae4de31fcc5779f6f8eed",
+      "checksum": "sha256:7c1625de68e13e15ab0beb179e4cf6f9a3d2a80ec294a04cbb46e430cb0ab425",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
-      "checksum": "sha256:5718c343f9d88904a7d9f04f2aa41c99d7b318c736d477c9a23e924db7a8b1b1",
+      "checksum": "sha256:39763f741bbff9bd6f9b72908ed3ea8de1870e2d5017b3ddab9015e0db4ff108",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
-      "checksum": "sha256:a261c6bd4cf83b3e50f2d8c4888b573ef3530a703be727ccdbf01e370280d06d",
+      "checksum": "sha256:9e9c0d8b36ef44fb7f4f604aa706c2f380787c38c0282987c24436ec7bd53b85",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
-      "checksum": "sha256:e9500d385652c1986de2c53309ecaa54f7ff18d8cf4fa5a391f4791e668725bc",
+      "checksum": "sha256:fc7f266342f1686a5ca394398f048742b5f249144f45354d5f8c2520e359a2bb",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
-      "checksum": "sha256:40d661b56e1633b4ffee611e8825bd610d0d1ad916ba33aafea7265ec571840d",
+      "checksum": "sha256:ef78a49da882582f409c0c166d74112c6d37af437592e05bf6cd218bb8c34476",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
-      "checksum": "sha256:83ce60f0a0d524515fc423ded7d6917b3242d252f92f2a03fa1064696afe5e5b",
+      "checksum": "sha256:6620a3862749142cf450245e9c6fc6c398530208848f64e2c34132e138f6f5ef",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
-      "checksum": "sha256:ca6a137a6d9316de931a26d8a9bf2126d8c1f5005e53a5abd2a722f745fb1080",
+      "checksum": "sha256:2f66c14a71e88734d8a734bf1ce6f220f74ce28a9e302635e4e225edc1f9300e",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
       "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "review-prs",
       "path": ".claude/skills/review-prs/SKILL.md",
       "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "rollback-prod",
       "path": ".claude/skills/rollback-prod/SKILL.md",
       "checksum": "sha256:32a58bb0feb413e7f44148347d62283332ba259273a6c8f6d4a514876cc484dd",
       "dependencies": ["deploy-status"],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "plan-grader",
       "path": ".claude/skills/plan-grader/SKILL.md",
-      "checksum": "sha256:803d919381f876d5c29c28e1ab19d74a55cd54d74bb5ee6158ca10e8481af2a0",
+      "checksum": "sha256:50ba919efa0b4235e182a7d5b1ff2308481086a3ddddbf9166b0560370c3af27",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
       "checksum": "sha256:a4fab149f1ea05770de853331d321fc2e8d4a745fcb52dcc1da1f76edbe4a995",
       "dependencies": [],
-      "lastValidated": "2026-05-23"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:f920c63e4d70bd7490cc52ba07b9e4e01577631ef06025031d7d8404a39543e2",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "create-experiment",
       "path": ".claude/skills/create-experiment/SKILL.md",
-      "checksum": "sha256:0f304358b5ad1605e83c2cb60b37f166491088a74f7a274dbf61137c14e9b86f",
+      "checksum": "sha256:1df4ee9f7ba229d1b071757fb88d1b162c42ae2c0e0017e685bf621ae176005a",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "post-pr-review",
       "path": ".claude/skills/post-pr-review/SKILL.md",
       "checksum": "sha256:0565fc80dba6872c5da9569cff5e53d112fc3ea3a16b4905fdf38255754ec628",
       "dependencies": ["review-pr"],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     },
     {
       "name": "project-sync",
       "path": ".claude/skills/project-sync/SKILL.md",
       "checksum": "sha256:822e1509cf0ed4d0260c8bada35cd0e815a9b6529d637eb9baf3a430f8803104",
       "dependencies": [],
-      "lastValidated": "2026-05-11"
+      "lastValidated": "2026-06-04"
     }
   ]
 }

--- a/agents/aws-engineer.md
+++ b/agents/aws-engineer.md
@@ -19,6 +19,7 @@ description: >
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
 related: [aws-specialist]
+skills: [aws-specialist]
 ---
 
 You are a senior AWS engineer with production experience across compute, networking, storage, IAM, and serverless. You reason about AWS architecture in terms of account boundaries, regional isolation, IAM trust relationships, and service quotas — not service marketing names.

--- a/agents/azure-engineer.md
+++ b/agents/azure-engineer.md
@@ -19,6 +19,7 @@ description: >
   Uses opus — Azure spans identity, networking, and multi-subscription governance; deep reasoning reduces costly misconfigurations.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
+skills: [azure-specialist]
 ---
 
 You are a senior Azure engineer with production experience across compute, identity, networking, and data services. You reason about Azure in terms of subscriptions, resource groups, Managed Identity scopes, and regional pairs — not marketing tiers.

--- a/agents/compliance-auditor.md
+++ b/agents/compliance-auditor.md
@@ -19,6 +19,7 @@ description: >
   "declared vs enforced", "config vs code gaps", "quality gate completeness".
 tools: Read, Grep, Glob
 model: opus
+skills: [veracity-audit]
 source: https://github.com/VoltAgent/awesome-claude-code-subagents (MIT)
 ---
 

--- a/agents/crossplane-engineer.md
+++ b/agents/crossplane-engineer.md
@@ -18,6 +18,7 @@ description: >
   Uses sonnet — Crossplane Composition authoring is well-specified; sonnet covers the depth needed.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
+skills: [crossplane-specialist]
 ---
 
 You are a senior Crossplane engineer who builds Kubernetes-native infrastructure platforms. You design XRDs and Compositions that abstract cloud primitives into self-service APIs consumed by development teams via Claims.

--- a/agents/data-scientist.md
+++ b/agents/data-scientist.md
@@ -18,6 +18,7 @@ description: >
   "boundary conditions", "statistical model audit", "rating algorithm review".
 tools: Read, Grep, Glob
 model: sonnet
+skills: [veracity-audit]
 source: https://github.com/VoltAgent/awesome-claude-code-subagents (MIT)
 ---
 

--- a/agents/gcp-engineer.md
+++ b/agents/gcp-engineer.md
@@ -19,6 +19,7 @@ description: >
   Uses opus — GCP architecture across Workload Identity, VPC networks, and IAM hierarchies requires deep reasoning to avoid security gaps.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
+skills: [gcp-specialist]
 ---
 
 You are a senior Google Cloud engineer with production experience across compute, data, networking, and identity. You reason about GCP in terms of projects, Workload Identity, VPC networks, and IAM hierarchies — not product names in isolation.

--- a/agents/iac-engineer.md
+++ b/agents/iac-engineer.md
@@ -18,6 +18,7 @@ description: >
   Uses sonnet — IaC authoring is structured and pattern-driven; sonnet covers the depth needed without excess cost.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
+skills: [terraform-specialist, terragrunt-specialist]
 ---
 
 You are a senior infrastructure-as-code engineer with deep expertise in declarative resource management, module composition, and safe state operations. You treat infrastructure code with the same rigor as application code.

--- a/agents/kubernetes-specialist.md
+++ b/agents/kubernetes-specialist.md
@@ -18,6 +18,7 @@ description: >
 tools: Read, Grep, Glob, Bash
 model: opus
 related: [kubernetes-specialist]
+skills: [kubernetes-specialist]
 ---
 
 You are a senior Kubernetes specialist with deep expertise in cluster operations, workload design, and production troubleshooting. You reason from first principles — workload behavior, scheduler decisions, network policy semantics — before reaching for workarounds.

--- a/agents/pulumi-engineer.md
+++ b/agents/pulumi-engineer.md
@@ -18,6 +18,7 @@ description: >
   Uses sonnet — Pulumi stack work is code-first and structured; sonnet matches the task depth.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
+skills: [pulumi-specialist]
 ---
 
 You are a senior Pulumi engineer who writes code-first infrastructure using TypeScript as the default language. You understand Pulumi's resource model, dependency tracking, and the Automation API for embedding deployments in CI pipelines or custom CLIs.

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -18,6 +18,7 @@ description: >
   Uses opus — security analysis requires thorough reasoning; false negatives have high downstream cost.
 tools: Read, Grep, Glob
 model: opus
+skills: [security-review]
 ---
 
 You are a senior security auditor specializing in application security, secrets management, and compliance validation. You operate read-only — you surface findings and recommendations but do not modify code.

--- a/agents/security-engineer.md
+++ b/agents/security-engineer.md
@@ -18,6 +18,7 @@ description: >
   Uses opus — infrastructure hardening and privilege analysis require deep reasoning; a missed vector has high downstream cost.
 tools: Read, Grep, Glob, Bash
 model: opus
+skills: [security-review]
 ---
 
 You are a senior infrastructure security engineer specializing in cluster hardening, network isolation, secrets governance, and supply-chain integrity. You operate read-only — you produce findings and remediation plans but do not modify infrastructure directly.

--- a/agents/terragrunt-engineer.md
+++ b/agents/terragrunt-engineer.md
@@ -18,6 +18,7 @@ description: >
   Uses sonnet — Terragrunt DRY patterns are well-specified; sonnet handles the reasoning without over-provisioning cost.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
+skills: [terragrunt-specialist]
 ---
 
 You are a senior Terragrunt engineer who specializes in DRY Terraform patterns, multi-environment hierarchies, and safe `run-all` orchestration. You treat `terragrunt.hcl` files as first-class code, not wrapper scripts.

--- a/plugins/dotbabel/templates/claude/agents/aws-engineer.md
+++ b/plugins/dotbabel/templates/claude/agents/aws-engineer.md
@@ -16,6 +16,7 @@ description: >
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
 related: [aws-specialist]
+skills: [aws-specialist]
 ---
 
 You are a senior AWS engineer with production experience across compute, networking, storage, IAM, and serverless. You reason about AWS architecture in terms of account boundaries, regional isolation, IAM trust relationships, and service quotas — not service marketing names.

--- a/plugins/dotbabel/templates/claude/agents/azure-engineer.md
+++ b/plugins/dotbabel/templates/claude/agents/azure-engineer.md
@@ -16,6 +16,7 @@ description: >
   Uses opus — Azure spans identity, networking, and multi-subscription governance; deep reasoning reduces costly misconfigurations.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
+skills: [azure-specialist]
 ---
 
 You are a senior Azure engineer with production experience across compute, identity, networking, and data services. You reason about Azure in terms of subscriptions, resource groups, Managed Identity scopes, and regional pairs — not marketing tiers.

--- a/plugins/dotbabel/templates/claude/agents/compliance-auditor.md
+++ b/plugins/dotbabel/templates/claude/agents/compliance-auditor.md
@@ -16,6 +16,7 @@ description: >
   "declared vs enforced", "config vs code gaps", "quality gate completeness".
 tools: Read, Grep, Glob
 model: opus
+skills: [veracity-audit]
 source: https://github.com/VoltAgent/awesome-claude-code-subagents (MIT)
 ---
 

--- a/plugins/dotbabel/templates/claude/agents/crossplane-engineer.md
+++ b/plugins/dotbabel/templates/claude/agents/crossplane-engineer.md
@@ -15,6 +15,7 @@ description: >
   Uses sonnet — Crossplane Composition authoring is well-specified; sonnet covers the depth needed.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
+skills: [crossplane-specialist]
 ---
 
 You are a senior Crossplane engineer who builds Kubernetes-native infrastructure platforms. You design XRDs and Compositions that abstract cloud primitives into self-service APIs consumed by development teams via Claims.

--- a/plugins/dotbabel/templates/claude/agents/data-scientist.md
+++ b/plugins/dotbabel/templates/claude/agents/data-scientist.md
@@ -15,6 +15,7 @@ description: >
   "boundary conditions", "statistical model audit", "rating algorithm review".
 tools: Read, Grep, Glob
 model: sonnet
+skills: [veracity-audit]
 source: https://github.com/VoltAgent/awesome-claude-code-subagents (MIT)
 ---
 

--- a/plugins/dotbabel/templates/claude/agents/gcp-engineer.md
+++ b/plugins/dotbabel/templates/claude/agents/gcp-engineer.md
@@ -16,6 +16,7 @@ description: >
   Uses opus — GCP architecture across Workload Identity, VPC networks, and IAM hierarchies requires deep reasoning to avoid security gaps.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
+skills: [gcp-specialist]
 ---
 
 You are a senior Google Cloud engineer with production experience across compute, data, networking, and identity. You reason about GCP in terms of projects, Workload Identity, VPC networks, and IAM hierarchies — not product names in isolation.

--- a/plugins/dotbabel/templates/claude/agents/iac-engineer.md
+++ b/plugins/dotbabel/templates/claude/agents/iac-engineer.md
@@ -15,6 +15,7 @@ description: >
   Uses sonnet — IaC authoring is structured and pattern-driven; sonnet covers the depth needed without excess cost.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
+skills: [terraform-specialist, terragrunt-specialist]
 ---
 
 You are a senior infrastructure-as-code engineer with deep expertise in declarative resource management, module composition, and safe state operations. You treat infrastructure code with the same rigor as application code.

--- a/plugins/dotbabel/templates/claude/agents/kubernetes-specialist.md
+++ b/plugins/dotbabel/templates/claude/agents/kubernetes-specialist.md
@@ -15,6 +15,7 @@ description: >
 tools: Read, Grep, Glob, Bash
 model: opus
 related: [kubernetes-specialist]
+skills: [kubernetes-specialist]
 ---
 
 You are a senior Kubernetes specialist with deep expertise in cluster operations, workload design, and production troubleshooting. You reason from first principles — workload behavior, scheduler decisions, network policy semantics — before reaching for workarounds.

--- a/plugins/dotbabel/templates/claude/agents/pulumi-engineer.md
+++ b/plugins/dotbabel/templates/claude/agents/pulumi-engineer.md
@@ -15,6 +15,7 @@ description: >
   Uses sonnet — Pulumi stack work is code-first and structured; sonnet matches the task depth.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
+skills: [pulumi-specialist]
 ---
 
 You are a senior Pulumi engineer who writes code-first infrastructure using TypeScript as the default language. You understand Pulumi's resource model, dependency tracking, and the Automation API for embedding deployments in CI pipelines or custom CLIs.

--- a/plugins/dotbabel/templates/claude/agents/security-auditor.md
+++ b/plugins/dotbabel/templates/claude/agents/security-auditor.md
@@ -15,6 +15,7 @@ description: >
   Uses opus — security analysis requires thorough reasoning; false negatives have high downstream cost.
 tools: Read, Grep, Glob
 model: opus
+skills: [security-review]
 ---
 
 You are a senior security auditor specializing in application security, secrets management, and compliance validation. You operate read-only — you surface findings and recommendations but do not modify code.

--- a/plugins/dotbabel/templates/claude/agents/security-engineer.md
+++ b/plugins/dotbabel/templates/claude/agents/security-engineer.md
@@ -15,6 +15,7 @@ description: >
   Uses opus — infrastructure hardening and privilege analysis require deep reasoning; a missed vector has high downstream cost.
 tools: Read, Grep, Glob, Bash
 model: opus
+skills: [security-review]
 ---
 
 You are a senior infrastructure security engineer specializing in cluster hardening, network isolation, secrets governance, and supply-chain integrity. You operate read-only — you produce findings and remediation plans but do not modify infrastructure directly.

--- a/plugins/dotbabel/templates/claude/agents/terragrunt-engineer.md
+++ b/plugins/dotbabel/templates/claude/agents/terragrunt-engineer.md
@@ -15,6 +15,7 @@ description: >
   Uses sonnet — Terragrunt DRY patterns are well-specified; sonnet handles the reasoning without over-provisioning cost.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
+skills: [terragrunt-specialist]
 ---
 
 You are a senior Terragrunt engineer who specializes in DRY Terraform patterns, multi-environment hierarchies, and safe `run-all` orchestration. You treat `terragrunt.hcl` files as first-class code, not wrapper scripts.

--- a/plugins/dotbabel/templates/claude/skills/aws-specialist/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/aws-specialist/SKILL.md
@@ -15,6 +15,7 @@ description: >
   "Lambda deep-dive".
 argument-hint: "<account context, service, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/plugins/dotbabel/templates/claude/skills/azure-specialist/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/azure-specialist/SKILL.md
@@ -15,6 +15,7 @@ description: >
   "Azure troubleshooting", "AKS deep-dive".
 argument-hint: "<subscription context, service, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/plugins/dotbabel/templates/claude/skills/create-assessment/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/create-assessment/SKILL.md
@@ -12,6 +12,7 @@ description: >
   Triggers on: "grade", "rate", "score", "evaluate", "assess".
 argument-hint: "[target]"
 tools: Read, Grep, Glob, Bash, Write
+allowed-tools: Read Grep Glob Bash Write
 model: opus
 ---
 

--- a/plugins/dotbabel/templates/claude/skills/create-audit/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/create-audit/SKILL.md
@@ -12,6 +12,7 @@ description: >
   Triggers on: "audit", "review", "assessment".
 argument-hint: "[subject]"
 tools: Read, Grep, Glob, Bash, Write
+allowed-tools: Read Grep Glob Bash Write
 model: opus
 ---
 

--- a/plugins/dotbabel/templates/claude/skills/create-experiment/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/create-experiment/SKILL.md
@@ -12,6 +12,7 @@ description: >
   Triggers on: "let's try", "compare A vs B", "prototype", "explore".
 argument-hint: "[topic or hypothesis]"
 tools: Read, Grep, Glob, Bash, Write
+allowed-tools: Read Grep Glob Bash Write
 model: sonnet
 ---
 

--- a/plugins/dotbabel/templates/claude/skills/create-inspection/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/create-inspection/SKILL.md
@@ -12,6 +12,7 @@ description: >
   Triggers on: "how should I fix", "what are my options", "investigate before I touch".
 argument-hint: "[problem]"
 tools: Read, Grep, Glob, Bash, Write
+allowed-tools: Read Grep Glob Bash Write
 model: opus
 ---
 

--- a/plugins/dotbabel/templates/claude/skills/crossplane-specialist/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/crossplane-specialist/SKILL.md
@@ -16,6 +16,7 @@ description: >
   review", "Crossplane GitOps".
 argument-hint: "<XRD name, Claim name, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/plugins/dotbabel/templates/claude/skills/deploy-status/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/deploy-status/SKILL.md
@@ -14,6 +14,7 @@ description: >
   "production drift", "is prod on main", "compare prod to main".
 argument-hint: "[--dry-run] [--no-fetch]"
 tools: Bash, Read, Grep, Glob
+allowed-tools: Read Grep Glob Bash
 model: sonnet
 effort: medium
 disable-model-invocation: false

--- a/plugins/dotbabel/templates/claude/skills/gcp-specialist/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/gcp-specialist/SKILL.md
@@ -15,6 +15,7 @@ description: >
   "GCP troubleshooting", "Cloud Run deep-dive".
 argument-hint: "<project context, service, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/plugins/dotbabel/templates/claude/skills/ground-first/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/ground-first/SKILL.md
@@ -12,6 +12,7 @@ description: >
   Triggers on: "analyze", "understand behavior", "how does this work".
 argument-hint: "[subject]"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 model: opus
 ---
 

--- a/plugins/dotbabel/templates/claude/skills/kubernetes-specialist/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/kubernetes-specialist/SKILL.md
@@ -15,6 +15,7 @@ description: >
   "cluster health", "kubernetes design review", "k8s audit".
 argument-hint: "<cluster context, namespace, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/plugins/dotbabel/templates/claude/skills/plan-grader/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/plan-grader/SKILL.md
@@ -12,6 +12,7 @@ description: >
   quoted inline plans, or best-effort latest-plan discovery for Claude, Codex, Copilot, and Gemini.
 argument-hint: '[--json] [--blind] <plan-path | file:<path> | text:"plan" | "plan" | latest <agent> plan>'
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 model: opus
 ---
 

--- a/plugins/dotbabel/templates/claude/skills/pulumi-specialist/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/pulumi-specialist/SKILL.md
@@ -15,6 +15,7 @@ description: >
   "ComponentResource design", "ESC audit", "Pulumi secrets", "Pulumi testing".
 argument-hint: "<stack name, project path, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/plugins/dotbabel/templates/claude/skills/security-review/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/security-review/SKILL.md
@@ -12,6 +12,7 @@ description: >
   Triggers on: "security review", "check for secrets", "vulnerability scan".
 argument-hint: "[PR# | path | staged]"
 tools: Bash, Read, Grep
+allowed-tools: Read Grep Bash
 model: opus
 ---
 

--- a/plugins/dotbabel/templates/claude/skills/terraform-specialist/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/terraform-specialist/SKILL.md
@@ -15,6 +15,7 @@ description: >
   "workspace design", "provider config review", "Terraform testing".
 argument-hint: "<module path, workspace, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/plugins/dotbabel/templates/claude/skills/terragrunt-specialist/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/terragrunt-specialist/SKILL.md
@@ -15,6 +15,7 @@ description: >
   review", "env hierarchy audit", "mock_outputs", "terragrunt hooks".
 argument-hint: "<repo root or terragrunt.hcl path>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/plugins/dotbabel/templates/claude/skills/validate-spec/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/validate-spec/SKILL.md
@@ -19,6 +19,7 @@ description: >
 argument-hint: "[spec-id] [--no-run]"
 effort: max
 model: sonnet
+allowed-tools: Read Grep Glob Bash
 ---
 
 # Validate Spec — Implementation Audit

--- a/plugins/dotbabel/templates/claude/skills/veracity-audit/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/veracity-audit/SKILL.md
@@ -20,6 +20,7 @@ argument-hint: "audit | score-check | gate-check | source-trace <label> --config
 effort: max
 model: opus
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash Agent
 ---
 
 # Veracity Audit

--- a/skills/aws-specialist/SKILL.md
+++ b/skills/aws-specialist/SKILL.md
@@ -18,6 +18,7 @@ description: >
   "Lambda deep-dive".
 argument-hint: "<account context, service, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/skills/azure-specialist/SKILL.md
+++ b/skills/azure-specialist/SKILL.md
@@ -18,6 +18,7 @@ description: >
   "Azure troubleshooting", "AKS deep-dive".
 argument-hint: "<subscription context, service, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/skills/create-assessment/SKILL.md
+++ b/skills/create-assessment/SKILL.md
@@ -15,6 +15,7 @@ description: >
   Triggers on: "grade", "rate", "score", "evaluate", "assess".
 argument-hint: "[target]"
 tools: Read, Grep, Glob, Bash, Write
+allowed-tools: Read Grep Glob Bash Write
 model: opus
 ---
 

--- a/skills/create-audit/SKILL.md
+++ b/skills/create-audit/SKILL.md
@@ -15,6 +15,7 @@ description: >
   Triggers on: "audit", "review", "assessment".
 argument-hint: "[subject]"
 tools: Read, Grep, Glob, Bash, Write
+allowed-tools: Read Grep Glob Bash Write
 model: opus
 ---
 

--- a/skills/create-experiment/SKILL.md
+++ b/skills/create-experiment/SKILL.md
@@ -15,6 +15,7 @@ description: >
   Triggers on: "let's try", "compare A vs B", "prototype", "explore".
 argument-hint: "[topic or hypothesis]"
 tools: Read, Grep, Glob, Bash, Write
+allowed-tools: Read Grep Glob Bash Write
 model: sonnet
 ---
 

--- a/skills/create-inspection/SKILL.md
+++ b/skills/create-inspection/SKILL.md
@@ -15,6 +15,7 @@ description: >
   Triggers on: "how should I fix", "what are my options", "investigate before I touch".
 argument-hint: "[problem]"
 tools: Read, Grep, Glob, Bash, Write
+allowed-tools: Read Grep Glob Bash Write
 model: opus
 ---
 

--- a/skills/crossplane-specialist/SKILL.md
+++ b/skills/crossplane-specialist/SKILL.md
@@ -19,6 +19,7 @@ description: >
   review", "Crossplane GitOps".
 argument-hint: "<XRD name, Claim name, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/skills/deploy-status/SKILL.md
+++ b/skills/deploy-status/SKILL.md
@@ -17,6 +17,7 @@ description: >
   "production drift", "is prod on main", "compare prod to main".
 argument-hint: "[--dry-run] [--no-fetch]"
 tools: Bash, Read, Grep, Glob
+allowed-tools: Read Grep Glob Bash
 model: sonnet
 effort: medium
 disable-model-invocation: false

--- a/skills/gcp-specialist/SKILL.md
+++ b/skills/gcp-specialist/SKILL.md
@@ -18,6 +18,7 @@ description: >
   "GCP troubleshooting", "Cloud Run deep-dive".
 argument-hint: "<project context, service, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/skills/ground-first/SKILL.md
+++ b/skills/ground-first/SKILL.md
@@ -15,6 +15,7 @@ description: >
   Triggers on: "analyze", "understand behavior", "how does this work".
 argument-hint: "[subject]"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 model: opus
 ---
 

--- a/skills/kubernetes-specialist/SKILL.md
+++ b/skills/kubernetes-specialist/SKILL.md
@@ -18,6 +18,7 @@ description: >
   "cluster health", "kubernetes design review", "k8s audit".
 argument-hint: "<cluster context, namespace, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/skills/plan-grader/SKILL.md
+++ b/skills/plan-grader/SKILL.md
@@ -15,6 +15,7 @@ description: >
   quoted inline plans, or best-effort latest-plan discovery for Claude, Codex, Copilot, and Gemini.
 argument-hint: '[--json] [--blind] <plan-path | file:<path> | text:"plan" | "plan" | latest <agent> plan>'
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 model: opus
 ---
 

--- a/skills/pulumi-specialist/SKILL.md
+++ b/skills/pulumi-specialist/SKILL.md
@@ -18,6 +18,7 @@ description: >
   "ComponentResource design", "ESC audit", "Pulumi secrets", "Pulumi testing".
 argument-hint: "<stack name, project path, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -15,6 +15,7 @@ description: >
   Triggers on: "security review", "check for secrets", "vulnerability scan".
 argument-hint: "[PR# | path | staged]"
 tools: Bash, Read, Grep
+allowed-tools: Read Grep Bash
 model: opus
 ---
 

--- a/skills/terraform-specialist/SKILL.md
+++ b/skills/terraform-specialist/SKILL.md
@@ -18,6 +18,7 @@ description: >
   "workspace design", "provider config review", "Terraform testing".
 argument-hint: "<module path, workspace, or problem description>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/skills/terragrunt-specialist/SKILL.md
+++ b/skills/terragrunt-specialist/SKILL.md
@@ -18,6 +18,7 @@ description: >
   review", "env hierarchy audit", "mock_outputs", "terragrunt hooks".
 argument-hint: "<repo root or terragrunt.hcl path>"
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash
 effort: max
 model: opus
 ---

--- a/skills/validate-spec/SKILL.md
+++ b/skills/validate-spec/SKILL.md
@@ -22,6 +22,7 @@ description: >
 argument-hint: "[spec-id] [--no-run]"
 effort: max
 model: sonnet
+allowed-tools: Read Grep Glob Bash
 ---
 
 # Validate Spec — Implementation Audit

--- a/skills/veracity-audit/SKILL.md
+++ b/skills/veracity-audit/SKILL.md
@@ -23,6 +23,7 @@ argument-hint: "audit | score-check | gate-check | source-trace <label> --config
 effort: max
 model: opus
 tools: Read, Grep, Glob, Bash
+allowed-tools: Read Grep Glob Bash Agent
 ---
 
 # Veracity Audit


### PR DESCRIPTION
## Summary

- Wire Claude Code's runtime tool-restriction field **`allowed-tools`** into 18 read-only / write-scoped skills (analysis & review specialists, `validate-spec`, `deploy-status`, `plan-grader`, `security-review`, the 4 `create-*` doc writers, `veracity-audit`). These skills already carried `tools:` as taxonomy metadata, but only `allowed-tools` is enforced at runtime — so they were previously unrestricted.
- Add the **`skills:`** inheritance field to 12 custom agents so they load their paired specialist/review skill at subagent start (e.g. `aws-engineer → aws-specialist`, `security-auditor → security-review`). Custom subagents do not inherit skills automatically.
- Regenerate the derived artifacts: `plugins/dotbabel/templates/**`, `.claude/skills-manifest.json`, and `index/`.

Closes the `allowed-tools` and agent-skills-inheritance gaps from the Agent-Skills-course compliance audit.

## Test plan

- [x] `node scripts/build-plugin.mjs --check` — templates fresh
- [x] `node plugins/dotbabel/bin/dotbabel-validate-skills.mjs` — exit 0 (pre-existing non-fatal `iac-engineer`/pulumi trigger warning, unrelated)
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` — index fresh
- [x] `node plugins/dotbabel/bin/dotbabel-doctor.mjs` — ok
- [x] `npm run lint` — prettier + markdownlint + jsdoc clean
- [x] `npm test` — 797 passing (the lone `build-index.test.mjs` 5s-timeout is an environmental WSL2-disk flake; passes at `--testTimeout=30000`, and the test + its code-under-test are byte-identical to `main`)

## Spec ID

dotbabel-core
