### PR TITLE
fix(check-on-stop): find project markers per sub-project, not at the root

### DIFF
--- a/plugins/dotbabel/hooks/check-on-stop.sh
+++ b/plugins/dotbabel/hooks/check-on-stop.sh
@@ -134,6 +134,58 @@ clear_state() {
 command -v git >/dev/null 2>&1 || exit 0
 git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
+# `git status --porcelain` reports paths relative to the repository TOP LEVEL,
+# not to the -C directory, so every changed path is resolved against this.
+GIT_TOP=$(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -n "$GIT_TOP" ] || exit 0
+
+# marker_for <lang> — the file that identifies a project root for a language.
+# C# is empty on purpose: it matches a glob (*.csproj / *.sln), handled below.
+marker_for() {
+  case "$1" in
+    go)     printf 'go.mod' ;;
+    rust)   printf 'Cargo.toml' ;;
+    ts)     printf 'tsconfig.json' ;;
+    java)   printf 'pom.xml' ;;
+    *)      printf '' ;;
+  esac
+}
+
+# find_project_root <lang> <dir> — print the nearest directory at or above
+# <dir> that holds the language's marker. The walk stops at the repo top.
+#
+# The marker used to be looked up at $ROOT only, which made this hook a silent
+# no-op on every monorepo: squadranks keeps go.mod at api/go.mod, so a Go edit
+# found no marker at the root and no check ever ran.
+#
+# The result must stay inside $ROOT. $ROOT is the directory the user put on
+# the trust allowlist, and these checkers execute repo-controlled build code,
+# so a root discovered outside it is refused rather than checked.
+find_project_root() {
+  local lang="$1" dir="$2" marker parent f
+  marker=$(marker_for "$lang")
+  while :; do
+    if [ -n "$marker" ]; then
+      if [ -f "$dir/$marker" ]; then
+        case "$dir/" in "$ROOT"/*) printf '%s' "$dir"; return 0 ;; esac
+        return 1
+      fi
+    else
+      for f in "$dir"/*.csproj "$dir"/*.sln; do
+        if [ -e "$f" ]; then
+          case "$dir/" in "$ROOT"/*) printf '%s' "$dir"; return 0 ;; esac
+          return 1
+        fi
+      done
+    fi
+    [ "$dir" = "$GIT_TOP" ] && return 1
+    parent="${dir%/*}"
+    [ -n "$parent" ] || return 1
+    [ "$parent" = "$dir" ] && return 1
+    dir="$parent"
+  done
+}
+
 # -z and --untracked-files=all are both load-bearing:
 #
 #   -z   disables git's C-quoting. `core.quotePath` defaults to true, so a
@@ -169,12 +221,18 @@ while IFS= read -r -d '' entry; do
   case "$base" in *.*) ;; *) continue ;; esac
   ext="${base##*.}"
   case "${ext,,}" in
-    go)                TOUCHED[go]=1 ;;
-    rs)                TOUCHED[rust]=1 ;;
-    ts|tsx|mts|cts)    TOUCHED[ts]=1 ;;
-    java)              TOUCHED[java]=1 ;;
-    cs)                TOUCHED[csharp]=1 ;;
+    go)                lang=go ;;
+    rs)                lang=rust ;;
+    ts|tsx|mts|cts)    lang=ts ;;
+    java)              lang=java ;;
+    cs)                lang=csharp ;;
+    *)                 continue ;;
   esac
+  # Key on language AND project root, so a monorepo runs one check per
+  # sub-project instead of one check for the whole tree.
+  abs="$GIT_TOP/$path"
+  proj=$(find_project_root "$lang" "${abs%/*}") || continue
+  TOUCHED["$lang"$'\t'"$proj"]=1
 done < <(git -C "$ROOT" status --porcelain -z --untracked-files=all 2>/dev/null)
 
 if [ "$SAW_CHANGE" -eq 0 ]; then
@@ -208,44 +266,46 @@ have() { command -v "$1" >/dev/null 2>&1; }
 # 127 means "not applicable here" — no marker, or no toolchain — and is
 # always treated as silence, never as a finding.
 
+# Each takes the project root as $1 — find_project_root already proved the
+# marker is there, so none of them re-tests for it. `cd` happens in a subshell
+# so the caller's working directory is never disturbed between projects.
+
 chk_go() {
-  [ -f "$ROOT/go.mod" ] || return 127
   have go || return 127
-  run_bounded go vet ./... 2>&1
+  ( cd "$1" && run_bounded go vet ./... ) 2>&1
 }
 
 chk_rust() {
-  [ -f "$ROOT/Cargo.toml" ] || return 127
   have cargo || return 127
-  run_bounded cargo check --quiet --message-format short 2>&1
+  ( cd "$1" && run_bounded cargo check --quiet --message-format short ) 2>&1
 }
 
 chk_ts() {
-  [ -f "$ROOT/tsconfig.json" ] || return 127
-  local bin="$ROOT/node_modules/.bin/tsc"
-  if [ ! -x "$bin" ]; then
-    have tsc || return 127
+  # node_modules is often hoisted to the repo top in a monorepo, so look in
+  # the project first and then at the top before falling back to PATH.
+  local bin=""
+  if [ -x "$1/node_modules/.bin/tsc" ]; then
+    bin="$1/node_modules/.bin/tsc"
+  elif [ -x "$GIT_TOP/node_modules/.bin/tsc" ]; then
+    bin="$GIT_TOP/node_modules/.bin/tsc"
+  elif have tsc; then
     bin=tsc
+  else
+    return 127
   fi
-  run_bounded "$bin" --noEmit -p "$ROOT/tsconfig.json" 2>&1
+  ( cd "$1" && run_bounded "$bin" --noEmit -p "$1/tsconfig.json" ) 2>&1
 }
 
 chk_java() {
-  [ -f "$ROOT/pom.xml" ] || return 127
   have mvn || return 127
   # -o (offline) so a turn-end check can never sit downloading Maven Central.
   # A cold cache fails fast and is swallowed by NOISE_RX rather than reported.
-  run_bounded mvn -o -q -DskipTests compile 2>&1
+  ( cd "$1" && run_bounded mvn -o -q -DskipTests compile ) 2>&1
 }
 
 chk_csharp() {
-  local found=""
-  for f in "$ROOT"/*.csproj "$ROOT"/*.sln; do
-    if [ -e "$f" ]; then found=1; break; fi
-  done
-  [ -n "$found" ] || return 127
   have dotnet || return 127
-  run_bounded dotnet build --nologo -v q --no-restore 2>&1
+  ( cd "$1" && run_bounded dotnet build --nologo -v q --no-restore ) 2>&1
 }
 
 # ---------------------------------------------------------------- run ----
@@ -253,12 +313,17 @@ chk_csharp() {
 FAILED_LANGS=()
 REPORT=""
 
-cd "$ROOT" || exit 0
-
-for lang in "${!TOUCHED[@]}"; do
+for key in "${!TOUCHED[@]}"; do
+  lang="${key%%$'\t'*}"
+  proj="${key#*$'\t'}"
+  # A readable label: the project's path relative to the repo top, or "." at
+  # the top itself. This is what tells a monorepo user WHICH project failed.
+  label="${proj#"$GIT_TOP"}"
+  label="${label#/}"
+  [ -n "$label" ] || label="."
   out=""
   rc=0
-  out=$("chk_$lang" 2>/dev/null) || rc=$?
+  out=$("chk_$lang" "$proj" 2>/dev/null) || rc=$?
   [ "$rc" -eq 0 ] && continue
   [ "$rc" -eq 127 ] && continue
   # Timed out, or killed. Not a code defect.
@@ -267,10 +332,10 @@ for lang in "${!TOUCHED[@]}"; do
   if printf '%s' "$out" | grep -qE "$NOISE_RX"; then
     continue
   fi
-  FAILED_LANGS+=("$lang")
+  FAILED_LANGS+=("$lang:$label")
   body=$(printf '%s\n' "$out" | head -n "$MAX_LINES" || true)
   total=$(printf '%s\n' "$out" | wc -l || true)
-  REPORT+="[$lang] project check failed"$'\n'
+  REPORT+="[$lang $label] project check failed"$'\n'
   if [ -n "$body" ]; then
     REPORT+="${body:0:3000}"$'\n'
   else

--- a/plugins/dotbabel/tests/bats/check-on-stop.bats
+++ b/plugins/dotbabel/tests/bats/check-on-stop.bats
@@ -295,6 +295,82 @@ seed_go() {
   [ -z "$output" ]
 }
 
+# A stub that records the directory it ran in. The monorepo tests care about
+# WHERE the check runs, which argv alone cannot show.
+stub_cwd_recorder() {
+  local name="$1" rc="${2:-0}"
+  cat > "$STUB_BIN/$name" <<STUB
+#!/usr/bin/env bash
+printf '%s\t%s\n' "$name" "\$PWD" >> "$STUB_LOG"
+exit $rc
+STUB
+  chmod +x "$STUB_BIN/$name"
+}
+
+@test "monorepo: a marker in a subdirectory is found" {
+  # The squadranks shape: go.mod lives at api/go.mod, not at the root. The
+  # previous lookup only checked \$ROOT/go.mod, so nothing ever ran.
+  mkdir -p "$REPO/api"
+  printf 'module example.com/api\n\ngo 1.21\n' > "$REPO/api/go.mod"
+  printf 'package main\n\nfunc main() {}\n' > "$REPO/api/main.go"
+  stub_checker go 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [ "$status" -eq 0 ]
+  [[ "$(stub_calls go)" == *"vet"* ]]
+}
+
+@test "monorepo: the check runs inside the sub-project, not the repo root" {
+  mkdir -p "$REPO/api"
+  printf 'module example.com/api\n\ngo 1.21\n' > "$REPO/api/go.mod"
+  printf 'package main\n' > "$REPO/api/main.go"
+  stub_cwd_recorder go 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [[ "$(stub_calls go)" == *"$REPO/api"* ]]
+}
+
+@test "monorepo: two sub-projects of one language each get a check" {
+  mkdir -p "$REPO/api" "$REPO/worker"
+  printf 'module example.com/api\n\ngo 1.21\n' > "$REPO/api/go.mod"
+  printf 'module example.com/worker\n\ngo 1.21\n' > "$REPO/worker/go.mod"
+  printf 'package main\n' > "$REPO/api/main.go"
+  printf 'package main\n' > "$REPO/worker/main.go"
+  stub_cwd_recorder go 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [[ "$(stub_calls go)" == *"$REPO/api"* ]]
+  [[ "$(stub_calls go)" == *"$REPO/worker"* ]]
+  [ "$(stub_calls go | wc -l)" -eq 2 ]
+}
+
+@test "monorepo: the nearest marker wins" {
+  # A file under api/ must use api/go.mod even when the root has one too.
+  printf 'module example.com/root\n\ngo 1.21\n' > "$REPO/go.mod"
+  mkdir -p "$REPO/api"
+  printf 'module example.com/api\n\ngo 1.21\n' > "$REPO/api/go.mod"
+  printf 'package main\n' > "$REPO/api/main.go"
+  stub_cwd_recorder go 0
+  feed_stop_json "$HOOK" false "$REPO"
+  [[ "$(stub_calls go)" == *"$REPO/api"* ]]
+  [ "$(stub_calls go | wc -l)" -eq 1 ]
+}
+
+@test "monorepo: the report names which sub-project failed" {
+  mkdir -p "$REPO/api"
+  printf 'module example.com/api\n\ngo 1.21\n' > "$REPO/api/go.mod"
+  printf 'package main\n' > "$REPO/api/main.go"
+  stub_checker go 1 "" "main.go:3: something is wrong"
+  feed_stop_json "$HOOK" false "$REPO"
+  [[ "$output" == *"[go api]"* ]]
+}
+
+@test "a file with no marker anywhere above it runs nothing" {
+  # Walking up must stop at the repo top rather than escaping the repo.
+  printf 'package main\n' > "$REPO/orphan.go"
+  stub_checker go 1 "" "should not run"
+  feed_stop_json "$HOOK" false "$REPO"
+  [ "$status" -eq 0 ]
+  [ -z "$(stub_calls go)" ]
+}
+
 @test "go: modified .go + go.mod + toolchain dispatches go vet" {
   seed_go
   stub_checker go 0


### PR DESCRIPTION
## Summary

- Finds project markers by walking up from each changed file, instead of looking only at the repo root.
- Closes the last open finding from the #281 review: the hook was a **silent no-op on every monorepo**.
- A monorepo now runs one check per sub-project, and the report says which one failed.

## The gap

Every `chk_*` tested for its marker at `$ROOT` only. squadranks keeps `go.mod` at `api/go.mod`, so a Go edit found nothing at the root and no check ran. Verified against the real repo with a temporary allowlist: exit 0, no output.

The failure was silent. The hook says nothing when it finds nothing, so "your monorepo is unprotected" looked exactly like "everything passed".

## What changed

`TOUCHED` is now keyed on language **and** project root. `find_project_root` walks up from each changed file's directory to the nearest marker, bounded by the repo top level.

Three details:

- **Path resolution.** `git status --porcelain` reports paths relative to the repository top level, not to the `-C` directory. Paths now resolve against `rev-parse --show-toplevel`.
- **Trust boundary.** A discovered root outside `$ROOT` is refused. `$ROOT` is what the user put on the allowlist, and these checkers execute repo-controlled build code, so the walk must never hand a check an unauthorized directory.
- **`chk_*` signature.** Each takes the project root as `$1` and runs `cd` in a subshell. The marker test inside them is gone, because discovery already proved it. `chk_ts` also looks for a hoisted `node_modules/.bin/tsc` at the repo top, the normal workspace layout.

## Test plan

- [x] `npx bats plugins/dotbabel/tests/bats/check-on-stop.bats` — 47/47 (was 41)
- [x] **Non-vacuity proven**: restored the previous root-only lookup and re-ran. 5 of the 6 new tests fail against it. The sixth pins that a file with no marker above it still runs nothing.
- [x] All 41 pre-existing tests pass unchanged, so the `chk_*` refactor kept behavior.
- [x] `npx bats plugins/dotbabel/tests/bats/` — 570/570
- [x] `npm test` — 936 tests / 53 files
- [x] shellcheck CI line verbatim — clean
- [x] `npm run dogfood` — all pass
- [x] `npm run docs:stamp-check` — 14 docs stamped

The fixture reproduces the squadranks shape (`api/go.mod`, no root marker). I did not run against the real squadranks checkout, because that needs a modified file there and it belongs to other active sessions.

## Spec ID

dotbabel-core
