### PR TITLE
ci(test): gate test workflow off local-attest attestation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,41 @@ permissions:
   contents: read
 
 jobs:
+  # Local-attest gate: a SHA-pinned PR comment from a trusted user (OWNER) lets
+  # a maintainer skip the redundant remote test run after verifying locally.
+  # See skills/local-attest/references/operator-guide.md. Fail-closed: if the
+  # gh api call errors, grep exits non-zero -> attested=false -> tests run.
+  classify:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+    outputs:
+      attested: ${{ steps.attest.outputs.attested }}
+    steps:
+      - name: Check for local attestation
+        id: attest
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          MARKER="<!-- local-attest verified-sha=${HEAD_SHA} -->"
+          if gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+               --jq '.[] | select(.author_association == "OWNER") | .body | split("\n")[0]' \
+             | grep -qFx "$MARKER"; then
+            echo "Local attestation found for ${HEAD_SHA} — remote test job will skip."
+            echo "attested=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No local attestation for ${HEAD_SHA} — remote test job will run."
+            echo "attested=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: classify
+    if: needs.classify.outputs.attested != 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.local-attest.config.mjs
+++ b/.local-attest.config.mjs
@@ -1,7 +1,14 @@
 export default {
+  // The `test` workflow (.github/workflows/test.yml) is gated off a local
+  // attestation, so these legs must reproduce its `test` job exactly:
+  // vitest+coverage, the validate-settings suite, and bats. lint/dogfood/
+  // build-plugin are run too for full local pre-push confidence (their
+  // workflows are not gated).
   matrix: [
     { name: "lint", mode: "hard", command: "npm run lint" },
-    { name: "test", mode: "hard", command: "npm test" },
+    { name: "test", mode: "hard", command: "npm test -- --coverage" },
+    { name: "validate-settings", mode: "hard", command: "bash plugins/dotbabel/tests/test_validate_settings.sh" },
+    { name: "bats", mode: "hard", command: "npx bats plugins/dotbabel/tests/bats/" },
     { name: "dogfood", mode: "hard", command: "npm run dogfood" },
     { name: "build-plugin --check", mode: "hard", command: "npm run build-plugin -- --check" },
   ],


### PR DESCRIPTION
## Summary

- Add a `classify` job to `.github/workflows/test.yml` that reads PR comments for a SHA-pinned `<!-- local-attest verified-sha=<HEAD_SHA> -->` marker authored by a trusted user (OWNER) and gates the `test` job off it (`needs: classify` + `if: needs.classify.outputs.attested != 'true'`). Fail-closed: any `gh api` error makes the grep exit non-zero → `attested=false` → tests run.
- Align `.local-attest.config.mjs` so its legs reproduce the gated `test` job exactly (vitest+coverage, validate-settings suite, bats), keeping the attestation honest. lint/dogfood/build-plugin legs remain for full local pre-push verification.

This makes `/local-attest` functional: after a maintainer runs the matrix locally and posts the attestation, the redundant remote `test` run skips for that exact commit. A new push changes the head SHA and CI runs again automatically.

The "Protect main" ruleset enforces no required status checks, so a skipped `test` job cannot leave a required check pending / block merges.

## Test plan

- [x] `npx prettier@3 --check .github/workflows/test.yml` — clean
- [x] `.local-attest.config.mjs` parses; 6 legs resolved
- [x] Gate wiring verified: `classify` exposes `outputs.attested`; `test` has `needs: classify` + `if: needs.classify.outputs.attested != 'true'`
- [x] `npm run lint` — prettier + markdownlint + jsdoc clean
- [x] `npm run dogfood` — all validators pass (pre-existing non-fatal `iac-engineer`/pulumi trigger warning, unrelated)
- [x] `node scripts/build-plugin.mjs --check` — fresh
- [x] All 6 config legs verified green locally (lint, vitest+coverage, validate-settings 12/12, bats 375 ok, dogfood, build-plugin --check)

## Spec ID

dotbabel-core
