### PR TITLE
fix(check-on-stop): parse porcelain with -z and --untracked-files=all

### DIFF
--- a/plugins/dotbabel/hooks/check-on-stop.sh
+++ b/plugins/dotbabel/hooks/check-on-stop.sh
@@ -134,20 +134,37 @@ clear_state() {
 command -v git >/dev/null 2>&1 || exit 0
 git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
-CHANGED=$(git -C "$ROOT" status --porcelain 2>/dev/null) || exit 0
-if [ -z "$CHANGED" ]; then
-  # Nothing changed this turn — a conversational turn, not an edit turn.
-  clear_state
-  exit 0
-fi
-
+# -z and --untracked-files=all are both load-bearing:
+#
+#   -z   disables git's C-quoting. `core.quotePath` defaults to true, so a
+#        path with any byte >= 0x80 is emitted wrapped in quotes —
+#        `?? "caf\303\251.rs"` — and the trailing quote lands in the
+#        extension (`rs"`), matching no arm below. One accented directory
+#        component silently disabled checking for everything beneath it.
+#
+#   --untracked-files=all  expands new directories. The default collapses
+#        them to a single `?? newdir/` entry, whose basename is empty, so a
+#        file created in a brand-new directory was never seen — which is
+#        exactly the turn most worth checking. The explicit flag also
+#        overrides a repo-level `status.showUntrackedFiles=no`.
+#
+# Reading NUL-delimited records means the loop cannot use a here-string (a
+# bash variable cannot hold NUL), so it consumes a process substitution —
+# which still runs in the current shell, keeping TOUCHED assignments visible.
 declare -A TOUCHED=()
-while IFS= read -r line; do
-  [ -n "$line" ] || continue
-  # Strip the two-column status plus its separating space, then take the
-  # destination of a rename ("R  old -> new").
-  path="${line:3}"
-  case "$path" in *" -> "*) path="${path##* -> }" ;; esac
+SAW_CHANGE=0
+while IFS= read -r -d '' entry; do
+  [ -n "$entry" ] || continue
+  SAW_CHANGE=1
+  # Under -z a rename emits TWO records: "R  <new>" then a bare "<old>" with
+  # no XY prefix (the " -> " form exists only in the non -z encoding). Strip
+  # the prefix only when the record actually carries one. Classifying the
+  # rename source as well as its destination is harmless — both extensions
+  # belong to the same language in any realistic rename.
+  case "$entry" in
+    ??" "*) path="${entry:3}" ;;
+    *)      path="$entry" ;;
+  esac
   base="${path##*/}"
   case "$base" in *.*) ;; *) continue ;; esac
   ext="${base##*.}"
@@ -158,7 +175,13 @@ while IFS= read -r line; do
     java)              TOUCHED[java]=1 ;;
     cs)                TOUCHED[csharp]=1 ;;
   esac
-done <<< "$CHANGED"
+done < <(git -C "$ROOT" status --porcelain -z --untracked-files=all 2>/dev/null)
+
+if [ "$SAW_CHANGE" -eq 0 ]; then
+  # Nothing changed this turn — a conversational turn, not an edit turn.
+  clear_state
+  exit 0
+fi
 
 [ "${#TOUCHED[@]}" -gt 0 ] || exit 0
 

--- a/plugins/dotbabel/tests/bats/check-on-stop.bats
+++ b/plugins/dotbabel/tests/bats/check-on-stop.bats
@@ -347,6 +347,83 @@ seed_go() {
   [[ "$(stub_calls dotnet)" == *"build"* ]]
 }
 
