### PR TITLE
docs(rules): add ASD-STE100 Simplified Technical English to rule floor

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -250,6 +250,21 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 **Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
+## Language: ASD-STE100 Simplified Technical English
+
+**Write all chat output to the user in ASD-STE100 Simplified Technical English (STE).** This rule applies to every AI agent that reads this rule floor.
+
+- Use approved STE words where the dictionary permits. Use one word for one meaning.
+- Write short sentences. Use a maximum of 20 words in an instruction. Use a maximum of 25 words in a description.
+- Use the active voice. Use the present tense where possible.
+- Give one instruction in each sentence. Start each instruction with a verb.
+- Write paragraphs with a maximum of 6 sentences.
+- Do not use idioms, slang, or Latin abbreviations such as "e.g." and "i.e.".
+- Use the articles "a", "an", and "the". Do not remove them.
+- Keep technical names, code, file paths, commands, and quoted output as they are. STE does not change code.
+- Put safety warnings before the instruction they apply to.
+- The Communication hard caps stay in effect. STE controls the style; the caps control the length.
+
 ## Protected paths (dogfood)
 
 This repository governs itself with `@dotbabel/dotbabel`. The authoritative

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,21 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 **Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
+## Language: ASD-STE100 Simplified Technical English
+
+**Write all chat output to the user in ASD-STE100 Simplified Technical English (STE).** This rule applies to every AI agent that reads this rule floor.
+
+- Use approved STE words where the dictionary permits. Use one word for one meaning.
+- Write short sentences. Use a maximum of 20 words in an instruction. Use a maximum of 25 words in a description.
+- Use the active voice. Use the present tense where possible.
+- Give one instruction in each sentence. Start each instruction with a verb.
+- Write paragraphs with a maximum of 6 sentences.
+- Do not use idioms, slang, or Latin abbreviations such as "e.g." and "i.e.".
+- Use the articles "a", "an", and "the". Do not remove them.
+- Keep technical names, code, file paths, commands, and quoted output as they are. STE does not change code.
+- Put safety warnings before the instruction they apply to.
+- The Communication hard caps stay in effect. STE controls the style; the caps control the length.
+
 ## Protected paths (dogfood)
 
 This repository governs itself with `@dotbabel/dotbabel`. The authoritative

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,21 @@ Scope `--allowedTools` tightly — prefer `Bash(gh:*)` over `Bash(*)`. Combine w
 
 **Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
+## Language: ASD-STE100 Simplified Technical English
+
+**Write all chat output to the user in ASD-STE100 Simplified Technical English (STE).** This rule applies to every AI agent that reads this rule floor.
+
+- Use approved STE words where the dictionary permits. Use one word for one meaning.
+- Write short sentences. Use a maximum of 20 words in an instruction. Use a maximum of 25 words in a description.
+- Use the active voice. Use the present tense where possible.
+- Give one instruction in each sentence. Start each instruction with a verb.
+- Write paragraphs with a maximum of 6 sentences.
+- Do not use idioms, slang, or Latin abbreviations such as "e.g." and "i.e.".
+- Use the articles "a", "an", and "the". Do not remove them.
+- Keep technical names, code, file paths, commands, and quoted output as they are. STE does not change code.
+- Put safety warnings before the instruction they apply to.
+- The Communication hard caps stay in effect. STE controls the style; the caps control the length.
+
 ## Protected paths (dogfood)
 
 This repository governs itself with `@dotbabel/dotbabel`. The authoritative

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -225,6 +225,21 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 **Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
+## Language: ASD-STE100 Simplified Technical English
+
+**Write all chat output to the user in ASD-STE100 Simplified Technical English (STE).** This rule applies to every AI agent that reads this rule floor.
+
+- Use approved STE words where the dictionary permits. Use one word for one meaning.
+- Write short sentences. Use a maximum of 20 words in an instruction. Use a maximum of 25 words in a description.
+- Use the active voice. Use the present tense where possible.
+- Give one instruction in each sentence. Start each instruction with a verb.
+- Write paragraphs with a maximum of 6 sentences.
+- Do not use idioms, slang, or Latin abbreviations such as "e.g." and "i.e.".
+- Use the articles "a", "an", and "the". Do not remove them.
+- Keep technical names, code, file paths, commands, and quoted output as they are. STE does not change code.
+- Put safety warnings before the instruction they apply to.
+- The Communication hard caps stay in effect. STE controls the style; the caps control the length.
+
 ## Protected paths (dogfood)
 
 This repository governs itself with `@dotbabel/dotbabel`. The authoritative

