### PR TITLE
fix(hooks): filter toolchain noise per line, and match it case-insensitively

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -411,3 +411,123 @@ dotbabel show pre-pr --json
 ```
 
 Exit 1 if the artifact is not found. Exit 2 if the index is missing.
+
+---
+
+## `dotbabel-project-sync`
+
+Fan out this repo's `CLAUDE.md`, `.claude/commands` and `.claude/skills` into
+Codex / Gemini / Copilot project-scope analogues. Repo-local; user-scope
+artifacts are `dotbabel bootstrap`'s job.
+
+| Flag            | Default |                                        |
+| --------------- | ------- | -------------------------------------- |
+| `--repo <path>` | `cwd`   | Target repo root                       |
+| `--all`         | false   | Fan out regardless of CLI presence     |
+| `--force`       | false   | Replace conflicting existing targets   |
+| `--dry-run`     | false   | Report planned actions, mutate nothing |
+
+Gated on CLI presence by default: a target is skipped when its CLI is not on
+PATH. `.dotbabel.json` `gate_on_cli_presence` controls that; `--all` overrides.
+
+---
+
+## `dotbabel-check-project-sync`
+
+Read-only counterpart. Verifies the wiring matches what `project-sync` would
+produce, without writing anything — the CI-safe form.
+
+| Flag            | Default |                  |
+| --------------- | ------- | ---------------- |
+| `--repo <path>` | `cwd`   | Target repo root |
+
+---
+
+## `dotbabel-generate-instructions`
+
+Render `CLAUDE.md`'s rule-floor block into `AGENTS.md`, `GEMINI.md`,
+`.github/copilot-instructions.md` and the per-CLI user-scope templates.
+
+| Flag                 | Default          |                                       |
+| -------------------- | ---------------- | ------------------------------------- |
+| `--repo-root <path>` | resolved via git | Override repo root                    |
+| `--dry-run`          | false            | Report planned writes, mutate nothing |
+
+Hand-editing a generated block is reverted by the next run and is detected by
+`dotbabel-check-instructions-fresh`. Edit `CLAUDE.md` and re-run this instead.
+
+---
+
+## `dotbabel-local-attest`
+
+Run the configured CI matrix locally and, on a clean pass, post an attestation
+comment so the remote pipeline can skip itself for that commit. Exists to
+protect CI minutes.
+
+| Flag              | Default                |                                   |
+| ----------------- | ---------------------- | --------------------------------- |
+| `--pr <N>`        | open PR for the branch | Target PR                         |
+| `--no-push`       | false                  | Do not `git push` after attesting |
+| `--dry-run`       | false                  | Print the comment; post nothing   |
+| `--config <path>` | discovered             | Override the config file location |
+
+Config discovery, in order: `.local-attest.config.mjs`,
+`.local-attest.config.json`, then `package.json#local-attest`.
+
+The attestation is SHA-pinned, so a push after attesting invalidates it. Commit
+first, attest second.
+
+---
+
+## `dotbabel-pr-stack`
+
+Reason about stacked pull requests — dependency graph, merge order, and the
+exact commands a child needs once its parent has merged.
+
+| Subcommand | Purpose                                                          |
+| ---------- | ---------------------------------------------------------------- |
+| `graph`    | Print the raw dependency graph                                   |
+| `plan`     | What can land now, what is blocked, and any structural problems  |
+| `next`     | The commands to move a child PR after its parent merged          |
+| `gate`     | Evaluate a precondition (`local-attest` \| `merge` \| `skip-ci`) |
+| `phases`   | The canonical pipeline phase order                               |
+
+| Flag                 | Default  |                                              |
+| -------------------- | -------- | -------------------------------------------- |
+| `--trunk <ref>`      | `main`   | Trunk branch name                            |
+| `--limit <N>`        | 100      | Max PRs to enumerate                         |
+| `--pr <N>`           | —        | Required by `next` and `gate`                |
+| `--parent <N>`       | —        | Required by `next`                           |
+| `--parent-sha <sha>` | —        | Parent head SHA, captured **before** merging |
+| `--remote <name>`    | `origin` | Git remote                                   |
+| `--gate <name>`      | —        | Gate to evaluate                             |
+| `--sha <rev>`        | `HEAD`   | Commit to inspect for `--gate skip-ci`       |
+
+Capture `--parent-sha` before the parent merges. The repo squash-merges, so the
+parent's original commits are not ancestors of the squashed commit and
+`git rebase --onto` needs that SHA to know what to drop. `merge-pr` deletes the
+branch, so the ref can be gone by the time you want it.
+
+**Exits 1** from `plan` on a structural problem (cycle, orphan base, two open
+PRs on one head). Those need a human decision, not a retry.
+
+---
+
+## `dotbabel-handoff`
+
+Cross-agent and cross-machine session handoff. See
+[handoff-guide.md](./handoff-guide.md) for the full surface — this entry exists
+so the bin is discoverable from the reference.
+
+| Subcommand | Purpose                                        |
+| ---------- | ---------------------------------------------- |
+| `pull`     | Render a local session as a handoff block      |
+| `push`     | Publish to the remote transport repo           |
+| `fetch`    | Retrieve a handoff pushed from another machine |
+| `list`     | Enumerate local sessions                       |
+| `search`   | Find a session by content                      |
+| `prune`    | Delete aged transport branches                 |
+| `doctor`   | Preflight the remote transport                 |
+
+The remote transport is a user-owned private git repo named by
+`DOTBABEL_HANDOFF_REPO`. `push` without a query requires `--from <cli>`.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -197,6 +197,20 @@ Both checkers fail open. A missing `jq`, a missing toolchain, bash 3.2, an
 unmatched extension, a vendored path or a generated file all produce silence
 rather than an error.
 
