### PR TITLE
ci(lint): pin prettier and stop style-checking generated manifest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@
 - [ ] `bash plugins/dotbabel/tests/test_validate_settings.sh` — 12/12
 - [ ] `node scripts/check-jsdoc-coverage.mjs plugins/dotbabel/src` — ok
 - [ ] Root dogfood: `npm run dogfood` — all validators exit 0
+
 <!-- Add manual verification steps if relevant -->
 
 <!--

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,4 +50,6 @@ jobs:
         with: { node-version: "22" }
       # Check only JSON/YAML/MD — the .mjs source is deliberately lightly formatted
       # (see .prettierrc.json); running on .mjs today would churn a lot.
-      - run: npx --yes prettier@3 --check "**/*.{json,yml,yaml,md}" --ignore-path .gitignore --ignore-path .prettierignore --ignore-unknown
+      # Pin the exact version: `prettier@3` floats, so a new 3.x minor silently
+      # reformats the rules under an untouched repo and reddens main with no commit.
+      - run: npx --yes prettier@3.9.6 --check "**/*.{json,yml,yaml,md}" --ignore-path .gitignore --ignore-path .prettierignore --ignore-unknown

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 CHANGELOG.md
+.claude/skills-manifest.json

--- a/plugins/dotbabel/templates/claude/skills/azure-specialist/references/devops.md
+++ b/plugins/dotbabel/templates/claude/skills/azure-specialist/references/devops.md
@@ -48,7 +48,7 @@ stages:
 version: v1.1.0
 steps:
   - build: -t $Registry/my-app:{{.Run.ID}} .
-  - push: [$Registry/my-app:{{.Run.ID}}]
+  - push: [$Registry/my-app: { { .Run.ID } }]
 triggers:
   base:
     - image: mcr.microsoft.com/dotnet/aspnet:8.0

--- a/skills/azure-specialist/references/devops.md
+++ b/skills/azure-specialist/references/devops.md
@@ -48,7 +48,7 @@ stages:
 version: v1.1.0
 steps:
   - build: -t $Registry/my-app:{{.Run.ID}} .
-  - push: [$Registry/my-app:{{.Run.ID}}]
+  - push: [$Registry/my-app: { { .Run.ID } }]
 triggers:
   base:
     - image: mcr.microsoft.com/dotnet/aspnet:8.0


### PR DESCRIPTION
## Summary

- Pin `prettier@3` → `prettier@3.9.6` in `lint.yml` — the floating range let CI change its own formatting rules with no commit
- Add `.claude/skills-manifest.json` to `.prettierignore` — it is generated output, and its generator and prettier disagree permanently
- Reformat the three files that drifted, using the now-pinned version

Restores `main` to green. It went red on `c1f6853` (#265), the first push since 2026-06-14.

## Root causes — two, neither a code defect

**1. Floating prettier.** `lint.yml:53` ran `npx --yes prettier@3`. CI resolved **3.9.6**; the last green run (2026-06-14) used an earlier 3.x. Three files nobody touched — `.github/PULL_REQUEST_TEMPLATE.md` and both copies of `azure-specialist/references/devops.md` — began failing with zero commits between green and red. A check whose rules change underneath the repo cannot tell you whether the repo changed.

This was also why local verification passed before merge: the dev machine had 3.8.2 cached and reported all four files clean.

**2. Generator vs. linter.** `.claude/skills-manifest.json` is written by `dotbabel-validate-skills.mjs --update` via `JSON.stringify(_, null, 2)`, which expands single-element arrays across three lines:

```json
"dependencies": [
  "deploy-status"
],
```

prettier collapses those to `["deploy-status"]`. The two will never agree — hand-formatting is reverted by the next `--update`, so **every** run of `--update` reddens lint. Ignoring it matches how the repo already treats `CHANGELOG.md`, which is generated by release-please for the same reason.

## Why lint didn't catch this on #265

`lint.yml:6` does trigger on `pull_request`. That job was never acquired — the same hosted-runner starvation that failed both CodeQL jobs at 15m3s on #265. The PR showed only GitGuardian as a completed check.

## Test plan

- [x] `npx --yes prettier@3.9.6 --check "**/*.{json,yml,yaml,md}" --ignore-path .gitignore --ignore-path .prettierignore --ignore-unknown` → `All matched files use Prettier code style!`
- [x] Reproduced the CI failure locally with 3.9.6 before fixing (all 4 files flagged, matching the CI log exactly)
- [x] `node plugins/dotbabel/bin/dotbabel-validate-skills.mjs` → `✓ manifest valid (39 skills)`, `✓ agents valid (no errors)`
- [x] `node plugins/dotbabel/bin/dotbabel-index.mjs --check` → `✓ index fresh (63 artifacts)`

## Follow-up, deliberately not in this PR

Pinning stops the silent drift but freezes the version. Dependabot already covers this repo — if it does not watch GitHub Actions `npx` invocations, a periodic manual bump is the tradeoff, and it is the right one: a version bump should arrive as a reviewable diff, not as a surprise red build.

## Spec ID

dotbabel-core

🤖 Generated with [Claude Code](https://claude.com/claude-code)