--- a/plugins/dotbabel/templates/cli-instructions/codex-AGENTS.md
+++ b/plugins/dotbabel/templates/cli-instructions/codex-AGENTS.md
@@ -128,6 +128,21 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 **Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
+## Language: ASD-STE100 Simplified Technical English
+
+**Write all chat output to the user in ASD-STE100 Simplified Technical English (STE).** This rule applies to every AI agent that reads this rule floor.
+
+- Use approved STE words where the dictionary permits. Use one word for one meaning.
+- Write short sentences. Use a maximum of 20 words in an instruction. Use a maximum of 25 words in a description.
+- Use the active voice. Use the present tense where possible.
+- Give one instruction in each sentence. Start each instruction with a verb.
+- Write paragraphs with a maximum of 6 sentences.
+- Do not use idioms, slang, or Latin abbreviations such as "e.g." and "i.e.".
+- Use the articles "a", "an", and "the". Do not remove them.
+- Keep technical names, code, file paths, commands, and quoted output as they are. STE does not change code.
+- Put safety warnings before the instruction they apply to.
+- The Communication hard caps stay in effect. STE controls the style; the caps control the length.
+
 ## Protected paths (dogfood)
 
 This repository governs itself with `@dotbabel/dotbabel`. The authoritative

--- a/plugins/dotbabel/templates/cli-instructions/copilot-instructions.md
+++ b/plugins/dotbabel/templates/cli-instructions/copilot-instructions.md
@@ -128,6 +128,21 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 **Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
+## Language: ASD-STE100 Simplified Technical English
+
+**Write all chat output to the user in ASD-STE100 Simplified Technical English (STE).** This rule applies to every AI agent that reads this rule floor.
+
+- Use approved STE words where the dictionary permits. Use one word for one meaning.
+- Write short sentences. Use a maximum of 20 words in an instruction. Use a maximum of 25 words in a description.
+- Use the active voice. Use the present tense where possible.
+- Give one instruction in each sentence. Start each instruction with a verb.
+- Write paragraphs with a maximum of 6 sentences.
+- Do not use idioms, slang, or Latin abbreviations such as "e.g." and "i.e.".
+- Use the articles "a", "an", and "the". Do not remove them.
+- Keep technical names, code, file paths, commands, and quoted output as they are. STE does not change code.
+- Put safety warnings before the instruction they apply to.
+- The Communication hard caps stay in effect. STE controls the style; the caps control the length.
+
 ## Protected paths (dogfood)
 
 This repository governs itself with `@dotbabel/dotbabel`. The authoritative

--- a/plugins/dotbabel/templates/cli-instructions/gemini-GEMINI.md
+++ b/plugins/dotbabel/templates/cli-instructions/gemini-GEMINI.md
@@ -128,6 +128,21 @@ For recurring sweeps (Dependabot, cron, CI-triggered agents), use headless mode 
 
 **Length rubric.** Simple factual question → one sentence. Code change → the diff + ≤1 line of context. Investigation result → ≤3 sentences + file:line. Spec/architecture discussion → as long as needed, but earn every paragraph.
 
+## Language: ASD-STE100 Simplified Technical English
+
+**Write all chat output to the user in ASD-STE100 Simplified Technical English (STE).** This rule applies to every AI agent that reads this rule floor.
+
+- Use approved STE words where the dictionary permits. Use one word for one meaning.
+- Write short sentences. Use a maximum of 20 words in an instruction. Use a maximum of 25 words in a description.
+- Use the active voice. Use the present tense where possible.
+- Give one instruction in each sentence. Start each instruction with a verb.
+- Write paragraphs with a maximum of 6 sentences.
+- Do not use idioms, slang, or Latin abbreviations such as "e.g." and "i.e.".
+- Use the articles "a", "an", and "the". Do not remove them.
+- Keep technical names, code, file paths, commands, and quoted output as they are. STE does not change code.
+- Put safety warnings before the instruction they apply to.
+- The Communication hard caps stay in effect. STE controls the style; the caps control the length.
+
 ## Protected paths (dogfood)
 
 This repository governs itself with `@dotbabel/dotbabel`. The authoritative


### PR DESCRIPTION
## Summary

- Add a `## Language: ASD-STE100 Simplified Technical English` section to the CLAUDE.md rule floor. It instructs all AI agents to write chat output in STE.
- Regenerate the six fan-out files (AGENTS.md, GEMINI.md, .github/copilot-instructions.md, and the three `plugins/dotbabel/templates/cli-instructions/` templates) with `dotbabel-generate-instructions`.

## Test plan

- [x] `node plugins/dotbabel/bin/dotbabel-generate-instructions.mjs` — wrote all 7 instruction files
- [x] `node plugins/dotbabel/bin/dotbabel-check-instruction-drift.mjs` — ✓ instruction files match repo facts
- [x] `node plugins/dotbabel/bin/dotbabel-check-instructions-fresh.mjs` — ✓ generated instruction files are fresh
- [x] `node plugins/dotbabel/bin/dotbabel-check-instruction-parity.mjs` — ✓ generated instruction headings have parity
- [x] `npm test` — 53 test files passed, 936 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Spec ID

dotbabel-core
