### PR TITLE
docs(rule-floor): enforce hard caps on response length and shape

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -235,9 +235,20 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 ## Communication
 
-- Match response length to the task. A simple question gets a direct answer, not headers and sections.
-- State results and decisions directly. Don't narrate internal deliberation.
-- Bias toward action. Write a brief plan (5 bullets max), then start implementing. Do not iterate on plans without producing code.
+**Hard caps. Not aspirational — enforced.**
+
+- Default response is ≤3 sentences. Prose, not bullets. No headers.
+- Never restate the question. Never preface with "Let me…", "I'll…", "Here's…", "Looking at…", "Based on…". Start with the answer.
+- Never summarize what you just did at end-of-turn. The diff and tool output already show it. One line max if a follow-up genuinely matters; otherwise zero lines.
+- No bullet lists unless the answer is genuinely ≥3 peer items. Two items = a sentence with "and".
+- No headers (`##`, `###`) in chat responses. Headers belong in files, not conversation.
+- Tool-use narration: one short sentence per _meaningful_ step (found the bug, changing direction, blocked). Silent for routine reads/greps.
+- No hedging filler: "essentially", "basically", "it's worth noting", "to be clear", "I should mention", "keep in mind", "as you can see".
+- No closing affirmations: "Let me know if…", "Happy to…", "Hope this helps", "Feel free to…". Just stop.
+- Code answers: show the code. Skip the prose explanation unless asked. If the user wants the reasoning they'll ask.
+- When in doubt: cut it. A terse answer the user re-asks for detail on beats a wall they have to skim.
+
+**Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
 ## Protected paths (dogfood)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,20 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 ## Communication
 
-- Match response length to the task. A simple question gets a direct answer, not headers and sections.
-- State results and decisions directly. Don't narrate internal deliberation.
-- Bias toward action. Write a brief plan (5 bullets max), then start implementing. Do not iterate on plans without producing code.
+**Hard caps. Not aspirational — enforced.**
+
+- Default response is ≤3 sentences. Prose, not bullets. No headers.
+- Never restate the question. Never preface with "Let me…", "I'll…", "Here's…", "Looking at…", "Based on…". Start with the answer.
+- Never summarize what you just did at end-of-turn. The diff and tool output already show it. One line max if a follow-up genuinely matters; otherwise zero lines.
+- No bullet lists unless the answer is genuinely ≥3 peer items. Two items = a sentence with "and".
+- No headers (`##`, `###`) in chat responses. Headers belong in files, not conversation.
+- Tool-use narration: one short sentence per _meaningful_ step (found the bug, changing direction, blocked). Silent for routine reads/greps.
+- No hedging filler: "essentially", "basically", "it's worth noting", "to be clear", "I should mention", "keep in mind", "as you can see".
+- No closing affirmations: "Let me know if…", "Happy to…", "Hope this helps", "Feel free to…". Just stop.
+- Code answers: show the code. Skip the prose explanation unless asked. If the user wants the reasoning they'll ask.
+- When in doubt: cut it. A terse answer the user re-asks for detail on beats a wall they have to skim.
+
+**Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
 ## Protected paths (dogfood)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,9 +144,20 @@ Scope `--allowedTools` tightly — prefer `Bash(gh:*)` over `Bash(*)`. Combine w
 
 ## Communication
 
-- Match response length to the task. A simple question gets a direct answer, not headers and sections.
-- State results and decisions directly. Don't narrate internal deliberation.
-- Bias toward action. Write a brief plan (5 bullets max), then start implementing. Do not iterate on plans without producing code.
+**Hard caps. Not aspirational — enforced.**
+
+- Default response is ≤3 sentences. Prose, not bullets. No headers.
+- Never restate the question. Never preface with "Let me…", "I'll…", "Here's…", "Looking at…", "Based on…". Start with the answer.
+- Never summarize what you just did at end-of-turn. The diff and tool output already show it. One line max if a follow-up genuinely matters; otherwise zero lines.
+- No bullet lists unless the answer is genuinely ≥3 peer items. Two items = a sentence with "and".
+- No headers (`##`, `###`) in chat responses. Headers belong in files, not conversation.
+- Tool-use narration: one short sentence per _meaningful_ step (found the bug, changing direction, blocked). Silent for routine reads/greps.
+- No hedging filler: "essentially", "basically", "it's worth noting", "to be clear", "I should mention", "keep in mind", "as you can see".
+- No closing affirmations: "Let me know if…", "Happy to…", "Hope this helps", "Feel free to…". Just stop.
+- Code answers: show the code. Skip the prose explanation unless asked. If the user wants the reasoning they'll ask.
+- When in doubt: cut it. A terse answer the user re-asks for detail on beats a wall they have to skim.
+
+**Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
 ## Protected paths (dogfood)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -210,9 +210,20 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 ## Communication
 
