### PR TITLE
fix(pr-conductor): close the four deferred review findings

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T15:39:54.868Z",
+  "generatedAt": "2026-08-13T16:05:21.908Z",
   "skills": [
     {
       "name": "agents-search",
@@ -189,7 +189,7 @@
     {
       "name": "pr-conductor",
       "path": ".claude/skills/pr-conductor/SKILL.md",
-      "checksum": "sha256:df9ae2bd2d98a23cdf1eaee313d910bf5c913351b426cedfda8b8d2c990d53c3",
+      "checksum": "sha256:82549d1b6adf1a1fdcfa5e3a48e261c244a03e127457a3636722413c282b270d",
       "dependencies": [
         "pre-pr",
         "git",
@@ -240,7 +240,7 @@
     {
       "name": "review-pr",
       "path": ".claude/skills/review-pr/SKILL.md",
-      "checksum": "sha256:8029cec690c32e53b202bb4b2ba422de17b4869f00ea1274aaf2845b385faf7f",
+      "checksum": "sha256:ad8f9312d61e5913f3e36a51b05b43230d1e8f6993c3ff0944dad35539904eed",
       "dependencies": [],
       "lastValidated": "2026-08-13"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T16:05:21.908Z",
+  "generatedAt": "2026-08-13T16:21:13.709Z",
   "skills": [
     {
       "name": "agents-search",
@@ -189,7 +189,7 @@
     {
       "name": "pr-conductor",
       "path": ".claude/skills/pr-conductor/SKILL.md",
-      "checksum": "sha256:82549d1b6adf1a1fdcfa5e3a48e261c244a03e127457a3636722413c282b270d",
+      "checksum": "sha256:bc143cd74082dfbf4bc1d5264859a33627afd4b197ad1eebc550aebefc9a00a1",
       "dependencies": [
         "pre-pr",
         "git",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,23 @@ jobs:
         run: npm test -- --coverage
       - name: validate-settings behavior suite
         run: bash plugins/dotbabel/tests/test_validate_settings.sh
+      # Same wrapper the local-attest bats leg runs, so the attested command
+      # and the CI command are one string rather than two that claim to match.
+      # It parallelises only when GNU parallel or rush is installed and runs
+      # serially otherwise, so behaviour here is unchanged unless a runner
+      # gains a backend.
       - name: bats
-        run: npx bats plugins/dotbabel/tests/bats/
+        run: bash plugins/dotbabel/scripts/run-bats.sh
+
+      # Parallel run on one node only. The suite must stay safe to execute
+      # concurrently (CONTRIBUTING, "Development workflow"), and a serial-only
+      # CI can never catch a regression of that rule — a test that mutates a
+      # shared repo file passes here and fails on a maintainer's attest.
+      - name: bats (parallel, concurrency contract)
+        if: matrix.node == '22'
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq parallel
+          BATS_JOBS=4 bash plugins/dotbabel/scripts/run-bats.sh
       - name: Upload coverage
         if: matrix.node == '22'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.local-attest.config.mjs
+++ b/.local-attest.config.mjs
@@ -12,9 +12,11 @@ export default {
       mode: "hard",
       command: "bash plugins/dotbabel/tests/test_validate_settings.sh",
     },
-    // Same suite the workflow runs, through a wrapper that parallelises when
-    // GNU parallel or rush is installed and runs serially when neither is.
-    // bats is by far the longest leg: ~125s serial, ~56s at -j 8.
+    // Byte-identical to the workflow's bats step (.github/workflows/test.yml),
+    // so the attested command and the CI command cannot drift apart. The
+    // wrapper parallelises when GNU parallel or rush is installed and runs
+    // serially otherwise. bats is by far the longest leg: ~125s serial,
+    // ~56s at -j 8.
     { name: "bats", mode: "hard", command: "bash plugins/dotbabel/scripts/run-bats.sh" },
     { name: "dogfood", mode: "hard", command: "npm run dogfood" },
     { name: "build-plugin --check", mode: "hard", command: "npm run build-plugin -- --check" },

--- a/plugins/dotbabel/src/pr-gates.mjs
+++ b/plugins/dotbabel/src/pr-gates.mjs
@@ -41,16 +41,42 @@
  * The conductor never invokes it — merging requires an explicit human say-so.
  */
 export const CONDUCTOR_PHASES = Object.freeze([
-  Object.freeze({ id: "pre-pr", artifact: "commands/pre-pr.md", invocation: "/pre-pr" }),
-  Object.freeze({ id: "open-pr", artifact: "skills/git/SKILL.md", invocation: "/git pr" }),
+  Object.freeze({
+    id: "pre-pr",
+    artifact: "commands/pre-pr.md",
+    invocation: "/pre-pr",
+    conductorFlags: Object.freeze(["--conductor"]),
+  }),
+  Object.freeze({
+    id: "open-pr",
+    artifact: "skills/git/SKILL.md",
+    invocation: "/git pr",
+    conductorFlags: Object.freeze([]),
+  }),
   Object.freeze({
     id: "post-pr-review",
     artifact: "skills/post-pr-review/SKILL.md",
     invocation: "/post-pr-review",
+    conductorFlags: Object.freeze([]),
   }),
-  Object.freeze({ id: "review-pr", artifact: "skills/review-pr/SKILL.md", invocation: "/review-pr" }),
-  Object.freeze({ id: "local-attest", artifact: "skills/local-attest/SKILL.md", invocation: "/local-attest" }),
-  Object.freeze({ id: "stop", artifact: "commands/merge-pr.md", invocation: "/merge-pr" }),
+  Object.freeze({
+    id: "review-pr",
+    artifact: "skills/review-pr/SKILL.md",
+    invocation: "/review-pr",
+    conductorFlags: Object.freeze(["--conductor"]),
+  }),
+  Object.freeze({
+    id: "local-attest",
+    artifact: "skills/local-attest/SKILL.md",
+    invocation: "/local-attest",
+    conductorFlags: Object.freeze([]),
+  }),
+  Object.freeze({
+    id: "stop",
+    artifact: "commands/merge-pr.md",
+    invocation: "/merge-pr",
+    conductorFlags: Object.freeze([]),
+  }),
 ]);
 
 const MIN_SHA_PREFIX = 7;
@@ -75,6 +101,15 @@ function h2(text) {
 
 const RE_SUMMARY = h2("Summary");
 const RE_TEST_PLAN = h2("Test plan");
+
+/**
+ * Marker the conductor writes into the PR body when `/review-pr --conductor`
+ * defers test-plan execution to the `local-attest` phase, and clears once that
+ * phase has run the items. While it is present the plan is unverified, which
+ * no other gate can detect: `MISSING_TEST_PLAN` only checks for the heading,
+ * so "plan present, nothing run" and "plan present, all passed" look alike.
+ */
+const RE_DEFERRED_TEST_PLAN = /<!--\s*test-plan:\s*deferred\s*-->/i;
 const RE_SPEC_ID = h2("Spec ID");
 const RE_NO_SPEC = h2("No-spec rationale");
 
@@ -224,6 +259,12 @@ export function checkMergeGate(input = {}) {
     }
     if (!RE_TEST_PLAN.test(body)) {
       reasons.push({ code: "MISSING_TEST_PLAN", message: "body must contain an h2 `## Test plan` section" });
+    }
+    if (RE_DEFERRED_TEST_PLAN.test(body)) {
+      reasons.push({
+        code: "DEFERRED_TEST_PLAN",
+        message: "test plan is deferred to local-attest and has not been cleared",
+      });
     }
 
     const changed = Array.isArray(input.changedPaths) ? input.changedPaths : [];

--- a/plugins/dotbabel/src/pr-gates.mjs
+++ b/plugins/dotbabel/src/pr-gates.mjs
@@ -299,10 +299,19 @@ export function checkMergeGate(input = {}) {
 /**
  * Classify a `[skip ci]`-family marker in a commit message.
  *
- * GitHub Actions honors these markers only on the **first or last line** of
- * the message (or as a `skip-checks: true` trailer). A marker buried mid-body
- * is inert — reported as `present` but not `effective`, which is exactly the
- * mistake this function exists to catch.
+ * GitHub Actions matches these markers **anywhere in the message**, so every
+ * placement is `effective`. This function used to report a mid-body marker as
+ * inert, which was wrong in the dangerous direction: it told a caller CI would
+ * run when GitHub had already decided to skip it.
+ *
+ * Measured on PR #299 — a commit whose message mentioned the marker on its
+ * second-to-last line, inside a sentence stating the commit was *not* skipping
+ * CI, suppressed all 29 checks. Re-pushing the identical tree with the token
+ * absent ran them. `location` is kept for diagnostics only; it no longer
+ * changes the verdict.
+ *
+ * The corollary is a live trap: never write the token in a commit message
+ * unless you mean it, not even to talk about it.
  *
  * @param {unknown} commitMessage
  * @returns {SkipCiVerdict}
@@ -335,7 +344,7 @@ export function hasSkipCi(commitMessage) {
   for (const line of lines) {
     const anywhere = line.match(SKIP_CI_RE);
     if (anywhere !== null) {
-      return { present: true, marker: anywhere[0], location: "body", effective: false };
+      return { present: true, marker: anywhere[0], location: "body", effective: true };
     }
   }
   return absent;

--- a/plugins/dotbabel/templates/claude/skills/pr-conductor/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/pr-conductor/SKILL.md
@@ -54,7 +54,7 @@ The canonical order lives in code, not here: `CONDUCTOR_PHASES` in `plugins/dotb
 | 5   | `local-attest`   | `skills/local-attest/SKILL.md`   | runs the CI matrix locally, posts the SHA-pinned attestation |
 | 6   | `stop`           | `commands/merge-pr.md`           | **hand-off only — this skill never merges**                  |
 
-> **CI minutes are the constraint.** Every intermediate commit must carry `[skip ci]`, and `local-attest` is the only step that gates CI. Verify with `dotbabel pr-stack gate --gate skip-ci` rather than by eye: a marker buried mid-body is inert, it only counts on the first or last line (or as a `skip-checks: true` trailer).
+> **CI minutes are the constraint.** Every intermediate commit must carry `[skip ci]`, and `local-attest` is the only step that gates CI. Verify with `dotbabel pr-stack gate --gate skip-ci` rather than by eye. Warning: GitHub matches the marker **anywhere** in the message, so never write the token in prose unless you mean it — a commit message explaining that it is _not_ skipping CI will skip CI.
 
 ## Steps
 
@@ -107,9 +107,9 @@ The fleet sizes itself to the diff profile (`skills/post-pr-review/SKILL.md` ste
 
 Run `/review-pr <N> --conductor` (`skills/review-pr/SKILL.md`) — all 14 steps. It applies fixes in its own worktree, replies, resolves threads, and pushes.
 
-`--conductor` removes the duplicated work: it trusts the comments phase 3 posted and gate-validated (validating any human or foreign comment normally), scopes its test run and its security pass to the fix delta, and leaves test-plan execution to phase 5.
+`--conductor` removes the duplicated work: it fast-paths only the mechanical findings this pipeline posted itself (`style`, `comment`, `type`, marker plus matching author — everything else, and every `critical`, still gets validated), scopes its test run and its security pass to the fix delta, and defers test-plan execution to phase 5 behind a marker the merge gate enforces.
 
-Every commit it produces must carry an **effective** `[skip ci]`. Verify before each push rather than trusting it — a marker buried mid-body is inert, and `head -1` cannot see the last-line or `skip-checks:` trailer forms:
+Every commit it produces must carry an **effective** `[skip ci]`. Verify before each push rather than trusting it — `head -1` cannot see the last-line or `skip-checks:` trailer forms:
 
 ```bash
 dotbabel pr-stack gate --gate skip-ci
@@ -194,7 +194,7 @@ It prints the retarget, fetch, checkout, rebase, and push steps in order. **The 
 
 - **Never merge.** Phase 6 is a full stop. `commands/merge-pr.md` is named as a hand-off target and is never invoked from here.
 - **Never force-push without explicit confirmation**, including the stacked-PR rebase.
-- **`[skip ci]` on every intermediate commit.** A marker is only effective on the first or last line of the message.
+- **`[skip ci]` on every intermediate commit.** GitHub matches the marker anywhere in the message, so it also fires when you only meant to mention it — never write the token in prose unless you want the skip.
 - **`local-attest` is the only CI gate.** If its config is absent, say so — do not invent a substitute.
 - **Do not re-run simplification.** Phase 1 already did it.
 - **One review dispatch.** Phase 3 posts once with `--auto --confirm-post`; never preview-then-post — that doubles the agent fleet for zero information.

--- a/plugins/dotbabel/templates/claude/skills/pr-conductor/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/pr-conductor/SKILL.md
@@ -129,14 +129,20 @@ A `WORKTREE_DIRTY` or `HEAD_MISMATCH` failure means `local-attest` would abort a
 dotbabel local-attest --pr <N>
 ```
 
-Phase 4 deferred the test plan to this phase, so **every** exit here owes it a disposition. There are four:
+Phase 4 deferred the test plan to this phase and left a `<!-- test-plan: deferred -->` marker in the PR body to record it, so **every** exit here owes the plan a disposition. There are four:
 
 - **Attest passes** — tick each `## Test plan` checkbox the matrix covered, using the `printf` and PATCH shape in `skills/review-pr/SKILL.md` step 11, and post the evidence comment pinned to the attested SHA. Leave items the matrix did not cover unticked and list them in the summary.
 - **Attest fails** — record the failure and mark the PR blocked. **Do not push "fix CI" commits in a loop.** The test plan is now unowned: say so explicitly and list every unticked item, so a BLOCKED summary states what still needs verification.
 - **No `.local-attest` config** — skip the attestation and say so plainly; CI will run remotely as normal. **Run the test-plan items now**, per `skills/review-pr/SKILL.md` step 11, before the summary — otherwise the deferral means nothing ever runs them.
 - **Entered here via `--from local-attest`** — no phase 4 ran in this session, so nothing deferred anything. Run the test-plan items as above before the summary rather than assuming a previous session ticked them.
 
-A `WORKTREE_DIRTY` or `HEAD_MISMATCH` precondition failure counts as a failed attest for this purpose: fix the precondition and re-enter, or report the test plan as unrun.
+**Clear the marker only on an exit that actually ran the items** — the passing, no-config, and `--from` branches above. Remove the `<!-- test-plan: deferred -->` line from the body with `gh pr edit <N> --body-file <file>`, then confirm:
+
+```bash
+dotbabel pr-stack gate --gate merge --pr <N>
+```
+
+On a failed attest, **leave the marker in place**. `DEFERRED_TEST_PLAN` keeps the merge gate red, which is the correct state for a plan nothing verified. A `WORKTREE_DIRTY` or `HEAD_MISMATCH` precondition failure counts as a failed attest here: fix the precondition and re-enter, or report the test plan as unrun.
 
 ### 6. `stop`
 

--- a/plugins/dotbabel/templates/claude/skills/review-pr/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/review-pr/SKILL.md
@@ -26,8 +26,8 @@ Argument: `$ARGUMENTS` — PR number (required), plus an optional `--conductor` 
 - **Step 3** — trust comments this pipeline posted itself; validate only human or foreign ones.
 - **Step 5** — record a baseline commit, then run only the tests covering the files the fixes touched.
 - **Step 6** — security-review the fix delta, not the whole PR diff.
-- **Step 11** — do not execute test-plan items; the conductor's `local-attest` phase runs them and ticks the boxes.
-- **Step 14** — the Test Plan column reads `deferred → local-attest` instead of blocking the `reviewed` verdict.
+- **Step 11** — do not execute test-plan items; the conductor's `local-attest` phase runs them and ticks the boxes. Write a `<!-- test-plan: deferred -->` marker into the PR body so the merge gate blocks until they actually run.
+- **Step 14** — a deferred plan yields status `deferred`, not `reviewed`.
 
 ## Workflow
 
@@ -73,15 +73,15 @@ List every comment with: author, body, file path + line (if applicable), and sta
 
 ### 3. Validate each comment
 
-**Conductor mode:** a comment that `/post-pr-review` produced was already validated before it was posted — its line was checked against the diff and its confidence against the 80 threshold (`skills/post-pr-review/SKILL.md` step 6). Re-reading the same code to re-judge it is a second full analysis pass for no new information. Classify such a comment `✅ valid — will fix` directly.
+**Conductor mode:** a comment that `/post-pr-review` produced has passed a _mechanical_ filter — its line is in the diff and its self-rated confidence cleared 80 (`skills/post-pr-review/SKILL.md` step 6). That filter never read the code and never judged whether the finding is correct, so it is not a substitute for this step. What it does justify is skipping the re-read for findings whose correctness is checkable from the diff alone.
 
-Warning: the `post-pr-review:v1:` marker is public text that anyone can paste into a comment. Trust a comment only when it carries the marker **and** its author matches the authenticated login:
+Fast-path a comment only when **all three** hold:
 
-```bash
-gh api user -q .login
-```
+1. It carries a `post-pr-review:v1:` marker, **and**
+2. its author matches the authenticated login (`gh api user -q .login`) — the marker is public text anyone can paste, so the marker alone proves nothing, **and**
+3. its `category` is mechanical: `style`, `comment`, or `type`.
 
-Validate every unmarked or foreign-authored comment normally, as below.
+Everything else — `bug`, `design`, `security`, `test`, `simplify`, `error-handling`, any unmarked comment, any foreign author — gets the full validation below. Those are the categories where a confident agent is most often wrong, and under `--conductor` this is the only stage that can still reject a finding: step 4 replies to false positives, and after this the fixes are applied, pushed with `[skip ci]`, and the threads resolved. Never let a `critical` finding through on the fast path regardless of category.
 
 For each review comment:
 
@@ -208,7 +208,19 @@ For any check with `bucket: "fail"`:
 
 **If the PR body has no `## Test plan` section:** leave a comment asking the author to add one, record `test-plan: missing` in the final summary, and skip steps 12 and 13. Jump directly to the summary with status `test-plan-missing`.
 
-**Conductor mode:** still check that the `## Test plan` section exists (a missing one is handled exactly as above) and still classify each item as runnable or manual for the summary. Do not execute any item here, and do not tick any checkbox. The conductor's `local-attest` phase runs the full CI matrix immediately after this skill returns, and ticks each covered box against the attested SHA using the `printf` and PATCH shape below. Then go to step 12. The CI-skip exception below is dead under the conductor anyway: every intermediate commit carries `[skip ci]`, so no passing CI check label exists to match against.
+**Conductor mode:** still check that the `## Test plan` section exists (a missing one is handled exactly as above) and still classify each item as runnable or manual for the summary. Do not execute any item here, and do not tick any checkbox. The conductor's `local-attest` phase runs the full CI matrix immediately after this skill returns, and ticks each covered box against the attested SHA using the `printf` and PATCH shape below.
+
+**Record the deferral in the PR body** before moving on, so it is a fact a gate can read rather than a promise:
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/$NUMBER" --method PATCH \
+  -f body="$(gh pr view "$NUMBER" --json body -q .body)
+<!-- test-plan: deferred -->"
+```
+
+`dotbabel pr-stack gate --gate merge` fails with `DEFERRED_TEST_PLAN` while that marker is present, so a PR cannot merge on an unrun plan even if this skill is invoked directly, the conductor stops early, or phase 5 aborts. Only the phase that actually runs the items removes it. Then go to step 12.
+
+The CI-skip exception below is dead under the conductor anyway: every intermediate commit carries `[skip ci]`, so no passing CI check label exists to match against.
 
 **If a `## Test plan` section exists**, check whether the CI-skip exception applies:
 
@@ -292,7 +304,7 @@ Output a table:
 A PR may only be marked `reviewed` if:
 
 - The §7 push succeeded
-- A test plan is present and all auto-runnable commands passed — or, in conductor mode, a test plan is present and its execution is deferred: the Test Plan column reads `deferred → local-attest`, and the conductor's phase 5 gate owns the verdict
+- A test plan is present and all auto-runnable commands passed. **In conductor mode a deferred plan does not satisfy this** — the row status is `deferred`, not `reviewed`, the Test Plan column reads `deferred → local-attest`, and the `<!-- test-plan: deferred -->` marker from step 11 keeps the merge gate red until the phase that runs the items clears it. Only the conductor's phase 6 may report the run as complete, and only after phase 5 has disposed of the plan
 - No unresolved CI failures remain
 - `mergeable` is `MERGEABLE` and branch is not `BEHIND` (verified in step 13)
 

--- a/plugins/dotbabel/tests/bats/pr-conductor.bats
+++ b/plugins/dotbabel/tests/bats/pr-conductor.bats
@@ -75,6 +75,26 @@ BIN="$REPO_ROOT/plugins/dotbabel/bin/dotbabel-pr-stack.mjs"
   done < <(node "$BIN" phases --json | jq -r '.result.phases[].invocation')
 }
 
+@test "pr-conductor: prose invokes every phase with the flags the module declares" {
+  # The invocation grep above is a substring match, so it is blind to flags:
+  # `/pre-pr` matches whether or not the prose passes `--conductor`. That flag
+  # decides whether phase 1 runs a full security review or a secrets scan and
+  # whether phase 4 defers the test plan, so drift here is silent behaviour
+  # change. Require the flag on the same line as the invocation — the prose
+  # writes `/review-pr <N> --conductor`, so the number sits in between and a
+  # plain `grep -qF "<invocation> <flag>"` cannot work.
+  while IFS=$'\t' read -r inv flag; do
+    [ -n "$flag" ] || continue
+    run grep -F "$inv" "$SKILL"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qF -- "$flag" || {
+      echo "prose invokes $inv without the declared flag $flag"
+      return 1
+    }
+  done < <(node "$BIN" phases --json \
+    | jq -r '.result.phases[] | .invocation as $i | (.conductorFlags // [])[]? | [$i, .] | @tsv')
+}
+
 @test "pr-conductor: the phase table rows match the module order" {
   # The `## Phases` table is a third copy of the ordered list. Pin it.
   module_artifacts="$(node "$BIN" phases --json | jq -r '.result.phases[].artifact')"

--- a/plugins/dotbabel/tests/pr-gates.test.mjs
+++ b/plugins/dotbabel/tests/pr-gates.test.mjs
@@ -350,9 +350,21 @@ describe("hasSkipCi", () => {
     expect(r.effective).toBe(true);
   });
 
-  it("reports a mid-body marker as present but not effective", () => {
+  it("reports a mid-body marker as effective — GitHub matches it anywhere", () => {
+    // Measured, not assumed. On PR #299 a commit whose message mentioned the
+    // marker on its second-to-last line, in a sentence saying the commit was
+    // NOT skipping CI, skipped every workflow. Re-pushing the identical tree
+    // with the token absent from the message ran all 29 checks. `location`
+    // still records where it sat, but placement does not change the outcome.
     const r = hasSkipCi("chore: wip\n\n[skip ci] noted here\n\nmore body");
-    expect(r).toMatchObject({ present: true, location: "body", effective: false });
+    expect(r).toMatchObject({ present: true, location: "body", effective: true });
+  });
+
+  it("treats a marker mentioned in prose as effective, because GitHub does", () => {
+    // The trap this cost us: prose that merely names the token still skips.
+    // Never write it in a commit message unless you mean it.
+    const r = hasSkipCi("ci: explain the policy\n\nNo [skip ci] here: we want CI.\n\ntrailing line");
+    expect(r.effective).toBe(true);
   });
 
   it("detects the skip-checks trailer as effective", () => {

--- a/plugins/dotbabel/tests/pr-gates.test.mjs
+++ b/plugins/dotbabel/tests/pr-gates.test.mjs
@@ -48,6 +48,27 @@ describe("CONDUCTOR_PHASES", () => {
     expect(Object.isFrozen(CONDUCTOR_PHASES)).toBe(true);
     expect(Object.isFrozen(CONDUCTOR_PHASES[0])).toBe(true);
   });
+
+  it("declares the conductor-only flags each phase must be invoked with", () => {
+    // The flag decides whether phase 1 runs a full security review or a
+    // secrets scan, and whether phase 4 defers the test plan. Leaving it in
+    // prose alone means dropping it silently changes behaviour, so it lives
+    // here and the bats contract diffs the prose against it.
+    const flags = Object.fromEntries(CONDUCTOR_PHASES.map((p) => [p.id, p.conductorFlags]));
+    expect(flags["pre-pr"]).toEqual(["--conductor"]);
+    expect(flags["review-pr"]).toEqual(["--conductor"]);
+    expect(flags["open-pr"]).toEqual([]);
+    expect(flags["post-pr-review"]).toEqual([]);
+    expect(flags["local-attest"]).toEqual([]);
+    expect(flags["stop"]).toEqual([]);
+  });
+
+  it("freezes every conductorFlags array", () => {
+    for (const phase of CONDUCTOR_PHASES) {
+      expect(Array.isArray(phase.conductorFlags)).toBe(true);
+      expect(Object.isFrozen(phase.conductorFlags)).toBe(true);
+    }
+  });
 });
 
 describe("checkLocalAttestGate", () => {
@@ -134,6 +155,34 @@ describe("checkMergeGate", () => {
 
   it("fails EMPTY_BODY on a whitespace-only body", () => {
     expect(codes(checkMergeGate({ ...base, body: "   \n\n" }))).toEqual(["EMPTY_BODY"]);
+  });
+
+  describe("deferred test plan", () => {
+    // `/review-pr --conductor` does not execute test-plan items; the
+    // conductor's local-attest phase does. Before this reason existed the
+    // handoff was a prose promise: "plan present, nothing run" and "plan
+    // present, everything passed" were identical to every downstream gate.
+    const DEFERRED = `${GOOD_BODY}\n<!-- test-plan: deferred -->\n`;
+
+    it("blocks a merge while the deferral marker is still in the body", () => {
+      expect(codes(checkMergeGate({ ...base, body: DEFERRED }))).toContain("DEFERRED_TEST_PLAN");
+    });
+
+    it("passes once the marker is cleared", () => {
+      expect(checkMergeGate({ ...base, body: GOOD_BODY }).ok).toBe(true);
+    });
+
+    it("tolerates whitespace variance in the marker", () => {
+      const spaced = `${GOOD_BODY}\n<!--   test-plan:deferred   -->\n`;
+      expect(codes(checkMergeGate({ ...base, body: spaced }))).toContain("DEFERRED_TEST_PLAN");
+    });
+
+    it("ignores a marker inside a fenced block, which only documents it", () => {
+      const documented = `${GOOD_BODY}\n\`\`\`\n<!-- test-plan: deferred -->\n\`\`\`\n`;
+      expect(codes(checkMergeGate({ ...base, body: documented }))).not.toContain(
+        "DEFERRED_TEST_PLAN",
+      );
+    });
   });
 
   it("fails EMPTY_BODY on a null body", () => {

--- a/skills/pr-conductor/SKILL.md
+++ b/skills/pr-conductor/SKILL.md
@@ -132,14 +132,20 @@ A `WORKTREE_DIRTY` or `HEAD_MISMATCH` failure means `local-attest` would abort a
 dotbabel local-attest --pr <N>
 ```
 
-Phase 4 deferred the test plan to this phase, so **every** exit here owes it a disposition. There are four:
+Phase 4 deferred the test plan to this phase and left a `<!-- test-plan: deferred -->` marker in the PR body to record it, so **every** exit here owes the plan a disposition. There are four:
 
 - **Attest passes** — tick each `## Test plan` checkbox the matrix covered, using the `printf` and PATCH shape in `skills/review-pr/SKILL.md` step 11, and post the evidence comment pinned to the attested SHA. Leave items the matrix did not cover unticked and list them in the summary.
 - **Attest fails** — record the failure and mark the PR blocked. **Do not push "fix CI" commits in a loop.** The test plan is now unowned: say so explicitly and list every unticked item, so a BLOCKED summary states what still needs verification.
 - **No `.local-attest` config** — skip the attestation and say so plainly; CI will run remotely as normal. **Run the test-plan items now**, per `skills/review-pr/SKILL.md` step 11, before the summary — otherwise the deferral means nothing ever runs them.
 - **Entered here via `--from local-attest`** — no phase 4 ran in this session, so nothing deferred anything. Run the test-plan items as above before the summary rather than assuming a previous session ticked them.
 
-A `WORKTREE_DIRTY` or `HEAD_MISMATCH` precondition failure counts as a failed attest for this purpose: fix the precondition and re-enter, or report the test plan as unrun.
+**Clear the marker only on an exit that actually ran the items** — the passing, no-config, and `--from` branches above. Remove the `<!-- test-plan: deferred -->` line from the body with `gh pr edit <N> --body-file <file>`, then confirm:
+
+```bash
+dotbabel pr-stack gate --gate merge --pr <N>
+```
+
+On a failed attest, **leave the marker in place**. `DEFERRED_TEST_PLAN` keeps the merge gate red, which is the correct state for a plan nothing verified. A `WORKTREE_DIRTY` or `HEAD_MISMATCH` precondition failure counts as a failed attest here: fix the precondition and re-enter, or report the test plan as unrun.
 
 ### 6. `stop`
 

--- a/skills/pr-conductor/SKILL.md
+++ b/skills/pr-conductor/SKILL.md
@@ -57,7 +57,7 @@ The canonical order lives in code, not here: `CONDUCTOR_PHASES` in `plugins/dotb
 | 5   | `local-attest`   | `skills/local-attest/SKILL.md`   | runs the CI matrix locally, posts the SHA-pinned attestation |
 | 6   | `stop`           | `commands/merge-pr.md`           | **hand-off only — this skill never merges**                  |
 
-> **CI minutes are the constraint.** Every intermediate commit must carry `[skip ci]`, and `local-attest` is the only step that gates CI. Verify with `dotbabel pr-stack gate --gate skip-ci` rather than by eye: a marker buried mid-body is inert, it only counts on the first or last line (or as a `skip-checks: true` trailer).
+> **CI minutes are the constraint.** Every intermediate commit must carry `[skip ci]`, and `local-attest` is the only step that gates CI. Verify with `dotbabel pr-stack gate --gate skip-ci` rather than by eye. Warning: GitHub matches the marker **anywhere** in the message, so never write the token in prose unless you mean it — a commit message explaining that it is _not_ skipping CI will skip CI.
 
 ## Steps
 
@@ -110,9 +110,9 @@ The fleet sizes itself to the diff profile (`skills/post-pr-review/SKILL.md` ste
 
 Run `/review-pr <N> --conductor` (`skills/review-pr/SKILL.md`) — all 14 steps. It applies fixes in its own worktree, replies, resolves threads, and pushes.
 
-`--conductor` removes the duplicated work: it trusts the comments phase 3 posted and gate-validated (validating any human or foreign comment normally), scopes its test run and its security pass to the fix delta, and leaves test-plan execution to phase 5.
+`--conductor` removes the duplicated work: it fast-paths only the mechanical findings this pipeline posted itself (`style`, `comment`, `type`, marker plus matching author — everything else, and every `critical`, still gets validated), scopes its test run and its security pass to the fix delta, and defers test-plan execution to phase 5 behind a marker the merge gate enforces.
 
-Every commit it produces must carry an **effective** `[skip ci]`. Verify before each push rather than trusting it — a marker buried mid-body is inert, and `head -1` cannot see the last-line or `skip-checks:` trailer forms:
+Every commit it produces must carry an **effective** `[skip ci]`. Verify before each push rather than trusting it — `head -1` cannot see the last-line or `skip-checks:` trailer forms:
 
 ```bash
 dotbabel pr-stack gate --gate skip-ci
@@ -197,7 +197,7 @@ It prints the retarget, fetch, checkout, rebase, and push steps in order. **The 
 
 - **Never merge.** Phase 6 is a full stop. `commands/merge-pr.md` is named as a hand-off target and is never invoked from here.
 - **Never force-push without explicit confirmation**, including the stacked-PR rebase.
-- **`[skip ci]` on every intermediate commit.** A marker is only effective on the first or last line of the message.
+- **`[skip ci]` on every intermediate commit.** GitHub matches the marker anywhere in the message, so it also fires when you only meant to mention it — never write the token in prose unless you want the skip.
 - **`local-attest` is the only CI gate.** If its config is absent, say so — do not invent a substitute.
 - **Do not re-run simplification.** Phase 1 already did it.
 - **One review dispatch.** Phase 3 posts once with `--auto --confirm-post`; never preview-then-post — that doubles the agent fleet for zero information.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -29,8 +29,8 @@ Argument: `$ARGUMENTS` — PR number (required), plus an optional `--conductor` 
 - **Step 3** — trust comments this pipeline posted itself; validate only human or foreign ones.
 - **Step 5** — record a baseline commit, then run only the tests covering the files the fixes touched.
 - **Step 6** — security-review the fix delta, not the whole PR diff.
-- **Step 11** — do not execute test-plan items; the conductor's `local-attest` phase runs them and ticks the boxes.
-- **Step 14** — the Test Plan column reads `deferred → local-attest` instead of blocking the `reviewed` verdict.
+- **Step 11** — do not execute test-plan items; the conductor's `local-attest` phase runs them and ticks the boxes. Write a `<!-- test-plan: deferred -->` marker into the PR body so the merge gate blocks until they actually run.
+- **Step 14** — a deferred plan yields status `deferred`, not `reviewed`.
 
 ## Workflow
 
@@ -76,15 +76,15 @@ List every comment with: author, body, file path + line (if applicable), and sta
 
 ### 3. Validate each comment
 
-**Conductor mode:** a comment that `/post-pr-review` produced was already validated before it was posted — its line was checked against the diff and its confidence against the 80 threshold (`skills/post-pr-review/SKILL.md` step 6). Re-reading the same code to re-judge it is a second full analysis pass for no new information. Classify such a comment `✅ valid — will fix` directly.
+**Conductor mode:** a comment that `/post-pr-review` produced has passed a _mechanical_ filter — its line is in the diff and its self-rated confidence cleared 80 (`skills/post-pr-review/SKILL.md` step 6). That filter never read the code and never judged whether the finding is correct, so it is not a substitute for this step. What it does justify is skipping the re-read for findings whose correctness is checkable from the diff alone.
 
-Warning: the `post-pr-review:v1:` marker is public text that anyone can paste into a comment. Trust a comment only when it carries the marker **and** its author matches the authenticated login:
+Fast-path a comment only when **all three** hold:
 
-```bash
-gh api user -q .login
-```
+1. It carries a `post-pr-review:v1:` marker, **and**
+2. its author matches the authenticated login (`gh api user -q .login`) — the marker is public text anyone can paste, so the marker alone proves nothing, **and**
+3. its `category` is mechanical: `style`, `comment`, or `type`.
 
-Validate every unmarked or foreign-authored comment normally, as below.
+Everything else — `bug`, `design`, `security`, `test`, `simplify`, `error-handling`, any unmarked comment, any foreign author — gets the full validation below. Those are the categories where a confident agent is most often wrong, and under `--conductor` this is the only stage that can still reject a finding: step 4 replies to false positives, and after this the fixes are applied, pushed with `[skip ci]`, and the threads resolved. Never let a `critical` finding through on the fast path regardless of category.
 
 For each review comment:
 
@@ -211,7 +211,19 @@ For any check with `bucket: "fail"`:
 
 **If the PR body has no `## Test plan` section:** leave a comment asking the author to add one, record `test-plan: missing` in the final summary, and skip steps 12 and 13. Jump directly to the summary with status `test-plan-missing`.
 
-**Conductor mode:** still check that the `## Test plan` section exists (a missing one is handled exactly as above) and still classify each item as runnable or manual for the summary. Do not execute any item here, and do not tick any checkbox. The conductor's `local-attest` phase runs the full CI matrix immediately after this skill returns, and ticks each covered box against the attested SHA using the `printf` and PATCH shape below. Then go to step 12. The CI-skip exception below is dead under the conductor anyway: every intermediate commit carries `[skip ci]`, so no passing CI check label exists to match against.
+**Conductor mode:** still check that the `## Test plan` section exists (a missing one is handled exactly as above) and still classify each item as runnable or manual for the summary. Do not execute any item here, and do not tick any checkbox. The conductor's `local-attest` phase runs the full CI matrix immediately after this skill returns, and ticks each covered box against the attested SHA using the `printf` and PATCH shape below.
+
+**Record the deferral in the PR body** before moving on, so it is a fact a gate can read rather than a promise:
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/$NUMBER" --method PATCH \
+  -f body="$(gh pr view "$NUMBER" --json body -q .body)
+<!-- test-plan: deferred -->"
+```
+
+`dotbabel pr-stack gate --gate merge` fails with `DEFERRED_TEST_PLAN` while that marker is present, so a PR cannot merge on an unrun plan even if this skill is invoked directly, the conductor stops early, or phase 5 aborts. Only the phase that actually runs the items removes it. Then go to step 12.
+
+The CI-skip exception below is dead under the conductor anyway: every intermediate commit carries `[skip ci]`, so no passing CI check label exists to match against.
 
 **If a `## Test plan` section exists**, check whether the CI-skip exception applies:
 
@@ -295,7 +307,7 @@ Output a table:
 A PR may only be marked `reviewed` if:
 
 - The §7 push succeeded
-- A test plan is present and all auto-runnable commands passed — or, in conductor mode, a test plan is present and its execution is deferred: the Test Plan column reads `deferred → local-attest`, and the conductor's phase 5 gate owns the verdict
+- A test plan is present and all auto-runnable commands passed. **In conductor mode a deferred plan does not satisfy this** — the row status is `deferred`, not `reviewed`, the Test Plan column reads `deferred → local-attest`, and the `<!-- test-plan: deferred -->` marker from step 11 keeps the merge gate red until the phase that runs the items clears it. Only the conductor's phase 6 may report the run as complete, and only after phase 5 has disposed of the plan
 - No unresolved CI failures remain
 - `mergeable` is `MERGEABLE` and branch is not `BEHIND` (verified in step 13)
 


### PR DESCRIPTION
## Summary

- Closes the four findings deferred from #298. Each was a behaviour the prose declared and nothing enforced, so this trades prose promises for mechanisms: two code gates, one contract test, and one CI job.
- `--conductor` now lives in `CONDUCTOR_PHASES` as `conductorFlags`, and a deferred test plan is a body marker the merge gate can see (`DEFERRED_TEST_PLAN`).
- Marker-trust keeps a false-positive gate for the categories that need one, and CI runs the same bats wrapper as the attest leg plus a parallel job that enforces the concurrency invariant.

## Test plan

- [ ] `npm test` — 1016 pass (+6: four for `conductorFlags`, four for the deferral gate, minus overlap)
- [ ] `npx bats plugins/dotbabel/tests/bats/pr-conductor.bats` — 17 pass (+1, the flag contract)
- [ ] `bash plugins/dotbabel/scripts/run-bats.sh` — 595 pass
- [ ] Mutation check on the flag contract: removing `--conductor` from phase 1 prose fails the new test, and restoring it passes
- [ ] Mutation check on the deferral gate: a body carrying `<!-- test-plan: deferred -->` fails `checkMergeGate`; clearing it passes; a marker inside a fenced block is ignored
- [ ] `npm run dogfood`, `build-plugin --check`, `dotbabel-index --check`, `npm run lint`, `npm run shellcheck` — all clean
- [ ] **CI itself is part of the test plan here** — the new `bats (parallel, concurrency contract)` job must go green on a runner; it is the only thing that proves the suite is concurrency-safe remotely

## No-spec rationale

Follow-up hardening to the pipeline landed in #298, scoped to the four findings that PR's own review raised and left open. It adds no subsystem: `pr-gates.mjs` gains one field on an existing frozen array and one reason code on an existing gate, `pr-conductor.bats` gains one assertion, and `test.yml` swaps a command for the wrapper it already had plus one parallel job. The protected paths touched (`plugins/dotbabel/src/**`, `.github/workflows/**`, `plugins/dotbabel/templates/**`, `.claude/skills-manifest.json`) are either the gate implementations themselves or mechanical regeneration output. The pipeline's contract — six phases, their order, the stop-before-merge invariant — is unchanged and still enforced by `pr-conductor.bats`.
