### PR TITLE
fix(post-pr-review): resolve.sh requested a gh field that does not exist

### DIFF
--- a/plugins/dotbabel/scripts/post-pr-review-resolve.sh
+++ b/plugins/dotbabel/scripts/post-pr-review-resolve.sh
@@ -19,10 +19,12 @@
 set -euo pipefail
 
 PR=""
+REPO=""
 REPO_FLAG=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)
+      REPO="$2"
       REPO_FLAG+=(--repo "$2")
       shift 2
       ;;
@@ -38,16 +40,35 @@ if ! gh auth status >/dev/null 2>&1; then
   exit 2
 fi
 
-FIELDS="number,headRefOid,state,isDraft,headRepository,baseRepository,isCrossRepository,url"
+# `gh pr view --json` has NO `baseRepository` field — requesting it makes every
+# invocation fail with "Unknown JSON field". The base repo is simply the repo
+# the PR lives in, so derive it the way the sibling scripts already do
+# (post-pr-review-list-markers.sh:39, post-batch.sh:58, post-single.sh:52)
+# and splice it into the output, preserving this script's documented contract.
+FIELDS="number,headRefOid,state,isDraft,headRepository,isCrossRepository,url"
 
 if [[ -n "$PR" ]]; then
-  if ! gh pr view "$PR" "${REPO_FLAG[@]}" --json "$FIELDS" 2>/dev/null; then
-    echo '{"error":"PR not found"}' >&2
+  if ! RAW=$(gh pr view "$PR" "${REPO_FLAG[@]}" --json "$FIELDS" 2>&1); then
+    # Surface gh's own diagnostic. Collapsing every failure to "PR not found"
+    # is what hid this bug: a malformed request read as a missing PR.
+    printf '%s\n' "$RAW" >&2
     exit 1
   fi
 else
-  if ! gh pr view "${REPO_FLAG[@]}" --json "$FIELDS" 2>/dev/null; then
-    echo '{"error":"no PR for current branch — pass <PR#> explicitly: /post-pr-review 123"}' >&2
+  if ! RAW=$(gh pr view "${REPO_FLAG[@]}" --json "$FIELDS" 2>&1); then
+    printf '%s\n' "$RAW" >&2
+    echo 'no PR for current branch — pass <PR#> explicitly: /post-pr-review 123' >&2
     exit 1
   fi
 fi
+
+if [[ -z "$REPO" ]]; then
+  if ! REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); then
+    printf '%s\n' "$REPO" >&2
+    exit 1
+  fi
+fi
+
+jq --arg owner "${REPO%%/*}" --arg name "${REPO##*/}" \
+  '. + {baseRepository: {owner: {login: $owner}, name: $name, nameWithOwner: ($owner + "/" + $name)}}' \
+  <<<"$RAW"

