### PR TITLE
feat(skills): add /release-conductor as a skill

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,126 +1,7 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-07T18:28:38.392Z",
+  "generatedAt": "2026-08-07T21:32:28.868Z",
   "skills": [
-    {
-      "name": "audit-and-fix",
-      "path": ".claude/skills/audit-and-fix/SKILL.md",
-      "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "code-simplifier",
-      "path": ".claude/skills/code-simplifier/SKILL.md",
-      "checksum": "sha256:e24c64485f950d93815f492de5673aaa3ff65abb0df91fb41e41a40b68017cff",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "changelog",
-      "path": ".claude/commands/changelog.md",
-      "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "create-assessment",
-      "path": ".claude/skills/create-assessment/SKILL.md",
-      "checksum": "sha256:7d364824b0ce34d5703a3db91956b4607182b52be79bc5fdec9583c73ef6f73c",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "create-audit",
-      "path": ".claude/skills/create-audit/SKILL.md",
-      "checksum": "sha256:c65ff762a76e721fd0169cee087c582198c628a7a79b518792b168b2b6001cd4",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "dependabot-sweep",
-      "path": ".claude/commands/dependabot-sweep.md",
-      "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "detect-flaky",
-      "path": ".claude/skills/detect-flaky/SKILL.md",
-      "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "deploy-status",
-      "path": ".claude/skills/deploy-status/SKILL.md",
-      "checksum": "sha256:9119370d74077eae376afa72b28fff9cfd7617fd11b310590ddd6eb6c3d9258f",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "fix-with-evidence",
-      "path": ".claude/skills/fix-with-evidence/SKILL.md",
-      "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "flyctl",
-      "path": ".claude/skills/flyctl/SKILL.md",
-      "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "git",
-      "path": ".claude/skills/git/SKILL.md",
-      "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "ground-first",
-      "path": ".claude/skills/ground-first/SKILL.md",
-      "checksum": "sha256:0a8a9c125bc3fd0a3fe5cacb4f8cf6ff5971895ea1b703037a8712d3b5e15dd6",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "markdown",
-      "path": ".claude/commands/markdown.md",
-      "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "merge-pr",
-      "path": ".claude/commands/merge-pr.md",
-      "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "create-inspection",
-      "path": ".claude/skills/create-inspection/SKILL.md",
-      "checksum": "sha256:d8febaf15dd98a5d72fe97f8f41fd7d0a83ed98f0a11ab7ecedeedeaec544e85",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "review-pr",
-      "path": ".claude/skills/review-pr/SKILL.md",
-      "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "security-review",
-      "path": ".claude/skills/security-review/SKILL.md",
-      "checksum": "sha256:c8447582929b315402af24e304acd4addaa9be7120e895ca25d4c897ba84cfda",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
@@ -129,23 +10,9 @@
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "spec",
-      "path": ".claude/skills/spec/SKILL.md",
-      "checksum": "sha256:9ec1c67a434bf90512a2dcb5a68c4bb3bffd65c1bee967fa370164ec6ea84002",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "validate-spec",
-      "path": ".claude/skills/validate-spec/SKILL.md",
-      "checksum": "sha256:13320e86060cb9a74d9ee98aecbbb9eff43c6100b47f09debe15f7049f6c050c",
-      "dependencies": [],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "kubernetes-specialist",
-      "path": ".claude/skills/kubernetes-specialist/SKILL.md",
-      "checksum": "sha256:e3f0404dbd80ebdfce9df79df0a9bf501574abafcb7cd5a656c2afd4519428fb",
+      "name": "audit-and-fix",
+      "path": ".claude/skills/audit-and-fix/SKILL.md",
+      "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
@@ -164,23 +31,44 @@
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "gcp-specialist",
-      "path": ".claude/skills/gcp-specialist/SKILL.md",
-      "checksum": "sha256:39763f741bbff9bd6f9b72908ed3ea8de1870e2d5017b3ddab9015e0db4ff108",
+      "name": "changelog",
+      "path": ".claude/commands/changelog.md",
+      "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "terraform-specialist",
-      "path": ".claude/skills/terraform-specialist/SKILL.md",
-      "checksum": "sha256:9e9c0d8b36ef44fb7f4f604aa706c2f380787c38c0282987c24436ec7bd53b85",
+      "name": "code-simplifier",
+      "path": ".claude/skills/code-simplifier/SKILL.md",
+      "checksum": "sha256:e24c64485f950d93815f492de5673aaa3ff65abb0df91fb41e41a40b68017cff",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "terragrunt-specialist",
-      "path": ".claude/skills/terragrunt-specialist/SKILL.md",
-      "checksum": "sha256:fc7f266342f1686a5ca394398f048742b5f249144f45354d5f8c2520e359a2bb",
+      "name": "create-assessment",
+      "path": ".claude/skills/create-assessment/SKILL.md",
+      "checksum": "sha256:7d364824b0ce34d5703a3db91956b4607182b52be79bc5fdec9583c73ef6f73c",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "create-audit",
+      "path": ".claude/skills/create-audit/SKILL.md",
+      "checksum": "sha256:c65ff762a76e721fd0169cee087c582198c628a7a79b518792b168b2b6001cd4",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "create-experiment",
+      "path": ".claude/skills/create-experiment/SKILL.md",
+      "checksum": "sha256:424f23db1e1ba2cfc32c215bc4ae8f8dd8f710274161884252ac1fcfb28dcd3c",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "create-inspection",
+      "path": ".claude/skills/create-inspection/SKILL.md",
+      "checksum": "sha256:d8febaf15dd98a5d72fe97f8f41fd7d0a83ed98f0a11ab7ecedeedeaec544e85",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
@@ -192,16 +80,58 @@
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "pulumi-specialist",
-      "path": ".claude/skills/pulumi-specialist/SKILL.md",
-      "checksum": "sha256:6620a3862749142cf450245e9c6fc6c398530208848f64e2c34132e138f6f5ef",
+      "name": "dependabot-sweep",
+      "path": ".claude/commands/dependabot-sweep.md",
+      "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "veracity-audit",
-      "path": ".claude/skills/veracity-audit/SKILL.md",
-      "checksum": "sha256:2f66c14a71e88734d8a734bf1ce6f220f74ce28a9e302635e4e225edc1f9300e",
+      "name": "deploy-status",
+      "path": ".claude/skills/deploy-status/SKILL.md",
+      "checksum": "sha256:9119370d74077eae376afa72b28fff9cfd7617fd11b310590ddd6eb6c3d9258f",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "detect-flaky",
+      "path": ".claude/skills/detect-flaky/SKILL.md",
+      "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "fix-with-evidence",
+      "path": ".claude/skills/fix-with-evidence/SKILL.md",
+      "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "flyctl",
+      "path": ".claude/skills/flyctl/SKILL.md",
+      "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "gcp-specialist",
+      "path": ".claude/skills/gcp-specialist/SKILL.md",
+      "checksum": "sha256:39763f741bbff9bd6f9b72908ed3ea8de1870e2d5017b3ddab9015e0db4ff108",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "git",
+      "path": ".claude/skills/git/SKILL.md",
+      "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "ground-first",
+      "path": ".claude/skills/ground-first/SKILL.md",
+      "checksum": "sha256:0a8a9c125bc3fd0a3fe5cacb4f8cf6ff5971895ea1b703037a8712d3b5e15dd6",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
@@ -209,6 +139,94 @@
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
       "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "kubernetes-specialist",
+      "path": ".claude/skills/kubernetes-specialist/SKILL.md",
+      "checksum": "sha256:e3f0404dbd80ebdfce9df79df0a9bf501574abafcb7cd5a656c2afd4519428fb",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "local-attest",
+      "path": ".claude/skills/local-attest/SKILL.md",
+      "checksum": "sha256:a4fab149f1ea05770de853331d321fc2e8d4a745fcb52dcc1da1f76edbe4a995",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "markdown",
+      "path": ".claude/commands/markdown.md",
+      "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "merge-pr",
+      "path": ".claude/commands/merge-pr.md",
+      "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "plan-grader",
+      "path": ".claude/skills/plan-grader/SKILL.md",
+      "checksum": "sha256:50ba919efa0b4235e182a7d5b1ff2308481086a3ddddbf9166b0560370c3af27",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "post-pr-review",
+      "path": ".claude/skills/post-pr-review/SKILL.md",
+      "checksum": "sha256:0565fc80dba6872c5da9569cff5e53d112fc3ea3a16b4905fdf38255754ec628",
+      "dependencies": [
+        "review-pr"
+      ],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "pre-pr",
+      "path": ".claude/commands/pre-pr.md",
+      "checksum": "sha256:f920c63e4d70bd7490cc52ba07b9e4e01577631ef06025031d7d8404a39543e2",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "project-sync",
+      "path": ".claude/skills/project-sync/SKILL.md",
+      "checksum": "sha256:822e1509cf0ed4d0260c8bada35cd0e815a9b6529d637eb9baf3a430f8803104",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "pulumi-specialist",
+      "path": ".claude/skills/pulumi-specialist/SKILL.md",
+      "checksum": "sha256:6620a3862749142cf450245e9c6fc6c398530208848f64e2c34132e138f6f5ef",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "release-conductor",
+      "path": ".claude/skills/release-conductor/SKILL.md",
+      "checksum": "sha256:968cce5a0ef4fa0c01d5badf367bd7616b30fd87f4245cd9cad5a2ccf8868b24",
+      "dependencies": [
+        "deploy-status"
+      ],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "reproduce-bug",
+      "path": ".claude/skills/reproduce-bug/SKILL.md",
+      "checksum": "sha256:e73ae70e76b0c4a0ba43dc42d01596b2df1e97ffa7813a9fab45012711408b51",
+      "dependencies": [],
+      "lastValidated": "2026-08-07"
+    },
+    {
+      "name": "review-pr",
+      "path": ".claude/skills/review-pr/SKILL.md",
+      "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
@@ -229,53 +247,44 @@
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "plan-grader",
-      "path": ".claude/skills/plan-grader/SKILL.md",
-      "checksum": "sha256:50ba919efa0b4235e182a7d5b1ff2308481086a3ddddbf9166b0560370c3af27",
+      "name": "security-review",
+      "path": ".claude/skills/security-review/SKILL.md",
+      "checksum": "sha256:c8447582929b315402af24e304acd4addaa9be7120e895ca25d4c897ba84cfda",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "local-attest",
-      "path": ".claude/skills/local-attest/SKILL.md",
-      "checksum": "sha256:a4fab149f1ea05770de853331d321fc2e8d4a745fcb52dcc1da1f76edbe4a995",
+      "name": "spec",
+      "path": ".claude/skills/spec/SKILL.md",
+      "checksum": "sha256:9ec1c67a434bf90512a2dcb5a68c4bb3bffd65c1bee967fa370164ec6ea84002",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "pre-pr",
-      "path": ".claude/commands/pre-pr.md",
-      "checksum": "sha256:f920c63e4d70bd7490cc52ba07b9e4e01577631ef06025031d7d8404a39543e2",
+      "name": "terraform-specialist",
+      "path": ".claude/skills/terraform-specialist/SKILL.md",
+      "checksum": "sha256:9e9c0d8b36ef44fb7f4f604aa706c2f380787c38c0282987c24436ec7bd53b85",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "create-experiment",
-      "path": ".claude/skills/create-experiment/SKILL.md",
-      "checksum": "sha256:424f23db1e1ba2cfc32c215bc4ae8f8dd8f710274161884252ac1fcfb28dcd3c",
+      "name": "terragrunt-specialist",
+      "path": ".claude/skills/terragrunt-specialist/SKILL.md",
+      "checksum": "sha256:fc7f266342f1686a5ca394398f048742b5f249144f45354d5f8c2520e359a2bb",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "post-pr-review",
-      "path": ".claude/skills/post-pr-review/SKILL.md",
-      "checksum": "sha256:0565fc80dba6872c5da9569cff5e53d112fc3ea3a16b4905fdf38255754ec628",
-      "dependencies": [
-        "review-pr"
-      ],
-      "lastValidated": "2026-08-07"
-    },
-    {
-      "name": "project-sync",
-      "path": ".claude/skills/project-sync/SKILL.md",
-      "checksum": "sha256:822e1509cf0ed4d0260c8bada35cd0e815a9b6529d637eb9baf3a430f8803104",
+      "name": "validate-spec",
+      "path": ".claude/skills/validate-spec/SKILL.md",
+      "checksum": "sha256:13320e86060cb9a74d9ee98aecbbb9eff43c6100b47f09debe15f7049f6c050c",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     },
     {
-      "name": "reproduce-bug",
-      "path": ".claude/skills/reproduce-bug/SKILL.md",
-      "checksum": "sha256:e73ae70e76b0c4a0ba43dc42d01596b2df1e97ffa7813a9fab45012711408b51",
+      "name": "veracity-audit",
+      "path": ".claude/skills/veracity-audit/SKILL.md",
+      "checksum": "sha256:2f66c14a71e88734d8a734bf1ce6f220f74ce28a9e302635e4e225edc1f9300e",
       "dependencies": [],
       "lastValidated": "2026-08-07"
     }

--- a/.codex/skills/release-conductor
+++ b/.codex/skills/release-conductor
@@ -1,0 +1,1 @@
+../../.claude/skills/release-conductor

--- a/.gemini/skills/release-conductor
+++ b/.gemini/skills/release-conductor
@@ -1,0 +1,1 @@
+../../.claude/skills/release-conductor

--- a/.github/instructions/release-conductor.instructions.md
+++ b/.github/instructions/release-conductor.instructions.md
@@ -1,0 +1,1 @@
+../../.claude/skills/release-conductor/SKILL.md

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotbabel.dev/schemas/index.schema.json",
-  "generatedAt": "2026-08-07T18:57:06.264Z",
+  "generatedAt": "2026-08-07T21:32:15.882Z",
   "version": "2.12.0",
   "artifacts": [
     {
@@ -721,6 +721,21 @@
         "platform": ["pulumi"],
         "task": ["debugging", "review"],
         "maturity": "validated"
+      },
+      "version": "1.0.0",
+      "owner": "@kaiohenricunha"
+    },
+    {
+      "id": "release-conductor",
+      "type": "skill",
+      "path": "skills/release-conductor/SKILL.md",
+      "name": "release-conductor",
+      "description": "Gate the open release-please PR before merging: verify CI green, feature PRs landed, no release blockers, changelog reflects intent. One-word approval, then merge. Reports the resulting release.yml run URL. release-please owns the changelog/bump/tag; release.yml owns OIDC npm publish — this skill only gates the merge in between. Triggers on: \"ship a release\", \"cut a release\", \"merge the release PR\", \"is the release ready\", \"verify the release\".\n",
+      "facets": {
+        "domain": ["devex"],
+        "platform": ["github-actions"],
+        "task": ["review", "runtime-ops"],
+        "maturity": "draft"
       },
       "version": "1.0.0",
       "owner": "@kaiohenricunha"

--- a/index/by-facet.json
+++ b/index/by-facet.json
@@ -30,6 +30,7 @@
       "post-pr-review",
       "pre-pr",
       "project-sync",
+      "release-conductor",
       "reproduce-bug",
       "review-pr",
       "review-prs",
@@ -133,6 +134,7 @@
       "local-attest",
       "merge-pr",
       "post-pr-review",
+      "release-conductor",
       "review-pr",
       "review-prs"
     ],
@@ -204,6 +206,7 @@
       "post-pr-review",
       "pre-pr",
       "pulumi-specialist",
+      "release-conductor",
       "review-pr",
       "review-prs",
       "security-auditor",
@@ -261,7 +264,8 @@
       "docker-engineer",
       "flyctl",
       "kubernetes-specialist",
-      "local-attest"
+      "local-attest",
+      "release-conductor"
     ],
     "testing": [
       "detect-flaky",
@@ -335,6 +339,7 @@
       "pre-pr",
       "project-sync",
       "pulumi-engineer",
+      "release-conductor",
       "review-prs",
       "rollback-prod",
       "security-auditor",

--- a/index/by-type.json
+++ b/index/by-type.json
@@ -50,6 +50,7 @@
     "post-pr-review",
     "project-sync",
     "pulumi-specialist",
+    "release-conductor",
     "reproduce-bug",
     "review-pr",
     "review-prs",

--- a/plugins/dotbabel/.claude-plugin/plugin.json
+++ b/plugins/dotbabel/.claude-plugin/plugin.json
@@ -56,6 +56,7 @@
     "./templates/claude/skills/post-pr-review/SKILL.md",
     "./templates/claude/skills/project-sync/SKILL.md",
     "./templates/claude/skills/pulumi-specialist/SKILL.md",
+    "./templates/claude/skills/release-conductor/SKILL.md",
     "./templates/claude/skills/reproduce-bug/SKILL.md",
     "./templates/claude/skills/review-pr/SKILL.md",
     "./templates/claude/skills/review-prs/SKILL.md",

--- a/plugins/dotbabel/templates/claude/skills-manifest.json
+++ b/plugins/dotbabel/templates/claude/skills-manifest.json
@@ -206,6 +206,13 @@
       "lastValidated": null
     },
     {
+      "name": "release-conductor",
+      "path": ".claude/skills/release-conductor/SKILL.md",
+      "checksum": "",
+      "dependencies": [],
+      "lastValidated": null
+    },
+    {
       "name": "reproduce-bug",
       "path": ".claude/skills/reproduce-bug/SKILL.md",
       "checksum": "",

--- a/plugins/dotbabel/templates/claude/skills/release-conductor/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/release-conductor/SKILL.md
@@ -1,0 +1,241 @@
+---
+id: release-conductor
+name: release-conductor
+type: skill
+version: 1.0.0
+domain: [devex]
+platform: [github-actions]
+task: [review, runtime-ops]
+maturity: draft
+description: >
+  Gate the open release-please PR before merging: verify CI green, feature PRs landed,
+  no release blockers, changelog reflects intent. One-word approval, then merge.
+  Reports the resulting release.yml run URL. release-please owns the changelog/bump/tag;
+  release.yml owns OIDC npm publish — this skill only gates the merge in between.
+  Triggers on: "ship a release", "cut a release", "merge the release PR",
+  "is the release ready", "verify the release".
+argument-hint: "[verify <tag>]"
+model: sonnet
+user-invocable: true
+disable-model-invocation: true
+headless_safe: false
+allowed-tools: Read Bash Grep Glob
+---
+
+Gate the open release-please PR before merging. release-please drafts the changelog and version bump; `release.yml` handles OIDC npm publish on tag push. This skill is the human-in-the-loop step between them: verifies the PR is safe to merge, then merges it.
+
+Trigger: when the user says "ship a release", "cut a release", "merge the release PR", "is the release ready", or invokes `/release-conductor`. Also `/release-conductor verify <tag>` for post-publish smoke test.
+
+Arguments: `$ARGUMENTS` — optional subcommand:
+
+- (empty) — full gate + merge flow on the currently open release-please PR.
+- `verify <tag>` — post-publish smoke test for a published tag (e.g. `verify v2.8.0`).
+
+**Lifecycle:**
+
+```
+feature PRs merged → release-please opens release PR → /release-conductor (gate + merge) → release.yml (OIDC publish) → /release-conductor verify <tag>
+```
+
+## Steps
+
+### 0. Branch on subcommand
+
+If `$ARGUMENTS` starts with `verify`, jump to the **`verify` subcommand** section below.
+
+Otherwise, continue with the gate + merge flow.
+
+### 1. Find the open release-please PR
+
+```bash
+gh pr list --state open --search "head:release-please--" \
+  --json number,title,headRefName,mergeable,mergeStateStatus,labels,body
+```
+
+- **Zero matches.** Check what's accumulated since the last tag:
+
+  ```bash
+  LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+  git log "$LAST_TAG"..origin/main --oneline --no-merges
+  ```
+
+  If the log contains `feat:` / `fix:` / `perf:` / `refactor:` commits but no PR is open, suggest:
+
+  ```bash
+  gh run list --workflow=release-please.yml --limit 3
+  ```
+
+  release-please may have failed or not run. STOP and surface the most recent run.
+
+  If the log contains only `chore:` / `style:` / `test:` / `build:` / `ci:` / `docs:` commits, report:
+  `no shippable changes — release-please correctly held off.` STOP.
+
+- **One match.** Record `RELEASE_PR=$pr_number` and continue.
+
+- **Multiple matches.** STOP and ask the user which to ship — this signals a release-please config issue (multi-package monorepo without `include-component-in-tag`, etc.).
+
+### 2. Show what's being shipped
+
+```bash
+gh pr view $RELEASE_PR --json title,body | jq -r '.title, .body'
+gh pr diff $RELEASE_PR -- CHANGELOG.md | head -120
+gh pr view $RELEASE_PR --json files --jq '.files[].path'
+```
+
+Report:
+
+- PR title (release-please format: `chore(main): release X.Y.Z`)
+- The changelog section being added (first ~120 lines of the diff)
+- Files changed by the PR (should be `CHANGELOG.md`, `package.json`, `.release-please-manifest.json`, and any post-bump regen — `index/`, `docs/` stamps)
+
+### 3. Verify CI on the release PR
+
+```bash
+gh pr checks $RELEASE_PR
+```
+
+- Any check `failing` → STOP. Print the failing check names; tell the user to address them before re-running.
+- Any check `pending` → STOP. Tell the user to wait for CI to finish.
+- All checks pass → continue.
+
+Sanity check on `main`:
+
+```bash
+gh run list --branch main --limit 5 --json conclusion,name,createdAt
+```
+
+If the most recent run on `main` is failing, surface as **WARNING** (not blocking) — release.yml will run against the tag, not `main`, so a stale main failure won't break publish, but it's worth knowing.
+
+### 4. Verify no release blockers and feature PRs landed
+
+```bash
+LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+LAST_TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
+
+# Feature PRs merged since last tag
+gh pr list --state merged --search "merged:>$LAST_TAG_DATE base:main" \
+  --limit 50 --json number,title,headRefName,labels
+
+# Open PRs flagged as blockers
+gh pr list --state open --search "label:release-blocker,do-not-release,wip" \
+  --json number,title,labels
+```
+
+- Report count of feature PRs merged since `$LAST_TAG`.
+- Any open PR with `release-blocker` or `do-not-release` label → STOP. Surface the PR numbers.
+- Any **merged** PR with those labels (mistakes happen) → surface as WARNING.
+
+### 5. Sanity-check the bump
+
+```bash
+PREV_VERSION=${LAST_TAG#v}
+NEW_VERSION=$(gh pr view $RELEASE_PR --json title --jq .title \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+echo "Bump: $PREV_VERSION → $NEW_VERSION"
+```
+
+Inspect conventional-commit types since last tag:
+
+```bash
+git log "$LAST_TAG"..origin/main --pretty=format:'%s%n%b' --no-merges \
+  | grep -E '^(feat|fix|perf|refactor|docs)(\(.+\))?!?:|BREAKING CHANGE:' \
+  | sort -u
+```
+
+Expected bump (post-1.0):
+
+- `feat!:` or `BREAKING CHANGE:` anywhere → **major**
+- `feat:` (no breaking) → **minor**
+- `fix:` / `perf:` / `refactor:` only → **patch**
+
+For pre-1.0 packages, read `release-please-config.json` — `bump-minor-pre-major` promotes major→minor; `bump-patch-for-minor-pre-major` promotes minor→patch.
+
+If release-please's bump diverges from expectation, surface as **WARNING** with the divergence (likely config). Do not block — release-please's config is the source of truth.
+
+### 6. Go/no-go summary
+
+```
+Release-conductor: PR #$RELEASE_PR — $PREV_VERSION → $NEW_VERSION
+
+  Step 2 — Files:           CHANGELOG.md, package.json, .release-please-manifest.json, …
+  Step 3 — CI release PR:   ✓ green
+                         |  ✗ failing: <names> (BLOCKED)
+                         |  ⏳ pending (BLOCKED — wait)
+  Step 3 — CI main:         ✓ green
+                         |  ⚠ recent failures (not blocking publish)
+  Step 4 — Blockers:        none
+                         |  ✗ open: PR #N (label) (BLOCKED)
+  Step 4 — Landed PRs:      N feature PRs since $LAST_TAG
+  Step 5 — Bump:            ✓ matches commit types
+                         |  ⚠ release-please chose $NEW_VERSION, expected $EXPECTED (<reason>)
+
+Status: READY — say "ship" to merge PR #$RELEASE_PR (squash) and trigger release.yml.
+     |  BLOCKED — <reason>. Fix and re-run /release-conductor.
+```
+
+### 7. Merge on explicit approval
+
+Wait for the user to say `ship`, `merge`, `go`, or `lgtm`. CI green alone is not authorization.
+
+On approval:
+
+```bash
+gh pr merge $RELEASE_PR --squash --delete-branch
+```
+
+If the repo overrides merge method (check `.github/settings.yml` or repo settings UI), follow the override and note it in the report.
+
+### 8. Report the publish pipeline run
+
+release-please's GitHub Action creates the `v$NEW_VERSION` tag immediately after merge; the tag push fires `release.yml`. Report the most recent runs so the user can track:
+
+```bash
+TAG="v$NEW_VERSION"
+gh run list --workflow=release.yml --limit 3 \
+  --json url,headBranch,status,conclusion,createdAt
+```
+
+Do not poll. Print:
+
+```
+Merged PR #$RELEASE_PR ($PREV_VERSION → $NEW_VERSION)
+Tag should appear shortly: $TAG
+Track release.yml above. Once it shows ✓ success:
+  /release-conductor verify $TAG
+```
+
+## `verify <tag>` subcommand
+
+Post-publish smoke test. No gating, no merge — just three checks.
+
+```bash
+TAG=$(echo "$ARGUMENTS" | awk '{print $2}')
+VERSION=${TAG#v}
+PKG=$(node -p "require('./package.json').name")
+
+# 1. release.yml conclusion for this tag
+gh run list --workflow=release.yml --branch "$TAG" --limit 1 \
+  --json conclusion,url,databaseId
+
+# 2. npm has the version
+npm view "$PKG@$VERSION" version dist.tarball
+
+# 3. GitHub release exists
+gh release view "$TAG" --json url,publishedAt,name
+```
+
+Report PASS / FAIL per check. Specifics:
+
+- **release.yml conclusion** — `success` = PASS. `in_progress` = "still running, retry in ~60s." `failure` = FAIL, print URL.
+- **npm view** — exit 0 = PASS. 404 = "not yet propagated (npm CDN lag, up to ~60s)." Other error = FAIL.
+- **gh release view** — exit 0 = PASS. `release not found` = FAIL.
+
+## Rules
+
+- **Never reimplement release-please.** This skill does not write CHANGELOG.md, bump versions, or create tags. release-please owns that; this skill only gates the merge of release-please's PR.
+- **Never publish to npm directly.** OIDC publish happens in `release.yml` on tag push. The skill stops at `gh pr merge`.
+- **Require explicit verbal approval.** `ship` / `merge` / `go` / `lgtm`. CI green alone is not authorization.
+- **One release PR at a time.** Multiple open `release-please--*` PRs → stop and ask. Likely a config issue.
+- **Squash merge by default.** Matches `/merge-pr` convention. Repo override (if any) wins, but record it.
+- **No polling.** Print the run URL and exit. Use `verify <tag>` later.
+- **Pre-1.0 bump checks read config.** Don't assume semver — `release-please-config.json` may have `bump-minor-pre-major` flags that alter the expected bump.

--- a/skills/release-conductor/SKILL.md
+++ b/skills/release-conductor/SKILL.md
@@ -1,0 +1,244 @@
+---
+id: release-conductor
+name: release-conductor
+type: skill
+version: 1.0.0
+domain: [devex]
+platform: [github-actions]
+task: [review, runtime-ops]
+maturity: draft
+owner: "@kaiohenricunha"
+created: 2026-05-26
+updated: 2026-08-07
+description: >
+  Gate the open release-please PR before merging: verify CI green, feature PRs landed,
+  no release blockers, changelog reflects intent. One-word approval, then merge.
+  Reports the resulting release.yml run URL. release-please owns the changelog/bump/tag;
+  release.yml owns OIDC npm publish — this skill only gates the merge in between.
+  Triggers on: "ship a release", "cut a release", "merge the release PR",
+  "is the release ready", "verify the release".
+argument-hint: "[verify <tag>]"
+model: sonnet
+user-invocable: true
+disable-model-invocation: true
+headless_safe: false
+allowed-tools: Read Bash Grep Glob
+---
+
+Gate the open release-please PR before merging. release-please drafts the changelog and version bump; `release.yml` handles OIDC npm publish on tag push. This skill is the human-in-the-loop step between them: verifies the PR is safe to merge, then merges it.
+
+Trigger: when the user says "ship a release", "cut a release", "merge the release PR", "is the release ready", or invokes `/release-conductor`. Also `/release-conductor verify <tag>` for post-publish smoke test.
+
+Arguments: `$ARGUMENTS` — optional subcommand:
+
+- (empty) — full gate + merge flow on the currently open release-please PR.
+- `verify <tag>` — post-publish smoke test for a published tag (e.g. `verify v2.8.0`).
+
+**Lifecycle:**
+
+```
+feature PRs merged → release-please opens release PR → /release-conductor (gate + merge) → release.yml (OIDC publish) → /release-conductor verify <tag>
+```
+
+## Steps
+
+### 0. Branch on subcommand
+
+If `$ARGUMENTS` starts with `verify`, jump to the **`verify` subcommand** section below.
+
+Otherwise, continue with the gate + merge flow.
+
+### 1. Find the open release-please PR
+
+```bash
+gh pr list --state open --search "head:release-please--" \
+  --json number,title,headRefName,mergeable,mergeStateStatus,labels,body
+```
+
+- **Zero matches.** Check what's accumulated since the last tag:
+
+  ```bash
+  LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+  git log "$LAST_TAG"..origin/main --oneline --no-merges
+  ```
+
+  If the log contains `feat:` / `fix:` / `perf:` / `refactor:` commits but no PR is open, suggest:
+
+  ```bash
+  gh run list --workflow=release-please.yml --limit 3
+  ```
+
+  release-please may have failed or not run. STOP and surface the most recent run.
+
+  If the log contains only `chore:` / `style:` / `test:` / `build:` / `ci:` / `docs:` commits, report:
+  `no shippable changes — release-please correctly held off.` STOP.
+
+- **One match.** Record `RELEASE_PR=$pr_number` and continue.
+
+- **Multiple matches.** STOP and ask the user which to ship — this signals a release-please config issue (multi-package monorepo without `include-component-in-tag`, etc.).
+
+### 2. Show what's being shipped
+
+```bash
+gh pr view $RELEASE_PR --json title,body | jq -r '.title, .body'
+gh pr diff $RELEASE_PR -- CHANGELOG.md | head -120
+gh pr view $RELEASE_PR --json files --jq '.files[].path'
+```
+
+Report:
+
+- PR title (release-please format: `chore(main): release X.Y.Z`)
+- The changelog section being added (first ~120 lines of the diff)
+- Files changed by the PR (should be `CHANGELOG.md`, `package.json`, `.release-please-manifest.json`, and any post-bump regen — `index/`, `docs/` stamps)
+
+### 3. Verify CI on the release PR
+
+```bash
+gh pr checks $RELEASE_PR
+```
+
+- Any check `failing` → STOP. Print the failing check names; tell the user to address them before re-running.
+- Any check `pending` → STOP. Tell the user to wait for CI to finish.
+- All checks pass → continue.
+
+Sanity check on `main`:
+
+```bash
+gh run list --branch main --limit 5 --json conclusion,name,createdAt
+```
+
+If the most recent run on `main` is failing, surface as **WARNING** (not blocking) — release.yml will run against the tag, not `main`, so a stale main failure won't break publish, but it's worth knowing.
+
+### 4. Verify no release blockers and feature PRs landed
+
+```bash
+LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+LAST_TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
+
+# Feature PRs merged since last tag
+gh pr list --state merged --search "merged:>$LAST_TAG_DATE base:main" \
+  --limit 50 --json number,title,headRefName,labels
+
+# Open PRs flagged as blockers
+gh pr list --state open --search "label:release-blocker,do-not-release,wip" \
+  --json number,title,labels
+```
+
+- Report count of feature PRs merged since `$LAST_TAG`.
+- Any open PR with `release-blocker` or `do-not-release` label → STOP. Surface the PR numbers.
+- Any **merged** PR with those labels (mistakes happen) → surface as WARNING.
+
+### 5. Sanity-check the bump
+
+```bash
+PREV_VERSION=${LAST_TAG#v}
+NEW_VERSION=$(gh pr view $RELEASE_PR --json title --jq .title \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+echo "Bump: $PREV_VERSION → $NEW_VERSION"
+```
+
+Inspect conventional-commit types since last tag:
+
+```bash
+git log "$LAST_TAG"..origin/main --pretty=format:'%s%n%b' --no-merges \
+  | grep -E '^(feat|fix|perf|refactor|docs)(\(.+\))?!?:|BREAKING CHANGE:' \
+  | sort -u
+```
+
+Expected bump (post-1.0):
+
+- `feat!:` or `BREAKING CHANGE:` anywhere → **major**
+- `feat:` (no breaking) → **minor**
+- `fix:` / `perf:` / `refactor:` only → **patch**
+
+For pre-1.0 packages, read `release-please-config.json` — `bump-minor-pre-major` promotes major→minor; `bump-patch-for-minor-pre-major` promotes minor→patch.
+
+If release-please's bump diverges from expectation, surface as **WARNING** with the divergence (likely config). Do not block — release-please's config is the source of truth.
+
+### 6. Go/no-go summary
+
+```
+Release-conductor: PR #$RELEASE_PR — $PREV_VERSION → $NEW_VERSION
+
+  Step 2 — Files:           CHANGELOG.md, package.json, .release-please-manifest.json, …
+  Step 3 — CI release PR:   ✓ green
+                         |  ✗ failing: <names> (BLOCKED)
+                         |  ⏳ pending (BLOCKED — wait)
+  Step 3 — CI main:         ✓ green
+                         |  ⚠ recent failures (not blocking publish)
+  Step 4 — Blockers:        none
+                         |  ✗ open: PR #N (label) (BLOCKED)
+  Step 4 — Landed PRs:      N feature PRs since $LAST_TAG
+  Step 5 — Bump:            ✓ matches commit types
+                         |  ⚠ release-please chose $NEW_VERSION, expected $EXPECTED (<reason>)
+
+Status: READY — say "ship" to merge PR #$RELEASE_PR (squash) and trigger release.yml.
+     |  BLOCKED — <reason>. Fix and re-run /release-conductor.
+```
+
+### 7. Merge on explicit approval
+
+Wait for the user to say `ship`, `merge`, `go`, or `lgtm`. CI green alone is not authorization.
+
+On approval:
+
+```bash
+gh pr merge $RELEASE_PR --squash --delete-branch
+```
+
+If the repo overrides merge method (check `.github/settings.yml` or repo settings UI), follow the override and note it in the report.
+
+### 8. Report the publish pipeline run
+
+release-please's GitHub Action creates the `v$NEW_VERSION` tag immediately after merge; the tag push fires `release.yml`. Report the most recent runs so the user can track:
+
+```bash
+TAG="v$NEW_VERSION"
+gh run list --workflow=release.yml --limit 3 \
+  --json url,headBranch,status,conclusion,createdAt
+```
+
+Do not poll. Print:
+
+```
+Merged PR #$RELEASE_PR ($PREV_VERSION → $NEW_VERSION)
+Tag should appear shortly: $TAG
+Track release.yml above. Once it shows ✓ success:
+  /release-conductor verify $TAG
+```
+
+## `verify <tag>` subcommand
+
+Post-publish smoke test. No gating, no merge — just three checks.
+
+```bash
+TAG=$(echo "$ARGUMENTS" | awk '{print $2}')
+VERSION=${TAG#v}
+PKG=$(node -p "require('./package.json').name")
+
+# 1. release.yml conclusion for this tag
+gh run list --workflow=release.yml --branch "$TAG" --limit 1 \
+  --json conclusion,url,databaseId
+
+# 2. npm has the version
+npm view "$PKG@$VERSION" version dist.tarball
+
+# 3. GitHub release exists
+gh release view "$TAG" --json url,publishedAt,name
+```
+
+Report PASS / FAIL per check. Specifics:
+
+- **release.yml conclusion** — `success` = PASS. `in_progress` = "still running, retry in ~60s." `failure` = FAIL, print URL.
+- **npm view** — exit 0 = PASS. 404 = "not yet propagated (npm CDN lag, up to ~60s)." Other error = FAIL.
+- **gh release view** — exit 0 = PASS. `release not found` = FAIL.
+
+## Rules
+
+- **Never reimplement release-please.** This skill does not write CHANGELOG.md, bump versions, or create tags. release-please owns that; this skill only gates the merge of release-please's PR.
+- **Never publish to npm directly.** OIDC publish happens in `release.yml` on tag push. The skill stops at `gh pr merge`.
+- **Require explicit verbal approval.** `ship` / `merge` / `go` / `lgtm`. CI green alone is not authorization.
+- **One release PR at a time.** Multiple open `release-please--*` PRs → stop and ask. Likely a config issue.
+- **Squash merge by default.** Matches `/merge-pr` convention. Repo override (if any) wins, but record it.
+- **No polling.** Print the run URL and exit. Use `verify <tag>` later.
+- **Pre-1.0 bump checks read config.** Don't assume semver — `release-please-config.json` may have `bump-minor-pre-major` flags that alter the expected bump.


### PR DESCRIPTION
## Summary

- Revive #237 as `skills/release-conductor/SKILL.md` instead of a command
- Regenerate every derived artifact rather than hand-merging the conflicts that stalled it
- Add the consumer template copy #237 was missing

Closes #237.

## #237 was never actually broken

It has sat `DIRTY` with two failing checks since **2026-05-26**. All three problems were stale plumbing:

| Failure | Cause | Status |
|---|---|---|
| `prettier` | `.claude/skills-manifest.json` — generator vs. linter | **fixed today** in #267 (`.prettierignore`) |
| `self` | manifest stale | regenerated here |
| `self` | missing `templates/claude/commands/release-conductor.md` | `build-plugin` now emits the skill template |

Its worktree HEAD equalled the PR head with a clean tree and no commits since May, so nothing was in flight on it.

**The feature content is unchanged.** The body is byte-identical to `commands/release-conductor.md` at `d055bc5`; only frontmatter differs.

## Why a skill rather than a command

It merges PRs. `CLAUDE.md` says side-effectful workflows belong in `skills/<id>/SKILL.md` with `disable-model-invocation: true`, and specifically not to "fall back to commands solely for safety". The original frontmatter already carried `argument-hint`, `model` and `headless_safe` — skill shape wearing `type: command`.

Added `user-invocable: true`, `allowed-tools`, and `disable-model-invocation: true`, matching `flyctl`, `rollback-prod` and `local-attest`, the repo's other side-effectful skills. So `/release-conductor` still works when you ask for it, but the model will not invoke it on its own.

## Generated, not hand-merged

#237's conflicts were entirely in generated files, which is why rebasing it looked expensive. Nothing here was resolved by hand:

- `scripts/build-plugin.mjs` → template copy + template manifest + `plugin.json`
- `dotbabel-index` → `index/*.json`
- `.claude/skills-manifest.json` → entry added manually, because `refreshChecksums` (`validate-skills-inventory.mjs:213-224`) only walks entries that already exist and never adds new ones

That last one is a papercut worth its own fix later: adding any skill requires hand-editing the manifest, and the only signal you forgot is an orphan error after the fact.

## Test plan

- [x] `npm test` → **806 passed** across 51 files
- [x] `dotbabel-validate-skills` → `✓ manifest valid (40 skills)`, `✓ agents valid`
- [x] `dotbabel-index --check` → `✓ index fresh (64 artifacts)`
- [x] `scripts/build-plugin.mjs --check` → `✓ plugin templates fresh (160 files + manifest)`
- [x] `dotbabel-validate-specs` → `✓ 4 spec(s) valid`
- [x] prettier clean; markdownlint 0 issues in 563 files
- [x] `dotbabel-show release-conductor --type skill` resolves
- [x] Body verified byte-identical to `d055bc5:commands/release-conductor.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Spec ID

dotbabel-core