+### Toolchain noise
+
+Some output means "the toolchain failed to run", not "the code is wrong" — a
+version-manager shim that is on `PATH` but not installed, a cold Maven cache
+under `mvn -o`, or `NETSDK1004` from `dotnet build --no-restore` on a fresh
+clone. None is something the model can fix by editing source.
+
+Those lines are dropped **individually**, and the rest of the output is still
+reported. A check whose output is entirely noise stays silent. Matching is
+case-insensitive, so a tool that capitalises its message is still recognised.
+
+A checker that fails with no output at all is reported rather than swallowed —
+silence from a failing checker is worth surfacing.
+
 ---
 
 ## Troubleshooting

--- a/plugins/dotbabel/hooks/check-on-stop.sh
+++ b/plugins/dotbabel/hooks/check-on-stop.sh
@@ -79,7 +79,20 @@ readonly CHECK_TIMEOUT="${CHECK_ON_STOP_TIMEOUT:-120}"
 readonly MAX_LINES="${CHECK_ON_STOP_MAX_LINES:-30}"
 readonly MAX_BLOCKS=2
 
-readonly NOISE_RX='not installed for the toolchain|command not found|No such file or directory|is not recognized as|Permission denied|cannot execute binary|unrecognized command-line option|Unable to find|could not resolve dependencies|Cannot access central'
+# Matched case-INSENSITIVELY (grep -i, below). That is deliberate, not
+# cosmetic: Maven emits "Could not resolve dependencies" with a capital C, so a
+# case-sensitive match against the lowercase alternative never fired, and the
+# cold-cache suppression this file documents for `mvn -o` did not work at all.
+#
+# "cannot access .* in offline mode" replaces a hard-coded "Cannot access
+# central". The repository id is whatever the user's settings.xml names, so
+# anyone behind a corporate mirror saw "Cannot access nexus (...)" and matched
+# nothing.
+#
+# The NETSDK1004 group is the .NET counterpart. `dotnet build --no-restore`
+# emits it on any fresh clone, because obj/ is gitignored by the standard
+# template — a state the model cannot fix by editing .cs files.
+readonly NOISE_RX='not installed for the toolchain|command not found|No such file or directory|is not recognized as|Permission denied|cannot execute binary|unrecognized command-line option|Unable to find|could not resolve dependencies|cannot access .* in offline mode|NETSDK1004|assets file .* not found|run a nuget package restore'
 
 INPUT=$(cat)
 
