### PR TITLE
fix(local-attest): re-check HEAD after the matrix before publishing

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,181 +1,181 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-08T21:03:15.244Z",
+  "generatedAt": "2026-08-09T16:37:18.468Z",
   "skills": [
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "audit-and-fix",
       "path": ".claude/skills/audit-and-fix/SKILL.md",
       "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:ba954a78351a0988ccd7ab00574bde2f6aa0d4dab0b5a32fb755f14957411358",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:7c1625de68e13e15ab0beb179e4cf6f9a3d2a80ec294a04cbb46e430cb0ab425",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "code-simplifier",
       "path": ".claude/skills/code-simplifier/SKILL.md",
       "checksum": "sha256:e24c64485f950d93815f492de5673aaa3ff65abb0df91fb41e41a40b68017cff",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "create-assessment",
       "path": ".claude/skills/create-assessment/SKILL.md",
       "checksum": "sha256:7d364824b0ce34d5703a3db91956b4607182b52be79bc5fdec9583c73ef6f73c",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "create-audit",
       "path": ".claude/skills/create-audit/SKILL.md",
       "checksum": "sha256:c65ff762a76e721fd0169cee087c582198c628a7a79b518792b168b2b6001cd4",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "create-experiment",
       "path": ".claude/skills/create-experiment/SKILL.md",
       "checksum": "sha256:424f23db1e1ba2cfc32c215bc4ae8f8dd8f710274161884252ac1fcfb28dcd3c",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "create-inspection",
       "path": ".claude/skills/create-inspection/SKILL.md",
       "checksum": "sha256:d8febaf15dd98a5d72fe97f8f41fd7d0a83ed98f0a11ab7ecedeedeaec544e85",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:ef78a49da882582f409c0c166d74112c6d37af437592e05bf6cd218bb8c34476",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "deploy-status",
       "path": ".claude/skills/deploy-status/SKILL.md",
       "checksum": "sha256:9119370d74077eae376afa72b28fff9cfd7617fd11b310590ddd6eb6c3d9258f",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/skills/detect-flaky/SKILL.md",
       "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/skills/fix-with-evidence/SKILL.md",
       "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "flyctl",
       "path": ".claude/skills/flyctl/SKILL.md",
       "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:39763f741bbff9bd6f9b72908ed3ea8de1870e2d5017b3ddab9015e0db4ff108",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "git",
       "path": ".claude/skills/git/SKILL.md",
       "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "ground-first",
       "path": ".claude/skills/ground-first/SKILL.md",
       "checksum": "sha256:0a8a9c125bc3fd0a3fe5cacb4f8cf6ff5971895ea1b703037a8712d3b5e15dd6",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
       "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:e3f0404dbd80ebdfce9df79df0a9bf501574abafcb7cd5a656c2afd4519428fb",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
-      "checksum": "sha256:a4fab149f1ea05770de853331d321fc2e8d4a745fcb52dcc1da1f76edbe4a995",
+      "checksum": "sha256:387fb7d3c71146ac22f79203a647ebebc0aaadf3dad5e38b9777c6ad02a1fdb1",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "plan-grader",
       "path": ".claude/skills/plan-grader/SKILL.md",
       "checksum": "sha256:50ba919efa0b4235e182a7d5b1ff2308481086a3ddddbf9166b0560370c3af27",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "post-pr-review",
@@ -184,7 +184,7 @@
       "dependencies": [
         "review-pr"
       ],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "pr-conductor",
@@ -198,28 +198,28 @@
         "local-attest",
         "merge-pr"
       ],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:fa4809bcd036c784b96ee70ee76999cd69fbfd104aa32543b53cc0c1b6b733ed",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "project-sync",
       "path": ".claude/skills/project-sync/SKILL.md",
       "checksum": "sha256:822e1509cf0ed4d0260c8bada35cd0e815a9b6529d637eb9baf3a430f8803104",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:6620a3862749142cf450245e9c6fc6c398530208848f64e2c34132e138f6f5ef",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "release-conductor",
