### PR TITLE
feat(spec): harden scaffolds against unverifiable specs

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,279 +1,283 @@
 {
   "version": 1,
-  "generatedAt": "2026-06-14T14:28:47.412Z",
+  "generatedAt": "2026-08-06T20:54:53.642Z",
   "skills": [
     {
       "name": "audit-and-fix",
       "path": ".claude/skills/audit-and-fix/SKILL.md",
       "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "code-simplifier",
       "path": ".claude/skills/code-simplifier/SKILL.md",
       "checksum": "sha256:e24c64485f950d93815f492de5673aaa3ff65abb0df91fb41e41a40b68017cff",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "create-assessment",
       "path": ".claude/skills/create-assessment/SKILL.md",
       "checksum": "sha256:7d364824b0ce34d5703a3db91956b4607182b52be79bc5fdec9583c73ef6f73c",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "create-audit",
       "path": ".claude/skills/create-audit/SKILL.md",
       "checksum": "sha256:c65ff762a76e721fd0169cee087c582198c628a7a79b518792b168b2b6001cd4",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/skills/detect-flaky/SKILL.md",
       "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "deploy-status",
       "path": ".claude/skills/deploy-status/SKILL.md",
       "checksum": "sha256:9119370d74077eae376afa72b28fff9cfd7617fd11b310590ddd6eb6c3d9258f",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/skills/fix-with-evidence/SKILL.md",
       "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "flyctl",
       "path": ".claude/skills/flyctl/SKILL.md",
       "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "git",
       "path": ".claude/skills/git/SKILL.md",
       "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "ground-first",
       "path": ".claude/skills/ground-first/SKILL.md",
       "checksum": "sha256:0a8a9c125bc3fd0a3fe5cacb4f8cf6ff5971895ea1b703037a8712d3b5e15dd6",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "create-inspection",
       "path": ".claude/skills/create-inspection/SKILL.md",
       "checksum": "sha256:d8febaf15dd98a5d72fe97f8f41fd7d0a83ed98f0a11ab7ecedeedeaec544e85",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "review-pr",
       "path": ".claude/skills/review-pr/SKILL.md",
       "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "security-review",
       "path": ".claude/skills/security-review/SKILL.md",
       "checksum": "sha256:c8447582929b315402af24e304acd4addaa9be7120e895ca25d4c897ba84cfda",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
-      "checksum": "sha256:8ba4947eeb77c8fb14ffcc83568c94aaa233c92c0ebb696ac219aa85a81d55a9",
+      "checksum": "sha256:95689539632a4f993e466431be5fb5400db72e958e7c2254fc2fceb1a6f1e189",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:13320e86060cb9a74d9ee98aecbbb9eff43c6100b47f09debe15f7049f6c050c",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:e3f0404dbd80ebdfce9df79df0a9bf501574abafcb7cd5a656c2afd4519428fb",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:ba954a78351a0988ccd7ab00574bde2f6aa0d4dab0b5a32fb755f14957411358",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:7c1625de68e13e15ab0beb179e4cf6f9a3d2a80ec294a04cbb46e430cb0ab425",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:39763f741bbff9bd6f9b72908ed3ea8de1870e2d5017b3ddab9015e0db4ff108",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:9e9c0d8b36ef44fb7f4f604aa706c2f380787c38c0282987c24436ec7bd53b85",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:fc7f266342f1686a5ca394398f048742b5f249144f45354d5f8c2520e359a2bb",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:ef78a49da882582f409c0c166d74112c6d37af437592e05bf6cd218bb8c34476",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:6620a3862749142cf450245e9c6fc6c398530208848f64e2c34132e138f6f5ef",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2f66c14a71e88734d8a734bf1ce6f220f74ce28a9e302635e4e225edc1f9300e",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
       "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "review-prs",
       "path": ".claude/skills/review-prs/SKILL.md",
       "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "rollback-prod",
       "path": ".claude/skills/rollback-prod/SKILL.md",
       "checksum": "sha256:32a58bb0feb413e7f44148347d62283332ba259273a6c8f6d4a514876cc484dd",
-      "dependencies": ["deploy-status"],
-      "lastValidated": "2026-06-14"
+      "dependencies": [
+        "deploy-status"
+      ],
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "plan-grader",
       "path": ".claude/skills/plan-grader/SKILL.md",
       "checksum": "sha256:50ba919efa0b4235e182a7d5b1ff2308481086a3ddddbf9166b0560370c3af27",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
       "checksum": "sha256:a4fab149f1ea05770de853331d321fc2e8d4a745fcb52dcc1da1f76edbe4a995",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:f920c63e4d70bd7490cc52ba07b9e4e01577631ef06025031d7d8404a39543e2",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "create-experiment",
       "path": ".claude/skills/create-experiment/SKILL.md",
       "checksum": "sha256:424f23db1e1ba2cfc32c215bc4ae8f8dd8f710274161884252ac1fcfb28dcd3c",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "post-pr-review",
       "path": ".claude/skills/post-pr-review/SKILL.md",
       "checksum": "sha256:0565fc80dba6872c5da9569cff5e53d112fc3ea3a16b4905fdf38255754ec628",
-      "dependencies": ["review-pr"],
-      "lastValidated": "2026-06-14"
+      "dependencies": [
+        "review-pr"
+      ],
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "project-sync",
       "path": ".claude/skills/project-sync/SKILL.md",
       "checksum": "sha256:822e1509cf0ed4d0260c8bada35cd0e815a9b6529d637eb9baf3a430f8803104",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     },
     {
       "name": "reproduce-bug",
       "path": ".claude/skills/reproduce-bug/SKILL.md",
       "checksum": "sha256:e73ae70e76b0c4a0ba43dc42d01596b2df1e97ffa7813a9fab45012711408b51",
       "dependencies": [],
-      "lastValidated": "2026-06-14"
+      "lastValidated": "2026-08-06"
     }
   ]
 }