@@ -336,8 +349,19 @@ for key in "${!TOUCHED[@]}"; do
   [ "$rc" -eq 127 ] && continue
   # Timed out, or killed. Not a code defect.
   { [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; } && continue
-  # The toolchain failed to run rather than finding a defect.
-  if printf '%s' "$out" | grep -qE "$NOISE_RX"; then
+  # Drop the lines that mean "the toolchain failed to run" and keep the rest.
+  #
+  # This used to discard the ENTIRE output on a single match, which was far too
+  # blunt: a long mvn or dotnet failure containing one incidental
+  # "No such file or directory" lost every genuine compile error with it, and
+  # the hook then reported success on a broken build.
+  had_output=0
+  [ -n "${out//[[:space:]]/}" ] && had_output=1
+  out=$(printf '%s\n' "$out" | grep -viE "$NOISE_RX" || true)
+  # Output existed but was entirely toolchain noise: nothing to report. This is
+  # distinct from a checker that produced no output at all, which still reports
+  # below — silence from a failing checker is worth surfacing.
+  if [ "$had_output" -eq 1 ] && [ -z "${out//[[:space:]]/}" ]; then
     continue
   fi
   FAILED_LANGS+=("$lang:$label")

--- a/plugins/dotbabel/hooks/check-on-write.sh
+++ b/plugins/dotbabel/hooks/check-on-write.sh
@@ -246,10 +246,19 @@ RAW=$("$FN" "$FILE") || RC=$?
 [ "$RC" -eq 0 ] && exit 0
 [ "$RC" -eq 127 ] && exit 0
 
-# The toolchain failed to run rather than finding a defect. Discard the ENTIRE
-# output, not just the offending line: gcc aborts at the first missing include
-# and every subsequent diagnostic is downstream garbage.
-if printf '%s' "$RAW" | grep -qE "$NOISE_RX"; then
+# Drop the lines that mean "the toolchain failed to run" and keep the rest.
+#
+# The original whole-output discard was justified by gcc aborting at the first
+# missing include, which made every later line garbage. C/C++ is no longer
+# dispatched here — it needs a build graph, so it moved to the Stop hook — and
+# with that gone the blunt version only costs real findings: one incidental
+# match anywhere would silence an otherwise valid diagnostic.
+HAD_OUTPUT=0
+[ -n "${RAW//[[:space:]]/}" ] && HAD_OUTPUT=1
+RAW=$(printf '%s\n' "$RAW" | grep -viE "$NOISE_RX" || true)
+# Output existed but was entirely toolchain noise. Distinct from a checker that
+# produced nothing at all, which still reports below.
+if [ "$HAD_OUTPUT" -eq 1 ] && [ -z "${RAW//[[:space:]]/}" ]; then
   exit 0
 fi
 

--- a/plugins/dotbabel/tests/bats/check-on-stop.bats
+++ b/plugins/dotbabel/tests/bats/check-on-stop.bats
@@ -634,6 +634,66 @@ STUB
   [ -z "$output" ]
 }
 
