### PR TITLE
fix(release-conductor): fetch tags before deriving LAST_TAG

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-08T19:21:47.825Z",
+  "generatedAt": "2026-08-08T21:03:15.244Z",
   "skills": [
     {
       "name": "agents-search",
@@ -224,7 +224,7 @@
     {
       "name": "release-conductor",
       "path": ".claude/skills/release-conductor/SKILL.md",
-      "checksum": "sha256:968cce5a0ef4fa0c01d5badf367bd7616b30fd87f4245cd9cad5a2ccf8868b24",
+      "checksum": "sha256:82d522ae0f5296b9eabd935283f6d8b3354d98c36d5f7c3429ed67c60dea302a",
       "dependencies": [
         "deploy-status"
       ],

--- a/plugins/dotbabel/templates/claude/skills/release-conductor/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/release-conductor/SKILL.md
@@ -39,11 +39,21 @@ feature PRs merged → release-please opens release PR → /release-conductor (g
 
 ## Steps
 
-### 0. Branch on subcommand
+### 0. Refresh local refs, then branch on subcommand
 
-If `$ARGUMENTS` starts with `verify`, jump to the **`verify` subcommand** section below.
+If `$ARGUMENTS` starts with `verify`, jump to the **`verify` subcommand** section below — it reads only from `gh` and needs no local git state.
 
-Otherwise, continue with the gate + merge flow.
+Otherwise refresh before anything reads local git state:
+
+```bash
+git fetch origin main --tags --prune-tags
+```
+
+**This is load-bearing — do not skip it.** Steps 4 and 5 derive `LAST_TAG` from local tags and diff against `origin/main`. On a clone whose tags are stale, every downstream number is wrong _and still looks plausible_: the bump comparison, the "PRs merged since last tag" list, and the commit-type check all describe the wrong release window, and nothing blocks — the gate reports READY on a false picture.
+
+Observed in practice: a clone three tags behind reported the bump as `2.10.0 → 2.13.0` with 23 landed PRs, when the truth was `2.12.0 → 2.13.0` with 3.
+
+Then continue with the gate + merge flow.
 
 ### 1. Find the open release-please PR
 
@@ -55,7 +65,9 @@ gh pr list --state open --search "head:release-please--" \
 - **Zero matches.** Check what's accumulated since the last tag:
 
   ```bash
+  # Requires the step 0 fetch — stale tags here mean the wrong commit window.
   LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+  [ -n "$LAST_TAG" ] || { echo "no v* tag found — run: git fetch origin --tags"; exit 1; }
   git log "$LAST_TAG"..origin/main --oneline --no-merges
   ```
 
@@ -109,7 +121,10 @@ If the most recent run on `main` is failing, surface as **WARNING** (not blockin
 ### 4. Verify no release blockers and feature PRs landed
 
 ```bash
+# Requires the step 0 fetch. A stale tag here silently shifts the whole
+# release window: wrong bump, wrong landed-PR list, wrong commit-type check.
 LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+[ -n "$LAST_TAG" ] || { echo "no v* tag found — run: git fetch origin --tags"; exit 1; }
 LAST_TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
 
 # Feature PRs merged since last tag
@@ -239,3 +254,4 @@ Report PASS / FAIL per check. Specifics:
 - **Squash merge by default.** Matches `/merge-pr` convention. Repo override (if any) wins, but record it.
 - **No polling.** Print the run URL and exit. Use `verify <tag>` later.
 - **Pre-1.0 bump checks read config.** Don't assume semver — `release-please-config.json` may have `bump-minor-pre-major` flags that alter the expected bump.
+- **Always fetch tags before reading them.** `LAST_TAG` comes from the local tag list; a stale clone yields a wrong release window that still reports READY. Step 0's fetch is not optional.

--- a/plugins/dotbabel/tests/bats/release-conductor.bats
+++ b/plugins/dotbabel/tests/bats/release-conductor.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# Contract tests for skills/release-conductor/SKILL.md.
+#
+# The skill derives LAST_TAG from the LOCAL tag list and diffs against
+# origin/main. Without a preceding fetch, a stale clone silently produces the
+# wrong release window — wrong bump, wrong landed-PR list, wrong commit-type
+# check — and the gate still reports READY. Nothing blocks, so the failure is
+# invisible unless something pins the ordering. That is what these tests do.
+
+load helpers
+
+SKILL="$REPO_ROOT/skills/release-conductor/SKILL.md"
+
+@test "release-conductor: SKILL.md exists" {
+  [ -f "$SKILL" ]
+}
+
+@test "release-conductor: fetches tags before reading them" {
+  run grep -qE 'git fetch .*--tags' "$SKILL"
+  [ "$status" -eq 0 ]
+}
+
+@test "release-conductor: the tag fetch precedes every git tag --list" {
+  fetch_line="$(grep -nE 'git fetch .*--tags' "$SKILL" | head -1 | cut -d: -f1)"
+  [ -n "$fetch_line" ]
+
+  # Every local tag read must come after the fetch, or it reads stale data.
+  while read -r n; do
+    [ "$n" -gt "$fetch_line" ] || {
+      echo "git tag --list at line $n precedes the fetch at line $fetch_line"
+      return 1
+    }
+  done < <(grep -nE 'git tag --list' "$SKILL" | cut -d: -f1)
+}
+
+@test "release-conductor: fetch refreshes origin/main as well as tags" {
+  # Steps 1 and 5 diff against origin/main; a stale remote ref is the same
+  # class of bug as a stale tag.
+  run grep -qE 'git fetch origin main .*--tags' "$SKILL"
+  [ "$status" -eq 0 ]
+}
+
+@test "release-conductor: every LAST_TAG assignment is guarded against empty" {
+  assigns="$(grep -cE '^ *LAST_TAG=\$\(git tag --list' "$SKILL")"
+  guards="$(grep -cE '^ *\[ -n "\$LAST_TAG" \]' "$SKILL")"
+  [ "$assigns" -gt 0 ]
+  [ "$assigns" -eq "$guards" ]
+}
+
+@test "release-conductor: still refuses to publish or reimplement release-please" {
+  run grep -qE 'Never publish to npm directly' "$SKILL"
+  [ "$status" -eq 0 ]
+  run grep -qE 'Never reimplement release-please' "$SKILL"
+  [ "$status" -eq 0 ]
+  # The skill stops at the merge; it must never invoke npm publish itself.
+  run grep -nE '^\s*npm publish' "$SKILL"
+  [ "$status" -eq 1 ]
+}
+
+@test "release-conductor: still requires explicit verbal approval before merging" {
+  run grep -qE 'Require explicit verbal approval' "$SKILL"
+  [ "$status" -eq 0 ]
+}

--- a/skills/release-conductor/SKILL.md
+++ b/skills/release-conductor/SKILL.md
@@ -42,11 +42,21 @@ feature PRs merged → release-please opens release PR → /release-conductor (g
 
 ## Steps
 
-### 0. Branch on subcommand
+### 0. Refresh local refs, then branch on subcommand
 
-If `$ARGUMENTS` starts with `verify`, jump to the **`verify` subcommand** section below.
+If `$ARGUMENTS` starts with `verify`, jump to the **`verify` subcommand** section below — it reads only from `gh` and needs no local git state.
 
-Otherwise, continue with the gate + merge flow.
+Otherwise refresh before anything reads local git state:
+
+```bash
+git fetch origin main --tags --prune-tags
+```
+
+**This is load-bearing — do not skip it.** Steps 4 and 5 derive `LAST_TAG` from local tags and diff against `origin/main`. On a clone whose tags are stale, every downstream number is wrong _and still looks plausible_: the bump comparison, the "PRs merged since last tag" list, and the commit-type check all describe the wrong release window, and nothing blocks — the gate reports READY on a false picture.
+
+Observed in practice: a clone three tags behind reported the bump as `2.10.0 → 2.13.0` with 23 landed PRs, when the truth was `2.12.0 → 2.13.0` with 3.
+
+Then continue with the gate + merge flow.
 
 ### 1. Find the open release-please PR
 
@@ -58,7 +68,9 @@ gh pr list --state open --search "head:release-please--" \
 - **Zero matches.** Check what's accumulated since the last tag:
 
   ```bash
+  # Requires the step 0 fetch — stale tags here mean the wrong commit window.
   LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+  [ -n "$LAST_TAG" ] || { echo "no v* tag found — run: git fetch origin --tags"; exit 1; }
   git log "$LAST_TAG"..origin/main --oneline --no-merges
   ```
 
@@ -112,7 +124,10 @@ If the most recent run on `main` is failing, surface as **WARNING** (not blockin
 ### 4. Verify no release blockers and feature PRs landed
 
 ```bash
+# Requires the step 0 fetch. A stale tag here silently shifts the whole
+# release window: wrong bump, wrong landed-PR list, wrong commit-type check.
 LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+[ -n "$LAST_TAG" ] || { echo "no v* tag found — run: git fetch origin --tags"; exit 1; }
 LAST_TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
 
 # Feature PRs merged since last tag
@@ -242,3 +257,4 @@ Report PASS / FAIL per check. Specifics:
 - **Squash merge by default.** Matches `/merge-pr` convention. Repo override (if any) wins, but record it.
 - **No polling.** Print the run URL and exit. Use `verify <tag>` later.
 - **Pre-1.0 bump checks read config.** Don't assume semver — `release-please-config.json` may have `bump-minor-pre-major` flags that alter the expected bump.
+- **Always fetch tags before reading them.** `LAST_TAG` comes from the local tag list; a stale clone yields a wrong release window that still reports READY. Step 0's fetch is not optional.


### PR DESCRIPTION
## Summary

- `/release-conductor` steps 4 and 5 derived `LAST_TAG` from the **local** tag list and diffed against `origin/main` with no preceding fetch (`skills/release-conductor/SKILL.md:61,115` pre-fix). On a stale clone, the bump comparison, the "PRs merged since last tag" list, and the conventional-commit type check all describe the wrong release window — and **nothing blocks**, so the gate reports READY on a false picture.
- Step 0 now runs `git fetch origin main --tags --prune-tags` before anything reads local git state, with the failure mode documented inline so it isn't trimmed as boilerplate later. Refreshing `origin/main` matters too — steps 1 and 5 diff against it, and a stale remote ref is the same class of bug.
- Both `LAST_TAG` assignments now abort on an empty tag list instead of silently expanding to `..origin/main`, which would diff the entire history.
- The `verify <tag>` subcommand is untouched; it reads only from `gh`.

Found while shipping 2.13.0 (#277): a clone three tags behind reported the bump as `2.10.0 → 2.13.0` with **23** landed PRs, when the truth was `2.12.0 → 2.13.0` with **3**. The 20 extras were already-published releases. The gate said READY both times — only re-running after `git fetch --tags` exposed the difference.

Adds `release-conductor.bats`, the skill's first test. It pins the *ordering* (the fetch must precede every `git tag --list`), that the fetch covers both tags and `origin/main`, and that every `LAST_TAG` assignment is guarded — plus the two invariants that make the skill safe at all: never publish directly, and require explicit verbal approval before merging.

## Test plan

- [x] `npx bats plugins/dotbabel/tests/bats/release-conductor.bats` — 7/7 pass
- [x] Verified non-vacuous: against the pre-fix `SKILL.md`, 4 of the 7 assertions fail (`fetches tags`, `fetch precedes every git tag --list`, `fetch refreshes origin/main`, `LAST_TAG guarded`); restoring the fix turns them green
- [x] Template mirror regenerated — `plugins/dotbabel/templates/claude/skills/release-conductor/SKILL.md` carries the fetch
- [x] `npm run lint`, `npm run dogfood`, `dotbabel-doctor`, `dotbabel-index --check`, `build-plugin --check`, `validate-skills` — all pass
- [x] Checksum refreshed after prettier reformatted the skill (the `CONTRIBUTING.md:121-127` ordering pitfall)

## No-spec rationale

Bug fix to one existing skill's prose plus its first regression test. Touches `plugins/dotbabel/templates/**` only as generated output of `scripts/build-plugin.mjs`, introduces no new subsystem, adds no CLI surface, and changes no public contract — the skill's steps, arguments, and stop-before-publish behavior are unchanged.