+@test "a non-ASCII filename still triggers its check" {
+  # core.quotePath defaults on, so without -z git emits `?? "caf\303\251.rs"`
+  # and the trailing quote lands in the extension, matching no arm.
+  printf '[package]\nname="x"\nversion="0.1.0"\n' > "$REPO/Cargo.toml"
+  printf 'fn main() {}\n' > "$REPO/café.rs"
+  stub_checker cargo 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [ "$status" -eq 0 ]
+  [ -n "$(stub_calls cargo)" ]
+}
+
+@test "a non-ASCII directory component still triggers its check" {
+  # One accented directory silently disabled checking for everything below it.
+  printf '[package]\nname="x"\nversion="0.1.0"\n' > "$REPO/Cargo.toml"
+  mkdir -p "$REPO/münchen"
+  printf 'fn main() {}\n' > "$REPO/münchen/lib.rs"
+  stub_checker cargo 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [ -n "$(stub_calls cargo)" ]
+}
+
+@test "a file in a brand-new untracked directory triggers its check" {
+  # The default --untracked-files=normal collapses these to `?? newdir/`,
+  # whose basename is empty — so the turn that creates a package was the one
+  # turn guaranteed not to be checked.
+  seed_go
+  git -C "$REPO" add -A && git -C "$REPO" commit -q -m marker
+  mkdir -p "$REPO/pkg/newthing"
+  printf 'package newthing\n' > "$REPO/pkg/newthing/a.go"
+  stub_checker go 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [ "$status" -eq 0 ]
+  [ -n "$(stub_calls go)" ]
+}
+
+@test "status.showUntrackedFiles=no is overridden" {
+  seed_go
+  git -C "$REPO" add -A && git -C "$REPO" commit -q -m marker
+  git -C "$REPO" config status.showUntrackedFiles no
+  printf 'package main\n' > "$REPO/brand_new.go"
+  stub_checker go 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [ -n "$(stub_calls go)" ]
+}
+
+@test "a renamed file triggers its check" {
+  # Under -z a rename is two records: "R  <new>" then a bare "<old>". The
+  # bare record carries no XY prefix and must not have three chars chopped.
+  seed_go
+  git -C "$REPO" add -A && git -C "$REPO" commit -q -m marker
+  git -C "$REPO" mv main.go renamed.go
+  stub_checker go 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [ "$status" -eq 0 ]
+  [ -n "$(stub_calls go)" ]
+}
+
+@test "a path with spaces triggers its check" {
+  seed_go
+  mkdir -p "$REPO/dir with spaces"
+  printf 'package x\n' > "$REPO/dir with spaces/file name.go"
+  stub_checker go 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [ -n "$(stub_calls go)" ]
+}
+
+@test "still a no-op when nothing changed, under -z" {
+  # SAW_CHANGE replaced the old `[ -z "$CHANGED" ]` test; pin it still holds.
+  seed_go
+  git -C "$REPO" add -A && git -C "$REPO" commit -q -m marker
+  stub_checker go 1 "" "should not run"
+  feed_stop_json "$HOOK" false "$REPO"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ -z "$(stub_calls go)" ]
+}
+
 @test "two touched languages run both checks" {
   seed_go
   printf '[package]\nname="x"\nversion="0.1.0"\n' > "$REPO/Cargo.toml"


### PR DESCRIPTION
## Summary

- Parses `git status --porcelain` with `-z` and `--untracked-files=all`, closing the two gating gaps recorded during the #281 review.
- Both were **silent** failures: the hook says nothing when it finds nothing, so an unchecked turn looked exactly like a clean one.

## The two gaps

**1. C-quoted paths.** `core.quotePath` defaults to true, so any path with a byte >= 0x80 is emitted quoted:

```
$ git status --porcelain
?? "caf\303\251.rs"
```

The trailing quote landed in the extension (`rs"`), which matched no arm of the language `case`. One accented **directory** component disabled checking for every file below it.

**2. Collapsed untracked directories.** The default `--untracked-files=normal` reports a new directory as one entry:

```
$ git status --porcelain
?? newdir/
```

Its basename is empty, so the entry was skipped — meaning the turn that creates a new package was the one turn guaranteed not to be checked. The explicit flag also overrides a repo-level `status.showUntrackedFiles=no`.

## Consequences of `-z`

- Records are NUL-delimited, and a bash variable cannot hold NUL, so the loop can no longer use a here-string. It consumes a process substitution instead — still the current shell, so `TOUCHED` assignments stay visible. The empty-input check moved to a `SAW_CHANGE` flag.
- The rename encoding changes: instead of one `R  old -> new` record, `-z` emits `R  <new>` then a bare `<old>` with no `XY ` prefix. The prefix is now stripped only when the record carries one.

## Test plan

- [x] `npx bats plugins/dotbabel/tests/bats/check-on-stop.bats` — 41/41 (was 34)
- [x] **Non-vacuity proven**: restored the previous parser and re-ran; 4 of the 7 new tests fail against it. The other 3 (rename, spaces, no-change) pass on both and guard against regression from this rewrite.
- [x] `npx bats plugins/dotbabel/tests/bats/` — 564/564
- [x] `npm test` — 936 tests / 53 files
- [x] shellcheck CI line verbatim — clean
- [x] `npm run dogfood` — all pass, `spec coverage ok (0 protected file(s) changed)`
- [x] `npm run docs:stamp-check` — 14 docs stamped
- [x] Both gaps reproduced against real git before the fix, and confirmed fixed after

## Spec ID

dotbabel-core