--- a/plugins/dotbabel/templates/claude/skills/spec/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/spec/SKILL.md
@@ -115,10 +115,14 @@ When the user pastes back results, integrate findings into the appropriate secti
 
 When all sections are filled (or the user says "done" / "finalize"):
 
-1. Do a consistency pass — check cross-references are valid, constraint IDs are used, no orphaned references.
-2. Update README with final status: all sections marked `[x] done` or `[ ] skipped`.
-3. Add a "Quick Start" section to README pointing to the most important sections.
-4. Tell the user the spec is complete and where to find it.
+1. Do a **structural** consistency pass — cross-references valid, constraint IDs used, no orphaned references.
+2. Do a **content** consistency pass — three checks, each reported to the user:
+   - Every quality claim in §1/§2 has a matching constraint in §7.
+   - Every measurement in `research/` (DOC-N) became a §7 constraint, or was dropped with a stated reason.
+   - §6.4 covers every output §5 ships.
+3. Update README with final status: all sections marked `[x] done` or `[ ] skipped`.
+4. Add a "Quick Start" section to README pointing to the most important sections.
+5. Tell the user the spec is complete and where to find it.
 
 ---
 
@@ -132,6 +136,12 @@ Use these templates when creating each section file in Phase 1.
 # §1 — Problem / Motivation
 
 > Why does this exist? What's broken? Why now?
+
+## The Question
+
+<!-- The single question a user asks that this feature answers.
+     One sentence, in the user's words, not the system's.
+     If you cannot write it, the spec is not ready for §2. -->
 
 ## Why
 
@@ -282,11 +292,26 @@ Each prompt should include:
 
 ## 6.4 Testing Strategy
 
-<!-- Per-unit matrix -->
+<!--
+For each kind below: name where it applies, or write "N/A — <reason>".
+An unexplained blank is not an answer.
 
-| Unit | UNIT | INTEGRATION | POST-DEPLOY |
-| ---- | ---- | ----------- | ----------- |
-|      |      |             |             |
+  · unit            — per-function behavior
+  · contract        — payload/API invariants that must never silently break
+  · property        — invariants across the input space, not per-case
+  · golden/fixture  — locks behavior against a validated reference
+  · integration     — real dependencies; replay against historical data
+  · mutation        — proves the suite constrains the code; use wherever the
+                      code and its tests share an author, human or agent
+  · statistical     — REQUIRED when the output is probabilistic, ranked, or
+                      scored: name the metric, the baseline, and the sample size
+  · load/torture    — behavior at full scale
+  · post-deploy     — what reality reports back after shipping
+-->
+
+| Unit | Kinds applied | N/A + reason |
+| ---- | ------------- | ------------ |
+|      |               |              |
 
 ## 6.5 Migration Sequence
 
@@ -307,6 +332,10 @@ Each prompt should include:
 # §7 — Non-Functional Requirements
 
 > Performance, reliability, operational, security constraints.
+
+<!-- Every constraint names a metric, a threshold, and what happens on breach.
+     "Fast", "reliable", "a drift alarm" are not constraints — they are adjectives.
+     A measurement recorded in research/ is not a constraint until it lands here. -->
 
 ## Performance
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -9,7 +9,7 @@ task: [documentation]
 maturity: validated
 owner: "@kaiohenricunha"
 created: 2025-01-01
-updated: 2026-04-17
+updated: 2026-08-06
 description: >
   Create structured engineering specs through interactive pairing.
   Use when the user wants to create a spec, design doc, technical specification,
@@ -118,10 +118,14 @@ When the user pastes back results, integrate findings into the appropriate secti
 
 When all sections are filled (or the user says "done" / "finalize"):
 