@@ -228,28 +228,28 @@
       "dependencies": [
         "deploy-status"
       ],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "reproduce-bug",
       "path": ".claude/skills/reproduce-bug/SKILL.md",
       "checksum": "sha256:e73ae70e76b0c4a0ba43dc42d01596b2df1e97ffa7813a9fab45012711408b51",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "review-pr",
       "path": ".claude/skills/review-pr/SKILL.md",
       "checksum": "sha256:ec5f4190ecd9284fb68f5281f83adfe031a895ed7aaa47767f43cab25f734960",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "review-prs",
       "path": ".claude/skills/review-prs/SKILL.md",
       "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "rollback-prod",
@@ -258,49 +258,49 @@
       "dependencies": [
         "deploy-status"
       ],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "security-review",
       "path": ".claude/skills/security-review/SKILL.md",
       "checksum": "sha256:c8447582929b315402af24e304acd4addaa9be7120e895ca25d4c897ba84cfda",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:9ec1c67a434bf90512a2dcb5a68c4bb3bffd65c1bee967fa370164ec6ea84002",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:9e9c0d8b36ef44fb7f4f604aa706c2f380787c38c0282987c24436ec7bd53b85",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:fc7f266342f1686a5ca394398f048742b5f249144f45354d5f8c2520e359a2bb",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:13320e86060cb9a74d9ee98aecbbb9eff43c6100b47f09debe15f7049f6c050c",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2f66c14a71e88734d8a734bf1ce6f220f74ce28a9e302635e4e225edc1f9300e",
       "dependencies": [],
-      "lastValidated": "2026-08-08"
+      "lastValidated": "2026-08-09"
     }
   ]
 }

