### PR TITLE
feat(local-attest): diagnostic modes, failure-complete audit log, toolchain pins

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T16:21:13.709Z",
+  "generatedAt": "2026-08-13T19:01:07.742Z",
   "skills": [
     {
       "name": "agents-search",
@@ -152,7 +152,7 @@
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
-      "checksum": "sha256:387fb7d3c71146ac22f79203a647ebebc0aaadf3dad5e38b9777c6ad02a1fdb1",
+      "checksum": "sha256:a051ef983183adb47bf1c60c96c70b58600347cc775efd80ba8c3b9378847f9a",
       "dependencies": [],
       "lastValidated": "2026-08-13"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T19:01:07.742Z",
+  "generatedAt": "2026-08-13T19:36:58.510Z",
   "skills": [
     {
       "name": "agents-search",
@@ -152,7 +152,7 @@
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
-      "checksum": "sha256:a051ef983183adb47bf1c60c96c70b58600347cc775efd80ba8c3b9378847f9a",
+      "checksum": "sha256:c57f5f556a33c66a795a918b36641685dddf33af2e16a0d1fdbc774da7ce6fd6",
       "dependencies": [],
       "lastValidated": "2026-08-13"
     },

--- a/.local-attest.config.mjs
+++ b/.local-attest.config.mjs
@@ -22,4 +22,9 @@ export default {
     { name: "build-plugin --check", mode: "hard", command: "npm run build-plugin -- --check" },
   ],
   pushAfterAttest: true,
+  // CI's test job runs node 20 and 22 (.github/workflows/test.yml); a local
+  // run can only certify one of them. Pin to 22 so an attest never silently
+  // runs on some other Node — the 20-leg coverage is genuinely skipped under
+  // attestation either way, which predates this pin.
+  toolchain: { node: "22" },
 };

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotbabel.dev/schemas/index.schema.json",
-  "generatedAt": "2026-08-13T19:01:07.422Z",
+  "generatedAt": "2026-08-13T19:36:58.038Z",
   "version": "2.16.0",
   "artifacts": [
     {
@@ -580,7 +580,7 @@
       "type": "skill",
       "path": "skills/local-attest/SKILL.md",
       "name": "local-attest",
-      "description": "Run the configured CI matrix locally and, on a clean pass, post a SHA-pinned OWNER-authored PR comment that gates downstream GitHub Actions jobs off for that exact commit. Skips the redundant remote run after a maintainer has already verified locally, saving runner minutes without weakening the gate. A new push changes the head SHA, the attestation stops matching, CI runs again. Side-effectful (posts a PR comment, applies a label, optionally pushes) and slow — minutes to tens of minutes, whatever the configured matrix costs. Diagnostic modes (--only, --from, --fail-fast) run subsets for the fix-retry loop and can never attest. Invoke only on explicit request.\n",
+      "description": "Run the configured CI matrix locally and, on a clean pass, post a SHA-pinned OWNER-authored PR comment that gates downstream GitHub Actions jobs off for that exact commit. Skips the redundant remote run after a maintainer has already verified locally, saving runner minutes without weakening the gate. A new push changes the head SHA, the attestation stops matching, CI runs again. Side-effectful (posts a PR comment, applies a label, optionally pushes) and slow — minutes to tens of minutes, whatever the configured matrix costs. Diagnostic modes (--only, --from) run subsets for the fix-retry loop and can never attest; --fail-fast works in both modes. Invoke only on explicit request.\n",
       "facets": {
         "domain": ["devex", "observability"],
         "platform": ["github-actions"],

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotbabel.dev/schemas/index.schema.json",
-  "generatedAt": "2026-08-13T14:14:51.258Z",
+  "generatedAt": "2026-08-13T19:01:07.422Z",
   "version": "2.16.0",
   "artifacts": [
     {
@@ -580,14 +580,14 @@
       "type": "skill",
       "path": "skills/local-attest/SKILL.md",
       "name": "local-attest",
-      "description": "Run the configured CI matrix locally and, on a clean pass, post a SHA-pinned OWNER-authored PR comment that gates downstream GitHub Actions jobs off for that exact commit. Skips the redundant remote run after a maintainer has already verified locally, saving runner minutes without weakening the gate. A new push changes the head SHA, the attestation stops matching, CI runs again. Side-effectful (posts a PR comment, applies a label, optionally pushes) and slow (10–15 min depending on matrix). Invoke only on explicit request.\n",
+      "description": "Run the configured CI matrix locally and, on a clean pass, post a SHA-pinned OWNER-authored PR comment that gates downstream GitHub Actions jobs off for that exact commit. Skips the redundant remote run after a maintainer has already verified locally, saving runner minutes without weakening the gate. A new push changes the head SHA, the attestation stops matching, CI runs again. Side-effectful (posts a PR comment, applies a label, optionally pushes) and slow — minutes to tens of minutes, whatever the configured matrix costs. Diagnostic modes (--only, --from, --fail-fast) run subsets for the fix-retry loop and can never attest. Invoke only on explicit request.\n",
       "facets": {
         "domain": ["devex", "observability"],
         "platform": ["github-actions"],
         "task": ["testing", "runtime-ops"],
         "maturity": "draft"
       },
-      "version": "1.0.0",
+      "version": "1.1.0",
       "owner": "@kaiohenricunha"
     },
     {

--- a/plugins/dotbabel/bin/dotbabel-local-attest.mjs
+++ b/plugins/dotbabel/bin/dotbabel-local-attest.mjs
@@ -9,12 +9,18 @@
  * GitHub-hosted runners after a maintainer has already verified locally.
  *
  * Usage:
- *   dotbabel local-attest [--pr <N>] [--no-push] [--dry-run] [--config <path>]
+ *   dotbabel local-attest [--pr <N>] [--no-push] [--dry-run] [--fail-fast]
+ *                         [--only <leg>] [--from <leg>] [--config <path>]
  *
  *   --pr <N>           Target PR number. Defaults to the open PR for the current branch.
  *   --no-push          Run the matrix + post comment + apply label, but do not `git push`.
  *   --dry-run          Run the matrix, render the comment, print it. Post nothing, label
  *                      nothing, push nothing. Use this to verify a new project's config.
+ *   --fail-fast        Stop launching legs after the first hard failure; unstarted legs
+ *                      are recorded not-run and the run can no longer attest.
+ *   --only <leg>       Diagnostic mode: run only the named leg(s), with relaxed
+ *                      preconditions (dirty tree fine, no PR needed). Never attests.
+ *   --from <leg>       Diagnostic mode: run the matrix suffix starting at the named leg.
  *   --config <path>    Override the .local-attest config file location.
  *
  * Config discovery (when --config not given):
@@ -37,7 +43,8 @@ import { parseArgs } from "../src/local-attest-lib.mjs";
 import { ConfigError, loadConfig } from "../src/local-attest-config.mjs";
 import { PreconditionError, execute, realDeps } from "../src/local-attest-runner.mjs";
 
-const HELP = `dotbabel-local-attest [--pr <N>] [--no-push] [--dry-run] [--config <path>]
+const HELP = `dotbabel-local-attest [--pr <N>] [--no-push] [--dry-run] [--fail-fast]
+                      [--only <leg>] [--from <leg>] [--config <path>]
 
 Run the configured CI matrix locally and, on a clean pass, post an attestation
 comment to the open PR so the remote pipeline skips itself for this commit.
@@ -46,6 +53,14 @@ Options:
   --pr <N>           Target PR number (defaults to the open PR for the branch)
   --no-push          Do not run \`git push\` after attesting
   --dry-run          Print the comment that would be posted; post nothing
+  --fail-fast        Stop launching legs after the first hard failure. A
+                     fail-fast run that stopped early can never attest; one
+                     where nothing failed completed the full matrix and can.
+  --only <leg>       Diagnostic mode: run only the named leg(s). Repeatable,
+                     or comma-separated. Relaxed preconditions (dirty tree
+                     fine, no PR needed); never posts, labels, or pushes.
+  --from <leg>       Diagnostic mode: run the matrix from the named leg to the
+                     end. Same rules as --only; mutually exclusive with it.
   --config <path>    Override the .local-attest config file location
   --help, -h         Show this help
   --version, -V      Show version
@@ -55,7 +70,11 @@ Config discovery (in order, when --config not given):
   .local-attest.config.json
   package.json#local-attest
 
-Exit codes: 0 ok, 1 attestation failure, 2 env error, 64 usage error.`;
+Every run whose matrix executes appends one line to the audit log
+(config.auditLogPath), tagged result: attested | hard-fail | head-moved |
+push-fail | post-fail | dry-run | diagnostic — failures leave a record too.
+
+Exit codes: 0 ok, 1 attestation/leg failure, 2 env error, 64 usage error.`;
 
 function fail(code, msg) {
   if (msg) process.stderr.write(`dotbabel-local-attest: ${msg}\n`);
@@ -105,11 +124,17 @@ async function main() {
       prOverride: argv.pr,
       push: argv.push,
       dryRun: argv.dryRun,
+      only: argv.only,
+      from: argv.from,
+      failFast: argv.failFast,
     });
     process.exit(result.exitCode);
   } catch (err) {
     if (err instanceof PreconditionError) {
       fail(1, err.message);
+    } else if (/** @type {any} */ (err).code === "USAGE") {
+      // filterMatrix throws usage errors (unknown --only/--from leg name).
+      fail(/** @type {any} */ (err).exitCode ?? EXIT_CODES.USAGE, err.message);
     } else {
       fail(2, err.message);
     }
@@ -117,8 +142,7 @@ async function main() {
 }
 
 // Run only when invoked as a CLI, not when imported by tests.
-const invokedDirect =
-  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const invokedDirect = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (invokedDirect) {
   main().catch((err) => fail(2, err.message));
 }

--- a/plugins/dotbabel/src/local-attest-config.mjs
+++ b/plugins/dotbabel/src/local-attest-config.mjs
@@ -18,6 +18,12 @@
  * @property {string} [cwd]
  * @property {Record<string, string>} [env]
  *
+ * @typedef {object} Toolchain
+ * @property {string} [node]   engines-style pin ("22", "22.x", ">=22"); the running
+ *                             node's major must match, or an attest run fails closed
+ * @property {string} [goMod]  path to a go.mod whose `go` directive's major.minor
+ *                             must match `go version` on PATH
+ *
  * @typedef {object} Config
  * @property {Leg[]} matrix
  * @property {string} label
@@ -26,6 +32,7 @@
  * @property {boolean} requireClean
  * @property {boolean} requireDocker
  * @property {boolean} pushAfterAttest
+ * @property {Toolchain|null} toolchain
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -41,6 +48,7 @@ export const DEFAULTS = Object.freeze({
   requireClean: true,
   requireDocker: false,
   pushAfterAttest: true,
+  toolchain: null,
 });
 
 /**
@@ -175,13 +183,15 @@ export function validateConfig(input) {
     if (leg.env !== undefined && (leg.env === null || typeof leg.env !== "object")) {
       throw new ConfigError(`config.matrix[${i}].env must be an object`);
     }
-    matrix.push(/** @type {Leg} */ ({
-      name,
-      mode: leg.mode,
-      command: leg.command,
-      ...(leg.cwd !== undefined ? { cwd: leg.cwd } : {}),
-      ...(leg.env !== undefined ? { env: { .../** @type {object} */ (leg.env) } } : {}),
-    }));
+    matrix.push(
+      /** @type {Leg} */ ({
+        name,
+        mode: leg.mode,
+        command: leg.command,
+        ...(leg.cwd !== undefined ? { cwd: leg.cwd } : {}),
+        ...(leg.env !== undefined ? { env: { .../** @type {object} */ (leg.env) } } : {}),
+      }),
+    );
   });
 
   if (typeof merged.label !== "string" || merged.label === "") {
@@ -209,8 +219,14 @@ export function validateConfig(input) {
     throw new ConfigError("config.trustedAssociations must be a non-empty array of strings");
   }
   const VALID_ASSOCIATIONS = new Set([
-    "OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR",
-    "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MANNEQUIN", "NONE",
+    "OWNER",
+    "MEMBER",
+    "COLLABORATOR",
+    "CONTRIBUTOR",
+    "FIRST_TIMER",
+    "FIRST_TIME_CONTRIBUTOR",
+    "MANNEQUIN",
+    "NONE",
   ]);
   for (const assoc of merged.trustedAssociations) {
     if (!VALID_ASSOCIATIONS.has(assoc)) {
@@ -225,6 +241,27 @@ export function validateConfig(input) {
     }
   }
 
+  /** @type {import("./local-attest-config.mjs").Toolchain|null} */
+  let toolchain = null;
+  if (merged.toolchain !== null && merged.toolchain !== undefined) {
+    if (typeof merged.toolchain !== "object" || Array.isArray(merged.toolchain)) {
+      throw new ConfigError("config.toolchain must be an object with optional node/goMod strings");
+    }
+    const t = /** @type {Record<string, unknown>} */ (merged.toolchain);
+    for (const key of Object.keys(t)) {
+      if (key !== "node" && key !== "goMod") {
+        throw new ConfigError(`config.toolchain.${key} is not a recognised pin (use node, goMod)`);
+      }
+      if (typeof t[key] !== "string" || t[key] === "") {
+        throw new ConfigError(`config.toolchain.${key} must be a non-empty string`);
+      }
+    }
+    toolchain = {
+      ...(t.node !== undefined ? { node: /** @type {string} */ (t.node) } : {}),
+      ...(t.goMod !== undefined ? { goMod: /** @type {string} */ (t.goMod) } : {}),
+    };
+  }
+
   return /** @type {Config} */ ({
     matrix,
     label: merged.label,
@@ -233,5 +270,6 @@ export function validateConfig(input) {
     requireClean: merged.requireClean,
     requireDocker: merged.requireDocker,
     pushAfterAttest: merged.pushAfterAttest,
+    toolchain,
   });
 }

--- a/plugins/dotbabel/src/local-attest-config.mjs
+++ b/plugins/dotbabel/src/local-attest-config.mjs
@@ -19,10 +19,14 @@
  * @property {Record<string, string>} [env]
  *
  * @typedef {object} Toolchain
- * @property {string} [node]   engines-style pin ("22", "22.x", ">=22"); the running
- *                             node's major must match, or an attest run fails closed
- * @property {string} [goMod]  path to a go.mod whose `go` directive's major.minor
- *                             must match `go version` on PATH
+ * @property {string} [node]   exact major version pin ("22"); the `node` on PATH
+ *                             must have that major, or an attest run fails closed.
+ *                             Range syntax (">=22", "^22") is rejected at
+ *                             validation — the check is exact-major only, and
+ *                             accepting ranges it would misread is worse than
+ *                             refusing them
+ * @property {string} [goMod]  path (relative, no "..") to a go.mod whose `go`
+ *                             directive's major.minor must match `go version`
  *
  * @typedef {object} Config
  * @property {Leg[]} matrix
@@ -248,12 +252,37 @@ export function validateConfig(input) {
       throw new ConfigError("config.toolchain must be an object with optional node/goMod strings");
     }
     const t = /** @type {Record<string, unknown>} */ (merged.toolchain);
+    // An empty pin block would silently disable the fail-closed check while
+    // looking like a declared pin — the one shape an operator produces by
+    // commenting out the only entry. Refuse it; omitting the key opts out.
+    if (Object.keys(t).length === 0) {
+      throw new ConfigError(
+        "config.toolchain must declare at least one pin (node, goMod) — omit the key to opt out",
+      );
+    }
     for (const key of Object.keys(t)) {
       if (key !== "node" && key !== "goMod") {
         throw new ConfigError(`config.toolchain.${key} is not a recognised pin (use node, goMod)`);
       }
       if (typeof t[key] !== "string" || t[key] === "") {
         throw new ConfigError(`config.toolchain.${key} must be a non-empty string`);
+      }
+    }
+    // The node check compares exact majors. Range syntax parses to its first
+    // integer, so ">=20" would BLOCK Node 22 — the documented meaning
+    // inverted. Reject it rather than misread it.
+    if (t.node !== undefined && /[><^~|]/.test(/** @type {string} */ (t.node))) {
+      throw new ConfigError(
+        `config.toolchain.node must be an exact major version pin like "22" — range syntax (${JSON.stringify(t.node)}) is not honored`,
+      );
+    }
+    if (t.goMod !== undefined) {
+      const goMod = /** @type {string} */ (t.goMod);
+      if (isAbsolute(goMod)) {
+        throw new ConfigError("config.toolchain.goMod must be a relative path");
+      }
+      if (goMod.split("/").some((seg) => seg === "..")) {
+        throw new ConfigError("config.toolchain.goMod must not contain '..' segments");
       }
     }
     toolchain = {

--- a/plugins/dotbabel/src/local-attest-lib.mjs
+++ b/plugins/dotbabel/src/local-attest-lib.mjs
@@ -244,7 +244,7 @@ export function tail(text, n = 10) {
  * @param {{ headSha: string, hostname: string, now?: Date }} ctx
  * @returns {string}
  */
-export function renderComment(results, { headSha, hostname, now }) {
+export function renderComment(results, { headSha, hostname, toolchain, now }) {
   const marker = buildAttestMarker(headSha);
   const ts = (now ?? new Date()).toISOString();
   const LABELS = {
@@ -272,6 +272,15 @@ export function renderComment(results, { headSha, hostname, now }) {
     `- Host: \`${hostname}\``,
     `- Attested at: \`${ts}\``,
     `- Verified SHA: \`${headSha}\``,
+    // Which toolchain this run certified — the marker above can switch off a
+    // multi-version CI matrix, so the comment records the one version it ran.
+    ...(toolchain && Object.keys(toolchain).length > 0
+      ? [
+          `- Toolchain: ${Object.entries(toolchain)
+            .map(([k, v]) => `${k} ${v}`)
+            .join(" \u00b7 ")}`,
+        ]
+      : []),
   ].join("\n");
 }
 
@@ -293,27 +302,34 @@ export function legStatus(r) {
 }
 
 /**
- * The mechanical attestation bar. Posting, labelling, and pushing are only
- * reachable when this returns true — a prose promise that "partial runs never
- * attest" is exactly the kind of obligation that drifts, so the run record
- * itself is judged instead.
+ * The mechanical attestation bar. Posting, labelling, and pushing live inside
+ * this predicate's guard in `execute` — a prose promise that "partial runs
+ * never attest" is exactly the kind of obligation that drifts, so the run
+ * record itself is judged instead.
  *
- * The flag check and the structural checks are deliberately redundant: with
- * `diagnostic` false a `notRun` entry "cannot" exist, but the structural
- * clauses catch the future wiring bug that makes it exist anyway.
+ * The first line of defense against a subset run attesting is control flow:
+ * `execute`'s diagnostic branch returns before the publication path, and the
+ * attest branch runs the full config matrix. This predicate is the second
+ * line, and its clauses are deliberately redundant with each other: pass the
+ * real `diagnostic` value (never a literal), and pass `expectedLegs` (the
+ * full matrix length) so a subset record is rejected even if the flag wiring
+ * is wrong — a filtered matrix produces fewer results than the config
+ * declares.
  *
  * Advisory failures do not block, matching the gate semantics the matrix
  * mirrors. A `--fail-fast` run in which nothing failed completed the full
  * matrix and may attest.
  *
- * @param {{ diagnostic?: boolean, results: Array<LegResult|undefined> }} run
+ * @param {{ diagnostic?: boolean, results: Array<LegResult|undefined>,
+ *           expectedLegs?: number }} run
  * @returns {boolean}
  */
-export function shouldAttest({ diagnostic, results }) {
+export function shouldAttest({ diagnostic, results, expectedLegs }) {
   return (
     diagnostic !== true &&
     Array.isArray(results) &&
     results.length > 0 &&
+    (expectedLegs === undefined || results.length === expectedLegs) &&
     results.every((r) => r && r.notRun !== true && typeof r.passed === "boolean") &&
     !results.some((r) => r && r.mode === "hard" && !r.passed)
   );
@@ -337,8 +353,8 @@ export function shouldAttest({ diagnostic, results }) {
  *
  * @param {{ result: string, pr: number|string|null, sha: string|null, hostname: string,
  *           advisoryFails: string[], results?: Array<LegResult|undefined>,
- *           flags?: { only?: string[], from?: string|null, failFast?: boolean, push?: boolean },
- *           dirty?: boolean, now?: Date }} input
+ *           flags?: { only?: string[], from?: string|null, failFast?: boolean, push?: boolean, dryRun?: boolean },
+ *           dirty?: boolean, toolchain?: { node?: string, go?: string }|null, now?: Date }} input
  * @returns {object}
  */
 export function buildAuditEntry({
@@ -350,6 +366,7 @@ export function buildAuditEntry({
   results,
   flags,
   dirty,
+  toolchain,
   now,
 }) {
   const entry = {
@@ -374,9 +391,14 @@ export function buildAuditEntry({
       from: flags.from ?? null,
       failFast: flags.failFast === true,
       push: flags.push !== false,
+      dryRun: flags.dryRun === true,
     };
   }
   if (dirty !== undefined) entry.dirty = dirty;
+  // The versions this run was certified against — the attestation can switch
+  // off a multi-version CI matrix, and the record should say which version it
+  // actually covered.
+  if (toolchain && Object.keys(toolchain).length > 0) entry.toolchain = toolchain;
   return entry;
 }
 

--- a/plugins/dotbabel/src/local-attest-lib.mjs
+++ b/plugins/dotbabel/src/local-attest-lib.mjs
@@ -17,6 +17,9 @@
  * @property {string} name
  * @property {LegMode} mode
  * @property {boolean} passed
+ * @property {boolean} [notRun]  true when fail-fast stopped the run before this leg launched;
+ *                               `passed` is false so a consumer that forgets to check errs
+ *                               toward reporting failure, never success
  * @property {number} durationS
  * @property {string} tail
  *
@@ -26,6 +29,9 @@
  * @property {boolean} dryRun
  * @property {string|null} config
  * @property {boolean} help
+ * @property {string[]} only
+ * @property {string|null} from
+ * @property {boolean} failFast
  */
 
 export const ATTEST_MARKER_PREFIX = "<!-- local-attest verified-sha=";
@@ -110,12 +116,22 @@ export function parseArgs(argv, die) {
       throw err;
     });
   /** @type {ParsedArgs} */
-  const args = { pr: null, push: true, dryRun: false, config: null, help: false };
+  const args = {
+    pr: null,
+    push: true,
+    dryRun: false,
+    config: null,
+    help: false,
+    only: [],
+    from: null,
+    failFast: false,
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--pr") {
       const v = argv[++i];
-      if (!v || !/^\d+$/.test(v)) return exit(64, `--pr requires a number, got ${v ?? "(missing)"}`);
+      if (!v || !/^\d+$/.test(v))
+        return exit(64, `--pr requires a number, got ${v ?? "(missing)"}`);
       args.pr = v;
     } else if (a === "--no-push") {
       args.push = false;
@@ -125,13 +141,85 @@ export function parseArgs(argv, die) {
       const v = argv[++i];
       if (!v) return exit(64, "--config requires a path");
       args.config = v;
+    } else if (a === "--only") {
+      const v = argv[++i];
+      if (!v) return exit(64, "--only requires a leg name");
+      args.only.push(v);
+    } else if (a === "--from") {
+      const v = argv[++i];
+      if (!v) return exit(64, "--from requires a leg name");
+      if (args.from !== null) return exit(64, "--from given more than once");
+      args.from = v;
+    } else if (a === "--fail-fast") {
+      args.failFast = true;
     } else if (a === "--help" || a === "-h") {
       args.help = true;
     } else {
       return exit(64, `unknown argument: ${a}`);
     }
   }
+  if (args.only.length > 0 && args.from !== null) {
+    return exit(64, "--only and --from are mutually exclusive — pick one");
+  }
   return args;
+}
+
+/**
+ * Select a subset of the matrix for a diagnostic run.
+ *
+ * `only` entries match leg names exactly and case-sensitively. A token that is
+ * not itself a leg name is split on commas — the order matters, because a leg
+ * name may legitimately contain a comma and must never be split apart. The
+ * selection preserves matrix order regardless of the order names were given,
+ * because the declared order is the only order the operator ever sees.
+ *
+ * `from` selects the suffix starting at the named leg's index.
+ *
+ * Unknown names throw with every valid name listed, so the fix is a copy-paste
+ * rather than a guessing game. No dependency injection happens: `--from` and
+ * `--only` run exactly what they name, which is precisely why a subset run can
+ * never attest (see {@link shouldAttest}).
+ *
+ * @param {Array<{name: string}>} matrix
+ * @param {{ only?: string[], from?: string|null }} sel
+ * @returns {Array<{name: string}>}
+ */
+export function filterMatrix(matrix, { only = [], from = null } = {}) {
+  const names = matrix.map((l) => l.name);
+  const unknown = (name) => {
+    const err = new Error(
+      `unknown leg ${JSON.stringify(name)} — valid legs:\n  ${names.join("\n  ")}`,
+    );
+    /** @type {any} */ (err).code = "USAGE";
+    /** @type {any} */ (err).exitCode = 64;
+    return err;
+  };
+
+  if (from !== null) {
+    const idx = names.indexOf(from);
+    if (idx === -1) throw unknown(from);
+    return matrix.slice(idx);
+  }
+
+  if (only.length > 0) {
+    const wanted = new Set();
+    for (const token of only) {
+      if (names.includes(token)) {
+        wanted.add(token);
+        continue;
+      }
+      for (const part of token
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)) {
+        if (!names.includes(part)) throw unknown(part);
+        wanted.add(part);
+      }
+    }
+    return matrix.filter((l) => wanted.has(l.name));
+  }
+
+  return matrix;
 }
 
 /**
@@ -159,11 +247,16 @@ export function tail(text, n = 10) {
 export function renderComment(results, { headSha, hostname, now }) {
   const marker = buildAttestMarker(headSha);
   const ts = (now ?? new Date()).toISOString();
+  const LABELS = {
+    pass: "pass",
+    fail: "FAIL",
+    "advisory-fail": "fail (advisory)",
+    // Unreachable when shouldAttest gates posting, but a future wiring bug
+    // must surface as "not run" — never as a pass.
+    "not-run": "not run (fail-fast)",
+  };
   const rows = results
-    .map((r) => {
-      const status = r.passed ? "pass" : r.mode === "advisory" ? "fail (advisory)" : "FAIL";
-      return `| ${r.name} | ${r.mode} | ${status} | ${r.durationS}s |`;
-    })
+    .map((r) => `| ${r.name} | ${r.mode} | ${LABELS[legStatus(r)]} | ${r.durationS}s |`)
     .join("\n");
   return [
     marker,
@@ -183,32 +276,212 @@ export function renderComment(results, { headSha, hostname, now }) {
 }
 
 /**
- * Shape one JSONL line for the audit log.
+ * Classify one leg result into its terminal status. The summary printer, the
+ * comment renderer, and the audit entry all derive their labels from this one
+ * function, so the three surfaces cannot disagree about what happened.
  *
- * @param {{ pr: number|string, sha: string, hostname: string, advisoryFails: string[], now?: Date }} input
- * @returns {{ ts: string, pr: number, sha: string, host: string, advisoryFails: string[] }}
+ * An absent record classifies as `not-run`: it was never executed, and saying
+ * so is the honest reading of a hole.
+ *
+ * @param {LegResult|undefined} r
+ * @returns {"pass"|"fail"|"advisory-fail"|"not-run"}
  */
-export function buildAuditEntry({ pr, sha, hostname, advisoryFails, now }) {
-  return {
-    ts: (now ?? new Date()).toISOString(),
-    pr: Number(pr),
-    sha,
-    host: hostname,
-    advisoryFails: [...advisoryFails],
-  };
+export function legStatus(r) {
+  if (!r || r.notRun) return "not-run";
+  if (r.passed) return "pass";
+  return r.mode === "advisory" ? "advisory-fail" : "fail";
 }
 
 /**
- * Summarize a matrix run.
+ * The mechanical attestation bar. Posting, labelling, and pushing are only
+ * reachable when this returns true — a prose promise that "partial runs never
+ * attest" is exactly the kind of obligation that drifts, so the run record
+ * itself is judged instead.
+ *
+ * The flag check and the structural checks are deliberately redundant: with
+ * `diagnostic` false a `notRun` entry "cannot" exist, but the structural
+ * clauses catch the future wiring bug that makes it exist anyway.
+ *
+ * Advisory failures do not block, matching the gate semantics the matrix
+ * mirrors. A `--fail-fast` run in which nothing failed completed the full
+ * matrix and may attest.
+ *
+ * @param {{ diagnostic?: boolean, results: Array<LegResult|undefined> }} run
+ * @returns {boolean}
+ */
+export function shouldAttest({ diagnostic, results }) {
+  return (
+    diagnostic !== true &&
+    Array.isArray(results) &&
+    results.length > 0 &&
+    results.every((r) => r && r.notRun !== true && typeof r.passed === "boolean") &&
+    !results.some((r) => r && r.mode === "hard" && !r.passed)
+  );
+}
+
+/**
+ * Shape one JSONL line for the audit log.
+ *
+ * Every legacy field (`ts`, `pr`, `sha`, `host`, `advisoryFails`) keeps its
+ * exact shape: lines written before `result` existed were only ever written
+ * after a successful post, so a reader may treat a missing `result` as
+ * `"attested"`. New fields are additive:
+ *
+ * - `result` — what the run concluded: attested | hard-fail | head-moved |
+ *   push-fail | post-fail | dry-run | diagnostic.
+ * - `legs` — per-leg terminal status and duration, via {@link legStatus}.
+ *   This is what makes failure distributions measurable at all.
+ * - `flags` — the invocation shape, so diagnostic lines are interpretable.
+ * - `dirty` — diagnostic runs only: a dirty tree's `sha` does not identify
+ *   the tree that ran, and the record says so.
+ *
+ * @param {{ result: string, pr: number|string|null, sha: string|null, hostname: string,
+ *           advisoryFails: string[], results?: Array<LegResult|undefined>,
+ *           flags?: { only?: string[], from?: string|null, failFast?: boolean, push?: boolean },
+ *           dirty?: boolean, now?: Date }} input
+ * @returns {object}
+ */
+export function buildAuditEntry({
+  result,
+  pr,
+  sha,
+  hostname,
+  advisoryFails,
+  results,
+  flags,
+  dirty,
+  now,
+}) {
+  const entry = {
+    ts: (now ?? new Date()).toISOString(),
+    pr: pr == null ? null : Number(pr),
+    sha: sha ?? null,
+    host: hostname,
+    advisoryFails: [...advisoryFails],
+    result,
+  };
+  if (Array.isArray(results)) {
+    entry.legs = results.map((r) => ({
+      name: r?.name ?? "(unknown)",
+      mode: r?.mode ?? "hard",
+      status: legStatus(r),
+      durationS: r?.durationS ?? 0,
+    }));
+  }
+  if (flags) {
+    entry.flags = {
+      only: [...(flags.only ?? [])],
+      from: flags.from ?? null,
+      failFast: flags.failFast === true,
+      push: flags.push !== false,
+    };
+  }
+  if (dirty !== undefined) entry.dirty = dirty;
+  return entry;
+}
+
+/**
+ * Summarize a matrix run. Not-run legs count as neither failure class — they
+ * were never executed, and counting them as failures would misreport a
+ * fail-fast stop as a pile of breakage.
  *
  * @param {LegResult[]} results
  * @returns {{ hardFails: LegResult[], advisoryFails: LegResult[], totalDurationS: number }}
  */
 export function summarizeResults(results) {
-  const hardFails = results.filter((r) => r.mode === "hard" && !r.passed);
-  const advisoryFails = results.filter((r) => r.mode === "advisory" && !r.passed);
+  const hardFails = results.filter((r) => !r.notRun && r.mode === "hard" && !r.passed);
+  const advisoryFails = results.filter((r) => !r.notRun && r.mode === "advisory" && !r.passed);
   const totalDurationS = results.reduce((acc, r) => acc + (r.durationS ?? 0), 0);
   return { hardFails, advisoryFails, totalDurationS };
+}
+
+// ---------------------------------------------------------------------------
+// Toolchain pins — config-declared, checked before a run
+// ---------------------------------------------------------------------------
+
+/**
+ * Major version out of an engines-style pin: "22", "22.x", ">=22", "^22.1.0".
+ * Null when no major can be read.
+ *
+ * @param {unknown} pin
+ * @returns {number|null}
+ */
+export function nodeMajorFromPin(pin) {
+  const m = /^[^\d]*(\d+)/.exec(String(pin ?? "").trim());
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Major version out of a runtime version string ("22.11.0").
+ *
+ * @param {unknown} version
+ * @returns {number|null}
+ */
+export function nodeMajorOf(version) {
+  const m = /^(\d+)/.exec(String(version ?? "").trim());
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * "major.minor" out of `go version` output ("go version go1.26.5 linux/amd64").
+ *
+ * @param {unknown} output
+ * @returns {string|null}
+ */
+export function goMajorMinorFromVersion(output) {
+  const m = /\bgo(\d+)\.(\d+)/.exec(String(output ?? ""));
+  return m ? `${m[1]}.${m[2]}` : null;
+}
+
+/**
+ * "major.minor" out of a go.mod `go` directive ("go 1.26.5").
+ *
+ * @param {unknown} text
+ * @returns {string|null}
+ */
+export function goMajorMinorFromGoMod(text) {
+  const m = /^go\s+(\d+)\.(\d+)/m.exec(String(text ?? ""));
+  return m ? `${m[1]}.${m[2]}` : null;
+}
+
+/**
+ * Compare the running toolchain against the config's pins. Returns one
+ * human-readable problem per mismatch. Unparseable versions count as
+ * problems — the attestation certifies "CI would pass", and a toolchain
+ * nobody can identify certifies nothing (fail-closed).
+ *
+ * No pin, no problems: the check is opt-in per config.
+ *
+ * @param {{ pin?: { node?: string, goMod?: string }|null, nodeVersion?: string,
+ *           goVersionOutput?: string, goModText?: string }} input
+ * @returns {string[]}
+ */
+export function toolchainProblems({ pin, nodeVersion, goVersionOutput, goModText }) {
+  if (!pin) return [];
+  const problems = [];
+  if (pin.node !== undefined) {
+    const want = nodeMajorFromPin(pin.node);
+    const have = nodeMajorOf(nodeVersion);
+    if (want === null || have === null) {
+      problems.push(
+        `cannot compare Node versions (running: ${have ?? "unparseable"}, pin: ${want ?? "unparseable"})`,
+      );
+    } else if (want !== have) {
+      problems.push(`Node ${have} is running but config.toolchain.node pins ${pin.node}`);
+    }
+  }
+  if (pin.goMod !== undefined) {
+    const want = goMajorMinorFromGoMod(goModText);
+    const have = goMajorMinorFromVersion(goVersionOutput);
+    if (want === null || have === null) {
+      problems.push(
+        `cannot compare Go versions (go version: ${have ?? "unparseable"}, ${pin.goMod}: ${want ?? "unparseable"})`,
+      );
+    } else if (want !== have) {
+      problems.push(`Go ${have} is on PATH but ${pin.goMod} pins ${want}`);
+    }
+  }
+  return problems;
 }
 
 /**

--- a/plugins/dotbabel/src/local-attest-runner.mjs
+++ b/plugins/dotbabel/src/local-attest-runner.mjs
@@ -21,6 +21,7 @@
  * @property {(cmd: string, opts?: { cwd?: string, env?: Record<string,string>, capture?: boolean }) => { status: number, stdout: string, stderr: string }} run
  * @property {(cmd: string, payload: object) => string} ghApiWithInput
  * @property {(path: string, line: string) => void} appendLog
+ * @property {(path: string) => string|null} [readFile]  utf8 read, null on any error
  * @property {() => string} hostname
  * @property {(msg: string) => void} log
  * @property {(msg: string) => void} warn
@@ -35,16 +36,19 @@
  * @property {string} repo
  * @property {string} pr
  * @property {string} headSha
+ * @property {{ node?: string, go?: string }|null} [toolchain]  versions measured
+ *   against the config pins; null when no pins are configured
  */
 
 import { spawnSync } from "node:child_process";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import os from "node:os";
 
 import {
   buildAuditEntry,
   filterMatrix,
   findAttestComment,
+  goMajorMinorFromVersion,
   legStatus,
   renderComment,
   shouldAttest,
@@ -86,6 +90,13 @@ export function realDeps() {
     },
     appendLog(path, line) {
       appendFileSync(path, line);
+    },
+    readFile(path) {
+      try {
+        return readFileSync(path, "utf8");
+      } catch {
+        return null;
+      }
     },
     hostname() {
       return os.hostname();
@@ -130,30 +141,39 @@ export class PreconditionError extends Error {
 }
 
 /**
- * Collect toolchain problems for the config's pins, gathering versions through
- * `deps.run` so tests can stub them. Config paths are repo-owned (the same
- * trust level as the leg commands the matrix executes verbatim).
+ * Compare the running toolchain against the config's pins, gathering versions
+ * through `deps.run`/`deps.readFile` so tests can stub them.
  *
  * @param {Deps} deps
  * @param {Config} cfg
- * @returns {string[]}
+ * @returns {{ problems: string[], seen: { node?: string, go?: string }|null }}
+ *   `problems` — one entry per mismatch or unparseable version;
+ *   `seen` — the versions actually measured, recorded in the audit line and
+ *   the attestation comment so the certified toolchain is auditable later.
  */
 function gatherToolchain(deps, cfg) {
   const pin = cfg.toolchain;
-  if (!pin) return [];
+  if (!pin) return { problems: [], seen: null };
   /** @type {Parameters<typeof toolchainProblems>[0]} */
   const inputs = { pin };
+  /** @type {{ node?: string, go?: string }} */
+  const seen = {};
   if (pin.node !== undefined) {
     const r = deps.run("node --version", { capture: true });
     inputs.nodeVersion = r.status === 0 ? r.stdout.trim().replace(/^v/, "") : "";
+    if (inputs.nodeVersion) seen.node = inputs.nodeVersion;
   }
   if (pin.goMod !== undefined) {
     const rv = deps.run("go version", { capture: true });
     inputs.goVersionOutput = rv.status === 0 ? rv.stdout : "";
-    const rf = deps.run(`cat "${pin.goMod}"`, { capture: true });
-    inputs.goModText = rf.status === 0 ? rf.stdout : "";
+    const parsed = goMajorMinorFromVersion(inputs.goVersionOutput);
+    if (parsed) seen.go = parsed;
+    // A direct file read, not a shell cat: this module forbids interpolating
+    // strings into shell commands, and validateConfig constrains the path the
+    // same way auditLogPath is constrained.
+    inputs.goModText = deps.readFile ? (deps.readFile(pin.goMod) ?? "") : "";
   }
-  return toolchainProblems(inputs);
+  return { problems: toolchainProblems(inputs), seen };
 }
 
 /**
@@ -178,7 +198,7 @@ export function checkDiagnosticPreconditions(deps, cfg) {
         "(config.requireDocker is true; diagnostic runs continue anyway.)",
     );
   }
-  for (const p of gatherToolchain(deps, cfg)) {
+  for (const p of gatherToolchain(deps, cfg).problems) {
     deps.warn(`WARNING: ${p} (diagnostic run — continuing; an attest run stops here)`);
   }
 }
@@ -286,11 +306,11 @@ export function checkPreconditions(deps, cfg, opts = {}) {
   // certifies a run CI would never perform. Diagnostic runs warn instead
   // (checkDiagnosticPreconditions) — iterating on the wrong toolchain is the
   // operator's business until they try to attest with it.
-  const toolchainIssues = gatherToolchain(deps, cfg);
-  if (toolchainIssues.length > 0) {
+  const toolchain = gatherToolchain(deps, cfg);
+  if (toolchain.problems.length > 0) {
     throw new PreconditionError(
       "toolchain mismatch — the attestation must certify the toolchain CI runs on:\n  " +
-        toolchainIssues.join("\n  "),
+        toolchain.problems.join("\n  "),
     );
   }
 
@@ -320,7 +340,7 @@ export function checkPreconditions(deps, cfg, opts = {}) {
     // Permission probe is a courtesy — never block on it.
   }
 
-  return { branch, repo, pr, headSha };
+  return { branch, repo, pr, headSha, toolchain: toolchain.seen };
 }
 
 /**
@@ -498,7 +518,7 @@ export function execute(deps, cfg, flags) {
   const from = flags.from ?? null;
   const failFast = flags.failFast === true;
   const diagnostic = only.length > 0 || from !== null;
-  const auditFlags = { only, from, failFast, push: flags.push };
+  const auditFlags = { only, from, failFast, push: flags.push, dryRun: flags.dryRun === true };
 
   if (diagnostic) {
     const matrix = filterMatrix(cfg.matrix, { only, from });
@@ -559,17 +579,19 @@ export function execute(deps, cfg, flags) {
       advisoryFails: advisoryFails.map((r) => r.name),
       results,
       flags: auditFlags,
+      toolchain: pre.toolchain,
     });
 
   const body = renderComment(results, {
     headSha: pre.headSha,
     hostname: deps.hostname(),
+    toolchain: pre.toolchain,
   });
 
   // The mechanical bar: posting is only reachable through this predicate.
   // hardFails covers the executed failures; shouldAttest additionally rejects
   // not-run legs and unsettled holes, so a fail-fast stop can never attest.
-  if (!shouldAttest({ diagnostic: false, results })) {
+  if (!shouldAttest({ diagnostic, results, expectedLegs: cfg.matrix.length })) {
     if (hardFails.length > 0) {
       deps.warn(
         `\n${hardFails.length} hard leg(s) failed: ${hardFails.map((r) => r.name).join(", ")}.`,
@@ -621,9 +643,17 @@ export function execute(deps, cfg, flags) {
       trustedAssociations: cfg.trustedAssociations,
     });
   } catch (err) {
-    // A gh outage after a long green matrix must still leave a record.
+    // A gh outage after a long green matrix must still leave a record — and
+    // it is an attestation failure (exit 1), not an environment error: the
+    // matrix ran green and only the publish step failed, exactly like a
+    // failed push one branch below.
     audit("post-fail");
-    throw err;
+    deps.warn(
+      "posting the attestation comment failed. Nothing was pushed or labelled; " +
+        "re-run to retry once gh recovers.\n" +
+        String(err?.message ?? err),
+    );
+    return { ok: false, body, results, pre, exitCode: 1 };
   }
 
   if (flags.push && cfg.pushAfterAttest) {
@@ -640,8 +670,12 @@ export function execute(deps, cfg, flags) {
     deps.log("Pushed.");
   }
 
-  applyLabel(deps, { repo: pre.repo, pr: pre.pr, label: cfg.label });
+  // Audit before the label: "attested" means comment + push, both done by
+  // here, and the label is best-effort decoration. In the reverse order a
+  // throw inside applyLabel would leave a published attestation with no
+  // record — the exact state the audit invariant exists to prevent.
   audit("attested");
+  applyLabel(deps, { repo: pre.repo, pr: pre.pr, label: cfg.label });
 
   if (flags.push && cfg.pushAfterAttest) {
     deps.log("Remote CI jobs gated by the attestation comment will skip for this commit.");

--- a/plugins/dotbabel/src/local-attest-runner.mjs
+++ b/plugins/dotbabel/src/local-attest-runner.mjs
@@ -43,10 +43,14 @@ import os from "node:os";
 
 import {
   buildAuditEntry,
+  filterMatrix,
   findAttestComment,
+  legStatus,
   renderComment,
+  shouldAttest,
   summarizeResults,
   tail,
+  toolchainProblems,
 } from "./local-attest-lib.mjs";
 
 /**
@@ -122,6 +126,60 @@ export class PreconditionError extends Error {
     super(message);
     this.name = "PreconditionError";
     this.code = "LOCAL_ATTEST_PRECONDITION";
+  }
+}
+
+/**
+ * Collect toolchain problems for the config's pins, gathering versions through
+ * `deps.run` so tests can stub them. Config paths are repo-owned (the same
+ * trust level as the leg commands the matrix executes verbatim).
+ *
+ * @param {Deps} deps
+ * @param {Config} cfg
+ * @returns {string[]}
+ */
+function gatherToolchain(deps, cfg) {
+  const pin = cfg.toolchain;
+  if (!pin) return [];
+  /** @type {Parameters<typeof toolchainProblems>[0]} */
+  const inputs = { pin };
+  if (pin.node !== undefined) {
+    const r = deps.run("node --version", { capture: true });
+    inputs.nodeVersion = r.status === 0 ? r.stdout.trim().replace(/^v/, "") : "";
+  }
+  if (pin.goMod !== undefined) {
+    const rv = deps.run("go version", { capture: true });
+    inputs.goVersionOutput = rv.status === 0 ? rv.stdout : "";
+    const rf = deps.run(`cat "${pin.goMod}"`, { capture: true });
+    inputs.goModText = rf.status === 0 ? rf.stdout : "";
+  }
+  return toolchainProblems(inputs);
+}
+
+/**
+ * The slim precondition set for a diagnostic (`--only`/`--from`) run. A dirty
+ * tree, a missing PR, and a diverged HEAD are all fine — iterating on a fix is
+ * the entire point, and a diagnostic run is structurally unable to attest
+ * (see shouldAttest). Docker and toolchain problems warn instead of failing:
+ * the selected legs will say so loudly if they actually needed them.
+ *
+ * @param {Deps} deps
+ * @param {Config} cfg
+ */
+export function checkDiagnosticPreconditions(deps, cfg) {
+  try {
+    capture(deps, "git rev-parse --git-dir");
+  } catch {
+    throw new PreconditionError("not inside a git repository.");
+  }
+  if (cfg.requireDocker && deps.run("docker info", { capture: true }).status !== 0) {
+    deps.warn(
+      "WARNING: Docker is not available — legs that need it will fail. " +
+        "(config.requireDocker is true; diagnostic runs continue anyway.)",
+    );
+  }
+  for (const p of gatherToolchain(deps, cfg)) {
+    deps.warn(`WARNING: ${p} (diagnostic run — continuing; an attest run stops here)`);
   }
 }
 
@@ -223,13 +281,35 @@ export function checkPreconditions(deps, cfg, opts = {}) {
     );
   }
 
+  // Toolchain pins are fail-closed on an attest run: the attestation claims
+  // "CI would pass", and a matrix run on a different Node or Go than CI uses
+  // certifies a run CI would never perform. Diagnostic runs warn instead
+  // (checkDiagnosticPreconditions) — iterating on the wrong toolchain is the
+  // operator's business until they try to attest with it.
+  const toolchainIssues = gatherToolchain(deps, cfg);
+  if (toolchainIssues.length > 0) {
+    throw new PreconditionError(
+      "toolchain mismatch — the attestation must certify the toolchain CI runs on:\n  " +
+        toolchainIssues.join("\n  "),
+    );
+  }
+
   // Trust list mismatch is a warning, not a failure: a non-trusted user can
   // still iterate; their attestation just won't skip CI. The skill prints
   // the warning once at the start of the run so it's loud.
   try {
     const me = capture(deps, "gh api user --jq .login");
-    const ownerAssoc = capture(deps, `gh api repos/${repo}/collaborators/${me}/permission --jq .permission`).toUpperCase();
-    const PERM_TO_ASSOC = { ADMIN: "OWNER", WRITE: "MEMBER", READ: "COLLABORATOR", MAINTAIN: "MEMBER", TRIAGE: "COLLABORATOR" };
+    const ownerAssoc = capture(
+      deps,
+      `gh api repos/${repo}/collaborators/${me}/permission --jq .permission`,
+    ).toUpperCase();
+    const PERM_TO_ASSOC = {
+      ADMIN: "OWNER",
+      WRITE: "MEMBER",
+      READ: "COLLABORATOR",
+      MAINTAIN: "MEMBER",
+      TRIAGE: "COLLABORATOR",
+    };
     const mapped = PERM_TO_ASSOC[ownerAssoc] ?? ownerAssoc;
     if (!cfg.trustedAssociations.includes(mapped)) {
       deps.warn(
@@ -247,14 +327,34 @@ export function checkPreconditions(deps, cfg, opts = {}) {
  * Execute the matrix sequentially. Each leg runs to completion; output is
  * tailed at 10 lines so large logs don't bloat the result struct.
  *
+ * With `failFast`, a hard failure stops launching further legs; the remainder
+ * are recorded as `{ notRun: true, passed: false }` — fail-closed for any
+ * consumer that forgets to check `notRun`, and never mistakable for a pass.
+ * Advisory failures never trip the abort: they cannot block an attestation,
+ * so stopping the run on one would only cost information.
+ *
  * @param {Deps} deps
  * @param {Leg[]} matrix
+ * @param {{ failFast?: boolean }} [opts]
  * @returns {LegResult[]}
  */
-export function runMatrix(deps, matrix) {
+export function runMatrix(deps, matrix, { failFast = false } = {}) {
   /** @type {LegResult[]} */
   const results = [];
+  let aborted = false;
   for (const leg of matrix) {
+    if (aborted) {
+      results.push({
+        name: leg.name,
+        mode: leg.mode,
+        passed: false,
+        notRun: true,
+        durationS: 0,
+        tail: "",
+      });
+      deps.log(`--- ${leg.name}: NOT RUN (fail-fast)`);
+      continue;
+    }
     deps.log(`\n=== ${leg.name} (${leg.mode}) ===`);
     const started = Date.now();
     const r = deps.run(leg.command, { cwd: leg.cwd, env: leg.env });
@@ -264,6 +364,10 @@ export function runMatrix(deps, matrix) {
     results.push({ name: leg.name, mode: leg.mode, passed, durationS, tail: output });
     deps.log(`--- ${leg.name}: ${passed ? "PASS" : "FAIL"} (${durationS}s)`);
     if (!passed) deps.log(output);
+    if (failFast && !passed && leg.mode === "hard") {
+      aborted = true;
+      deps.log(`fail-fast: ${leg.name} failed — remaining legs will not run.`);
+    }
   }
   return results;
 }
@@ -292,10 +396,9 @@ export function upsertComment(deps, { repo, pr, body, trustedAssociations }) {
     if (!Number.isFinite(id) || id <= 0) {
       throw new Error(`unexpected comment id: ${existing.id}`);
     }
-    deps.ghApiWithInput(
-      `gh api --method PATCH repos/${repo}/issues/comments/${id} --input -`,
-      { body },
-    );
+    deps.ghApiWithInput(`gh api --method PATCH repos/${repo}/issues/comments/${id} --input -`, {
+      body,
+    });
     deps.log(`Updated existing attestation comment ${id}.`);
     return { kind: "patch", commentId: id };
   }
@@ -329,56 +432,157 @@ export function applyLabel(deps, { repo, pr, label }) {
 }
 
 /**
- * Append one JSONL line to the audit log. Failures are swallowed.
+ * Append one JSONL line to the audit log. Best-effort: an unwritable log must
+ * never flip a green attest into a crash, nor mask the real exit code on a
+ * failure path — but it warns, because once the log is the failure record,
+ * silence is a bug.
+ *
+ * Everything besides `auditLogPath` flows through to `buildAuditEntry`.
  *
  * @param {Deps} deps
- * @param {{ auditLogPath: string, pr: string|number, sha: string, advisoryFails: string[], hostname: string }} args
+ * @param {{ auditLogPath: string } & Parameters<typeof buildAuditEntry>[0]} args
  */
-export function appendAuditLog(deps, { auditLogPath, pr, sha, advisoryFails, hostname }) {
+export function appendAuditLog(deps, { auditLogPath, ...entryInput }) {
   try {
-    const entry = buildAuditEntry({ pr, sha, hostname, advisoryFails });
+    const entry = buildAuditEntry(entryInput);
     deps.appendLog(auditLogPath, JSON.stringify(entry) + "\n");
   } catch (err) {
     deps.warn(`WARNING: audit log append failed (non-fatal): ${err.message || err}`);
   }
 }
 
+const SUMMARY_LABELS = {
+  pass: "PASS",
+  fail: "FAIL",
+  "advisory-fail": "fail (advisory)",
+  "not-run": "NOT RUN (fail-fast)",
+};
+
 /**
- * End-to-end orchestration: preconditions → matrix → push (optional) →
- * comment → label → audit. Returns the rendered comment body so the CLI
- * can print it in --dry-run mode.
+ * @param {Deps} deps
+ * @param {LegResult[]} results
+ */
+function printSummary(deps, results) {
+  deps.log("\n========== Summary ==========");
+  for (const r of results) {
+    deps.log(`  ${r.name.padEnd(28)} ${SUMMARY_LABELS[legStatus(r)]} (${r.durationS}s)`);
+  }
+}
+
+/**
+ * End-to-end orchestration. Two mutually exclusive shapes:
+ *
+ * Attest run (default): preconditions → matrix → head recheck → comment →
+ * push (optional) → label → audit. Posting is structurally gated on
+ * `shouldAttest` — a partial or failed run cannot reach it.
+ *
+ * Diagnostic run (`only`/`from` set): slim preconditions (dirty tree fine,
+ * no PR needed) → filtered matrix → audit. Never posts, labels, or pushes;
+ * exits 1 on ANY selected-leg failure, advisory included, because there is
+ * no gate to grade against and `--only knip` exiting 0 on a knip failure
+ * would be useless in a shell loop.
+ *
+ * Audit invariant: every run whose matrix settles writes exactly one JSONL
+ * line, tagged `result: attested | hard-fail | head-moved | push-fail |
+ * post-fail | dry-run | diagnostic`. Precondition failures write nothing —
+ * no matrix ran, and there may not even be a resolved PR or SHA to key on.
  *
  * @param {Deps} deps
  * @param {Config} cfg
- * @param {{ prOverride?: string|null, push: boolean, dryRun: boolean }} flags
- * @returns {{ ok: boolean, body: string, results: LegResult[], pre: Preconditions, exitCode: number }}
+ * @param {{ prOverride?: string|null, push: boolean, dryRun: boolean,
+ *           only?: string[], from?: string|null, failFast?: boolean }} flags
+ * @returns {{ ok: boolean, body: string, results: LegResult[], pre: Preconditions|null, exitCode: number }}
  */
 export function execute(deps, cfg, flags) {
+  const only = flags.only ?? [];
+  const from = flags.from ?? null;
+  const failFast = flags.failFast === true;
+  const diagnostic = only.length > 0 || from !== null;
+  const auditFlags = { only, from, failFast, push: flags.push };
+
+  if (diagnostic) {
+    const matrix = filterMatrix(cfg.matrix, { only, from });
+    checkDiagnosticPreconditions(deps, cfg);
+    let dirty = true;
+    let headSha = null;
+    try {
+      dirty = capture(deps, "git status --porcelain") !== "";
+      headSha = capture(deps, "git rev-parse HEAD");
+    } catch {
+      // Best-effort context for the audit line only.
+    }
+    deps.log(
+      `Diagnostic run: ${matrix.length} of ${cfg.matrix.length} leg(s) — attestation disabled.`,
+    );
+
+    const results = runMatrix(deps, matrix, { failFast });
+    printSummary(deps, results);
+    const { advisoryFails } = summarizeResults(results);
+    appendAuditLog(deps, {
+      auditLogPath: cfg.auditLogPath,
+      result: "diagnostic",
+      pr: flags.prOverride ?? null,
+      sha: headSha,
+      hostname: deps.hostname(),
+      advisoryFails: advisoryFails.map((r) => r.name),
+      results,
+      flags: auditFlags,
+      dirty,
+    });
+
+    const failed = results.filter((r) => !r.notRun && !r.passed);
+    if (failed.length > 0) {
+      deps.warn(`\n${failed.length} leg(s) failed: ${failed.map((r) => r.name).join(", ")}.`);
+      deps.warn("Diagnostic run — nothing was posted, labelled, or pushed.");
+      return { ok: false, body: "", results, pre: null, exitCode: 1 };
+    }
+    deps.log(
+      "\nAll selected legs passed. Diagnostic runs never attest — run a full attest before relying on the CI skip.",
+    );
+    return { ok: true, body: "", results, pre: null, exitCode: 0 };
+  }
+
   const pre = checkPreconditions(deps, cfg, { prOverride: flags.prOverride });
   deps.log(`Attesting PR #${pre.pr} (${pre.repo}) at ${pre.headSha.slice(0, 8)}.`);
 
-  const results = runMatrix(deps, cfg.matrix);
+  const results = runMatrix(deps, cfg.matrix, { failFast });
   const { hardFails, advisoryFails } = summarizeResults(results);
+  printSummary(deps, results);
 
-  deps.log("\n========== Summary ==========");
-  for (const r of results) {
-    let m;
-    if (r.passed) m = "PASS";
-    else if (r.mode === "advisory") m = "fail (advisory)";
-    else m = "FAIL";
-    deps.log(`  ${r.name.padEnd(28)} ${m} (${r.durationS}s)`);
-  }
+  const audit = (result) =>
+    appendAuditLog(deps, {
+      auditLogPath: cfg.auditLogPath,
+      result,
+      pr: pre.pr,
+      sha: pre.headSha,
+      hostname: deps.hostname(),
+      advisoryFails: advisoryFails.map((r) => r.name),
+      results,
+      flags: auditFlags,
+    });
 
   const body = renderComment(results, {
     headSha: pre.headSha,
     hostname: deps.hostname(),
   });
 
-  if (hardFails.length > 0) {
-    deps.warn(
-      `\n${hardFails.length} hard leg(s) failed: ${hardFails.map((r) => r.name).join(", ")}.`,
-    );
+  // The mechanical bar: posting is only reachable through this predicate.
+  // hardFails covers the executed failures; shouldAttest additionally rejects
+  // not-run legs and unsettled holes, so a fail-fast stop can never attest.
+  if (!shouldAttest({ diagnostic: false, results })) {
+    if (hardFails.length > 0) {
+      deps.warn(
+        `\n${hardFails.length} hard leg(s) failed: ${hardFails.map((r) => r.name).join(", ")}.`,
+      );
+    }
+    const notRun = results.filter((r) => r.notRun);
+    if (notRun.length > 0) {
+      deps.warn(
+        `${notRun.length} leg(s) did not run (fail-fast): ${notRun.map((r) => r.name).join(", ")}.`,
+      );
+    }
     deps.warn("No attestation posted, no label applied, nothing pushed.");
+    audit("hard-fail");
     return { ok: false, body, results, pre, exitCode: 1 };
   }
   if (advisoryFails.length > 0) {
@@ -388,8 +592,11 @@ export function execute(deps, cfg, flags) {
   }
 
   if (flags.dryRun) {
-    deps.log("\n--dry-run: would post the comment below; not posting, not labeling, not pushing.\n");
+    deps.log(
+      "\n--dry-run: would post the comment below; not posting, not labeling, not pushing.\n",
+    );
     deps.log(body);
+    audit("dry-run");
     return { ok: true, body, results, pre, exitCode: 0 };
   }
 
@@ -397,11 +604,27 @@ export function execute(deps, cfg, flags) {
   // publishes whatever HEAD is NOW. Those are only the same commit if nothing
   // touched the branch in between — re-assert that before any side effect, or
   // we publish untested work and vouch for it.
-  verifyHeadUnchanged(deps, pre);
+  try {
+    verifyHeadUnchanged(deps, pre);
+  } catch (err) {
+    audit("head-moved");
+    throw err;
+  }
 
   // Post the attestation comment BEFORE pushing so it is visible when the
   // push event fires GitHub Actions.
-  upsertComment(deps, { repo: pre.repo, pr: pre.pr, body, trustedAssociations: cfg.trustedAssociations });
+  try {
+    upsertComment(deps, {
+      repo: pre.repo,
+      pr: pre.pr,
+      body,
+      trustedAssociations: cfg.trustedAssociations,
+    });
+  } catch (err) {
+    // A gh outage after a long green matrix must still leave a record.
+    audit("post-fail");
+    throw err;
+  }
 
   if (flags.push && cfg.pushAfterAttest) {
     deps.log("\nPushing...");
@@ -411,19 +634,14 @@ export function execute(deps, cfg, flags) {
         "git push failed. The attestation comment was already posted but the branch was not pushed.\n" +
           "Fix the push issue and retry — `git push` alone is enough; the comment is already in place.",
       );
+      audit("push-fail");
       return { ok: false, body, results, pre, exitCode: 1 };
     }
     deps.log("Pushed.");
   }
 
   applyLabel(deps, { repo: pre.repo, pr: pre.pr, label: cfg.label });
-  appendAuditLog(deps, {
-    auditLogPath: cfg.auditLogPath,
-    pr: pre.pr,
-    sha: pre.headSha,
-    advisoryFails: advisoryFails.map((r) => r.name),
-    hostname: deps.hostname(),
-  });
+  audit("attested");
 
   if (flags.push && cfg.pushAfterAttest) {
     deps.log("Remote CI jobs gated by the attestation comment will skip for this commit.");

--- a/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
@@ -15,8 +15,8 @@ description: >
   A new push changes the head SHA, the attestation stops matching, CI runs
   again. Side-effectful (posts a PR comment, applies a label, optionally pushes)
   and slow — minutes to tens of minutes, whatever the configured matrix costs.
-  Diagnostic modes (--only, --from, --fail-fast) run subsets for the fix-retry
-  loop and can never attest. Invoke only on explicit request.
+  Diagnostic modes (--only, --from) run subsets for the fix-retry loop and can
+  never attest; --fail-fast works in both modes. Invoke only on explicit request.
 argument-hint: "[--pr <N>] [--no-push] [--dry-run] [--fail-fast] [--only <leg>] [--from <leg>] [--config <path>]"
 tools: Bash
 disable-model-invocation: true
@@ -63,9 +63,12 @@ tree, detached HEAD, no PR — iterating is the point), Docker and toolchain
 problems warn instead of failing. Leg names match exactly and case-sensitively;
 an unknown name lists every valid leg. The two flags are mutually exclusive.
 
-A diagnostic run **never** posts, labels, or pushes — not by convention but
-mechanically: attestation is gated on a run-record predicate (`shouldAttest`)
-that rejects any subset run. Exit is 1 when **any** selected leg fails,
+A diagnostic run **never** posts, labels, or pushes. Two mechanisms stack:
+the diagnostic branch in `execute` returns before the publication path even
+exists (and the attest branch always runs the full config matrix), and the
+`shouldAttest` predicate that gates publication receives the diagnostic flag
+plus the expected leg count, so a subset record is rejected even if the
+branch wiring were ever wrong. Exit is 1 when **any** selected leg fails,
 advisory legs included, because there is no attestation gate to grade against
 and `--only <advisory-leg>` exiting 0 on a failure would be useless in a loop.
 
@@ -96,6 +99,9 @@ and attests normally; one that stopped early cannot.
 - **`gh` authenticated** as a user whose `author_association` is in your
   config's `trustedAssociations` list (default: `["OWNER"]`).
 - **Docker running** if your config sets `requireDocker: true`.
+- **`auditLogPath` gitignored** (default `.local-attest-log.jsonl`). Every
+  run appends to it — including `--dry-run` — so with `requireClean` on, an
+  untracked log makes the next attest abort on the tool's own output.
 
 ## How the gate works
 

--- a/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
@@ -2,7 +2,7 @@
 id: local-attest
 name: local-attest
 type: skill
-version: 1.0.0
+version: 1.1.0
 domain: [devex, observability]
 platform: [github-actions]
 task: [testing, runtime-ops]
@@ -14,8 +14,10 @@ description: >
   already verified locally, saving runner minutes without weakening the gate.
   A new push changes the head SHA, the attestation stops matching, CI runs
   again. Side-effectful (posts a PR comment, applies a label, optionally pushes)
-  and slow (10–15 min depending on matrix). Invoke only on explicit request.
-argument-hint: "[--pr <N>] [--no-push] [--dry-run] [--config <path>]"
+  and slow — minutes to tens of minutes, whatever the configured matrix costs.
+  Diagnostic modes (--only, --from, --fail-fast) run subsets for the fix-retry
+  loop and can never attest. Invoke only on explicit request.
+argument-hint: "[--pr <N>] [--no-push] [--dry-run] [--fail-fast] [--only <leg>] [--from <leg>] [--config <path>]"
 tools: Bash
 disable-model-invocation: true
 user-invocable: true
@@ -28,9 +30,11 @@ a hidden marker comment to the open PR so the remote `Test` / `Preview` jobs
 read the marker and skip themselves for that exact commit.
 
 > **This skill is side-effectful and slow.** It runs every leg of your CI
-> matrix sequentially (typically 10–15 minutes), posts a PR comment, applies
-> a label, and pushes the current branch. Invoke only when you've decided to
-> attest a specific PR.
+> matrix sequentially — minutes to tens of minutes, whatever the configured
+> matrix costs — posts a PR comment, applies a label, and pushes the current
+> branch. Invoke only when you've decided to attest a specific PR. For the
+> fix-retry loop, use the diagnostic modes below instead: they run subsets,
+> tolerate a dirty tree, and are structurally unable to attest.
 
 ## Quick start
 
@@ -43,7 +47,35 @@ dotbabel local-attest --pr 123 --dry-run
 
 # Run + post + label, but do not git push (useful for offline review):
 dotbabel local-attest --pr 123 --no-push
+
+# Iterate on a fix: run one leg, dirty tree fine, no PR needed, never attests:
+dotbabel local-attest --only lint
+
+# Re-run the matrix from the leg that failed, stopping at the first hard failure:
+dotbabel local-attest --from bats --fail-fast
 ```
+
+## Diagnostic modes — the fix-retry loop
+
+`--only <leg>` (repeatable or comma-separated) and `--from <leg>` run a subset
+of the matrix under relaxed preconditions: any git repo state is fine (dirty
+tree, detached HEAD, no PR — iterating is the point), Docker and toolchain
+problems warn instead of failing. Leg names match exactly and case-sensitively;
+an unknown name lists every valid leg. The two flags are mutually exclusive.
+
+A diagnostic run **never** posts, labels, or pushes — not by convention but
+mechanically: attestation is gated on a run-record predicate (`shouldAttest`)
+that rejects any subset run. Exit is 1 when **any** selected leg fails,
+advisory legs included, because there is no attestation gate to grade against
+and `--only <advisory-leg>` exiting 0 on a failure would be useless in a loop.
+
+Subsets get exactly what they name — no dependency injection. `--from` a leg
+that reads a build artifact measures whatever artifact is lying around.
+
+`--fail-fast` works in both modes: the first **hard** failure stops launching
+further legs, which are recorded `not run (fail-fast)` — never as passes. A
+full run with `--fail-fast` where nothing failed completed the whole matrix
+and attests normally; one that stopped early cannot.
 
 ## Prerequisites
 
@@ -89,31 +121,49 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
 ## What the skill does, in order
 
 1. **Preconditions.** Branch exists, worktree clean (if `requireClean`), local
-   HEAD == PR head, `gh` authed, Docker available (if `requireDocker`). Any
-   failure aborts before a single test runs. The skill also warns (does not
-   fail) if your GitHub `author_association` on the repo (OWNER / MEMBER /
-   COLLABORATOR, etc.) is not in the config's `trustedAssociations` list — the
-   attestation will post but CI will ignore it.
+   HEAD == PR head, `gh` authed, Docker available (if `requireDocker`), and the
+   running toolchain matches `config.toolchain` pins (if set) — a matrix run on
+   a different Node or Go than CI uses certifies a run CI would never perform,
+   so a pin mismatch fails closed here. Any failure aborts before a single test
+   runs. The skill also warns (does not fail) if your GitHub
+   `author_association` on the repo (OWNER / MEMBER / COLLABORATOR, etc.) is
+   not in the config's `trustedAssociations` list — the attestation will post
+   but CI will ignore it.
 2. **Run matrix.** Each leg from the config runs sequentially. Hard legs must
    pass to attest; advisory legs are reported but never block. Stdout + stderr
-   are tailed at 10 lines per leg so the result table stays readable.
-3. **Hard-leg gate.** Any hard failure aborts: no comment, no label, no push.
+   are tailed at 10 lines per leg so the result table stays readable. With
+   `--fail-fast`, the first hard failure stops launching further legs; the
+   rest are recorded `not run`, never as passes.
+3. **Attestation bar.** Posting is gated on a run-record predicate: every leg
+   executed, zero hard fails, not a diagnostic subset. A run that fails the
+   bar aborts — no comment, no label, no push — and still writes its audit
+   line (`result: "hard-fail"`).
 4. **Re-check HEAD.** The matrix takes minutes — long enough for another agent
    session, another worktree, or you in a second terminal to commit onto the
    same branch. Step 1's check is stale by now, so HEAD and the worktree are
    re-asserted against what was actually tested. If either moved, everything
-   aborts: no comment, no label, no push. Without this the skill would attest
-   the pre-matrix SHA and then push whatever HEAD had become — publishing
-   commits it never tested and labelling the PR verified on an unrun head.
-5. **Push first** (if `pushAfterAttest` and not `--no-push`). The attestation
-   must never describe a SHA the remote hasn't seen.
-6. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
-   place; otherwise a new one is POSTed. Body always goes via `gh api --input -`
-   so multiline markdown can't be mangled by shell quoting.
+   aborts (`result: "head-moved"`): no comment, no label, no push. Without
+   this the skill would attest the pre-matrix SHA and then push whatever HEAD
+   had become — publishing commits it never tested and labelling the PR
+   verified on an unrun head.
+5. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
+   place; otherwise a new one is POSTed — before the push, so the marker is
+   already visible when the push event fires GitHub Actions. Body always goes
+   via `gh api --input -` so multiline markdown can't be mangled by shell
+   quoting.
+6. **Push** (if `pushAfterAttest` and not `--no-push`). A failed push records
+   `result: "push-fail"`; the comment is already in place, so a bare
+   `git push` retry completes the attestation.
 7. **Apply label** (default `ci/local-verified`). Best-effort; failure warns
    but does not abort.
 8. **Append audit log line** to the configured `auditLogPath` (default
-   `.local-attest-log.jsonl`). Best-effort.
+   `.local-attest-log.jsonl`). **Every run whose matrix executes writes
+   exactly one line**, tagged `result: attested | hard-fail | head-moved |
+push-fail | post-fail | dry-run | diagnostic`, with per-leg
+   `{name, mode, status, durationS}` — failures leave a record too, which is
+   what makes failure and duration distributions measurable. Lines written by
+   older versions have no `result` field and imply `attested`. Best-effort:
+   an unwritable log warns but never changes the run's outcome.
 
 ## Flags
 
@@ -122,6 +172,9 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
 | `--pr <N>`        | Target PR number. Defaults to the open PR for the current branch.                                                                            |
 | `--no-push`       | Run matrix + post + label, but skip `git push`.                                                                                              |
 | `--dry-run`       | Run matrix, render the comment, print it. Post nothing, label nothing, push nothing. Use this to validate a new project's config end-to-end. |
+| `--fail-fast`     | Stop launching legs after the first hard failure. Unstarted legs record as `not run`; a run that stopped early can never attest.             |
+| `--only <leg>`    | Diagnostic mode — run only the named leg(s). Repeatable or comma-separated. Relaxed preconditions; never attests. Exit 1 on any failure.     |
+| `--from <leg>`    | Diagnostic mode — run the matrix from the named leg to the end. Mutually exclusive with `--only`.                                            |
 | `--config <path>` | Override config discovery.                                                                                                                   |
 
 ## What this skill never does

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
@@ -36,8 +36,8 @@ type Config = {
   // Diagnostic runs (--only/--from) warn instead of failing. Unparseable
   // versions count as mismatches.
   toolchain?: {
-    node?: string; // engines-style pin ("22", "22.x", ">=22"); running node's major must match
-    goMod?: string; // path to a go.mod; its `go` directive's major.minor must match `go version`
+    node?: string; // exact major pin ("22"); range syntax (">=22", "^22") is rejected
+    goMod?: string; // relative path (no "..") to a go.mod; its go directive major.minor must match `go version`
   };
 };
 ```
@@ -54,8 +54,9 @@ Every run whose matrix executes appends exactly one JSONL line to
 `auditLogPath`, tagged `result: attested | hard-fail | head-moved | push-fail
 | post-fail | dry-run | diagnostic`, with per-leg
 `{name, mode, status, durationS}` (`status ∈ pass | fail | advisory-fail |
-not-run`), the invocation `flags`, and — for diagnostic runs — a `dirty`
-marker, because a dirty tree's `sha` does not identify the tree that ran.
+not-run`), the invocation `flags`, the certified `toolchain` versions when
+pins are configured, and — for diagnostic runs — a `dirty` marker, because a
+dirty tree's `sha` does not identify the tree that ran.
 Lines written by versions before `result` existed were only ever written
 after a successful post, so a missing `result` implies `attested`.
 

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
@@ -28,11 +28,36 @@ type Config = {
   trustedAssociations?: string[]; // gh author_association values that gate CI (default: ["OWNER"])
   requireClean?: boolean; // abort on dirty worktree (default: true)
   requireDocker?: boolean; // abort if `docker info` fails (default: false)
-  pushAfterAttest?: boolean; // git push after attest, before posting (default: true)
+  pushAfterAttest?: boolean; // git push after the comment posts (default: true)
+
+  // Optional toolchain pins. On an attest run a mismatch fails closed —
+  // the attestation claims "CI would pass", and a matrix run on a different
+  // Node or Go than CI uses certifies a run CI would never perform.
+  // Diagnostic runs (--only/--from) warn instead of failing. Unparseable
+  // versions count as mismatches.
+  toolchain?: {
+    node?: string; // engines-style pin ("22", "22.x", ">=22"); running node's major must match
+    goMod?: string; // path to a go.mod; its `go` directive's major.minor must match `go version`
+  };
 };
 ```
 
 The matrix is the only required field; everything else has sensible defaults.
+
+Pin the toolchain to whatever CI's setup steps install (`node-version:`,
+`go-version-file:`). If CI runs a version matrix, pin the one you attest with
+and note that the other legs are skipped under attestation regardless.
+
+## Audit log
+
+Every run whose matrix executes appends exactly one JSONL line to
+`auditLogPath`, tagged `result: attested | hard-fail | head-moved | push-fail
+| post-fail | dry-run | diagnostic`, with per-leg
+`{name, mode, status, durationS}` (`status ∈ pass | fail | advisory-fail |
+not-run`), the invocation `flags`, and — for diagnostic runs — a `dirty`
+marker, because a dirty tree's `sha` does not identify the tree that ran.
+Lines written by versions before `result` existed were only ever written
+after a successful post, so a missing `result` implies `attested`.
 
 ## Example 1 — minimal Node app
 

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/operator-guide.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/operator-guide.md
@@ -2,8 +2,9 @@
 
 CI minutes are billed; running the same matrix on GitHub-hosted runners after
 a maintainer has already verified the change locally is duplicated spend. The
-`/local-attest` skill lets a trusted user trade ~10–15 minutes of local
-runtime for a clean skip of the equivalent remote pipeline.
+`/local-attest` skill lets a trusted user trade the local runtime of the
+configured matrix — minutes to tens of minutes — for a clean skip of the
+equivalent remote pipeline.
 
 This guide is the operator contract for using the skill safely.
 
@@ -56,14 +57,25 @@ dotbabel local-attest --pr 123
 ```
 
 The skill runs every leg of your `.local-attest` matrix, prints a result
-table, pushes (if `pushAfterAttest`), posts/PATCHes the attestation comment,
+table, posts/PATCHes the attestation comment, pushes (if `pushAfterAttest` —
+the comment goes first so the marker is visible when the push event fires),
 applies the label, and appends a line to the audit log.
 
 `--dry-run` runs the matrix and prints the comment without posting anything.
-Use it to validate a new config end-to-end.
+Use it to validate a new config end-to-end. (Combined with `--only`/`--from`
+it is inert — diagnostic runs never post anyway.)
 
 `--no-push` skips the `git push` step but still posts the comment + label.
 Use it when you've pushed manually and just want to attest.
+
+`--fail-fast` stops launching legs after the first hard failure; unstarted
+legs are recorded `not-run` and a stopped run cannot attest. A `--fail-fast`
+run in which nothing failed completed the full matrix and attests normally.
+
+`--only <leg>` / `--from <leg>` are diagnostic modes for the fix-retry loop:
+subsets under relaxed preconditions (dirty tree fine, no PR needed) that never
+post, label, or push, and exit 1 on any selected-leg failure, advisory
+included.
 
 ## Trust model
 
@@ -128,9 +140,11 @@ the diff manually whenever either side changes.
 
 ### Long-running matrices
 
-Attestation runs sequentially. 10–15 minutes is typical; pathologically
-slow matrices (heavy e2e + multiple language runtimes) can hit 30+. That's
-the deliberate cost of skipping the remote run.
+Attestation runs the matrix sequentially and costs whatever the configured
+legs cost — minutes for a lint-and-unit matrix, tens of minutes with heavy
+e2e and multiple language runtimes. That's the deliberate price of skipping
+the remote run; use `--only`/`--from`/`--fail-fast` for iteration and save
+full runs for attestation.
 
 ### Audit
 
@@ -141,17 +155,31 @@ gh pr list --label ci/local-verified --state all
 ```
 
 The audit log (`.local-attest-log.jsonl` by default) records one JSONL line
-per attestation:
+for **every run whose matrix executes** — failures included — tagged with a
+`result` and per-leg statuses:
 
 ```json
 {
-  "ts": "2026-05-23T16:00:00.000Z",
+  "ts": "2026-08-13T16:00:00.000Z",
   "pr": 123,
   "sha": "abc1234...",
   "host": "wsl-laptop",
-  "advisoryFails": ["knip"]
+  "advisoryFails": ["knip"],
+  "result": "attested",
+  "legs": [{ "name": "lint", "mode": "hard", "status": "pass", "durationS": 17 }],
+  "flags": { "only": [], "from": null, "failFast": false, "push": true, "dryRun": false },
+  "toolchain": { "node": "22.11.0" }
 }
 ```
 
-Add the audit log to `.gitignore` if you don't want it in version control;
-the contract is single-line JSONL so any log shipper handles it natively.
+`result` is one of `attested | hard-fail | head-moved | push-fail | post-fail
+| dry-run | diagnostic`. Lines written by versions before `result` existed
+were only ever written after a successful post, so a missing `result` implies
+`attested`. Diagnostic lines add `dirty: true|false`, because a dirty tree's
+`sha` does not identify the tree that ran.
+
+**Add the audit log to `.gitignore` — this is a requirement when
+`requireClean` is on, not a preference.** Every run appends to it, including
+the `--dry-run` this guide recommends for validating a new config, so an
+untracked log makes the very next attest abort on its own output. The
+contract is single-line JSONL so any log shipper handles it natively.

--- a/plugins/dotbabel/tests/bats/local-attest-head-race.bats
+++ b/plugins/dotbabel/tests/bats/local-attest-head-race.bats
@@ -92,13 +92,19 @@ EOF
   [ "$status" -eq 1 ]
 }
 
-@test "local-attest: aborting on a moved HEAD writes no audit-log entry" {
+@test "local-attest: aborting on a moved HEAD audits result:head-moved, attests nothing" {
+  # Contract change (deliberate): the audit log records every run whose matrix
+  # settled, failures included — a moved HEAD leaves a result:head-moved line
+  # instead of vanishing without trace. Publication is still fully suppressed
+  # (the previous test pins that).
   write_config '{ name: "racy", mode: "hard", command: "git commit -q --allow-empty -m concurrent" }'
 
   cd "$REPO"
   run node "$BIN" --pr 42
   [ "$status" -eq 1 ]
-  [ ! -f "$REPO/.local-attest-log.jsonl" ]
+  [ -f "$REPO/.local-attest-log.jsonl" ]
+  run jq -r ".result" "$REPO/.local-attest-log.jsonl"
+  [ "$output" = "head-moved" ]
 }
 
 @test "local-attest: a leg that dirties the tree mid-matrix also aborts" {

--- a/plugins/dotbabel/tests/local-attest-config.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-config.test.mjs
@@ -3,14 +3,13 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-import {
-  ConfigError,
-  DEFAULTS,
-  loadConfig,
-  validateConfig,
-} from "../src/local-attest-config.mjs";
+import { ConfigError, DEFAULTS, loadConfig, validateConfig } from "../src/local-attest-config.mjs";
 
-const FIXTURES = resolve(import.meta.dirname ?? new URL(".", import.meta.url).pathname, "fixtures", "local-attest");
+const FIXTURES = resolve(
+  import.meta.dirname ?? new URL(".", import.meta.url).pathname,
+  "fixtures",
+  "local-attest",
+);
 
 function makeTmpDir() {
   const dir = mkdtempSync(join(tmpdir(), "local-attest-cfg-"));
@@ -156,9 +155,7 @@ describe("validateConfig", () => {
   });
 
   it("rejects auditLogPath with .. segments", () => {
-    expect(() =>
-      validateConfig({ ...base(), auditLogPath: "../escape.jsonl" }),
-    ).toThrow(/\.\./);
+    expect(() => validateConfig({ ...base(), auditLogPath: "../escape.jsonl" })).toThrow(/\.\./);
   });
 
   it("rejects empty trustedAssociations", () => {
@@ -168,15 +165,13 @@ describe("validateConfig", () => {
   });
 
   it("rejects non-string trustedAssociations entries", () => {
-    expect(() =>
-      validateConfig({ ...base(), trustedAssociations: ["OWNER", 42] }),
-    ).toThrow(/trustedAssociations/);
+    expect(() => validateConfig({ ...base(), trustedAssociations: ["OWNER", 42] })).toThrow(
+      /trustedAssociations/,
+    );
   });
 
   it("rejects non-boolean requireClean", () => {
-    expect(() =>
-      validateConfig({ ...base(), requireClean: "yes" }),
-    ).toThrow(/requireClean/);
+    expect(() => validateConfig({ ...base(), requireClean: "yes" })).toThrow(/requireClean/);
   });
 
   it("preserves matrix order", () => {
@@ -188,5 +183,24 @@ describe("validateConfig", () => {
       ],
     });
     expect(cfg.matrix.map((l) => l.name)).toEqual(["z", "a", "m"]);
+  });
+
+  it("defaults toolchain to null (the check is opt-in)", () => {
+    expect(validateConfig(base()).toolchain).toBeNull();
+  });
+
+  it("accepts toolchain pins for node and goMod", () => {
+    const cfg = validateConfig({ ...base(), toolchain: { node: "22", goMod: "api/go.mod" } });
+    expect(cfg.toolchain).toEqual({ node: "22", goMod: "api/go.mod" });
+  });
+
+  it("rejects non-object toolchain, unknown pins, and empty pin values", () => {
+    expect(() => validateConfig({ ...base(), toolchain: "22" })).toThrow(/toolchain/);
+    expect(() => validateConfig({ ...base(), toolchain: { python: "3" } })).toThrow(
+      /not a recognised pin/,
+    );
+    expect(() => validateConfig({ ...base(), toolchain: { node: "" } })).toThrow(
+      /non-empty string/,
+    );
   });
 });

--- a/plugins/dotbabel/tests/local-attest-config.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-config.test.mjs
@@ -203,4 +203,26 @@ describe("validateConfig", () => {
       /non-empty string/,
     );
   });
+
+  it("rejects an empty pin object — it would silently disable the check", () => {
+    expect(() => validateConfig({ ...base(), toolchain: {} })).toThrow(/at least one pin/);
+  });
+
+  it("rejects range syntax in the node pin — it would be misread, not honored", () => {
+    for (const bad of [">=22", "^22.1.0", "~22", "20 || 22"]) {
+      expect(() => validateConfig({ ...base(), toolchain: { node: bad } })).toThrow(/exact major/);
+    }
+    expect(validateConfig({ ...base(), toolchain: { node: "22" } }).toolchain).toEqual({
+      node: "22",
+    });
+  });
+
+  it("constrains goMod like auditLogPath: relative, no dot-dot", () => {
+    expect(() => validateConfig({ ...base(), toolchain: { goMod: "/etc/go.mod" } })).toThrow(
+      /relative/,
+    );
+    expect(() => validateConfig({ ...base(), toolchain: { goMod: "../go.mod" } })).toThrow(
+      /'\.\.'/,
+    );
+  });
 });

--- a/plugins/dotbabel/tests/local-attest-lib.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-lib.test.mjs
@@ -5,12 +5,20 @@ import {
   buildAttestMarker,
   buildAuditEntry,
   buildGateSnippet,
+  filterMatrix,
   findAttestComment,
+  goMajorMinorFromGoMod,
+  goMajorMinorFromVersion,
   isAttested,
+  legStatus,
+  nodeMajorFromPin,
+  nodeMajorOf,
   parseArgs,
   renderComment,
+  shouldAttest,
   summarizeResults,
   tail,
+  toolchainProblems,
 } from "../src/local-attest-lib.mjs";
 
 describe("buildAttestMarker", () => {
@@ -50,9 +58,7 @@ describe("isAttested", () => {
   const marker = `${ATTEST_MARKER_PREFIX}${SHA} -->`;
 
   it("returns true for an OWNER comment matching the SHA", () => {
-    const comments = [
-      { author_association: "OWNER", body: `${marker}\nbody text here` },
-    ];
+    const comments = [{ author_association: "OWNER", body: `${marker}\nbody text here` }];
     expect(isAttested(comments, SHA)).toBe(true);
   });
 
@@ -124,6 +130,9 @@ describe("parseArgs", () => {
       dryRun: false,
       config: null,
       help: false,
+      only: [],
+      from: null,
+      failFast: false,
     });
   });
 
@@ -150,17 +159,26 @@ describe("parseArgs", () => {
 
   it("rejects non-numeric --pr", () => {
     const die = (code, msg) => ({ code, msg });
-    expect(parseArgs(["--pr", "abc"], die)).toEqual({ code: 64, msg: expect.stringContaining("--pr") });
+    expect(parseArgs(["--pr", "abc"], die)).toEqual({
+      code: 64,
+      msg: expect.stringContaining("--pr"),
+    });
   });
 
   it("rejects unknown flags", () => {
     const die = (code, msg) => ({ code, msg });
-    expect(parseArgs(["--bogus"], die)).toEqual({ code: 64, msg: expect.stringContaining("unknown") });
+    expect(parseArgs(["--bogus"], die)).toEqual({
+      code: 64,
+      msg: expect.stringContaining("unknown"),
+    });
   });
 
   it("rejects --config with no value", () => {
     const die = (code, msg) => ({ code, msg });
-    expect(parseArgs(["--config"], die)).toEqual({ code: 64, msg: expect.stringContaining("--config") });
+    expect(parseArgs(["--config"], die)).toEqual({
+      code: 64,
+      msg: expect.stringContaining("--config"),
+    });
   });
 });
 
@@ -234,21 +252,67 @@ describe("renderComment", () => {
 });
 
 describe("buildAuditEntry", () => {
-  it("produces the documented .local-attest-log.jsonl shape", () => {
+  const RESULTS = [
+    { name: "lint", mode: "hard", passed: true, durationS: 3, tail: "" },
+    { name: "test", mode: "hard", passed: false, durationS: 7, tail: "boom" },
+    { name: "knip", mode: "advisory", passed: false, durationS: 2, tail: "" },
+    { name: "bats", mode: "hard", passed: false, notRun: true, durationS: 0, tail: "" },
+  ];
+
+  it("keeps every legacy field byte-compatible (pre-change lines imply attested)", () => {
     const e = buildAuditEntry({
+      result: "attested",
       pr: "123",
       sha: "abc1234",
       hostname: "host",
       advisoryFails: ["knip"],
+      results: RESULTS,
       now: new Date("2026-01-01T00:00:00Z"),
     });
-    expect(e).toEqual({
+    expect(e).toMatchObject({
       ts: "2026-01-01T00:00:00.000Z",
       pr: 123,
       sha: "abc1234",
       host: "host",
       advisoryFails: ["knip"],
     });
+  });
+
+  it("records the run outcome and per-leg statuses", () => {
+    const e = buildAuditEntry({
+      result: "hard-fail",
+      pr: 9,
+      sha: "abc1234",
+      hostname: "h",
+      advisoryFails: ["knip"],
+      results: RESULTS,
+      now: new Date(),
+    });
+    expect(e.result).toBe("hard-fail");
+    expect(e.legs).toEqual([
+      { name: "lint", mode: "hard", status: "pass", durationS: 3 },
+      { name: "test", mode: "hard", status: "fail", durationS: 7 },
+      { name: "knip", mode: "advisory", status: "advisory-fail", durationS: 2 },
+      { name: "bats", mode: "hard", status: "not-run", durationS: 0 },
+    ]);
+  });
+
+  it("records flags and diagnostic dirtiness; a missing pr stays null, not 0", () => {
+    const e = buildAuditEntry({
+      result: "diagnostic",
+      pr: null,
+      sha: null,
+      hostname: "h",
+      advisoryFails: [],
+      results: RESULTS.slice(0, 1),
+      flags: { only: ["lint"], from: null, failFast: false, push: false },
+      dirty: true,
+      now: new Date(),
+    });
+    expect(e.pr).toBeNull();
+    expect(e.sha).toBeNull();
+    expect(e.dirty).toBe(true);
+    expect(e.flags).toEqual({ only: ["lint"], from: null, failFast: false, push: false });
   });
 
   it("copies the advisoryFails array (no shared reference)", () => {
@@ -278,6 +342,191 @@ describe("summarizeResults", () => {
     expect(s.advisoryFails.map((r) => r.name)).toEqual(["c"]);
     expect(s.totalDurationS).toBe(10);
   });
+
+  it("does not count not-run legs as failures — they were never executed", () => {
+    const results = [
+      { name: "a", mode: "hard", passed: false, durationS: 2, tail: "" },
+      { name: "b", mode: "hard", passed: false, notRun: true, durationS: 0, tail: "" },
+      { name: "c", mode: "advisory", passed: false, notRun: true, durationS: 0, tail: "" },
+    ];
+    const s = summarizeResults(results);
+    expect(s.hardFails.map((r) => r.name)).toEqual(["a"]);
+    expect(s.advisoryFails).toEqual([]);
+  });
+});
+
+describe("legStatus", () => {
+  it("classifies every terminal state, one source of truth for renderer and audit", () => {
+    expect(legStatus({ mode: "hard", passed: true })).toBe("pass");
+    expect(legStatus({ mode: "hard", passed: false })).toBe("fail");
+    expect(legStatus({ mode: "advisory", passed: false })).toBe("advisory-fail");
+    expect(legStatus({ mode: "hard", passed: false, notRun: true })).toBe("not-run");
+    expect(legStatus(undefined)).toBe("not-run");
+  });
+});
+
+describe("parseArgs diagnostic flags", () => {
+  it("defaults include only/from/failFast", () => {
+    const a = parseArgs([]);
+    expect(a.only).toEqual([]);
+    expect(a.from).toBeNull();
+    expect(a.failFast).toBe(false);
+  });
+
+  it("accumulates repeatable --only", () => {
+    const a = parseArgs(["--only", "lint", "--only", "test"]);
+    expect(a.only).toEqual(["lint", "test"]);
+  });
+
+  it("captures --from once and rejects a repeat", () => {
+    expect(parseArgs(["--from", "test"]).from).toBe("test");
+    expect(() => parseArgs(["--from", "a", "--from", "b"])).toThrow(/--from given more than once/);
+  });
+
+  it("rejects --only together with --from", () => {
+    expect(() => parseArgs(["--only", "lint", "--from", "test"])).toThrow(/mutually exclusive/);
+  });
+
+  it("rejects --only and --from with no value", () => {
+    expect(() => parseArgs(["--only"])).toThrow(/requires a leg name/);
+    expect(() => parseArgs(["--from"])).toThrow(/requires a leg name/);
+  });
+
+  it("toggles --fail-fast", () => {
+    expect(parseArgs(["--fail-fast"]).failFast).toBe(true);
+  });
+});
+
+describe("filterMatrix", () => {
+  const MATRIX = [
+    { name: "npm ci", mode: "hard", command: "npm ci" },
+    { name: "lint, strict", mode: "hard", command: "x" },
+    { name: "test", mode: "hard", command: "y" },
+    { name: "bats", mode: "hard", command: "z" },
+  ];
+
+  it("returns the matrix untouched with no filters", () => {
+    expect(filterMatrix(MATRIX, {})).toEqual(MATRIX);
+  });
+
+  it("--only selects by exact name, preserving matrix order", () => {
+    const out = filterMatrix(MATRIX, { only: ["bats", "npm ci"] });
+    expect(out.map((l) => l.name)).toEqual(["npm ci", "bats"]);
+  });
+
+  it("splits comma-separated --only values", () => {
+    const out = filterMatrix(MATRIX, { only: ["test,bats"] });
+    expect(out.map((l) => l.name)).toEqual(["test", "bats"]);
+  });
+
+  it("never splits a token that is itself a leg name containing a comma", () => {
+    const out = filterMatrix(MATRIX, { only: ["lint, strict"] });
+    expect(out.map((l) => l.name)).toEqual(["lint, strict"]);
+  });
+
+  it("--from selects the suffix from the named leg's index", () => {
+    const out = filterMatrix(MATRIX, { from: "test" });
+    expect(out.map((l) => l.name)).toEqual(["test", "bats"]);
+  });
+
+  it("unknown names fail with every valid name listed; matching is case-sensitive", () => {
+    expect(() => filterMatrix(MATRIX, { only: ["nope"] })).toThrow(/npm ci.*test.*bats/s);
+    expect(() => filterMatrix(MATRIX, { only: ["Test"] })).toThrow(/unknown leg/);
+    expect(() => filterMatrix(MATRIX, { from: "nope" })).toThrow(/unknown leg/);
+  });
+});
+
+describe("shouldAttest", () => {
+  const pass = (name, mode = "hard") => ({ name, mode, passed: true, durationS: 1, tail: "" });
+
+  it("attests a full clean run, advisory failures included", () => {
+    const results = [
+      pass("a"),
+      { name: "k", mode: "advisory", passed: false, durationS: 1, tail: "" },
+    ];
+    expect(shouldAttest({ diagnostic: false, results })).toBe(true);
+  });
+
+  it("never attests a diagnostic run, even all-green", () => {
+    expect(shouldAttest({ diagnostic: true, results: [pass("a")] })).toBe(false);
+  });
+
+  it("never attests when any leg was not run", () => {
+    const results = [
+      pass("a"),
+      { name: "b", mode: "hard", passed: false, notRun: true, durationS: 0, tail: "" },
+    ];
+    expect(shouldAttest({ diagnostic: false, results })).toBe(false);
+  });
+
+  it("never attests on a hard failure, an empty matrix, or an unsettled hole", () => {
+    expect(
+      shouldAttest({
+        diagnostic: false,
+        results: [{ name: "a", mode: "hard", passed: false, durationS: 1, tail: "" }],
+      }),
+    ).toBe(false);
+    expect(shouldAttest({ diagnostic: false, results: [] })).toBe(false);
+    expect(shouldAttest({ diagnostic: false, results: [pass("a"), undefined] })).toBe(false);
+  });
+});
+
+describe("toolchain helpers", () => {
+  it("parses node majors from pins and versions", () => {
+    for (const pin of ["22", "22.x", ">=22", "^22.1.0"]) {
+      expect(nodeMajorFromPin(pin)).toBe(22);
+    }
+    expect(nodeMajorFromPin("")).toBeNull();
+    expect(nodeMajorFromPin("abc")).toBeNull();
+    expect(nodeMajorOf("22.11.0")).toBe(22);
+    expect(nodeMajorOf("junk")).toBeNull();
+  });
+
+  it("parses go major.minor from `go version` output and go.mod text", () => {
+    expect(goMajorMinorFromVersion("go version go1.26.5 linux/amd64")).toBe("1.26");
+    expect(goMajorMinorFromVersion("garbage")).toBeNull();
+    expect(goMajorMinorFromGoMod("module x\n\ngo 1.26.5\n")).toBe("1.26");
+    expect(goMajorMinorFromGoMod("")).toBeNull();
+  });
+
+  it("toolchainProblems: match is silent, mismatch and unparseable are problems (fail-closed)", () => {
+    const ok = toolchainProblems({
+      pin: { node: "22" },
+      nodeVersion: "22.11.0",
+    });
+    expect(ok).toEqual([]);
+
+    const bad = toolchainProblems({
+      pin: { node: "22", goMod: "api/go.mod" },
+      nodeVersion: "20.1.0",
+      goVersionOutput: "go version go1.25.0 linux/amd64",
+      goModText: "go 1.26.5\n",
+    });
+    expect(bad.length).toBe(2);
+
+    const unparseable = toolchainProblems({
+      pin: { node: "22" },
+      nodeVersion: "junk",
+    });
+    expect(unparseable.length).toBe(1);
+  });
+
+  it("no pin means no problems — the check is opt-in per config", () => {
+    expect(toolchainProblems({ pin: null, nodeVersion: "junk" })).toEqual([]);
+    expect(toolchainProblems({ pin: undefined, nodeVersion: "junk" })).toEqual([]);
+  });
+});
+
+describe("renderComment not-run defense", () => {
+  it("renders a not-run leg as not run, never as pass", () => {
+    const SHA = "abc1234abc1234abc1234abc1234abc1234abc12";
+    const body = renderComment(
+      [{ name: "bats", mode: "hard", passed: false, notRun: true, durationS: 0, tail: "" }],
+      { headSha: SHA, hostname: "h", now: new Date() },
+    );
+    expect(body).toContain("not run (fail-fast)");
+    expect(body).not.toMatch(/\| bats \| hard \| pass/);
+  });
 });
 
 describe("buildGateSnippet", () => {
@@ -296,8 +545,8 @@ describe("buildGateSnippet", () => {
 
   it("rejects empty or non-array trustedAssociations", () => {
     expect(() => buildGateSnippet({ trustedAssociations: [] })).toThrow(/non-empty array/);
-    expect(() =>
-      buildGateSnippet({ trustedAssociations: /** @type {any} */ ("OWNER") }),
-    ).toThrow(/non-empty array/);
+    expect(() => buildGateSnippet({ trustedAssociations: /** @type {any} */ ("OWNER") })).toThrow(
+      /non-empty array/,
+    );
   });
 });

--- a/plugins/dotbabel/tests/local-attest-lib.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-lib.test.mjs
@@ -312,7 +312,13 @@ describe("buildAuditEntry", () => {
     expect(e.pr).toBeNull();
     expect(e.sha).toBeNull();
     expect(e.dirty).toBe(true);
-    expect(e.flags).toEqual({ only: ["lint"], from: null, failFast: false, push: false });
+    expect(e.flags).toEqual({
+      only: ["lint"],
+      from: null,
+      failFast: false,
+      push: false,
+      dryRun: false,
+    });
   });
 
   it("copies the advisoryFails array (no shared reference)", () => {
@@ -459,6 +465,15 @@ describe("shouldAttest", () => {
     expect(shouldAttest({ diagnostic: false, results })).toBe(false);
   });
 
+  it("rejects a subset record via expectedLegs even when the diagnostic flag lies", () => {
+    // Control flow is the first defense; this clause is the second. A filtered
+    // matrix yields fewer results than the config declares, so even a run that
+    // wrongly reports diagnostic: false cannot attest on a subset.
+    const results = [pass("a")];
+    expect(shouldAttest({ diagnostic: false, results, expectedLegs: 3 })).toBe(false);
+    expect(shouldAttest({ diagnostic: false, results, expectedLegs: 1 })).toBe(true);
+  });
+
   it("never attests on a hard failure, an empty matrix, or an unsettled hole", () => {
     expect(
       shouldAttest({
@@ -514,6 +529,26 @@ describe("toolchain helpers", () => {
   it("no pin means no problems — the check is opt-in per config", () => {
     expect(toolchainProblems({ pin: null, nodeVersion: "junk" })).toEqual([]);
     expect(toolchainProblems({ pin: undefined, nodeVersion: "junk" })).toEqual([]);
+  });
+});
+
+describe("renderComment toolchain line", () => {
+  const SHA = "abc1234abc1234abc1234abc1234abc1234abc12";
+  const RESULTS = [{ name: "lint", mode: "hard", passed: true, durationS: 1, tail: "" }];
+
+  it("records the certified toolchain when pins were measured", () => {
+    const body = renderComment(RESULTS, {
+      headSha: SHA,
+      hostname: "h",
+      toolchain: { node: "22.11.0", go: "1.26" },
+      now: new Date(),
+    });
+    expect(body).toContain("- Toolchain: node 22.11.0 · go 1.26");
+  });
+
+  it("omits the line when no pins are configured", () => {
+    const body = renderComment(RESULTS, { headSha: SHA, hostname: "h", now: new Date() });
+    expect(body).not.toContain("Toolchain:");
   });
 });
 

--- a/plugins/dotbabel/tests/local-attest-runner.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-runner.test.mjs
@@ -17,8 +17,8 @@ import {
  * invocation. The `runReplies` parameter is a regex-keyed table mapping a
  * command-substring pattern to its mocked result.
  */
-function makeDeps({ runReplies = [], hostname = "stub-host" } = {}) {
-  const calls = { run: [], gh: [], log: [], warn: [], appendLog: [] };
+function makeDeps({ runReplies = [], readFileReplies = {}, hostname = "stub-host" } = {}) {
+  const calls = { run: [], gh: [], log: [], warn: [], appendLog: [], readFile: [] };
 
   const run = (cmd, opts = {}) => {
     calls.run.push({ cmd, opts });
@@ -43,6 +43,10 @@ function makeDeps({ runReplies = [], hostname = "stub-host" } = {}) {
       },
       appendLog(path, line) {
         calls.appendLog.push({ path, line });
+      },
+      readFile(path) {
+        calls.readFile.push(path);
+        return readFileReplies[path] ?? null;
       },
       hostname() {
         return hostname;
@@ -638,5 +642,101 @@ describe("toolchain precondition", () => {
     const { deps, calls } = makeDeps({ runReplies: happy });
     checkPreconditions(deps, baseConfig());
     expect(calls.run.some((c) => /node --version/.test(c.cmd))).toBe(false);
+  });
+
+  it("reads go.mod through deps.readFile, never a shell, and fails closed on mismatch", () => {
+    const cfg = baseConfig({ toolchain: { goMod: "api/go.mod" } });
+    const replies = [...happy, [/go version/, { stdout: "go version go1.25.0 linux/amd64\n" }]];
+    const { deps, calls } = makeDeps({
+      runReplies: replies,
+      readFileReplies: { "api/go.mod": "module x\n\ngo 1.26.5\n" },
+    });
+    expect(() => checkPreconditions(deps, cfg)).toThrow(/toolchain/i);
+    expect(calls.readFile).toEqual(["api/go.mod"]);
+    expect(calls.run.some((c) => /cat /.test(c.cmd))).toBe(false);
+  });
+
+  it("records the measured versions on the preconditions for the audit trail", () => {
+    const cfg = baseConfig({ toolchain: { node: "22" } });
+    const replies = [...happy, [/node --version/, { stdout: "v22.11.0\n" }]];
+    const { deps } = makeDeps({ runReplies: replies });
+    const pre = checkPreconditions(deps, cfg);
+    expect(pre.toolchain).toEqual({ node: "22.11.0" });
+  });
+
+  it("diagnostic runs warn on a pin mismatch instead of failing — the fix-retry loop survives", () => {
+    const cfg = baseConfig({ toolchain: { node: "9999" } });
+    const replies = [[/node --version/, { stdout: "v22.11.0\n" }]];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const r = execute(deps, cfg, {
+      prOverride: null,
+      push: true,
+      dryRun: false,
+      only: ["lint"],
+      from: null,
+      failFast: false,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(calls.warn.some((w) => /an attest run stops here/.test(w))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// audit completeness — the two remaining terminal paths
+// ---------------------------------------------------------------------------
+
+describe("execute audit completeness", () => {
+  const happy = [
+    [/git rev-parse --abbrev-ref HEAD/, { stdout: "feature\n" }],
+    [/git status --porcelain/, { stdout: "" }],
+    [/gh auth status/, { status: 0 }],
+    [/gh repo view --json nameWithOwner/, { stdout: "k/r\n" }],
+    [/gh pr view --json number/, { stdout: "42\n" }],
+    [/git rev-parse HEAD/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh pr view 42 --json headRefOid/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+  ];
+
+  it("post-fail: audits, warns, exits 1 like its sibling push-fail — not 2", () => {
+    const replies = [
+      ...happy,
+      [/gh api repos.*\/comments --paginate/, { status: 1, stderr: "gh down" }],
+    ];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const r = execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false });
+    expect(r.exitCode).toBe(1);
+    const entries = calls.appendLog.map((c) => JSON.parse(c.line));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].result).toBe("post-fail");
+    // A green matrix was spent; the failure record is the surviving evidence.
+    expect(entries[0].legs.every((l) => l.status === "pass")).toBe(true);
+    expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
+  });
+
+  it("the attested line lands even if applyLabel would throw, and records the toolchain", () => {
+    const cfg = baseConfig({ toolchain: { node: "22" } });
+    const replies = [
+      ...happy,
+      [/node --version/, { stdout: "v22.11.0\n" }],
+      [/gh api repos.*\/comments --paginate/, { stdout: "[]" }],
+      [
+        /gh label create/,
+        () => {
+          throw new Error("label exploded");
+        },
+      ],
+    ];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    let threw = false;
+    try {
+      execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    } catch {
+      threw = true;
+    }
+    // Whether or not the label throw propagates, the attested record exists.
+    const entries = calls.appendLog.map((c) => JSON.parse(c.line));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].result).toBe("attested");
+    expect(entries[0].toolchain).toEqual({ node: "22.11.0" });
+    expect(threw).toBe(true);
   });
 });

--- a/plugins/dotbabel/tests/local-attest-runner.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-runner.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import { validateConfig } from "../src/local-attest-config.mjs";
+import { shouldAttest } from "../src/local-attest-lib.mjs";
 import {
   PreconditionError,
   appendAuditLog,
@@ -94,7 +95,9 @@ describe("checkPreconditions", () => {
   });
 
   it("fails when not inside a git repo", () => {
-    const { deps } = makeDeps({ runReplies: [[/git rev-parse --abbrev-ref HEAD/, { status: 1, stderr: "fatal" }]] });
+    const { deps } = makeDeps({
+      runReplies: [[/git rev-parse --abbrev-ref HEAD/, { status: 1, stderr: "fatal" }]],
+    });
     expect(() => checkPreconditions(deps, baseConfig())).toThrow(PreconditionError);
   });
 
@@ -172,9 +175,7 @@ describe("checkPreconditions", () => {
 describe("runMatrix", () => {
   it("runs every leg in order and records pass/fail", () => {
     const { deps, calls } = makeDeps({
-      runReplies: [
-        [/echo test/, { status: 1, stderr: "boom" }],
-      ],
+      runReplies: [[/echo test/, { status: 1, stderr: "boom" }]],
     });
     const results = runMatrix(deps, baseConfig().matrix);
     expect(results.map((r) => r.name)).toEqual(["lint", "test", "knip"]);
@@ -314,39 +315,44 @@ describe("execute (orchestration)", () => {
     [/gh api repos\/.*\/collaborators\/.*\/permission/, { stdout: "ADMIN\n" }],
   ];
 
-  it("dry-run prints the body but never calls gh comments / label / push", () => {
+  // Contract change (deliberate): every run whose matrix settles writes exactly
+  // one audit line, tagged with `result`. The old contract — audit only on a
+  // successful post — meant the failure distribution was invisible, which is
+  // the data every tooling decision about this matrix needs.
+  const auditEntries = (calls) => calls.appendLog.map((c) => JSON.parse(c.line));
+
+  it("dry-run publishes nothing but still writes a result:dry-run audit line", () => {
     const cfg = baseConfig();
     const { deps, calls } = makeDeps({ runReplies: happy });
     const r = execute(deps, cfg, { prOverride: null, push: true, dryRun: true });
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(true);
     expect(calls.gh).toHaveLength(0);
-    expect(calls.appendLog).toHaveLength(0);
     expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
     expect(calls.run.some((c) => /gh label create/.test(c.cmd))).toBe(false);
     expect(r.body.split("\n")[0]).toMatch(/^<!-- local-attest verified-sha=[0-9a-f]{7,40} -->$/);
+    expect(auditEntries(calls)).toHaveLength(1);
+    expect(auditEntries(calls)[0].result).toBe("dry-run");
   });
 
-  it("exits 1 when a hard leg fails and posts nothing", () => {
+  it("exits 1 when a hard leg fails, posts nothing, and audits result:hard-fail", () => {
     const cfg = baseConfig();
-    const replies = [
-      ...happy,
-      [/echo test/, { status: 1, stderr: "boom" }],
-    ];
+    const replies = [...happy, [/echo test/, { status: 1, stderr: "boom" }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
     const r = execute(deps, cfg, { prOverride: null, push: true, dryRun: false });
     expect(r.exitCode).toBe(1);
     expect(r.ok).toBe(false);
     expect(calls.gh).toHaveLength(0);
-    expect(calls.appendLog).toHaveLength(0);
+    const entries = auditEntries(calls);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].result).toBe("hard-fail");
+    expect(entries[0].legs.find((l) => l.name === "test").status).toBe("fail");
+    expect(entries[0].legs.find((l) => l.name === "lint").status).toBe("pass");
   });
 
   it("posts + labels + audits on full pass (no dry-run)", () => {
     const cfg = baseConfig();
-    const replies = [
-      ...happy,
-      [/gh api repos.*\/comments/, { stdout: "[]" }],
-    ];
+    const replies = [...happy, [/gh api repos.*\/comments/, { stdout: "[]" }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
     const r = execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
     expect(r.exitCode).toBe(0);
@@ -374,9 +380,9 @@ describe("execute (orchestration)", () => {
 
   it("aborts when HEAD moves during the matrix", () => {
     const { deps } = makeDeps({ runReplies: [movingHead(), ...happy] });
-    expect(() => execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false })).toThrow(
-      PreconditionError,
-    );
+    expect(() =>
+      execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false }),
+    ).toThrow(PreconditionError);
   });
 
   it("names both SHAs so the operator can see what changed", () => {
@@ -391,22 +397,29 @@ describe("execute (orchestration)", () => {
     expect(err.message).toContain(NEW_SHA.slice(0, 8));
   });
 
-  it("publishes nothing when HEAD moved — no comment, no push, no label, no audit", () => {
+  it("publishes nothing when HEAD moved, but the settled matrix still gets an audit line", () => {
     const { deps, calls } = makeDeps({ runReplies: [movingHead(), ...happy] });
-    expect(() => execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false })).toThrow();
+    expect(() =>
+      execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false }),
+    ).toThrow();
     expect(calls.gh).toHaveLength(0);
-    expect(calls.appendLog).toHaveLength(0);
     expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
     expect(calls.run.some((c) => /gh pr edit 42 --add-label/.test(c.cmd))).toBe(false);
+    const entries = calls.appendLog.map((c) => JSON.parse(c.line));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].result).toBe("head-moved");
   });
 
   it("aborts when the tree becomes dirty during the matrix", () => {
     let seen = 0;
-    const dirtying = [/git status --porcelain/, () => ({ stdout: seen++ === 0 ? "" : " M src/x.mjs\n" })];
+    const dirtying = [
+      /git status --porcelain/,
+      () => ({ stdout: seen++ === 0 ? "" : " M src/x.mjs\n" }),
+    ];
     const { deps, calls } = makeDeps({ runReplies: [dirtying, ...happy] });
-    expect(() => execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false })).toThrow(
-      PreconditionError,
-    );
+    expect(() =>
+      execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false }),
+    ).toThrow(PreconditionError);
     expect(calls.gh).toHaveLength(0);
     expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
   });
@@ -416,5 +429,214 @@ describe("execute (orchestration)", () => {
     const r = execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: true });
     expect(r.exitCode).toBe(0);
     expect(calls.gh).toHaveLength(0);
+  });
+
+  it("audits result:push-fail when the push fails after the comment posted", () => {
+    const replies = [
+      ...happy,
+      [/gh api repos.*\/comments/, { stdout: "[]" }],
+      [/git push/, { status: 1, stderr: "rejected" }],
+    ];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const r = execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false });
+    expect(r.exitCode).toBe(1);
+    // The comment was already posted (dotbabel posts before pushing) — the
+    // audit line records that this run ended at the push, not at a green attest.
+    expect(calls.gh).toHaveLength(1);
+    const entries = calls.appendLog.map((c) => JSON.parse(c.line));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].result).toBe("push-fail");
+  });
+
+  it("the attested audit line carries result, per-leg statuses, and flags", () => {
+    const replies = [...happy, [/gh api repos.*\/comments/, { stdout: "[]" }]];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    execute(deps, baseConfig(), { prOverride: null, push: false, dryRun: false });
+    const entries = calls.appendLog.map((c) => JSON.parse(c.line));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].result).toBe("attested");
+    expect(entries[0].legs.map((l) => l.status)).toEqual(["pass", "pass", "pass"]);
+    expect(entries[0].flags.failFast).toBe(false);
+    // Legacy fields stay in place for pre-change readers.
+    expect(entries[0].pr).toBe(42);
+    expect(entries[0].sha).toMatch(/^abc1234/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fail-fast
+// ---------------------------------------------------------------------------
+
+describe("runMatrix --fail-fast", () => {
+  it("stops launching legs after a hard failure and marks the rest not-run", () => {
+    const replies = [[/echo lint/, { status: 1, stderr: "boom" }]];
+    const { deps } = makeDeps({ runReplies: replies });
+    const results = runMatrix(deps, baseConfig().matrix, { failFast: true });
+    expect(results.map((r) => r.name)).toEqual(["lint", "test", "knip"]);
+    expect(results[0].passed).toBe(false);
+    expect(results[1]).toMatchObject({ notRun: true, passed: false, durationS: 0 });
+    expect(results[2]).toMatchObject({ notRun: true, passed: false });
+    // No leg command after the failure was actually executed.
+    expect(deps === undefined).toBe(false);
+  });
+
+  it("an advisory failure never trips the abort", () => {
+    const cfg = validateConfig({
+      matrix: [
+        { name: "knip", mode: "advisory", command: "echo knip" },
+        { name: "test", mode: "hard", command: "echo test" },
+      ],
+    });
+    const replies = [[/echo knip/, { status: 1 }]];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const results = runMatrix(deps, cfg.matrix, { failFast: true });
+    expect(results[1].passed).toBe(true);
+    expect(results[1].notRun).toBeUndefined();
+    expect(calls.run.some((c) => /echo test/.test(c.cmd))).toBe(true);
+  });
+
+  it("a fail-fast run where nothing failed is a full run and may attest", () => {
+    const { deps } = makeDeps();
+    const results = runMatrix(deps, baseConfig().matrix, { failFast: true });
+    expect(results.every((r) => r.passed && !r.notRun)).toBe(true);
+    expect(shouldAttest({ diagnostic: false, results })).toBe(true);
+  });
+
+  it("without failFast, every leg still runs after a failure (existing contract)", () => {
+    const replies = [[/echo lint/, { status: 1 }]];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const results = runMatrix(deps, baseConfig().matrix, { failFast: false });
+    expect(results.every((r) => !r.notRun)).toBe(true);
+    expect(calls.run.some((c) => /echo knip/.test(c.cmd))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// diagnostic mode
+// ---------------------------------------------------------------------------
+
+describe("execute (diagnostic mode)", () => {
+  it("--only runs just the named legs, never posts/labels/pushes, audits result:diagnostic", () => {
+    const replies = [[/git status --porcelain/, { stdout: " M wip.txt\n" }]];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const r = execute(deps, baseConfig(), {
+      prOverride: null,
+      push: true,
+      dryRun: false,
+      only: ["lint"],
+      from: null,
+      failFast: false,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(calls.run.some((c) => /echo lint/.test(c.cmd))).toBe(true);
+    expect(calls.run.some((c) => /echo test/.test(c.cmd))).toBe(false);
+    expect(calls.gh).toHaveLength(0);
+    expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
+    expect(calls.run.some((c) => /gh label create/.test(c.cmd))).toBe(false);
+    const entries = calls.appendLog.map((c) => JSON.parse(c.line));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].result).toBe("diagnostic");
+    expect(entries[0].dirty).toBe(true);
+    expect(entries[0].flags.only).toEqual(["lint"]);
+  });
+
+  it("a dirty tree does not block a diagnostic run — iterating is the point", () => {
+    const replies = [[/git status --porcelain/, { stdout: " M wip.txt\n" }]];
+    const { deps } = makeDeps({ runReplies: replies });
+    const r = execute(deps, baseConfig(), {
+      prOverride: null,
+      push: true,
+      dryRun: false,
+      only: ["lint"],
+      from: null,
+      failFast: false,
+    });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it("exits 1 when any selected leg fails — advisory included, there is no gate to grade", () => {
+    const replies = [[/echo knip/, { status: 1 }]];
+    const { deps } = makeDeps({ runReplies: replies });
+    const r = execute(deps, baseConfig(), {
+      prOverride: null,
+      push: true,
+      dryRun: false,
+      only: ["knip"],
+      from: null,
+      failFast: false,
+    });
+    expect(r.exitCode).toBe(1);
+  });
+
+  it("--from runs the suffix of the matrix", () => {
+    const { deps, calls } = makeDeps();
+    const r = execute(deps, baseConfig(), {
+      prOverride: null,
+      push: true,
+      dryRun: false,
+      only: [],
+      from: "test",
+      failFast: false,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(calls.run.some((c) => /echo lint/.test(c.cmd))).toBe(false);
+    expect(calls.run.some((c) => /echo test/.test(c.cmd))).toBe(true);
+    expect(calls.run.some((c) => /echo knip/.test(c.cmd))).toBe(true);
+  });
+
+  it("an unknown leg name fails with exit code 64 semantics (usage error)", () => {
+    const { deps } = makeDeps();
+    let err;
+    try {
+      execute(deps, baseConfig(), {
+        prOverride: null,
+        push: true,
+        dryRun: false,
+        only: ["nope"],
+        from: null,
+        failFast: false,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.exitCode).toBe(64);
+    expect(err.message).toContain("lint");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toolchain precondition
+// ---------------------------------------------------------------------------
+
+describe("toolchain precondition", () => {
+  const happy = [
+    [/git rev-parse --abbrev-ref HEAD/, { stdout: "feature\n" }],
+    [/git status --porcelain/, { stdout: "" }],
+    [/gh auth status/, { status: 0 }],
+    [/gh repo view --json nameWithOwner/, { stdout: "k/r\n" }],
+    [/gh pr view --json number/, { stdout: "42\n" }],
+    [/git rev-parse HEAD/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh pr view 42 --json headRefOid/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+  ];
+
+  it("fails closed on an attest run when the running node does not match the pin", () => {
+    const cfg = baseConfig({ toolchain: { node: "9999" } });
+    const replies = [...happy, [/node --version/, { stdout: "v22.11.0\n" }]];
+    const { deps } = makeDeps({ runReplies: replies });
+    expect(() => checkPreconditions(deps, cfg)).toThrow(/toolchain/i);
+  });
+
+  it("passes when the pin matches", () => {
+    const cfg = baseConfig({ toolchain: { node: "22" } });
+    const replies = [...happy, [/node --version/, { stdout: "v22.11.0\n" }]];
+    const { deps } = makeDeps({ runReplies: replies });
+    expect(() => checkPreconditions(deps, cfg)).not.toThrow();
+  });
+
+  it("no toolchain config, no check — opt-in per repo", () => {
+    const { deps, calls } = makeDeps({ runReplies: happy });
+    checkPreconditions(deps, baseConfig());
+    expect(calls.run.some((c) => /node --version/.test(c.cmd))).toBe(false);
   });
 });

--- a/plugins/dotbabel/tests/local-attest-runner.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-runner.test.mjs
@@ -470,14 +470,14 @@ describe("execute (orchestration)", () => {
 describe("runMatrix --fail-fast", () => {
   it("stops launching legs after a hard failure and marks the rest not-run", () => {
     const replies = [[/echo lint/, { status: 1, stderr: "boom" }]];
-    const { deps } = makeDeps({ runReplies: replies });
+    const { deps, calls } = makeDeps({ runReplies: replies });
     const results = runMatrix(deps, baseConfig().matrix, { failFast: true });
     expect(results.map((r) => r.name)).toEqual(["lint", "test", "knip"]);
     expect(results[0].passed).toBe(false);
     expect(results[1]).toMatchObject({ notRun: true, passed: false, durationS: 0 });
     expect(results[2]).toMatchObject({ notRun: true, passed: false });
     // No leg command after the failure was actually executed.
-    expect(deps === undefined).toBe(false);
+    expect(calls.run.some((c) => /echo test|echo knip/.test(c.cmd))).toBe(false);
   });
 
   it("an advisory failure never trips the abort", () => {

--- a/plugins/dotbabel/tests/local-attest-smoke.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-smoke.test.mjs
@@ -117,11 +117,15 @@ describe("local-attest end-to-end smoke (synthetic, no real I/O)", () => {
     });
   });
 
-  it("I/O containment: dry-run never POSTs/PATCHes, never pushes, never writes audit log", () => {
+  it("I/O containment: dry-run never POSTs/PATCHes or pushes; the audit line is its only trace", () => {
+    // Contract change (deliberate): every run whose matrix settles writes one
+    // audit line — dry-runs included, tagged result:"dry-run" — so the log is
+    // a complete run history rather than a successes-only one.
     const { deps, calls } = happyDeps();
     execute(deps, squadranksShapedConfig(), { prOverride: null, push: true, dryRun: true });
     expect(calls.gh).toHaveLength(0);
-    expect(calls.appendLog).toHaveLength(0);
+    expect(calls.appendLog).toHaveLength(1);
+    expect(JSON.parse(calls.appendLog[0].line).result).toBe("dry-run");
     expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
     expect(calls.run.some((c) => /gh label create/.test(c.cmd))).toBe(false);
     expect(calls.run.some((c) => /gh pr edit/.test(c.cmd))).toBe(false);

--- a/skills/local-attest/SKILL.md
+++ b/skills/local-attest/SKILL.md
@@ -18,8 +18,8 @@ description: >
   A new push changes the head SHA, the attestation stops matching, CI runs
   again. Side-effectful (posts a PR comment, applies a label, optionally pushes)
   and slow — minutes to tens of minutes, whatever the configured matrix costs.
-  Diagnostic modes (--only, --from, --fail-fast) run subsets for the fix-retry
-  loop and can never attest. Invoke only on explicit request.
+  Diagnostic modes (--only, --from) run subsets for the fix-retry loop and can
+  never attest; --fail-fast works in both modes. Invoke only on explicit request.
 argument-hint: "[--pr <N>] [--no-push] [--dry-run] [--fail-fast] [--only <leg>] [--from <leg>] [--config <path>]"
 tools: Bash
 disable-model-invocation: true
@@ -66,9 +66,12 @@ tree, detached HEAD, no PR — iterating is the point), Docker and toolchain
 problems warn instead of failing. Leg names match exactly and case-sensitively;
 an unknown name lists every valid leg. The two flags are mutually exclusive.
 
-A diagnostic run **never** posts, labels, or pushes — not by convention but
-mechanically: attestation is gated on a run-record predicate (`shouldAttest`)
-that rejects any subset run. Exit is 1 when **any** selected leg fails,
+A diagnostic run **never** posts, labels, or pushes. Two mechanisms stack:
+the diagnostic branch in `execute` returns before the publication path even
+exists (and the attest branch always runs the full config matrix), and the
+`shouldAttest` predicate that gates publication receives the diagnostic flag
+plus the expected leg count, so a subset record is rejected even if the
+branch wiring were ever wrong. Exit is 1 when **any** selected leg fails,
 advisory legs included, because there is no attestation gate to grade against
 and `--only <advisory-leg>` exiting 0 on a failure would be useless in a loop.
 
@@ -99,6 +102,9 @@ and attests normally; one that stopped early cannot.
 - **`gh` authenticated** as a user whose `author_association` is in your
   config's `trustedAssociations` list (default: `["OWNER"]`).
 - **Docker running** if your config sets `requireDocker: true`.
+- **`auditLogPath` gitignored** (default `.local-attest-log.jsonl`). Every
+  run appends to it — including `--dry-run` — so with `requireClean` on, an
+  untracked log makes the next attest abort on the tool's own output.
 
 ## How the gate works
 

--- a/skills/local-attest/SKILL.md
+++ b/skills/local-attest/SKILL.md
@@ -2,14 +2,14 @@
 id: local-attest
 name: local-attest
 type: skill
-version: 1.0.0
+version: 1.1.0
 domain: [devex, observability]
 platform: [github-actions]
 task: [testing, runtime-ops]
 maturity: draft
 owner: "@kaiohenricunha"
 created: 2026-05-23
-updated: 2026-05-23
+updated: 2026-08-13
 description: >
   Run the configured CI matrix locally and, on a clean pass, post a SHA-pinned
   OWNER-authored PR comment that gates downstream GitHub Actions jobs off for
@@ -17,8 +17,10 @@ description: >
   already verified locally, saving runner minutes without weakening the gate.
   A new push changes the head SHA, the attestation stops matching, CI runs
   again. Side-effectful (posts a PR comment, applies a label, optionally pushes)
-  and slow (10–15 min depending on matrix). Invoke only on explicit request.
-argument-hint: "[--pr <N>] [--no-push] [--dry-run] [--config <path>]"
+  and slow — minutes to tens of minutes, whatever the configured matrix costs.
+  Diagnostic modes (--only, --from, --fail-fast) run subsets for the fix-retry
+  loop and can never attest. Invoke only on explicit request.
+argument-hint: "[--pr <N>] [--no-push] [--dry-run] [--fail-fast] [--only <leg>] [--from <leg>] [--config <path>]"
 tools: Bash
 disable-model-invocation: true
 user-invocable: true
@@ -31,9 +33,11 @@ a hidden marker comment to the open PR so the remote `Test` / `Preview` jobs
 read the marker and skip themselves for that exact commit.
 
 > **This skill is side-effectful and slow.** It runs every leg of your CI
-> matrix sequentially (typically 10–15 minutes), posts a PR comment, applies
-> a label, and pushes the current branch. Invoke only when you've decided to
-> attest a specific PR.
+> matrix sequentially — minutes to tens of minutes, whatever the configured
+> matrix costs — posts a PR comment, applies a label, and pushes the current
+> branch. Invoke only when you've decided to attest a specific PR. For the
+> fix-retry loop, use the diagnostic modes below instead: they run subsets,
+> tolerate a dirty tree, and are structurally unable to attest.
 
 ## Quick start
 
@@ -46,7 +50,35 @@ dotbabel local-attest --pr 123 --dry-run
 
 # Run + post + label, but do not git push (useful for offline review):
 dotbabel local-attest --pr 123 --no-push
+
+# Iterate on a fix: run one leg, dirty tree fine, no PR needed, never attests:
+dotbabel local-attest --only lint
+
+# Re-run the matrix from the leg that failed, stopping at the first hard failure:
+dotbabel local-attest --from bats --fail-fast
 ```
+
+## Diagnostic modes — the fix-retry loop
+
+`--only <leg>` (repeatable or comma-separated) and `--from <leg>` run a subset
+of the matrix under relaxed preconditions: any git repo state is fine (dirty
+tree, detached HEAD, no PR — iterating is the point), Docker and toolchain
+problems warn instead of failing. Leg names match exactly and case-sensitively;
+an unknown name lists every valid leg. The two flags are mutually exclusive.
+
+A diagnostic run **never** posts, labels, or pushes — not by convention but
+mechanically: attestation is gated on a run-record predicate (`shouldAttest`)
+that rejects any subset run. Exit is 1 when **any** selected leg fails,
+advisory legs included, because there is no attestation gate to grade against
+and `--only <advisory-leg>` exiting 0 on a failure would be useless in a loop.
+
+Subsets get exactly what they name — no dependency injection. `--from` a leg
+that reads a build artifact measures whatever artifact is lying around.
+
+`--fail-fast` works in both modes: the first **hard** failure stops launching
+further legs, which are recorded `not run (fail-fast)` — never as passes. A
+full run with `--fail-fast` where nothing failed completed the whole matrix
+and attests normally; one that stopped early cannot.
 
 ## Prerequisites
 
@@ -92,31 +124,49 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
 ## What the skill does, in order
 
 1. **Preconditions.** Branch exists, worktree clean (if `requireClean`), local
-   HEAD == PR head, `gh` authed, Docker available (if `requireDocker`). Any
-   failure aborts before a single test runs. The skill also warns (does not
-   fail) if your GitHub `author_association` on the repo (OWNER / MEMBER /
-   COLLABORATOR, etc.) is not in the config's `trustedAssociations` list — the
-   attestation will post but CI will ignore it.
+   HEAD == PR head, `gh` authed, Docker available (if `requireDocker`), and the
+   running toolchain matches `config.toolchain` pins (if set) — a matrix run on
+   a different Node or Go than CI uses certifies a run CI would never perform,
+   so a pin mismatch fails closed here. Any failure aborts before a single test
+   runs. The skill also warns (does not fail) if your GitHub
+   `author_association` on the repo (OWNER / MEMBER / COLLABORATOR, etc.) is
+   not in the config's `trustedAssociations` list — the attestation will post
+   but CI will ignore it.
 2. **Run matrix.** Each leg from the config runs sequentially. Hard legs must
    pass to attest; advisory legs are reported but never block. Stdout + stderr
-   are tailed at 10 lines per leg so the result table stays readable.
-3. **Hard-leg gate.** Any hard failure aborts: no comment, no label, no push.
+   are tailed at 10 lines per leg so the result table stays readable. With
+   `--fail-fast`, the first hard failure stops launching further legs; the
+   rest are recorded `not run`, never as passes.
+3. **Attestation bar.** Posting is gated on a run-record predicate: every leg
+   executed, zero hard fails, not a diagnostic subset. A run that fails the
+   bar aborts — no comment, no label, no push — and still writes its audit
+   line (`result: "hard-fail"`).
 4. **Re-check HEAD.** The matrix takes minutes — long enough for another agent
    session, another worktree, or you in a second terminal to commit onto the
    same branch. Step 1's check is stale by now, so HEAD and the worktree are
    re-asserted against what was actually tested. If either moved, everything
-   aborts: no comment, no label, no push. Without this the skill would attest
-   the pre-matrix SHA and then push whatever HEAD had become — publishing
-   commits it never tested and labelling the PR verified on an unrun head.
-5. **Push first** (if `pushAfterAttest` and not `--no-push`). The attestation
-   must never describe a SHA the remote hasn't seen.
-6. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
-   place; otherwise a new one is POSTed. Body always goes via `gh api --input -`
-   so multiline markdown can't be mangled by shell quoting.
+   aborts (`result: "head-moved"`): no comment, no label, no push. Without
+   this the skill would attest the pre-matrix SHA and then push whatever HEAD
+   had become — publishing commits it never tested and labelling the PR
+   verified on an unrun head.
+5. **Upsert comment.** Existing attestation comment (any SHA) is PATCHed in
+   place; otherwise a new one is POSTed — before the push, so the marker is
+   already visible when the push event fires GitHub Actions. Body always goes
+   via `gh api --input -` so multiline markdown can't be mangled by shell
+   quoting.
+6. **Push** (if `pushAfterAttest` and not `--no-push`). A failed push records
+   `result: "push-fail"`; the comment is already in place, so a bare
+   `git push` retry completes the attestation.
 7. **Apply label** (default `ci/local-verified`). Best-effort; failure warns
    but does not abort.
 8. **Append audit log line** to the configured `auditLogPath` (default
-   `.local-attest-log.jsonl`). Best-effort.
+   `.local-attest-log.jsonl`). **Every run whose matrix executes writes
+   exactly one line**, tagged `result: attested | hard-fail | head-moved |
+push-fail | post-fail | dry-run | diagnostic`, with per-leg
+   `{name, mode, status, durationS}` — failures leave a record too, which is
+   what makes failure and duration distributions measurable. Lines written by
+   older versions have no `result` field and imply `attested`. Best-effort:
+   an unwritable log warns but never changes the run's outcome.
 
 ## Flags
 
@@ -125,6 +175,9 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
 | `--pr <N>`        | Target PR number. Defaults to the open PR for the current branch.                                                                            |
 | `--no-push`       | Run matrix + post + label, but skip `git push`.                                                                                              |
 | `--dry-run`       | Run matrix, render the comment, print it. Post nothing, label nothing, push nothing. Use this to validate a new project's config end-to-end. |
+| `--fail-fast`     | Stop launching legs after the first hard failure. Unstarted legs record as `not run`; a run that stopped early can never attest.             |
+| `--only <leg>`    | Diagnostic mode — run only the named leg(s). Repeatable or comma-separated. Relaxed preconditions; never attests. Exit 1 on any failure.     |
+| `--from <leg>`    | Diagnostic mode — run the matrix from the named leg to the end. Mutually exclusive with `--only`.                                            |
 | `--config <path>` | Override config discovery.                                                                                                                   |
 
 ## What this skill never does

--- a/skills/local-attest/references/config.md
+++ b/skills/local-attest/references/config.md
@@ -36,8 +36,8 @@ type Config = {
   // Diagnostic runs (--only/--from) warn instead of failing. Unparseable
   // versions count as mismatches.
   toolchain?: {
-    node?: string; // engines-style pin ("22", "22.x", ">=22"); running node's major must match
-    goMod?: string; // path to a go.mod; its `go` directive's major.minor must match `go version`
+    node?: string; // exact major pin ("22"); range syntax (">=22", "^22") is rejected
+    goMod?: string; // relative path (no "..") to a go.mod; its go directive major.minor must match `go version`
   };
 };
 ```
@@ -54,8 +54,9 @@ Every run whose matrix executes appends exactly one JSONL line to
 `auditLogPath`, tagged `result: attested | hard-fail | head-moved | push-fail
 | post-fail | dry-run | diagnostic`, with per-leg
 `{name, mode, status, durationS}` (`status ∈ pass | fail | advisory-fail |
-not-run`), the invocation `flags`, and — for diagnostic runs — a `dirty`
-marker, because a dirty tree's `sha` does not identify the tree that ran.
+not-run`), the invocation `flags`, the certified `toolchain` versions when
+pins are configured, and — for diagnostic runs — a `dirty` marker, because a
+dirty tree's `sha` does not identify the tree that ran.
 Lines written by versions before `result` existed were only ever written
 after a successful post, so a missing `result` implies `attested`.
 

--- a/skills/local-attest/references/config.md
+++ b/skills/local-attest/references/config.md
@@ -28,11 +28,36 @@ type Config = {
   trustedAssociations?: string[]; // gh author_association values that gate CI (default: ["OWNER"])
   requireClean?: boolean; // abort on dirty worktree (default: true)
   requireDocker?: boolean; // abort if `docker info` fails (default: false)
-  pushAfterAttest?: boolean; // git push after attest, before posting (default: true)
+  pushAfterAttest?: boolean; // git push after the comment posts (default: true)
+
+  // Optional toolchain pins. On an attest run a mismatch fails closed —
+  // the attestation claims "CI would pass", and a matrix run on a different
+  // Node or Go than CI uses certifies a run CI would never perform.
+  // Diagnostic runs (--only/--from) warn instead of failing. Unparseable
+  // versions count as mismatches.
+  toolchain?: {
+    node?: string; // engines-style pin ("22", "22.x", ">=22"); running node's major must match
+    goMod?: string; // path to a go.mod; its `go` directive's major.minor must match `go version`
+  };
 };
 ```
 
 The matrix is the only required field; everything else has sensible defaults.
+
+Pin the toolchain to whatever CI's setup steps install (`node-version:`,
+`go-version-file:`). If CI runs a version matrix, pin the one you attest with
+and note that the other legs are skipped under attestation regardless.
+
+## Audit log
+
+Every run whose matrix executes appends exactly one JSONL line to
+`auditLogPath`, tagged `result: attested | hard-fail | head-moved | push-fail
+| post-fail | dry-run | diagnostic`, with per-leg
+`{name, mode, status, durationS}` (`status ∈ pass | fail | advisory-fail |
+not-run`), the invocation `flags`, and — for diagnostic runs — a `dirty`
+marker, because a dirty tree's `sha` does not identify the tree that ran.
+Lines written by versions before `result` existed were only ever written
+after a successful post, so a missing `result` implies `attested`.
 
 ## Example 1 — minimal Node app
 

--- a/skills/local-attest/references/operator-guide.md
+++ b/skills/local-attest/references/operator-guide.md
@@ -2,8 +2,9 @@
 
 CI minutes are billed; running the same matrix on GitHub-hosted runners after
 a maintainer has already verified the change locally is duplicated spend. The
-`/local-attest` skill lets a trusted user trade ~10–15 minutes of local
-runtime for a clean skip of the equivalent remote pipeline.
+`/local-attest` skill lets a trusted user trade the local runtime of the
+configured matrix — minutes to tens of minutes — for a clean skip of the
+equivalent remote pipeline.
 
 This guide is the operator contract for using the skill safely.
 
@@ -56,14 +57,25 @@ dotbabel local-attest --pr 123
 ```
 
 The skill runs every leg of your `.local-attest` matrix, prints a result
-table, pushes (if `pushAfterAttest`), posts/PATCHes the attestation comment,
+table, posts/PATCHes the attestation comment, pushes (if `pushAfterAttest` —
+the comment goes first so the marker is visible when the push event fires),
 applies the label, and appends a line to the audit log.
 
 `--dry-run` runs the matrix and prints the comment without posting anything.
-Use it to validate a new config end-to-end.
+Use it to validate a new config end-to-end. (Combined with `--only`/`--from`
+it is inert — diagnostic runs never post anyway.)
 
 `--no-push` skips the `git push` step but still posts the comment + label.
 Use it when you've pushed manually and just want to attest.
+
+`--fail-fast` stops launching legs after the first hard failure; unstarted
+legs are recorded `not-run` and a stopped run cannot attest. A `--fail-fast`
+run in which nothing failed completed the full matrix and attests normally.
+
+`--only <leg>` / `--from <leg>` are diagnostic modes for the fix-retry loop:
+subsets under relaxed preconditions (dirty tree fine, no PR needed) that never
+post, label, or push, and exit 1 on any selected-leg failure, advisory
+included.
 
 ## Trust model
 
@@ -128,9 +140,11 @@ the diff manually whenever either side changes.
 
 ### Long-running matrices
 
-Attestation runs sequentially. 10–15 minutes is typical; pathologically
-slow matrices (heavy e2e + multiple language runtimes) can hit 30+. That's
-the deliberate cost of skipping the remote run.
+Attestation runs the matrix sequentially and costs whatever the configured
+legs cost — minutes for a lint-and-unit matrix, tens of minutes with heavy
+e2e and multiple language runtimes. That's the deliberate price of skipping
+the remote run; use `--only`/`--from`/`--fail-fast` for iteration and save
+full runs for attestation.
 
 ### Audit
 
@@ -141,17 +155,31 @@ gh pr list --label ci/local-verified --state all
 ```
 
 The audit log (`.local-attest-log.jsonl` by default) records one JSONL line
-per attestation:
+for **every run whose matrix executes** — failures included — tagged with a
+`result` and per-leg statuses:
 
 ```json
 {
-  "ts": "2026-05-23T16:00:00.000Z",
+  "ts": "2026-08-13T16:00:00.000Z",
   "pr": 123,
   "sha": "abc1234...",
   "host": "wsl-laptop",
-  "advisoryFails": ["knip"]
+  "advisoryFails": ["knip"],
+  "result": "attested",
+  "legs": [{ "name": "lint", "mode": "hard", "status": "pass", "durationS": 17 }],
+  "flags": { "only": [], "from": null, "failFast": false, "push": true, "dryRun": false },
+  "toolchain": { "node": "22.11.0" }
 }
 ```
 
-Add the audit log to `.gitignore` if you don't want it in version control;
-the contract is single-line JSONL so any log shipper handles it natively.
+`result` is one of `attested | hard-fail | head-moved | push-fail | post-fail
+| dry-run | diagnostic`. Lines written by versions before `result` existed
+were only ever written after a successful post, so a missing `result` implies
+`attested`. Diagnostic lines add `dirty: true|false`, because a dirty tree's
+`sha` does not identify the tree that ran.
+
+**Add the audit log to `.gitignore` — this is a requirement when
+`requireClean` is on, not a preference.** Every run appends to it, including
+the `--dry-run` this guide recommends for validating a new config, so an
+untracked log makes the very next attest abort on its own output. The
+contract is single-line JSONL so any log shipper handles it natively.


### PR DESCRIPTION
## Summary

- The `/local-attest` audit log now records **every** run whose matrix executes — hard failures, head-moves, push/post failures, dry-runs, and diagnostics, each tagged with a `result` and per-leg `{name, mode, status, durationS}`. Previously failures exited before the only audit write, so the log held successes only and the failure/duration distributions that should drive matrix decisions did not exist.
- New diagnostic modes for the fix-retry loop: `--only <leg>` / `--from <leg>` run subsets under relaxed preconditions (dirty tree fine, no PR needed, offline-capable), and `--fail-fast` stops launching legs after the first hard failure. Subset and stopped-early runs are **mechanically** unable to attest via an exported, mutation-tested `shouldAttest` predicate — posting, labelling, and pushing live structurally inside its guard.
- Opt-in `config.toolchain` pins (`node`, `goMod`): an attest run on a toolchain CI does not use fails closed; diagnostic runs warn. This repo pins `node: "22"`.

## Test plan

- [x] `npm test` — 1059 pass (+27 new across lib/runner/config/smoke; three tests pinning the old successes-only audit contract deliberately updated)
- [x] `bash plugins/dotbabel/scripts/run-bats.sh` — 595 pass, including the updated `local-attest-head-race.bats` asserting a `result: "head-moved"` audit line
- [x] Mutation check: forcing `shouldAttest` to return true fails 4 tests
- [x] Live wiring on a dirty worktree: `--only "build-plugin --check"` ran one leg, refused to attest, exited 1 on the (genuinely) failing leg, and wrote `{"result":"diagnostic","dirty":true,...}`; `--only nope` exits 64 listing every valid leg; `--only x --from y` exits 64
- [x] `npm run dogfood`, `build-plugin --check`, `index --check`, `doctor`, `lint`, `shellcheck` — all pass

## No-spec rationale

Hardening of the existing local-attest subsystem, designed originally for a consumer repo's bespoke attest script and ported into the packaged skill so every dotbabel repo inherits it. No new subsystem: the runner keeps its sequential matrix and `Deps` injection; the audit format is additively extended with documented back-compat (`result` absent ⇒ `attested`); templates, index, and the skills manifest change only as regeneration output. The CI-gate semantics (marker format, OWNER trust, SHA pinning) are untouched.



