### PR TITLE
fix(security): bump js-yaml to 4.3.1 and harden argv-built subprocesses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.1",
         "prettier": "^3.5.0"
       },
       "bin": {
@@ -30,6 +30,7 @@
         "dotbabel-init": "plugins/dotbabel/bin/dotbabel-init.mjs",
         "dotbabel-list": "plugins/dotbabel/bin/dotbabel-list.mjs",
         "dotbabel-local-attest": "plugins/dotbabel/bin/dotbabel-local-attest.mjs",
+        "dotbabel-pr-stack": "plugins/dotbabel/bin/dotbabel-pr-stack.mjs",
         "dotbabel-project-init": "plugins/dotbabel/bin/dotbabel-project-init.mjs",
         "dotbabel-project-sync": "plugins/dotbabel/bin/dotbabel-project-sync.mjs",
         "dotbabel-search": "plugins/dotbabel/bin/dotbabel-search.mjs",
@@ -1240,9 +1241,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node": ">=20"
   },
   "overrides": {
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.3.1"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.5",
@@ -101,7 +101,7 @@
   "dependencies": {
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.1",
     "prettier": "^3.5.0"
   }
 }

--- a/plugins/dotbabel/src/lib/handoff-remote.mjs
+++ b/plugins/dotbabel/src/lib/handoff-remote.mjs
@@ -102,9 +102,16 @@ function fail(code, msg) {
 
 // ---- subprocess primitives ---------------------------------------------
 
-/** Spawn a shell script via spawnSync, returning {status, stdout, stderr}. */
+/**
+ * Spawn a shell script via spawnSync, returning {status, stdout, stderr}.
+ *
+ * `script` resolves from the install directory and `args` carries session
+ * file paths discovered on disk, so both are attacker-influenceable file
+ * names. They are passed as argv and never through a shell: `shell: false`
+ * lands after the `opts` spread so no caller can re-enable one.
+ */
 export function runScript(script, args, opts = {}) {
-  const res = spawnSync(script, args, { encoding: "utf8", ...opts });
+  const res = spawnSync(script, args, { encoding: "utf8", ...opts, shell: false });
   return {
     status: res.status ?? 2,
     stdout: res.stdout ?? "",

--- a/plugins/dotbabel/src/spec-harness-lib.mjs
+++ b/plugins/dotbabel/src/spec-harness-lib.mjs
@@ -111,15 +111,62 @@ export function pathExists(ctx, relativePath) {
   return existsSync(path.join(ctx.repoRoot, relativePath));
 }
 
-const FORBIDDEN_GIT_PREFIXES = ["--upload-pack", "--receive-pack", "--exec"];
+// `git` is re-exported from src/index.mjs, so `args` is caller-controlled and
+// must be treated as untrusted. Several git arguments are command execution in
+// disguise, and a deny-list cannot stay complete on its own — git keeps adding
+// options. Two layers close the gap:
+//
+//   1. `args[0]` must be a bare subcommand from ALLOWED_GIT_SUBCOMMANDS. Git
+//      honors `-c core.sshCommand=…`, `--config-env=`, `--exec-path=`,
+//      `--git-dir=`, and `-C` only *before* the subcommand, so this one rule
+//      blocks all of them. The allow-list also keeps out subcommands that run
+//      commands by design (`grep -O`, `difftool --extcmd`, `bisect run`,
+//      `submodule foreach`, `filter-branch`).
+//   2. The per-arg deny-list covers the remaining post-subcommand vectors.
+//
+// Callers that need a write or a plumbing subcommand should spawn git
+// themselves with their own validation rather than widen this helper.
+const ALLOWED_GIT_SUBCOMMANDS = new Set([
+  "branch",
+  "cat-file",
+  "describe",
+  "diff",
+  "for-each-ref",
+  "log",
+  "ls-files",
+  "ls-tree",
+  "merge-base",
+  "name-rev",
+  "remote",
+  "rev-list",
+  "rev-parse",
+  "show",
+  "show-ref",
+  "status",
+  "symbolic-ref",
+]);
+
+const FORBIDDEN_GIT_PREFIXES = [
+  "--upload-pack",
+  "--receive-pack",
+  "--exec",
+  "--ext-diff",
+  "--textconv",
+  "--open-files-in-pager",
+];
 
 /**
  * Run `git <args>` with `cwd = ctx.repoRoot`, return trimmed stdout.
  * Lets the underlying error bubble on non-zero exit.
  *
+ * Only the read-only subcommands in `ALLOWED_GIT_SUBCOMMANDS` are accepted,
+ * and `args[0]` must be that subcommand — see the note above.
+ *
  * @param {HarnessContext} ctx
  * @param {string[]} args
  * @returns {string}
+ * @throws {TypeError} When any arg is not a string.
+ * @throws {Error} When the subcommand is not allow-listed, or an arg is forbidden.
  */
 export function git(ctx, args) {
   for (const a of args) {
@@ -127,6 +174,10 @@ export function git(ctx, args) {
     if (FORBIDDEN_GIT_PREFIXES.some((p) => a.startsWith(p))) {
       throw new Error(`git: refusing forbidden arg: ${a}`);
     }
+  }
+  const subcommand = args[0];
+  if (!ALLOWED_GIT_SUBCOMMANDS.has(subcommand)) {
+    throw new Error(`git: refusing git subcommand: ${subcommand ?? "(none)"}`);
   }
   return execFileSync("git", args, { cwd: ctx.repoRoot, encoding: "utf8" }).trim();
 }

--- a/plugins/dotbabel/tests/handoff-remote-coverage.test.mjs
+++ b/plugins/dotbabel/tests/handoff-remote-coverage.test.mjs
@@ -54,6 +54,27 @@ describe("runScript", () => {
     expect(r.stdout).toBe("");
     expect(r.stderr).toBe("");
   });
+
+  // The script path and the session-file operands come from the filesystem,
+  // so a shell here would turn a crafted file name into command execution.
+  // argv-only spawning must not be overridable through `opts`.
+  it("spawns without a shell", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    lib.runScript("/bin/echo", ["hi"]);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "/bin/echo",
+      ["hi"],
+      expect.objectContaining({ shell: false }),
+    );
+  });
+
+  it("ignores a caller-supplied shell:true", () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    lib.runScript("/bin/echo", ["hi"], { shell: true, cwd: "/tmp" });
+    const opts = spawnSync.mock.calls.at(-1)[2];
+    expect(opts.shell).toBe(false);
+    expect(opts.cwd).toBe("/tmp");
+  });
 });
 
 // ---- runGit / runGitOrThrow --------------------------------------------