--- a/plugins/dotbabel/src/local-attest-runner.mjs
+++ b/plugins/dotbabel/src/local-attest-runner.mjs
@@ -126,6 +126,45 @@ export class PreconditionError extends Error {
 }
 
 /**
+ * Re-assert, after the matrix has run, that the tree still holds exactly what
+ * was tested. Preconditions are checked once up front, but the matrix takes
+ * minutes — long enough for another agent session, another worktree, or the
+ * user in a second terminal to commit onto the same branch.
+ *
+ * Without this, `execute` would attest the pre-matrix SHA and then
+ * `git push` whatever HEAD had become: publishing commits that were never
+ * tested, and labelling the PR `ci/local-verified` on a head nobody verified.
+ * Observed in practice — a matrix attested one SHA and pushed a different one
+ * that had landed during its 441-second test leg.
+ *
+ * @param {Deps} deps
+ * @param {Preconditions} pre
+ * @returns {void}
+ * @throws {PreconditionError} when HEAD moved or the tree became dirty
+ */
+export function verifyHeadUnchanged(deps, pre) {
+  const headNow = capture(deps, "git rev-parse HEAD");
+  if (headNow !== pre.headSha) {
+    throw new PreconditionError(
+      `HEAD moved while the matrix was running: tested ${pre.headSha.slice(0, 8)}, ` +
+        `now ${headNow.slice(0, 8)}.\n` +
+        "Nothing was posted, pushed, or labelled — the results describe a commit that is no " +
+        "longer checked out. Another writer touched this branch; re-run to attest the new head.",
+    );
+  }
+
+  const dirty = capture(deps, "git status --porcelain");
+  if (dirty !== "") {
+    throw new PreconditionError(
+      "The working tree became dirty while the matrix was running:\n" +
+        `${dirty}\n` +
+        "Nothing was posted, pushed, or labelled — the matrix tested a tree that does not " +
+        "match the commit it would attest. Clean the tree and re-run.",
+    );
+  }
+}
+
+/**
  * @param {Deps} deps
  * @param {Config} cfg
  * @param {{ prOverride?: string|null }} [opts]
@@ -354,9 +393,14 @@ export function execute(deps, cfg, flags) {
     return { ok: true, body, results, pre, exitCode: 0 };
   }
 
+  // The marker SHA is the HEAD captured before the matrix ran, but `git push`
+  // publishes whatever HEAD is NOW. Those are only the same commit if nothing
+  // touched the branch in between — re-assert that before any side effect, or
+  // we publish untested work and vouch for it.
+  verifyHeadUnchanged(deps, pre);
+
   // Post the attestation comment BEFORE pushing so it is visible when the
-  // push event fires GitHub Actions. The SHA embedded in the marker is the
-  // local HEAD, which is identical to what gets pushed.
+  // push event fires GitHub Actions.
   upsertComment(deps, { repo: pre.repo, pr: pre.pr, body, trustedAssociations: cfg.trustedAssociations });
 
   if (flags.push && cfg.pushAfterAttest) {

--- a/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
@@ -98,14 +98,21 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
    pass to attest; advisory legs are reported but never block. Stdout + stderr
    are tailed at 10 lines per leg so the result table stays readable.
 3. **Hard-leg gate.** Any hard failure aborts: no comment, no label, no push.
-4. **Push first** (if `pushAfterAttest` and not `--no-push`). The attestation
+4. **Re-check HEAD.** The matrix takes minutes — long enough for another agent
+   session, another worktree, or you in a second terminal to commit onto the
+   same branch. Step 1's check is stale by now, so HEAD and the worktree are
+   re-asserted against what was actually tested. If either moved, everything
+   aborts: no comment, no label, no push. Without this the skill would attest
+   the pre-matrix SHA and then push whatever HEAD had become — publishing
+   commits it never tested and labelling the PR verified on an unrun head.
+5. **Push first** (if `pushAfterAttest` and not `--no-push`). The attestation
    must never describe a SHA the remote hasn't seen.
-5. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
+6. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
    place; otherwise a new one is POSTed. Body always goes via `gh api --input -`
    so multiline markdown can't be mangled by shell quoting.
-6. **Apply label** (default `ci/local-verified`). Best-effort; failure warns
+7. **Apply label** (default `ci/local-verified`). Best-effort; failure warns
    but does not abort.
-7. **Append audit log line** to the configured `auditLogPath` (default
+8. **Append audit log line** to the configured `auditLogPath` (default
    `.local-attest-log.jsonl`). Best-effort.
 
 ## Flags

--- a/plugins/dotbabel/tests/bats/local-attest-head-race.bats
+++ b/plugins/dotbabel/tests/bats/local-attest-head-race.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# End-to-end race coverage for dotbabel-local-attest.
+#
+# The unit tests in local-attest-runner.test.mjs simulate a moving HEAD with a
+# stubbed `deps.run`. That proves the guard's logic but not that it fires in a
+# real repository against real git — and the bug it protects against was only
+# ever observed in the wild, when another agent session committed onto the
+# branch during a 441-second test leg.
+#
+# A matrix leg is arbitrary shell, so a leg that runs `git commit` reproduces
+# the race exactly: real git, real HEAD movement, real push target. Nothing
+# about the code path under test is mocked; only `gh` is faked, because the
+# alternative is talking to GitHub.
+#
+# The load-bearing assertion is the BARE REMOTE's head. If the guard fails,
+# `git push` publishes a commit the matrix never ran, and the remote moves.
+
+load helpers
+
+BIN="$REPO_ROOT/plugins/dotbabel/bin/dotbabel-local-attest.mjs"
+
+setup() {
+  REPO="$(make_tmp_git_repo)"
+  BARE="$REPO-bare.git"
+  GH_LOG="$(mktemp)"
+  export GH_LOG
+  # Record every gh invocation; answer the handful the runner needs.
+  with_fake_tool_bin gh '
+    printf "%s\n" "$*" >> "$GH_LOG"
+    case "$1 $2 $3" in
+      "auth status "*)            exit 0 ;;
+    esac
+    case "$*" in
+      "repo view --json nameWithOwner"*) echo "kaio/repo"; exit 0 ;;
+      "pr view --json number"*)         echo "42"; exit 0 ;;
+      # Report the repo tip so the START-of-run precondition passes.
+      "pr view 42 --json headRefOid"*)  git rev-parse HEAD; exit 0 ;;
+      "api user"*)                      echo "kaio"; exit 0 ;;
+      *permission*)                     echo "ADMIN"; exit 0 ;;
+      *comments\ --paginate*)           echo "[]"; exit 0 ;;
+    esac
+    exit 0
+  ' >/dev/null
+}
+
+teardown() {
+  [ -n "${REPO:-}" ] && rm -rf "$REPO" "$BARE" 2>/dev/null || true
+  [ -n "${GH_LOG:-}" ] && rm -f "$GH_LOG" 2>/dev/null || true
+}
+
+# Write a config whose matrix is $1 (raw JS array body), and commit it —
+# a real project tracks its config, and an untracked file would trip the
+# start-of-run clean-tree precondition before the matrix ever ran.
+write_config() {
+  cat > "$REPO/.local-attest.config.mjs" <<EOF
+export default { matrix: [ $1 ] };
+EOF
+  git -C "$REPO" add .local-attest.config.mjs
+  git -C "$REPO" commit -q -m "chore: add local-attest config"
+}
+
+@test "local-attest: a leg that commits mid-matrix aborts and pushes nothing" {
+  write_config '{ name: "racy", mode: "hard", command: "git commit -q --allow-empty -m concurrent" }'
+
+  remote_before="$(git -C "$BARE" rev-parse main)"
+
+  cd "$REPO"
+  run node "$BIN" --pr 42
+
+  # Assert the HARM first, so a regression reports "untested commit was
+  # published" rather than the less informative "exit code was not 1".
+  # Nothing the matrix did not run may reach the remote.
+  [ "$(git -C "$BARE" rev-parse main)" = "$remote_before" ]
+
+  # The commit really happened — this is a genuine race, not a simulated one.
+  [ "$(git -C "$REPO" rev-parse HEAD)" != "$remote_before" ]
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"HEAD moved"* ]]
+}
+
+@test "local-attest: aborting on a moved HEAD posts no comment and applies no label" {
+  write_config '{ name: "racy", mode: "hard", command: "git commit -q --allow-empty -m concurrent" }'
+
+  cd "$REPO"
+  run node "$BIN" --pr 42
+  [ "$status" -eq 1 ]
+
+  run grep -E "api --method (POST|PATCH)" "$GH_LOG"
+  [ "$status" -eq 1 ]
+  run grep -E "pr edit 42 --add-label" "$GH_LOG"
+  [ "$status" -eq 1 ]
+}
+
+@test "local-attest: aborting on a moved HEAD writes no audit-log entry" {
+  write_config '{ name: "racy", mode: "hard", command: "git commit -q --allow-empty -m concurrent" }'
+
+  cd "$REPO"
+  run node "$BIN" --pr 42
+  [ "$status" -eq 1 ]
+  [ ! -f "$REPO/.local-attest-log.jsonl" ]
+}
+
+@test "local-attest: a leg that dirties the tree mid-matrix also aborts" {
+  write_config '{ name: "dirty", mode: "hard", command: "echo changed >> README.md" }'
+
+  remote_before="$(git -C "$BARE" rev-parse main)"
+
+  cd "$REPO"
+  run node "$BIN" --pr 42
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"dirty"* ]]
+  [ "$(git -C "$BARE" rev-parse main)" = "$remote_before" ]
+}
+
+@test "local-attest: an unraced run still attests, labels and pushes" {
+  # Control: identical setup, a leg that leaves HEAD alone. Without this the
+  # abort tests could pass for the wrong reason (e.g. the bin failing early).
+  write_config '{ name: "quiet", mode: "hard", command: "true" }'
+
+  # Give the local branch a commit to push so the push is observable.
+  git -C "$REPO" commit -q --allow-empty -m "work to publish"
+  local_head="$(git -C "$REPO" rev-parse HEAD)"
+
+  cd "$REPO"
+  run node "$BIN" --pr 42
+  [ "$status" -eq 0 ]
+
+  # Comment posted, label applied, branch pushed.
+  run grep -E "api --method POST" "$GH_LOG"
+  [ "$status" -eq 0 ]
+  run grep -E "pr edit 42 --add-label" "$GH_LOG"
+  [ "$status" -eq 0 ]
+  [ "$(git -C "$BARE" rev-parse main)" = "$local_head" ]
+}
+
+@test "local-attest: --dry-run publishes nothing even when HEAD moves" {
+  write_config '{ name: "racy", mode: "hard", command: "git commit -q --allow-empty -m concurrent" }'
+
+  remote_before="$(git -C "$BARE" rev-parse main)"
+
+  cd "$REPO"
+  run node "$BIN" --pr 42 --dry-run
+  [ "$status" -eq 0 ]
+  [ "$(git -C "$BARE" rev-parse main)" = "$remote_before" ]
+  run grep -E "api --method (POST|PATCH)" "$GH_LOG"
+  [ "$status" -eq 1 ]
+}

--- a/plugins/dotbabel/tests/local-attest-runner.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-runner.test.mjs
@@ -23,7 +23,11 @@ function makeDeps({ runReplies = [], hostname = "stub-host" } = {}) {
     calls.run.push({ cmd, opts });
     for (const [pattern, result] of runReplies) {
       if (pattern.test(cmd)) {
-        return { status: 0, stdout: "", stderr: "", ...result };
+        // A function reply receives the calls-so-far so a test can change the
+        // answer between invocations — required to simulate a branch moving
+        // underneath a long-running matrix.
+        const resolved = typeof result === "function" ? result(calls.run) : result;
+        return { status: 0, stdout: "", stderr: "", ...resolved };
       }
     }
     return { status: 0, stdout: "", stderr: "" };
@@ -353,5 +357,64 @@ describe("execute (orchestration)", () => {
     // label create + label attach
     expect(calls.run.some((c) => /gh label create/.test(c.cmd))).toBe(true);
     expect(calls.run.some((c) => /gh pr edit 42 --add-label/.test(c.cmd))).toBe(true);
+  });
+
+  // Preconditions are checked once, up front; the matrix then runs for minutes.
+  // A concurrent writer on the same branch used to mean: attest the old SHA,
+  // then `git push` the new one — publishing untested commits and labelling the
+  // PR verified on a head nobody ran.
+  const OLD_SHA = "abc1234abc1234abc1234abc1234abc1234abc12";
+  const NEW_SHA = "def5678def5678def5678def5678def5678def56";
+
+  /** HEAD reports OLD_SHA on the precondition read, NEW_SHA on every later read. */
+  const movingHead = () => {
+    let seen = 0;
+    return [/git rev-parse HEAD/, () => ({ stdout: `${seen++ === 0 ? OLD_SHA : NEW_SHA}\n` })];
+  };
+
+  it("aborts when HEAD moves during the matrix", () => {
+    const { deps } = makeDeps({ runReplies: [movingHead(), ...happy] });
+    expect(() => execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false })).toThrow(
+      PreconditionError,
+    );
+  });
+
+  it("names both SHAs so the operator can see what changed", () => {
+    const { deps } = makeDeps({ runReplies: [movingHead(), ...happy] });
+    let err;
+    try {
+      execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).toContain(OLD_SHA.slice(0, 8));
+    expect(err.message).toContain(NEW_SHA.slice(0, 8));
+  });
+
+  it("publishes nothing when HEAD moved — no comment, no push, no label, no audit", () => {
+    const { deps, calls } = makeDeps({ runReplies: [movingHead(), ...happy] });
+    expect(() => execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false })).toThrow();
+    expect(calls.gh).toHaveLength(0);
+    expect(calls.appendLog).toHaveLength(0);
+    expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
+    expect(calls.run.some((c) => /gh pr edit 42 --add-label/.test(c.cmd))).toBe(false);
+  });
+
+  it("aborts when the tree becomes dirty during the matrix", () => {
+    let seen = 0;
+    const dirtying = [/git status --porcelain/, () => ({ stdout: seen++ === 0 ? "" : " M src/x.mjs\n" })];
+    const { deps, calls } = makeDeps({ runReplies: [dirtying, ...happy] });
+    expect(() => execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false })).toThrow(
+      PreconditionError,
+    );
+    expect(calls.gh).toHaveLength(0);
+    expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
+  });
+
+  it("dry-run is unaffected by the recheck — it publishes nothing anyway", () => {
+    const { deps, calls } = makeDeps({ runReplies: [movingHead(), ...happy] });
+    const r = execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: true });
+    expect(r.exitCode).toBe(0);
+    expect(calls.gh).toHaveLength(0);
   });
 });