+@test "every NOISE_RX alternative is suppressed" {
+  # One test per alternative. Before this, exactly one of them was covered, so
+  # a typo in any of the others was invisible.
+  seed_go
+  local phrase
+  for phrase in \
+    "not installed for the toolchain" \
+    "command not found" \
+    "No such file or directory" \
+    "is not recognized as an internal or external command" \
+    "Permission denied" \
+    "cannot execute binary file" \
+    "unrecognized command-line option" \
+    "Unable to find package Foo" \
+    "Could not resolve dependencies for project x" \
+    "Cannot access nexus (https://nexus.corp) in offline mode" \
+    "error NETSDK1004: Assets file not found" \
+    "Run a NuGet package restore"
+  do
+    stub_checker go 1 "" "$phrase"
+    feed_stop_json "$HOOK" false "$REPO"
+    [ "$status" -eq 0 ] || { echo "not silenced: $phrase"; return 1; }
+    [ -z "$output" ] || { echo "not silenced: $phrase -> $output"; return 1; }
+  done
+}
+
+@test "Maven's capital-C wording is suppressed" {
+  # Maven emits "Could not resolve dependencies", so the lowercase alternative
+  # never matched under a case-sensitive grep. This is the regression guard.
+  seed_go
+  stub_checker go 1 "" "[ERROR] Failed to execute goal: Could not resolve dependencies for project x"
+  feed_stop_json "$HOOK" false "$REPO"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "a real diagnostic survives a noise line beside it" {
+  # Whole-output discard used to lose every genuine compile error when one
+  # incidental noise line appeared anywhere in a long failure.
+  seed_go
+  cat > "$STUB_BIN/go" <<'STUB'
+#!/usr/bin/env bash
+echo "main.go:6:14: fmt.Printf format %d has arg of wrong type string"
+echo "note: module cache: No such file or directory"
+exit 1
+STUB
+  chmod +x "$STUB_BIN/go"
+  feed_stop_json "$HOOK" false "$REPO"
+  [[ "$output" == *"wrong type string"* ]]
+  [[ "$output" != *"No such file or directory"* ]]
+}
+
+@test "a failing checker with no output at all still reports" {
+  # Distinct from "output existed but was all noise", which stays silent.
+  seed_go
+  stub_checker go 1
+  feed_stop_json "$HOOK" false "$REPO"
+  [[ "$output" == *"exited 1 with no output"* ]]
+}
+
 @test "long check output is truncated" {
   seed_go
   cat > "$STUB_BIN/go" <<'STUB'

--- a/plugins/dotbabel/tests/bats/check-on-write.bats
+++ b/plugins/dotbabel/tests/bats/check-on-write.bats
@@ -280,9 +280,10 @@ teardown() {
   [ -z "$(stub_calls ruff)" ]
 }
 
-@test "one noise line discards the entire output" {
-  # Pins the "discard the ENTIRE output" policy, not just per-line filtering:
-  # gcc aborts at the first missing include and the rest is downstream garbage.
+@test "a noise line is dropped but a real finding beside it survives" {
+  # Replaces an earlier "discard the ENTIRE output" policy. That was justified
+  # by gcc aborting at the first missing include, but C/C++ no longer dispatches
+  # here, so the blunt version only cost real findings.
   printf 'x = 1\n' > "$WORK/a.py"
   cat > "$STUB_BIN/ruff" <<'STUB'
 #!/usr/bin/env bash
@@ -291,6 +292,23 @@ echo "ruff: command not found"
 exit 1
 STUB
   chmod +x "$STUB_BIN/ruff"
+  feed_post_tooluse_json "$HOOK" Edit "$WORK/a.py"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"E999"* ]]
+  [[ "$output" != *"command not found"* ]]
+}
+
+@test "output that is entirely noise stays silent" {
+  printf 'x = 1\n' > "$WORK/a.py"
+  stub_checker ruff 1 "" "ruff: command not found"
+  feed_post_tooluse_json "$HOOK" Edit "$WORK/a.py"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "noise matching is case-insensitive" {
+  printf 'x = 1\n' > "$WORK/a.py"
+  stub_checker ruff 1 "" "Command Not Found"
   feed_post_tooluse_json "$HOOK" Edit "$WORK/a.py"
   [ "$status" -eq 0 ]
   [ -z "$output" ]


### PR DESCRIPTION
## Summary

Closes the last four items recorded during the #281 review — the two Java/C# `NOISE_RX` bugs, the whole-output suppression, and the `cli-reference.md` bin gap.

## The four

**1. `NOISE_RX` was case-sensitive.** `check-on-stop.sh:340` used `grep -qE` against a lowercase `could not resolve dependencies`. Maven emits `Could not resolve dependencies` with a capital C, so the cold-cache suppression this file *documents* for `mvn -o` never fired once. Now matched case-insensitively, which also stops the next tool that capitalises its message from reintroducing it.

**2. `Cannot access central` was hard-coded to the default repository id.** Anyone behind a corporate mirror got `Cannot access nexus (...) in offline mode` and matched nothing. Replaced with a repository-id independent pattern.

**3. `NETSDK1004` was missing.** `dotnet build --no-restore` emits it on any fresh clone, because `obj/` is gitignored by the standard .NET template. Not a code defect, and unfixable by editing `.cs` files — but reported as one. Added the assets-file / NuGet-restore group.

**4. One noise line discarded the entire output.** A long `mvn` or `dotnet` failure containing one incidental `No such file or directory` lost every genuine compile error with it, and the hook then reported **success on a broken build**. Noise lines are now dropped individually and the rest is reported.

On (4): the whole-output policy was justified by gcc aborting at the first missing include, which makes every later line garbage. C/C++ stopped being dispatched per-file in #289 — it needs a build graph — so that justification went with it and only the cost remained.

Two states stay distinct on purpose: output that existed but was **entirely** noise stays silent, while a checker that fails with **no output at all** is still reported. Silence from a failing checker is worth surfacing.

## cli-reference gap

`project-sync`, `check-project-sync`, `generate-instructions`, `local-attest`, `pr-stack` and `handoff` had no reference sections. **22 of 23 bins are now documented**; the umbrella `dotbabel` is covered by the preamble. Flags were read from each bin's `--help`, not invented.

## Test plan

- [x] `npx bats plugins/dotbabel/tests/bats/` — **591/591** (was 585)
- [x] `npm test` — 977 tests / 54 files
- [x] shellcheck CI line verbatim — clean
- [x] `npm run lint`, `npm run docs:stamp-check` (15 docs @ v2.14.0), `npm run dogfood` — clean
- [x] **Non-vacuity proven**: restored both hooks from `origin/main` and re-ran. **5** of the new tests fail against the previous implementation, and only those.

New coverage: one case per `NOISE_RX` alternative — previously exactly **one of twelve** was covered, so a typo in any of the other eleven was invisible — plus Maven's capital-C wording, a real diagnostic surviving a noise line beside it, all-noise staying silent, and case-insensitive matching.

## Honest limits

I have neither `mvn` nor `dotnet` installed, so the Maven and .NET strings come from their documented output, not from a local run. That is exactly why the fix leans on case-insensitive matching and a repository-id independent pattern rather than on exact capitalisation being right.
