### PR TITLE
fix(ci): re-fire body-gated checks on edit, document the Spec ID rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -204,6 +204,7 @@ plugin with its own `scripts/lib/output.sh` + `src/lib/argv.mjs` conventions
   - `## Summary` — 1–3 bullets describing the change.
   - `## Test plan` — bulleted markdown checklist.
   - `## Spec ID` heading followed by the spec id — if the project uses spec IDs (check for `specs/` or `docs/specs/`). Must be an H2 heading; `dotbabel-check-spec-coverage` extracts it via H2 regex.
+- **The `## Spec ID` section must contain nothing but the id(s).** The extractor captures everything from that heading to the next H2 heading _or the end of the body_, then splits it on whitespace and treats every token as a spec id. Anything trailing — a generated-by footer, a sign-off, a link — is parsed as unknown spec ids and fails the gate. Put `## Spec ID` last with nothing after it, or follow it with another H2. `## No-spec rationale` is exempt — its body is only checked for non-emptiness, never tokenized — so prose and trailing content are safe there.
 - Never merge a PR with failing CI without explicit user approval.
 
 ## Shell & Scripting

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -3,7 +3,13 @@ name: dogfood
 on:
   push:
     branches: [main]
+  # `edited` matters: check-spec-coverage reads PR_BODY from the event payload
+  # (github.event.pull_request.body). Without it, a body-only failure — a missing
+  # or malformed Spec ID — cannot be fixed by editing the body, because no new
+  # event fires and a rerun replays the stale payload. The only recoveries were
+  # an empty commit or close/reopen.
   pull_request:
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -15,8 +15,12 @@ name: release-gate
 #     #133.
 
 on:
+  # `edited` for the same reason as dogfood.yml: PR_BODY comes from the event
+  # payload, and the `[skip-prev-release-check]` marker is something a reviewer
+  # adds by editing the body — which must re-fire the gate to take effect.
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Follow conventional commits such as `feat(handoff): ...`, `fix(cli): ...`, `test
   - `## Summary` — 1–3 bullets describing the change.
   - `## Test plan` — bulleted markdown checklist.
   - `## Spec ID` heading followed by the spec id — if the project uses spec IDs (check for `specs/` or `docs/specs/`). Must be an H2 heading; `dotbabel-check-spec-coverage` extracts it via H2 regex.
+- **The `## Spec ID` section must contain nothing but the id(s).** The extractor captures everything from that heading to the next H2 heading _or the end of the body_, then splits it on whitespace and treats every token as a spec id. Anything trailing — a generated-by footer, a sign-off, a link — is parsed as unknown spec ids and fails the gate. Put `## Spec ID` last with nothing after it, or follow it with another H2. `## No-spec rationale` is exempt — its body is only checked for non-emptiness, never tokenized — so prose and trailing content are safe there.
 - Never merge a PR with failing CI without explicit user approval.
 
 ## Shell & Scripting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Universal behavior for every Claude Code session in every repo. Project-level `C
   - `## Summary` — 1–3 bullets describing the change.
   - `## Test plan` — bulleted markdown checklist.
   - `## Spec ID` heading followed by the spec id — if the project uses spec IDs (check for `specs/` or `docs/specs/`). Must be an H2 heading; `dotbabel-check-spec-coverage` extracts it via H2 regex.
+- **The `## Spec ID` section must contain nothing but the id(s).** The extractor captures everything from that heading to the next H2 heading _or the end of the body_, then splits it on whitespace and treats every token as a spec id. Anything trailing — a generated-by footer, a sign-off, a link — is parsed as unknown spec ids and fails the gate. Put `## Spec ID` last with nothing after it, or follow it with another H2. `## No-spec rationale` is exempt — its body is only checked for non-emptiness, never tokenized — so prose and trailing content are safe there.
 - Never merge a PR with failing CI without explicit user approval.
 
 ## Shell & Scripting

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -179,6 +179,7 @@ The project follows Spec-Driven Development.
   - `## Summary` — 1–3 bullets describing the change.
   - `## Test plan` — bulleted markdown checklist.
   - `## Spec ID` heading followed by the spec id — if the project uses spec IDs (check for `specs/` or `docs/specs/`). Must be an H2 heading; `dotbabel-check-spec-coverage` extracts it via H2 regex.
+- **The `## Spec ID` section must contain nothing but the id(s).** The extractor captures everything from that heading to the next H2 heading _or the end of the body_, then splits it on whitespace and treats every token as a spec id. Anything trailing — a generated-by footer, a sign-off, a link — is parsed as unknown spec ids and fails the gate. Put `## Spec ID` last with nothing after it, or follow it with another H2. `## No-spec rationale` is exempt — its body is only checked for non-emptiness, never tokenized — so prose and trailing content are safe there.
 - Never merge a PR with failing CI without explicit user approval.
 
 ## Shell & Scripting

--- a/plugins/dotbabel/templates/cli-instructions/codex-AGENTS.md
+++ b/plugins/dotbabel/templates/cli-instructions/codex-AGENTS.md
@@ -82,6 +82,7 @@ Universal behavior for every Codex CLI session in every repo. Project-level `CLA
   - `## Summary` — 1–3 bullets describing the change.
   - `## Test plan` — bulleted markdown checklist.
   - `## Spec ID` heading followed by the spec id — if the project uses spec IDs (check for `specs/` or `docs/specs/`). Must be an H2 heading; `dotbabel-check-spec-coverage` extracts it via H2 regex.