--- a/skills/local-attest/SKILL.md
+++ b/skills/local-attest/SKILL.md
@@ -101,14 +101,21 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
    pass to attest; advisory legs are reported but never block. Stdout + stderr
    are tailed at 10 lines per leg so the result table stays readable.
 3. **Hard-leg gate.** Any hard failure aborts: no comment, no label, no push.
-4. **Push first** (if `pushAfterAttest` and not `--no-push`). The attestation
+4. **Re-check HEAD.** The matrix takes minutes — long enough for another agent
+   session, another worktree, or you in a second terminal to commit onto the
+   same branch. Step 1's check is stale by now, so HEAD and the worktree are
+   re-asserted against what was actually tested. If either moved, everything
+   aborts: no comment, no label, no push. Without this the skill would attest
+   the pre-matrix SHA and then push whatever HEAD had become — publishing
+   commits it never tested and labelling the PR verified on an unrun head.
+5. **Push first** (if `pushAfterAttest` and not `--no-push`). The attestation
    must never describe a SHA the remote hasn't seen.
-5. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
+6. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
    place; otherwise a new one is POSTed. Body always goes via `gh api --input -`
    so multiline markdown can't be mangled by shell quoting.
-6. **Apply label** (default `ci/local-verified`). Best-effort; failure warns
+7. **Apply label** (default `ci/local-verified`). Best-effort; failure warns
    but does not abort.