-1. Do a consistency pass — check cross-references are valid, constraint IDs are used, no orphaned references.
-2. Update README with final status: all sections marked `[x] done` or `[ ] skipped`.
-3. Add a "Quick Start" section to README pointing to the most important sections.
-4. Tell the user the spec is complete and where to find it.
+1. Do a **structural** consistency pass — cross-references valid, constraint IDs used, no orphaned references.
+2. Do a **content** consistency pass — three checks, each reported to the user:
+   - Every quality claim in §1/§2 has a matching constraint in §7.
+   - Every measurement in `research/` (DOC-N) became a §7 constraint, or was dropped with a stated reason.
+   - §6.4 covers every output §5 ships.
+3. Update README with final status: all sections marked `[x] done` or `[ ] skipped`.
+4. Add a "Quick Start" section to README pointing to the most important sections.
+5. Tell the user the spec is complete and where to find it.
 
 ---
 
@@ -135,6 +139,12 @@ Use these templates when creating each section file in Phase 1.
 # §1 — Problem / Motivation
 
 > Why does this exist? What's broken? Why now?
+
+## The Question
+
+<!-- The single question a user asks that this feature answers.
+     One sentence, in the user's words, not the system's.
+     If you cannot write it, the spec is not ready for §2. -->
 
 ## Why
 
@@ -285,11 +295,26 @@ Each prompt should include:
 
 ## 6.4 Testing Strategy
 
-<!-- Per-unit matrix -->
+<!--
+For each kind below: name where it applies, or write "N/A — <reason>".
+An unexplained blank is not an answer.
 
-| Unit | UNIT | INTEGRATION | POST-DEPLOY |
-| ---- | ---- | ----------- | ----------- |
-|      |      |             |             |
+  · unit            — per-function behavior
+  · contract        — payload/API invariants that must never silently break
+  · property        — invariants across the input space, not per-case
+  · golden/fixture  — locks behavior against a validated reference
+  · integration     — real dependencies; replay against historical data
+  · mutation        — proves the suite constrains the code; use wherever the
+                      code and its tests share an author, human or agent
+  · statistical     — REQUIRED when the output is probabilistic, ranked, or
+                      scored: name the metric, the baseline, and the sample size
+  · load/torture    — behavior at full scale
+  · post-deploy     — what reality reports back after shipping
+-->
+
+| Unit | Kinds applied | N/A + reason |
+| ---- | ------------- | ------------ |
+|      |               |              |
 
 ## 6.5 Migration Sequence
 
@@ -310,6 +335,10 @@ Each prompt should include:
 # §7 — Non-Functional Requirements
 
 > Performance, reliability, operational, security constraints.
+
+<!-- Every constraint names a metric, a threshold, and what happens on breach.
+     "Fast", "reliable", "a drift alarm" are not constraints — they are adjectives.
+     A measurement recorded in research/ is not a constraint until it lands here. -->
 
 ## Performance
 


### PR DESCRIPTION
## Summary

- Replace §6.4's `UNIT | INTEGRATION | POST-DEPLOY` matrix with a kinds menu (contract, property, golden, mutation, statistical, load) that requires either a placement or an explicit `N/A — <reason>`
- Add §1 "The Question", require §7 constraints to name a metric/threshold/breach action, and split the Phase 3 consistency pass into structural and content checks
- Mirror to the shipped template and refresh `.claude/skills-manifest.json`

## Motivation

Found while reviewing a spec this skill produced. Four gaps in that spec — no property tests, no mutation testing, an NFR reading "calibration drift alarm" with no metric or threshold, and a measurement recorded in `research/` that never became a constraint — traced to one cause: §6.4's column headers left no slot where those answers could go. The spec didn't omit them by oversight; the scaffold had no cell for them.

The contrast inside the skill makes the lesson concrete. §6.3 asks four pointed questions (read-first files, command, TDD test names, exact paths) and produced the strongest part of that spec. §6.4 offered an empty grid and produced the weakest. Scaffolds that force specificity work; empty cells produce empty thinking.

## Design notes

- **No mandates.** The menu forces a decision per kind, not a practice — `N/A — <reason>` is a complete answer.
- **§6.3 deliberately untouched.** It is the part that already works.
- **No new sections.** Every gap lived inside an existing one.
- Considered and rejected: a validator for `<read-first>` file:line citations. Line numbers drift constantly; it would be noise.

## Test plan

- [x] `node plugins/dotbabel/bin/dotbabel-validate-skills.mjs` → `✓ manifest valid (39 skills)`, `✓ agents valid (no errors)`
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` → `✓ index fresh (63 artifacts)`
- [x] `diff skills/spec/SKILL.md plugins/dotbabel/templates/claude/skills/spec/SKILL.md` → exactly the 3 expected frontmatter lines (`owner`, `created`, `updated`)
- [x] Manifest diff contains exactly 2 substantive checksum lines; the remainder is `lastValidated`/`generatedAt` restamping across all 39 skills

Pre-existing and unrelated, left alone: `agents/iac-engineer.md` claims trigger `pulumi`, also claimed by `pulumi-engineer`, without a `## Collaboration` cross-reference.

## Spec ID

dotbabel-core

🤖 Generated with [Claude Code](https://claude.com/claude-code)