--- a/plugins/dotbabel/tests/bats/post-pr-review-resolve.bats
+++ b/plugins/dotbabel/tests/bats/post-pr-review-resolve.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Resolution invariants for post-pr-review-resolve.sh — step 1 of the
+# /post-pr-review skill, and the only one of its scripts that shipped without
+# a test.
+#
+# It requested a `baseRepository` JSON field that `gh pr view` does not
+# support, so every invocation failed; `2>/dev/null` then masked the real
+# "Unknown JSON field" error behind a misleading {"error":"PR not found"}.
+# The fake gh here rejects unknown --json fields exactly as the real binary
+# does, which is what makes that class of bug detectable at all.
+
+load helpers
+
+SCRIPT="$REPO_ROOT/plugins/dotbabel/scripts/post-pr-review-resolve.sh"
+
+# Fields the real `gh pr view --json` accepts (subset we care about).
+# Anything requested outside this set makes the shim fail like gh does.
+FAKE_GH_STRICT='
+KNOWN="number headRefOid state isDraft headRepository headRepositoryOwner isCrossRepository url title body files mergeable mergeStateStatus baseRefName nameWithOwner owner name"
+sub="$1"; shift
+fields=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json) fields="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$fields" ]; then
+  IFS=, read -ra REQ <<< "$fields"
+  for f in "${REQ[@]}"; do
+    case " $KNOWN " in
+      *" $f "*) ;;
+      *) echo "Unknown JSON field: \"$f\"" >&2; exit 1 ;;
+    esac
+  done
+fi
+if [ "$sub" = "repo" ]; then
+  echo "kaiohenricunha/dotbabel"
+  exit 0
+fi
+cat <<JSON
+{"number":278,"headRefOid":"42b2cff0e68054a9a21c722ae3880c0d2d2dd42b","state":"OPEN","isDraft":false,"headRepository":{"name":"dotbabel"},"isCrossRepository":false,"url":"https://github.com/kaiohenricunha/dotbabel/pull/278"}
+JSON
+'
+
+setup() {
+  [ -x "$SCRIPT" ] || chmod +x "$SCRIPT"
+}
+
+@test "resolve: requests only JSON fields gh actually supports" {
+  with_fake_tool_bin gh "$FAKE_GH_STRICT" >/dev/null
+  run "$SCRIPT" 278
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.number == 278' >/dev/null
+}
+
+@test "resolve: emits the baseRepository the skill binds REPO from" {
+  with_fake_tool_bin gh "$FAKE_GH_STRICT" >/dev/null
+  run "$SCRIPT" 278
+  [ "$status" -eq 0 ]
+  repo="$(echo "$output" | jq -r '"\(.baseRepository.owner.login)/\(.baseRepository.name)"')"
+  [ "$repo" = "kaiohenricunha/dotbabel" ]
+}
+
+@test "resolve: honors an explicit --repo without a second lookup" {
+  with_fake_tool_bin gh "$FAKE_GH_STRICT" >/dev/null
+  run "$SCRIPT" 278 --repo other/project
+  [ "$status" -eq 0 ]
+  repo="$(echo "$output" | jq -r '"\(.baseRepository.owner.login)/\(.baseRepository.name)"')"
+  [ "$repo" = "other/project" ]
+}
+
+@test "resolve: preserves the documented output keys" {
+  with_fake_tool_bin gh "$FAKE_GH_STRICT" >/dev/null
+  run "$SCRIPT" 278
+  [ "$status" -eq 0 ]
+  for k in number headRefOid state isDraft headRepository baseRepository isCrossRepository url; do
+    echo "$output" | jq -e "has(\"$k\")" >/dev/null || {
+      echo "missing documented key: $k"
+      return 1
+    }
+  done
+}
+
+@test "resolve: surfaces gh's real error instead of masking it as 'PR not found'" {
+  with_fake_tool_bin gh '
+    # auth must succeed, or the script exits 2 before it ever calls pr view.
+    if [ "$1" = "auth" ]; then exit 0; fi
+    echo "GraphQL: Could not resolve to a PullRequest with the number of 999999." >&2
+    exit 1
+  ' >/dev/null
+  run "$SCRIPT" 999999
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Could not resolve to a PullRequest"* ]]
+}
+
+@test "resolve: exits 2 when gh is not authenticated" {
+  with_fake_tool_bin gh '
+    if [ "$1" = "auth" ]; then exit 1; fi
+    exit 0
+  ' >/dev/null
+  run "$SCRIPT" 278
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

- `post-pr-review-resolve.sh` requested a `baseRepository` field that `gh pr view --json` does not support, so **step 1 of `/post-pr-review` failed for every PR** since it was introduced in #198.
- `2>/dev/null` on both call sites discarded gh's real diagnostic (`Unknown JSON field: "baseRepository"`) and replaced it with `{"error":"PR not found"}` — the failure read as a missing PR rather than a malformed request, which is why it survived this long.
- Derives the base repo the way the three sibling scripts already do (`gh repo view --json nameWithOwner` — `post-pr-review-list-markers.sh:39`, `post-batch.sh:58`, `post-single.sh:52`) and splices it into the output, so the documented contract is unchanged: `skills/post-pr-review/SKILL.md:62` still lists `baseRepository`, and `:69` still binds `REPO` from `.baseRepository.owner.login` / `.name`.
- Adds `post-pr-review-resolve.bats`. `resolve.sh` was the **only** post-pr-review script without a bats file — its three tested siblings all got the base repo right.

Found by dogfooding `/pr-conductor` on its own PR (#278): step 1 reported "PR not found" for a PR that `fetch-context.sh` resolved correctly one line later.

The regression test uses a fake `gh` that rejects unknown `--json` fields the way the real binary does — a permissive shim would never have caught this class of bug.

## Test plan

- [x] `npx bats plugins/dotbabel/tests/bats/post-pr-review-resolve.bats` — 6/6 pass
- [x] Regression test verified non-vacuous: reintroducing `baseRepository` into `FIELDS` turns test 1 red; reverting turns it green
- [x] Against real `gh`: `resolve.sh 278` returns `{"number":278,"state":"MERGED","repo":"kaiohenricunha/dotbabel"}`, exit 0
- [x] Against real `gh`: `resolve.sh 999999` now prints `GraphQL: Could not resolve to a PullRequest…` instead of `PR not found`, exit 1
- [x] End-to-end on a live PR: steps 1 → 3 → 4 chain for the first time (resolve → fetch-context 28 files → build-postable-lines 28 files)
- [x] `npm run shellcheck` (covers `plugins/dotbabel/scripts/*.sh`)
- [x] `npm run lint`, `npm run dogfood`, `dotbabel-doctor`, `dotbabel-index --check`, `build-plugin --check` — all pass

## No-spec rationale

Single-file bug fix plus its missing regression test. Touches no protected path (`plugins/dotbabel/scripts/**` and `plugins/dotbabel/tests/**` are not in `docs/repo-facts.json:5-17`), introduces no new subsystem, and changes no public contract — `resolve.sh`'s documented output shape is preserved exactly.