-7. **Append audit log line** to the configured `auditLogPath` (default
+8. **Append audit log line** to the configured `auditLogPath` (default
    `.local-attest-log.jsonl`). Best-effort.
 
 ## Flags


### PR DESCRIPTION
## Summary

`local-attest` verified HEAD once, up front, then ran the matrix for minutes and pushed without re-checking. `execute()` captured `headSha` in `checkPreconditions` (`local-attest-runner.mjs:318`), embedded it in the attestation body (`:333-336`), and then ran a bare `git push` (`:364`). The inline comment claimed the marker SHA "is identical to what gets pushed" — true only if nothing touched the branch in between.

On a branch with a concurrent writer, it isn't, and every consequence is silent:

| | |
|---|---|
| Attestation posted for the **pre-matrix** SHA | stale, so CI correctly re-runs — harmless |
| `git push` publishes whatever HEAD **became** | **commits the matrix never tested** |
| `ci/local-verified` applied | to a PR head nobody verified |
| Audit log records the tested SHA | not the pushed one — a false record |

Observed while attesting #280: the matrix verified `24b5dd5` and pushed `6f435f4`, a commit another agent session landed during the 441-second `bats` leg. That commit happened to be fine; nothing in the tool knew or checked.

Adds `verifyHeadUnchanged()`, called immediately before the first side effect. It re-reads HEAD and worktree status and throws `PreconditionError` if either moved — nothing posted, pushed, labelled, or logged — naming both SHAs. `--dry-run` is unchanged; it publishes nothing regardless.

The worktree re-check is deliberate. A dirty tree doesn't change what gets pushed, but it means the matrix tested content differing from the commit being attested — vouching for a tree that never existed. Preconditions already require clean at the start; requiring it at the end holds the same guarantee across the whole run.

## Test plan

- [x] `npm test -- --coverage` — 941 passed / 53 files (4 new cases)
- [x] Coverage 89.13% stmts · 81.86% branches · 93.13% fns · 90.57% lines (gate 85/80/85/85)
- [x] Verified non-vacuous: commenting out the `verifyHeadUnchanged(deps, pre)` call turns **exactly** the four new tests red — `HEAD moves`, `names both SHAs`, `publishes nothing`, `tree becomes dirty`; restoring it returns 28/28
- [x] New cases assert zero side effects on abort: no `gh` comment, no `git push`, no `--add-label`, no audit-log append
- [x] `--dry-run` case confirms the recheck doesn't change dry-run behavior
- [x] `npm run lint`, `npm run dogfood`, `dotbabel-doctor`, `dotbabel-index --check`, `build-plugin --check` — all pass

## No-spec rationale

Bug fix to one existing function's ordering, plus its regression tests and a matching prose step in `skills/local-attest/SKILL.md`. Adds no new subsystem, no CLI surface, and no config option; the exported API gains one function used only internally by `execute()`. Behavior changes only on the previously-unhandled race — every path where HEAD is stable is byte-identical to before.
