### PR TITLE
ci(lint): resolve prettier from the lockfile instead of an npx literal

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,9 +47,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with: { node-version: "22" }
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
       # Check only JSON/YAML/MD — the .mjs source is deliberately lightly formatted
       # (see .prettierrc.json); running on .mjs today would churn a lot.
-      # Pin the exact version: `prettier@3` floats, so a new 3.x minor silently
-      # reformats the rules under an untouched repo and reddens main with no commit.
-      - run: npx --yes prettier@3.9.6 --check "**/*.{json,yml,yaml,md}" --ignore-path .gitignore --ignore-path .prettierignore --ignore-unknown
+      # Resolve prettier from the lockfile, never `npx prettier@<version>`: package.json
+      # is the single source of truth and Dependabot already tracks it there. A floating
+      # range reformats the rules under an untouched repo; a version literal in a `run:`
+      # step is tracked by nothing and rots silently. Both reddened main on 2026-08-07.
+      - run: npx prettier --check "**/*.{json,yml,yaml,md}" --ignore-path .gitignore --ignore-path .prettierignore --ignore-unknown


### PR DESCRIPTION
## Summary

- Resolve prettier from the lockfile (`npm ci` + `npx prettier`) instead of the `prettier@3.9.6` literal introduced in #267
- Add `cache: "npm"` to setup-node, matching `test.yml:58-61`

## Why #267 was the wrong mechanism

#267 correctly diagnosed that `npx --yes prettier@3` floats, and pinned it to `3.9.6`. That stops the drift but is **tracked by nothing**: Dependabot's `github-actions` ecosystem updates `uses:` refs, not version literals inside `run:` steps. The pin would rot in place.

Meanwhile prettier is already a declared dependency that Dependabot **does** track:

| Where | Version |
|---|---|
| `package.json` `dependencies.prettier` | `^3.5.0` |
| `package-lock.json` | `3.8.3` |
| `lint.yml` after #267 | `3.9.6` (hardcoded) |

Three versions, and the one CI used was governed by none of them. #254 is an open Dependabot bump to 3.9.5 that had no effect on CI whatsoever.

Sourcing from the lockfile makes `package.json` the single source of truth, and bumps arrive as reviewable PRs — which is what should have governed it from the start.

## This unblocks the Dependabot backlog

Every one of the 11 open Dependabot PRs that has a failing check is failing on **`prettier`, and only prettier** — verified on #254, #263, #259, #256, #261. The oldest is #254 from **2026-07-13**.

So the drift had been failing every PR in this repo for roughly three and a half weeks. It went unnoticed because the only PRs opened in that window were Dependabot's, and nobody was watching them. Main only went red on 2026-08-07 because that was the first push to main since June 14 — the merge exposed a pre-existing condition rather than introducing one.

The backlog is not 11 independent problems. It is one problem, 11 times.

## Test plan

- [x] `npm ci` → resolves prettier 3.8.3 from lockfile
- [x] `npx prettier --check "**/*.{json,yml,yaml,md}" --ignore-path .gitignore --ignore-path .prettierignore --ignore-unknown` → `All matched files use Prettier code style!`
- [x] Compatibility across the version window: 3.8.3 (current lockfile), 3.9.5 (what #254 brings) and 3.9.6 (what #267 pinned) all accept current main formatting — so this is safe both before and after #254 lands
- [x] `lint.yml` YAML parses; `cache: "npm"` matches the `test.yml:58-61` house pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Spec ID

dotbabel-core