-- Match response length to the task. A simple question gets a direct answer, not headers and sections.
-- State results and decisions directly. Don't narrate internal deliberation.
-- Bias toward action. Write a brief plan (5 bullets max), then start implementing. Do not iterate on plans without producing code.
+**Hard caps. Not aspirational — enforced.**
+
+- Default response is ≤3 sentences. Prose, not bullets. No headers.
+- Never restate the question. Never preface with "Let me…", "I'll…", "Here's…", "Looking at…", "Based on…". Start with the answer.
+- Never summarize what you just did at end-of-turn. The diff and tool output already show it. One line max if a follow-up genuinely matters; otherwise zero lines.
+- No bullet lists unless the answer is genuinely ≥3 peer items. Two items = a sentence with "and".
+- No headers (`##`, `###`) in chat responses. Headers belong in files, not conversation.
+- Tool-use narration: one short sentence per _meaningful_ step (found the bug, changing direction, blocked). Silent for routine reads/greps.
+- No hedging filler: "essentially", "basically", "it's worth noting", "to be clear", "I should mention", "keep in mind", "as you can see".
+- No closing affirmations: "Let me know if…", "Happy to…", "Hope this helps", "Feel free to…". Just stop.
+- Code answers: show the code. Skip the prose explanation unless asked. If the user wants the reasoning they'll ask.
+- When in doubt: cut it. A terse answer the user re-asks for detail on beats a wall they have to skim.
+
+**Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
 ## Protected paths (dogfood)
 

--- a/plugins/dotbabel/templates/cli-instructions/codex-AGENTS.md
+++ b/plugins/dotbabel/templates/cli-instructions/codex-AGENTS.md
@@ -113,9 +113,20 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 ## Communication
 
-- Match response length to the task. A simple question gets a direct answer, not headers and sections.
-- State results and decisions directly. Don't narrate internal deliberation.
-- Bias toward action. Write a brief plan (5 bullets max), then start implementing. Do not iterate on plans without producing code.
+**Hard caps. Not aspirational — enforced.**
+
+- Default response is ≤3 sentences. Prose, not bullets. No headers.
+- Never restate the question. Never preface with "Let me…", "I'll…", "Here's…", "Looking at…", "Based on…". Start with the answer.
+- Never summarize what you just did at end-of-turn. The diff and tool output already show it. One line max if a follow-up genuinely matters; otherwise zero lines.
+- No bullet lists unless the answer is genuinely ≥3 peer items. Two items = a sentence with "and".
+- No headers (`##`, `###`) in chat responses. Headers belong in files, not conversation.
+- Tool-use narration: one short sentence per _meaningful_ step (found the bug, changing direction, blocked). Silent for routine reads/greps.
+- No hedging filler: "essentially", "basically", "it's worth noting", "to be clear", "I should mention", "keep in mind", "as you can see".
+- No closing affirmations: "Let me know if…", "Happy to…", "Hope this helps", "Feel free to…". Just stop.
+- Code answers: show the code. Skip the prose explanation unless asked. If the user wants the reasoning they'll ask.
+- When in doubt: cut it. A terse answer the user re-asks for detail on beats a wall they have to skim.
+
+**Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
 ## Protected paths (dogfood)
 

--- a/plugins/dotbabel/templates/cli-instructions/copilot-instructions.md
+++ b/plugins/dotbabel/templates/cli-instructions/copilot-instructions.md
@@ -113,9 +113,20 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 ## Communication
 