+- **The `## Spec ID` section must contain nothing but the id(s).** The extractor captures everything from that heading to the next H2 heading _or the end of the body_, then splits it on whitespace and treats every token as a spec id. Anything trailing — a generated-by footer, a sign-off, a link — is parsed as unknown spec ids and fails the gate. Put `## Spec ID` last with nothing after it, or follow it with another H2. `## No-spec rationale` is exempt — its body is only checked for non-emptiness, never tokenized — so prose and trailing content are safe there.
 - Never merge a PR with failing CI without explicit user approval.
 
 ## Shell & Scripting

--- a/plugins/dotbabel/templates/cli-instructions/copilot-instructions.md
+++ b/plugins/dotbabel/templates/cli-instructions/copilot-instructions.md
@@ -82,6 +82,7 @@ Universal behavior for every Copilot CLI session in every repo. Project-level `C
   - `## Summary` — 1–3 bullets describing the change.
   - `## Test plan` — bulleted markdown checklist.
   - `## Spec ID` heading followed by the spec id — if the project uses spec IDs (check for `specs/` or `docs/specs/`). Must be an H2 heading; `dotbabel-check-spec-coverage` extracts it via H2 regex.
+- **The `## Spec ID` section must contain nothing but the id(s).** The extractor captures everything from that heading to the next H2 heading _or the end of the body_, then splits it on whitespace and treats every token as a spec id. Anything trailing — a generated-by footer, a sign-off, a link — is parsed as unknown spec ids and fails the gate. Put `## Spec ID` last with nothing after it, or follow it with another H2. `## No-spec rationale` is exempt — its body is only checked for non-emptiness, never tokenized — so prose and trailing content are safe there.
 - Never merge a PR with failing CI without explicit user approval.
 
 ## Shell & Scripting

--- a/plugins/dotbabel/templates/cli-instructions/gemini-GEMINI.md
+++ b/plugins/dotbabel/templates/cli-instructions/gemini-GEMINI.md
@@ -82,6 +82,7 @@ Universal behavior for every Gemini CLI session in every repo. Project-level `CL
   - `## Summary` — 1–3 bullets describing the change.
   - `## Test plan` — bulleted markdown checklist.
   - `## Spec ID` heading followed by the spec id — if the project uses spec IDs (check for `specs/` or `docs/specs/`). Must be an H2 heading; `dotbabel-check-spec-coverage` extracts it via H2 regex.
+- **The `## Spec ID` section must contain nothing but the id(s).** The extractor captures everything from that heading to the next H2 heading _or the end of the body_, then splits it on whitespace and treats every token as a spec id. Anything trailing — a generated-by footer, a sign-off, a link — is parsed as unknown spec ids and fails the gate. Put `## Spec ID` last with nothing after it, or follow it with another H2. `## No-spec rationale` is exempt — its body is only checked for non-emptiness, never tokenized — so prose and trailing content are safe there.
 - Never merge a PR with failing CI without explicit user approval.
 
 ## Shell & Scripting


### PR DESCRIPTION
## Summary

- Add `edited` to the `pull_request` trigger on `dogfood.yml` and `release-gate.yml`, so body-gated checks can be fixed by editing the body
- Document in `CLAUDE.md` that the `## Spec ID` section must contain nothing but the id(s), and regenerate the instruction fan-out

## The trigger bug

Both workflows read the PR body from the event payload:

| File | Line |
|---|---|
| `dogfood.yml` | `:29` — `PR_BODY: ${{ github.event.pull_request.body }}` |
| `release-gate.yml` | `:115` — same |

Neither declared `types:`, so both defaulted to `[opened, synchronize, reopened]`. A body-only failure was therefore **unfixable by editing the body** — no new event fires, and a rerun replays the stale payload. The only recoveries were an empty commit or close/reopen. #270 needed the latter.

`release-gate` is the sharper case: at `:127` it greps the body for `[skip-prev-release-check]` — a marker a reviewer adds *by editing the body*, which until now could not take effect without a push.

The cost is one extra run per title/body edit. That is small next to a gate that cannot be satisfied.

## The documentation gap

`CLAUDE.md` said `## Spec ID` must be an H2. It did not say the section must contain **nothing else**:

- `spec-harness-lib.mjs:287` — `extractTemplateSection` captures from the heading to the next H2 **or end of body**
- `check-spec-coverage.mjs:78` — splits that capture on `/[\s,]+/` and treats every token as a spec id

So a trailing generated-by footer parses as five unknown spec ids and fails the gate. That is exactly what happened on #267 and #270 — and **#267 was merged over the failing check**, because I verified #265's check list (where runner starvation meant `self` never ran) and did not re-check #267's. No repair is needed in the tree, but the governance gate on a protected-path PR was bypassed, which is the thing it exists to prevent.

Also documented the `## No-spec rationale` exemption: that section is only tested by `isMeaningfulSection` (`:67`) and never tokenized, so prose and trailing content are safe there. I initially wrote the opposite in the rule floor and corrected it after reading the code.

## Test plan

- [x] `npx prettier --check "**/*.{json,yml,yaml,md}" ...` → `All matched files use Prettier code style!` (3.9.6, via lockfile)
- [x] `npx markdownlint-cli2 "**/*.md" "#node_modules"` → `Summary: 0 issues in 0 files` across 563 files
- [x] `dotbabel-check-instruction-drift` → `✓ instruction files match repo facts`
- [x] `dotbabel-check-instruction-parity` → `✓ generated instruction headings have parity`
- [x] `dotbabel-check-instructions-fresh` → `✓ generated instruction files are fresh`
- [x] `dotbabel-validate-skills` → `✓ manifest valid (39 skills)`, `✓ agents valid`
- [x] `dotbabel-index --check` → `✓ index fresh (63 artifacts)`
- [x] Fan-out regenerated via `dotbabel-generate-instructions`, not hand-edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Spec ID

dotbabel-core