--- a/plugins/dotbabel/tests/spec-harness-lib.test.mjs
+++ b/plugins/dotbabel/tests/spec-harness-lib.test.mjs
@@ -83,15 +83,55 @@ describe("listRepoPaths", () => {
 describe("git arg validation", () => {
   it("throws on --upload-pack arg", () => {
     const ctx = createHarnessContext({ repoRoot: "/some/path" });
-    expect(() => git(ctx, ["--upload-pack=evil"])).toThrow("refusing forbidden arg");
+    expect(() => git(ctx, ["fetch", "--upload-pack=evil"])).toThrow("refusing forbidden arg");
   });
   it("throws on --receive-pack arg", () => {
     const ctx = createHarnessContext({ repoRoot: "/some/path" });
-    expect(() => git(ctx, ["--receive-pack=evil"])).toThrow("refusing forbidden arg");
+    expect(() => git(ctx, ["push", "--receive-pack=evil"])).toThrow("refusing forbidden arg");
   });
   it("throws on non-string arg", () => {
     const ctx = createHarnessContext({ repoRoot: "/some/path" });
     expect(() => git(ctx, [123])).toThrow(TypeError);
+  });
+
+  // Pre-command options are where `-c core.sshCommand=…`, `--config-env`,
+  // and `--exec-path` become arbitrary command execution. Requiring a bare
+  // allow-listed subcommand in slot 0 closes every one of them at once.
+  it.each([
+    ["-c", ["-c", "core.sshCommand=touch /tmp/pwned", "log"]],
+    ["--config-env", ["--config-env=core.pager=CMD", "log"]],
+    ["--exec-path", ["--exec-path=/tmp/evil", "log"]],
+    ["--git-dir", ["--git-dir=/tmp/evil", "log"]],
+    ["--work-tree", ["--work-tree=/tmp/evil", "log"]],
+    ["-C", ["-C", "/tmp/evil", "log"]],
+    // `--exec-path` trips the forbidden-arg deny-list before the subcommand
+    // check, so accept either rejection message here.
+  ])("rejects the pre-command option %s", (_label, args) => {
+    const ctx = createHarnessContext({ repoRoot: "/some/path" });
+    expect(() => git(ctx, args)).toThrow(/^git: refusing/);
+  });
+
+  it("rejects a subcommand outside the read-only allow-list", () => {
+    const ctx = createHarnessContext({ repoRoot: "/some/path" });
+    expect(() => git(ctx, ["grep", "-Otouch /tmp/pwned", "x"])).toThrow("refusing git subcommand");
+    expect(() => git(ctx, ["difftool", "--extcmd=touch /tmp/pwned"])).toThrow(
+      "refusing git subcommand",
+    );
+  });
+
+  it("rejects an empty arg list", () => {
+    const ctx = createHarnessContext({ repoRoot: "/some/path" });
+    expect(() => git(ctx, [])).toThrow("refusing git subcommand");
+  });
+
+  it("rejects --ext-diff, which runs a configured external differ", () => {
+    const ctx = createHarnessContext({ repoRoot: "/some/path" });
+    expect(() => git(ctx, ["log", "--ext-diff"])).toThrow("refusing forbidden arg");
+  });
+
+  it("runs an allow-listed read-only subcommand", () => {
+    const ctx = createHarnessContext({ repoRoot: path.join(__dirname, "..", "..", "..") });
+    expect(git(ctx, ["rev-parse", "--show-toplevel"])).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary

- Bump `js-yaml` to `4.3.1` in both `dependencies` and `overrides` — the override pin was holding the whole tree at `4.1.1`, so all three open Dependabot alerts (#13, #17, #21) applied. `npm audit` now reports zero vulnerabilities.
- Harden `spec-harness-lib.git()` (CodeQL #26): `args[0]` must be a bare read-only subcommand from an allow-list, which blocks every pre-command execution vector (`-c core.sshCommand=`, `--config-env`, `--exec-path`, `--git-dir`, `-C`) that the old deny-list let through. The deny-list also gained `--ext-diff`, `--textconv`, and `--open-files-in-pager`.
- Harden `handoff-remote.runScript()` (CodeQL #27): `shell: false` now lands after the `opts` spread, so no caller can re-enable a shell for a subprocess whose script path and file operands come from the filesystem.

## Notes

Only `build-index.mjs` parses YAML, and only from repo-local frontmatter, so the js-yaml DoS exposure was low — but the fix is in-range and free.

CodeQL did not accept the previous `startsWith` deny-list as a sanitizer. Alerts #26 and #27 may therefore survive the next scan even though both call sites are now correct. Dismiss them as false positives rather than widening the guards.

The lockfile diff is 15 lines: this branch's `npm install` stripped `libc` metadata from 10 optional rollup entries (npm 10.9.7 versus the npm 11 that wrote them), so those hunks were restored by hand.

## Test plan

- [x] `npm ci && npm test` — 948 passed, 53 files
- [x] `npm audit` — found 0 vulnerabilities
- [x] `npm run lint` — prettier, markdownlint, and jsdoc coverage all clean
- [x] `npm run dogfood` — all six validators pass
- [x] New tests cover the six pre-command options, the non-allow-listed subcommands (`grep -O`, `difftool --extcmd`), the empty arg list, `--ext-diff`, and a caller-supplied `shell: true`

## Spec ID

dotbabel-core