-- Match response length to the task. A simple question gets a direct answer, not headers and sections.
-- State results and decisions directly. Don't narrate internal deliberation.
-- Bias toward action. Write a brief plan (5 bullets max), then start implementing. Do not iterate on plans without producing code.
+**Hard caps. Not aspirational — enforced.**
+
+- Default response is ≤3 sentences. Prose, not bullets. No headers.
+- Never restate the question. Never preface with "Let me…", "I'll…", "Here's…", "Looking at…", "Based on…". Start with the answer.
+- Never summarize what you just did at end-of-turn. The diff and tool output already show it. One line max if a follow-up genuinely matters; otherwise zero lines.
+- No bullet lists unless the answer is genuinely ≥3 peer items. Two items = a sentence with "and".
+- No headers (`##`, `###`) in chat responses. Headers belong in files, not conversation.
+- Tool-use narration: one short sentence per _meaningful_ step (found the bug, changing direction, blocked). Silent for routine reads/greps.
+- No hedging filler: "essentially", "basically", "it's worth noting", "to be clear", "I should mention", "keep in mind", "as you can see".
+- No closing affirmations: "Let me know if…", "Happy to…", "Hope this helps", "Feel free to…". Just stop.
+- Code answers: show the code. Skip the prose explanation unless asked. If the user wants the reasoning they'll ask.
+- When in doubt: cut it. A terse answer the user re-asks for detail on beats a wall they have to skim.
+
+**Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
 ## Protected paths (dogfood)
 

--- a/plugins/dotbabel/templates/cli-instructions/gemini-GEMINI.md
+++ b/plugins/dotbabel/templates/cli-instructions/gemini-GEMINI.md
@@ -113,9 +113,20 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 ## Communication
 
-- Match response length to the task. A simple question gets a direct answer, not headers and sections.
-- State results and decisions directly. Don't narrate internal deliberation.
-- Bias toward action. Write a brief plan (5 bullets max), then start implementing. Do not iterate on plans without producing code.
+**Hard caps. Not aspirational — enforced.**
+
+- Default response is ≤3 sentences. Prose, not bullets. No headers.
+- Never restate the question. Never preface with "Let me…", "I'll…", "Here's…", "Looking at…", "Based on…". Start with the answer.
+- Never summarize what you just did at end-of-turn. The diff and tool output already show it. One line max if a follow-up genuinely matters; otherwise zero lines.
+- No bullet lists unless the answer is genuinely ≥3 peer items. Two items = a sentence with "and".
+- No headers (`##`, `###`) in chat responses. Headers belong in files, not conversation.
+- Tool-use narration: one short sentence per _meaningful_ step (found the bug, changing direction, blocked). Silent for routine reads/greps.
+- No hedging filler: "essentially", "basically", "it's worth noting", "to be clear", "I should mention", "keep in mind", "as you can see".
+- No closing affirmations: "Let me know if…", "Happy to…", "Hope this helps", "Feel free to…". Just stop.
+- Code answers: show the code. Skip the prose explanation unless asked. If the user wants the reasoning they'll ask.
+- When in doubt: cut it. A terse answer the user re-asks for detail on beats a wall they have to skim.
+
+**Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
 ## Protected paths (dogfood)
 


### PR DESCRIPTION
## Summary

- Replace the three soft Communication guidelines with enforceable hard caps: default ≤3 sentences, no chat headers, no bullet lists under 3 peer items, no end-of-turn summaries, no hedging filler, no closing affirmations, plus a length rubric per task type
- Regenerate the instruction fan-out so all four CLI rule-floor files carry it

## Why

The prior wording — _"match response length to the task"_, _"state results directly"_, _"bias toward action"_ — is advice, not a constraint. It expresses a preference without a threshold, which is exactly the failure this repo's own NFR rule names: an adjective where a number belongs. A rule with no measurable edge cannot be violated, so it is never enforced.

This draft was authored by @kaiohenricunha and had been sitting uncommitted in the main checkout. It is landed here on top of current `main` rather than committed from the dirty working tree, so it composes cleanly with the `## Spec ID` addition from #271.

## One change to the draft

`*meaningful*` → `_meaningful_`. MD049 and prettier both enforce underscore emphasis repo-wide; the original would have failed lint.

## Test plan

- [x] `npx prettier --check "**/*.{json,yml,yaml,md}" ...` → `All matched files use Prettier code style!`
- [x] `npx markdownlint-cli2 "**/*.md" "#node_modules"` → `Summary: 0 issues in 0 files`
- [x] `dotbabel-check-instruction-drift` → `✓ instruction files match repo facts`
- [x] `dotbabel-check-instruction-parity` → `✓ generated instruction headings have parity`
- [x] `dotbabel-check-instructions-fresh` → `✓ generated instruction files are fresh`
- [x] Fan-out produced by `dotbabel-generate-instructions`, not hand-edited

## Note for whoever holds the main checkout

`CLAUDE.md` there is still dirty with this same change, and `HEAD` sits at `1612924` — an unpushed commit from 2026-05-25 adding `/overnight-prep` (237 lines, verified **absent** from `origin/main`). That commit is real unpushed work, not a superseded duplicate. It is untouched here and needs its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Spec ID

dotbabel-core
