### PR TITLE
feat(local-attest): lanes, diff-gated legs, worktree restore, PR-body env

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T21:51:50.356Z",
+  "generatedAt": "2026-08-13T22:17:23.892Z",
   "skills": [
     {
       "name": "agents-search",
@@ -152,7 +152,7 @@
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
-      "checksum": "sha256:f3b1cc41267d1d77fc8155dff64a48d968524de784c73a661c7f64bbaa22200f",
+      "checksum": "sha256:688dc4b8e9c926627c6eab50c6bb836bad6787a4355ba588bbbb22792171d269",
       "dependencies": [],
       "lastValidated": "2026-08-13"
     },

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T19:36:58.510Z",
+  "generatedAt": "2026-08-13T21:51:50.356Z",
   "skills": [
     {
       "name": "agents-search",
@@ -152,7 +152,7 @@
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
-      "checksum": "sha256:c57f5f556a33c66a795a918b36641685dddf33af2e16a0d1fdbc774da7ce6fd6",
+      "checksum": "sha256:f3b1cc41267d1d77fc8155dff64a48d968524de784c73a661c7f64bbaa22200f",
       "dependencies": [],
       "lastValidated": "2026-08-13"
     },

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -480,12 +480,15 @@ Run the configured CI matrix locally and, on a clean pass, post an attestation
 comment so the remote pipeline can skip itself for that commit. Exists to
 protect CI minutes.
 
-| Flag              | Default                |                                   |
-| ----------------- | ---------------------- | --------------------------------- |
-| `--pr <N>`        | open PR for the branch | Target PR                         |
-| `--no-push`       | false                  | Do not `git push` after attesting |
-| `--dry-run`       | false                  | Print the comment; post nothing   |
-| `--config <path>` | discovered             | Override the config file location |
+| Flag              | Default                |                                                                                  |
+| ----------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| `--pr <N>`        | open PR for the branch | Target PR                                                                        |
+| `--no-push`       | false                  | Do not `git push` after attesting                                                |
+| `--dry-run`       | false                  | Print the comment; post nothing                                                  |
+| `--fail-fast`     | false                  | Stop launching legs after the first hard failure; a stopped run cannot attest    |
+| `--only <leg>`    | —                      | Diagnostic mode: run only the named leg(s); relaxed preconditions; never attests |
+| `--from <leg>`    | —                      | Diagnostic mode: run the matrix from the named leg to the end                    |
+| `--config <path>` | discovered             | Override the config file location                                                |
 
 Config discovery, in order: `.local-attest.config.mjs`,
 `.local-attest.config.json`, then `package.json#local-attest`.

--- a/index/artifacts.json
+++ b/index/artifacts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dotbabel.dev/schemas/index.schema.json",
-  "generatedAt": "2026-08-13T19:36:58.038Z",
+  "generatedAt": "2026-08-13T21:51:50.125Z",
   "version": "2.16.0",
   "artifacts": [
     {
@@ -587,7 +587,7 @@
         "task": ["testing", "runtime-ops"],
         "maturity": "draft"
       },
-      "version": "1.1.0",
+      "version": "1.2.0",
       "owner": "@kaiohenricunha"
     },
     {

--- a/plugins/dotbabel/bin/dotbabel-local-attest.mjs
+++ b/plugins/dotbabel/bin/dotbabel-local-attest.mjs
@@ -120,7 +120,7 @@ async function main() {
 
   const deps = realDeps();
   try {
-    const result = execute(deps, cfg, {
+    const result = await execute(deps, cfg, {
       prOverride: argv.pr,
       push: argv.push,
       dryRun: argv.dryRun,

--- a/plugins/dotbabel/src/local-attest-config.mjs
+++ b/plugins/dotbabel/src/local-attest-config.mjs
@@ -16,7 +16,21 @@
  * @property {"hard"|"advisory"} mode
  * @property {string} command
  * @property {string} [cwd]
- * @property {Record<string, string>} [env]
+ * @property {Record<string, string>} [env]           values must be strings — they flow
+ *                                                    verbatim into the child environment
+ * @property {string} [lane]                          legs sharing a lane run serially in
+ *                                                    matrix order; distinct lanes run
+ *                                                    concurrently; no lane = one shared
+ *                                                    default lane (fully sequential)
+ * @property {{ changedPaths: string[] }} [when]      run the leg only when SOME changed PR
+ *                                                    file matches one of these globs — a CI
+ *                                                    path filter mirrored locally; misses
+ *                                                    mark the leg skipped, never remove it
+ * @property {string[]} [skipWhenDiffOnly]            skip the leg when EVERY changed PR file
+ *                                                    matches one of these globs — a docs-only
+ *                                                    classify rule mirrored locally
+ * @property {boolean} [passPrBody]                   inject the PR body as env.PR_BODY for
+ *                                                    this leg (fetched once, empty on error)
  *
  * @typedef {object} Toolchain
  * @property {string} [node]   exact major version pin ("22"); the `node` on PATH
@@ -37,6 +51,10 @@
  * @property {boolean} requireDocker
  * @property {boolean} pushAfterAttest
  * @property {Toolchain|null} toolchain
+ * @property {string[]} restoreFiles  tracked files a leg is known to overwrite (e2e seeders);
+ *                                    snapshotted before the matrix and restored byte-exact in
+ *                                    a finally, BEFORE the post-matrix head recheck — without
+ *                                    this the recheck aborts every run on the leg's own writes
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -53,6 +71,7 @@ export const DEFAULTS = Object.freeze({
   requireDocker: false,
   pushAfterAttest: true,
   toolchain: null,
+  restoreFiles: [],
 });
 
 /**
@@ -187,6 +206,53 @@ export function validateConfig(input) {
     if (leg.env !== undefined && (leg.env === null || typeof leg.env !== "object")) {
       throw new ConfigError(`config.matrix[${i}].env must be an object`);
     }
+    if (leg.env !== undefined) {
+      for (const [k, v] of Object.entries(/** @type {object} */ (leg.env))) {
+        if (typeof v !== "string") {
+          throw new ConfigError(
+            `config.matrix[${i}].env.${k} must be a string — env values flow verbatim into the child environment`,
+          );
+        }
+      }
+    }
+    if (leg.lane !== undefined && (typeof leg.lane !== "string" || leg.lane === "")) {
+      throw new ConfigError(`config.matrix[${i}].lane must be a non-empty string`);
+    }
+    if (leg.when !== undefined) {
+      const w = /** @type {Record<string, unknown>} */ (leg.when);
+      if (!w || typeof w !== "object" || Array.isArray(w)) {
+        throw new ConfigError(
+          `config.matrix[${i}].when must be an object like { changedPaths: [globs] }`,
+        );
+      }
+      const keys = Object.keys(w);
+      if (keys.length !== 1 || keys[0] !== "changedPaths") {
+        throw new ConfigError(`config.matrix[${i}].when supports exactly one key: changedPaths`);
+      }
+      if (
+        !Array.isArray(w.changedPaths) ||
+        w.changedPaths.length === 0 ||
+        !w.changedPaths.every((g) => typeof g === "string" && g !== "")
+      ) {
+        throw new ConfigError(
+          `config.matrix[${i}].when.changedPaths must be a non-empty array of glob strings`,
+        );
+      }
+    }
+    if (leg.skipWhenDiffOnly !== undefined) {
+      if (
+        !Array.isArray(leg.skipWhenDiffOnly) ||
+        leg.skipWhenDiffOnly.length === 0 ||
+        !leg.skipWhenDiffOnly.every((g) => typeof g === "string" && g !== "")
+      ) {
+        throw new ConfigError(
+          `config.matrix[${i}].skipWhenDiffOnly must be a non-empty array of glob strings`,
+        );
+      }
+    }
+    if (leg.passPrBody !== undefined && typeof leg.passPrBody !== "boolean") {
+      throw new ConfigError(`config.matrix[${i}].passPrBody must be a boolean`);
+    }
     matrix.push(
       /** @type {Leg} */ ({
         name,
@@ -194,6 +260,18 @@ export function validateConfig(input) {
         command: leg.command,
         ...(leg.cwd !== undefined ? { cwd: leg.cwd } : {}),
         ...(leg.env !== undefined ? { env: { .../** @type {object} */ (leg.env) } } : {}),
+        ...(leg.lane !== undefined ? { lane: leg.lane } : {}),
+        ...(leg.when !== undefined
+          ? {
+              when: {
+                changedPaths: [.../** @type {{changedPaths: string[]}} */ (leg.when).changedPaths],
+              },
+            }
+          : {}),
+        ...(leg.skipWhenDiffOnly !== undefined
+          ? { skipWhenDiffOnly: [.../** @type {string[]} */ (leg.skipWhenDiffOnly)] }
+          : {}),
+        ...(leg.passPrBody !== undefined ? { passPrBody: leg.passPrBody } : {}),
       }),
     );
   });
@@ -291,6 +369,21 @@ export function validateConfig(input) {
     };
   }
 
+  if (
+    !Array.isArray(merged.restoreFiles) ||
+    !merged.restoreFiles.every((f) => typeof f === "string" && f !== "")
+  ) {
+    throw new ConfigError("config.restoreFiles must be an array of file paths");
+  }
+  for (const f of /** @type {string[]} */ (merged.restoreFiles)) {
+    if (isAbsolute(f)) {
+      throw new ConfigError("config.restoreFiles entries must be relative paths");
+    }
+    if (f.split("/").some((seg) => seg === "..")) {
+      throw new ConfigError("config.restoreFiles entries must not contain '..' segments");
+    }
+  }
+
   return /** @type {Config} */ ({
     matrix,
     label: merged.label,
@@ -300,5 +393,6 @@ export function validateConfig(input) {
     requireDocker: merged.requireDocker,
     pushAfterAttest: merged.pushAfterAttest,
     toolchain,
+    restoreFiles: [.../** @type {string[]} */ (merged.restoreFiles)],
   });
 }

--- a/plugins/dotbabel/src/local-attest-config.mjs
+++ b/plugins/dotbabel/src/local-attest-config.mjs
@@ -58,6 +58,8 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+
+import { UNSUPPORTED_GLOB_CHARS } from "./local-attest-lib.mjs";
 import { resolve as resolvePath, isAbsolute } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -238,6 +240,13 @@ export function validateConfig(input) {
           `config.matrix[${i}].when.changedPaths must be a non-empty array of glob strings`,
         );
       }
+      for (const g of w.changedPaths) {
+        if (UNSUPPORTED_GLOB_CHARS.test(/** @type {string} */ (g))) {
+          throw new ConfigError(
+            `config.matrix[${i}].when.changedPaths: ${JSON.stringify(g)} uses glob syntax this dialect does not support (only **, *, ?) — a copied CI glob that silently matches nothing would skip this leg on every PR`,
+          );
+        }
+      }
     }
     if (leg.skipWhenDiffOnly !== undefined) {
       if (
@@ -248,6 +257,13 @@ export function validateConfig(input) {
         throw new ConfigError(
           `config.matrix[${i}].skipWhenDiffOnly must be a non-empty array of glob strings`,
         );
+      }
+      for (const g of /** @type {string[]} */ (leg.skipWhenDiffOnly)) {
+        if (UNSUPPORTED_GLOB_CHARS.test(g)) {
+          throw new ConfigError(
+            `config.matrix[${i}].skipWhenDiffOnly: ${JSON.stringify(g)} uses glob syntax this dialect does not support (only **, *, ?)`,
+          );
+        }
       }
     }
     if (leg.passPrBody !== undefined && typeof leg.passPrBody !== "boolean") {

--- a/plugins/dotbabel/src/local-attest-lib.mjs
+++ b/plugins/dotbabel/src/local-attest-lib.mjs
@@ -17,6 +17,9 @@
  * @property {string} name
  * @property {LegMode} mode
  * @property {boolean} passed
+ * @property {boolean} [skipped]  true when diff rules (leg.when / leg.skipWhenDiffOnly)
+ *                               skipped this leg; `passed` is true because the matching
+ *                               CI job skips the same way
  * @property {boolean} [notRun]  true when fail-fast stopped the run before this leg launched;
  *                               `passed` is false so a consumer that forgets to check errs
  *                               toward reporting failure, never success
@@ -223,6 +226,73 @@ export function filterMatrix(matrix, { only = [], from = null } = {}) {
 }
 
 /**
+ * Translate a path glob into a RegExp: `**` crosses separators, `*` and `?`
+ * do not; everything else matches literally. Same zero-dependency semantics
+ * as the protected-path matcher in pr-gates.mjs — duplicated deliberately so
+ * the two modules stay decoupled.
+ *
+ * @param {string} glob
+ * @returns {RegExp}
+ */
+export function globToRegExp(glob) {
+  let out = "^";
+  for (let i = 0; i < glob.length; i += 1) {
+    const ch = glob[i];
+    if (ch === "*") {
+      if (glob[i + 1] === "*") {
+        out += ".*";
+        i += 1;
+        if (glob[i + 1] === "/") i += 1;
+      } else {
+        out += "[^/]*";
+      }
+    } else if (ch === "?") {
+      out += "[^/]";
+    } else {
+      out += ch.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  return new RegExp(`${out}$`);
+}
+
+/**
+ * Apply the config's diff rules to a matrix against the PR's changed files.
+ * Returns a NEW matrix (input untouched) in which affected legs carry
+ * `skipped: true` — legs are marked, never removed, so the result set stays
+ * config-length, the comment table lists every leg CI knows about, and
+ * `shouldAttest`'s expectedLegs invariant holds.
+ *
+ * Fail-open: a null/undefined/empty file list (API failure, zero-file PR)
+ * skips nothing — running too much is safe, running too little is not, since
+ * an attested PR skips every gated remote job.
+ *
+ * - `leg.when.changedPaths`: the leg runs only when SOME changed file matches
+ *   one of the globs (a CI path filter, mirrored locally).
+ * - `leg.skipWhenDiffOnly`: the leg is skipped when EVERY changed file
+ *   matches one of the globs (a docs-only classify rule, mirrored locally).
+ *
+ * @param {Array<object>} matrix
+ * @param {string[]|null|undefined} changedFiles
+ * @returns {Array<object>}
+ */
+export function markSkips(matrix, changedFiles) {
+  const files = Array.isArray(changedFiles) ? changedFiles : [];
+  if (files.length === 0) return matrix.map((leg) => ({ ...leg, skipped: false }));
+  return matrix.map((leg) => {
+    let skipped = false;
+    if (leg.when?.changedPaths) {
+      const res = leg.when.changedPaths.map(globToRegExp);
+      skipped = !files.some((f) => res.some((re) => re.test(f)));
+    }
+    if (!skipped && Array.isArray(leg.skipWhenDiffOnly) && leg.skipWhenDiffOnly.length > 0) {
+      const res = leg.skipWhenDiffOnly.map(globToRegExp);
+      skipped = files.every((f) => res.some((re) => re.test(f)));
+    }
+    return { ...leg, skipped };
+  });
+}
+
+/**
  * Return the last `n` lines of `text`, trimming trailing whitespace.
  *
  * @param {string} text
@@ -251,18 +321,31 @@ export function renderComment(results, { headSha, hostname, toolchain, now }) {
     pass: "pass",
     fail: "FAIL",
     "advisory-fail": "fail (advisory)",
+    skipped: "skipped (diff-scoped)",
     // Unreachable when shouldAttest gates posting, but a future wiring bug
     // must surface as "not run" — never as a pass.
     "not-run": "not run (fail-fast)",
   };
   const rows = results
-    .map((r) => `| ${r.name} | ${r.mode} | ${LABELS[legStatus(r)]} | ${r.durationS}s |`)
+    .map((r) => {
+      const duration = r.skipped ? "\u2014" : `${r.durationS}s`;
+      return `| ${r.name} | ${r.mode} | ${LABELS[legStatus(r)]} | ${duration} |`;
+    })
     .join("\n");
+  // Never claim the full matrix ran when it did not — the comment is the
+  // audit trail for what was actually verified.
+  const skippedCount = results.filter((r) => r.skipped).length;
+  const headline =
+    skippedCount > 0
+      ? `The CI check matrix ran locally and the hard legs passed for \`${headSha.slice(0, 8)}\`. ` +
+        `${skippedCount} leg(s) were skipped for this diff per the config's diff rules \u2014 ` +
+        "the corresponding CI jobs skip the same way."
+      : `The full CI check matrix ran locally and the hard legs passed for \`${headSha.slice(0, 8)}\`.`;
   return [
     marker,
     "## Local Attestation",
     "",
-    `The full CI check matrix ran locally and the hard legs passed for \`${headSha.slice(0, 8)}\`.`,
+    headline,
     "Test and Preview will skip for this commit. A new push re-runs CI automatically.",
     "",
     "| Check | Mode | Result | Duration |",
@@ -296,7 +379,9 @@ export function renderComment(results, { headSha, hostname, toolchain, now }) {
  * @returns {"pass"|"fail"|"advisory-fail"|"not-run"}
  */
 export function legStatus(r) {
-  if (!r || r.notRun) return "not-run";
+  if (!r) return "not-run";
+  if (r.skipped) return "skipped";
+  if (r.notRun) return "not-run";
   if (r.passed) return "pass";
   return r.mode === "advisory" ? "advisory-fail" : "fail";
 }
@@ -317,7 +402,8 @@ export function legStatus(r) {
  * declares.
  *
  * Advisory failures do not block, matching the gate semantics the matrix
- * mirrors. A `--fail-fast` run in which nothing failed completed the full
+ * mirrors. Diff-skipped legs are attestable: the corresponding CI jobs skip
+ * for the same diff, so the attestation claims nothing CI would have run. A `--fail-fast` run in which nothing failed completed the full
  * matrix and may attest.
  *
  * @param {{ diagnostic?: boolean, results: Array<LegResult|undefined>,
@@ -330,8 +416,10 @@ export function shouldAttest({ diagnostic, results, expectedLegs }) {
     Array.isArray(results) &&
     results.length > 0 &&
     (expectedLegs === undefined || results.length === expectedLegs) &&
-    results.every((r) => r && r.notRun !== true && typeof r.passed === "boolean") &&
-    !results.some((r) => r && r.mode === "hard" && !r.passed)
+    results.every(
+      (r) => r && (r.skipped === true || (r.notRun !== true && typeof r.passed === "boolean")),
+    ) &&
+    !results.some((r) => r && !r.skipped && r.mode === "hard" && !r.passed)
   );
 }
 

--- a/plugins/dotbabel/src/local-attest-lib.mjs
+++ b/plugins/dotbabel/src/local-attest-lib.mjs
@@ -227,9 +227,21 @@ export function filterMatrix(matrix, { only = [], from = null } = {}) {
 
 /**
  * Translate a path glob into a RegExp: `**` crosses separators, `*` and `?`
- * do not; everything else matches literally. Same zero-dependency semantics
+ * do not; everything else matches literally. This dialect is a strict subset
+ * of CI path-filter syntax — `{a,b}` alternation and `!` negation are NOT
+ * supported and are rejected at config validation (UNSUPPORTED_GLOB_CHARS),
+ * because a copied CI glob that silently matches nothing would skip its leg
+ * on every PR forever. Same zero-dependency semantics
  * as the protected-path matcher in pr-gates.mjs — duplicated deliberately so
  * the two modules stay decoupled.
+ *
+ * Characters from richer glob dialects that this matcher would misread are
+ * rejected at config validation via this pattern.
+ */
+export const UNSUPPORTED_GLOB_CHARS = /[!{}[\]]/;
+
+/**
+ * (see the dialect note in the doc block above UNSUPPORTED_GLOB_CHARS)
  *
  * @param {string} glob
  * @returns {RegExp}
@@ -338,8 +350,8 @@ export function renderComment(results, { headSha, hostname, toolchain, now }) {
   const headline =
     skippedCount > 0
       ? `The CI check matrix ran locally and the hard legs passed for \`${headSha.slice(0, 8)}\`. ` +
-        `${skippedCount} leg(s) were skipped for this diff per the config's diff rules \u2014 ` +
-        "the corresponding CI jobs skip the same way."
+        `${skippedCount} leg(s) were skipped for this diff per this repo's local-attest diff rules ` +
+        "(see .local-attest config; the rules are the config author's mirror of CI's own path filters)."
       : `The full CI check matrix ran locally and the hard legs passed for \`${headSha.slice(0, 8)}\`.`;
   return [
     marker,
@@ -376,12 +388,11 @@ export function renderComment(results, { headSha, hostname, toolchain, now }) {
  * so is the honest reading of a hole.
  *
  * @param {LegResult|undefined} r
- * @returns {"pass"|"fail"|"advisory-fail"|"not-run"}
+ * @returns {"pass"|"fail"|"advisory-fail"|"skipped"|"not-run"}
  */
 export function legStatus(r) {
-  if (!r) return "not-run";
+  if (!r || r.notRun) return "not-run";
   if (r.skipped) return "skipped";
-  if (r.notRun) return "not-run";
   if (r.passed) return "pass";
   return r.mode === "advisory" ? "advisory-fail" : "fail";
 }
@@ -402,8 +413,10 @@ export function legStatus(r) {
  * declares.
  *
  * Advisory failures do not block, matching the gate semantics the matrix
- * mirrors. Diff-skipped legs are attestable: the corresponding CI jobs skip
- * for the same diff, so the attestation claims nothing CI would have run. A `--fail-fast` run in which nothing failed completed the full
+ * mirrors. Diff-skipped legs are attestable ONLY alongside at least one
+ * executed leg, and their soundness rests on the config's globs mirroring
+ * the CI path filters — a burden the config author carries (see the
+ * operator guide's drift caveat); nothing here verifies the workflows. A `--fail-fast` run in which nothing failed completed the full
  * matrix and may attest.
  *
  * @param {{ diagnostic?: boolean, results: Array<LegResult|undefined>,
@@ -417,8 +430,16 @@ export function shouldAttest({ diagnostic, results, expectedLegs }) {
     results.length > 0 &&
     (expectedLegs === undefined || results.length === expectedLegs) &&
     results.every(
-      (r) => r && (r.skipped === true || (r.notRun !== true && typeof r.passed === "boolean")),
+      (r) =>
+        r &&
+        ((r.skipped === true && r.notRun !== true) ||
+          (r.notRun !== true && typeof r.passed === "boolean")),
     ) &&
+    // Floor: at least one leg actually executed. An all-skipped run has
+    // verified nothing, and the marker it would post switches off every gated
+    // CI job — for a diff that skips everything locally, CI's own path
+    // filters already skip the same jobs, so nothing is lost by refusing.
+    results.some((r) => r && !r.skipped && r.notRun !== true) &&
     !results.some((r) => r && !r.skipped && r.mode === "hard" && !r.passed)
   );
 }

--- a/plugins/dotbabel/src/local-attest-runner.mjs
+++ b/plugins/dotbabel/src/local-attest-runner.mjs
@@ -21,7 +21,8 @@
  * @property {(cmd: string, opts?: { cwd?: string, env?: Record<string,string>, capture?: boolean }) => { status: number, stdout: string, stderr: string }} run
  * @property {(cmd: string, payload: object) => string} ghApiWithInput
  * @property {(path: string, line: string) => void} appendLog
- * @property {(path: string) => string|null} [readFile]  utf8 read, null on any error
+ * @property {(path: string) => Buffer|string|null} [readFile]  raw read (Buffer in
+ *   realDeps; test stubs may return strings), null on any error
  * @property {(path: string, content: string) => void} [writeFile]  utf8 write; used only
  *   by the restoreFiles snapshot/restore
  * @property {(leg: Leg) => Promise<import("./local-attest-lib.mjs").LegResult>} [runLeg]
@@ -98,8 +99,10 @@ export function realDeps() {
       appendFileSync(path, line);
     },
     readFile(path) {
+      // No encoding: returns a Buffer so restoreFiles round-trips binaries
+      // byte-exact. Text consumers (gatherToolchain) coerce with String().
       try {
-        return readFileSync(path, "utf8");
+        return readFileSync(path);
       } catch {
         return null;
       }
@@ -231,7 +234,8 @@ function gatherToolchain(deps, cfg) {
     // A direct file read, not a shell cat: this module forbids interpolating
     // strings into shell commands, and validateConfig constrains the path the
     // same way auditLogPath is constrained.
-    inputs.goModText = deps.readFile ? (deps.readFile(pin.goMod) ?? "") : "";
+    const goModRaw = deps.readFile ? deps.readFile(pin.goMod) : null;
+    inputs.goModText = goModRaw === null ? "" : String(goModRaw);
   }
   return { problems: toolchainProblems(inputs), seen };
 }
@@ -485,7 +489,27 @@ export async function runMatrix(deps, matrix, { failFast = false } = {}) {
     }
   };
 
-  await Promise.all(lanes.map(runLane));
+  // allSettled, not all: a rejecting consumer-supplied runLeg must not unwind
+  // the caller while sibling lanes still have live children — the matrix must
+  // be quiescent before execute's restore runs. A rejected lane's unfilled
+  // slots become hard-failed records, which shouldAttest rejects.
+  const settled = await Promise.allSettled(lanes.map(runLane));
+  for (const outcome of settled) {
+    if (outcome.status === "rejected") {
+      deps.warn(`WARNING: a lane rejected: ${outcome.reason?.message ?? outcome.reason}`);
+    }
+  }
+  for (let i = 0; i < matrix.length; i += 1) {
+    if (!results[i]) {
+      results[i] = {
+        name: matrix[i].name,
+        mode: matrix[i].mode,
+        passed: false,
+        durationS: 0,
+        tail: "lane rejected before this leg settled",
+      };
+    }
+  }
   return results;
 }
 
@@ -596,17 +620,48 @@ export function snapshotRestoreFiles(deps, paths) {
  * @returns {string[]} the paths actually restored
  */
 export function restoreRestoreFiles(deps, snap) {
+  const same = (a, b) => {
+    if (a === null || b === null) return false;
+    if (typeof a === "string" || typeof b === "string") return String(a) === String(b);
+    return a.equals(b);
+  };
   const restored = [];
   for (const [rel, before] of snap) {
+    // A null SNAPSHOT means the file did not exist before the matrix — never
+    // create it. A null CURRENT read means a leg deleted it — that is the
+    // mutation the operator most wants undone, so restore it.
     if (before === null) continue;
     const now = deps.readFile ? deps.readFile(rel) : null;
-    if (now === null || now === before) continue;
+    if (same(now, before)) continue;
     if (deps.writeFile) {
       deps.writeFile(rel, before);
       restored.push(rel);
     }
   }
   return restored;
+}
+
+/**
+ * Guarded restore wrapper. A restore failure (read-only file, removed parent
+ * dir) must never replace the matrix's own exception or skip the audit line —
+ * it warns instead, and the unrestored file then surfaces as a dirty tree in
+ * verifyHeadUnchanged: fail-closed, correctly diagnosed, still audited.
+ *
+ * @param {Deps} deps
+ * @param {Map<string, Buffer|string|null>} snapshot
+ */
+function safeRestore(deps, snapshot) {
+  try {
+    const restored = restoreRestoreFiles(deps, snapshot);
+    if (restored.length > 0) {
+      deps.log(`Restored ${restored.length} seeded file(s): ${restored.join(", ")}`);
+    }
+  } catch (err) {
+    deps.warn(
+      `WARNING: restoring seeded files failed (${err?.message ?? err}) — ` +
+        "the head recheck will flag any residue as a dirty tree.",
+    );
+  }
 }
 
 const SUMMARY_LABELS = {
@@ -674,7 +729,14 @@ export async function execute(deps, cfg, flags) {
       `Diagnostic run: ${matrix.length} of ${cfg.matrix.length} leg(s) — attestation disabled.`,
     );
 
-    const results = await runMatrix(deps, matrix, { failFast });
+    // The fix-retry loop hits the seeding legs hardest — restore here too.
+    const diagSnapshot = snapshotRestoreFiles(deps, cfg.restoreFiles ?? []);
+    let results;
+    try {
+      results = await runMatrix(deps, matrix, { failFast });
+    } finally {
+      safeRestore(deps, diagSnapshot);
+    }
     printSummary(deps, results);
     const { advisoryFails } = summarizeResults(results);
     appendAuditLog(deps, {
@@ -712,14 +774,31 @@ export async function execute(deps, cfg, flags) {
   let matrix = cfg.matrix;
   const usesDiffRules = cfg.matrix.some((l) => l.when || l.skipWhenDiffOnly);
   if (usesDiffRules) {
+    // JSON output (not newline-splitting, which would fragment a legal
+    // newline-bearing path into non-matching pieces) plus a count cross-check
+    // against the PR's own changedFiles total: the Files endpoint silently
+    // caps at 3000 files, and a truncated list would bias BOTH diff rules
+    // toward skipping \u2014 the one direction this design must never fail in.
     let changedFiles = null;
     try {
-      changedFiles = capture(
+      const raw = capture(
         deps,
-        `gh api repos/${pre.repo}/pulls/${pre.pr}/files --paginate --jq '.[].filename'`,
-      )
+        `gh api repos/${pre.repo}/pulls/${pre.pr}/files --paginate --jq '[.[].filename]'`,
+      );
+      const parsed = raw
         .split("\n")
-        .filter(Boolean);
+        .filter(Boolean)
+        .flatMap((page) => JSON.parse(page));
+      const declared = Number(
+        capture(deps, `gh pr view ${pre.pr} --json changedFiles --jq .changedFiles`),
+      );
+      if (!Number.isFinite(declared) || declared !== parsed.length || declared >= 3000) {
+        deps.warn(
+          `WARNING: PR file list looks incomplete (parsed ${parsed.length}, PR declares ${declared}) \u2014 running every leg to be safe.`,
+        );
+      } else {
+        changedFiles = parsed;
+      }
     } catch {
       deps.warn("WARNING: could not read the PR file list \u2014 running every leg to be safe.");
     }
@@ -747,10 +826,7 @@ export async function execute(deps, cfg, flags) {
   try {
     results = await runMatrix(deps, matrix, { failFast });
   } finally {
-    const restored = restoreRestoreFiles(deps, snapshot);
-    if (restored.length > 0) {
-      deps.log(`Restored ${restored.length} seeded file(s): ${restored.join(", ")}`);
-    }
+    safeRestore(deps, snapshot);
   }
   const { hardFails, advisoryFails } = summarizeResults(results);
   printSummary(deps, results);

--- a/plugins/dotbabel/src/local-attest-runner.mjs
+++ b/plugins/dotbabel/src/local-attest-runner.mjs
@@ -22,6 +22,11 @@
  * @property {(cmd: string, payload: object) => string} ghApiWithInput
  * @property {(path: string, line: string) => void} appendLog
  * @property {(path: string) => string|null} [readFile]  utf8 read, null on any error
+ * @property {(path: string, content: string) => void} [writeFile]  utf8 write; used only
+ *   by the restoreFiles snapshot/restore
+ * @property {(leg: Leg) => Promise<import("./local-attest-lib.mjs").LegResult>} [runLeg]
+ *   async leg executor enabling concurrent lanes; absent in a stub, runMatrix
+ *   falls back to a promise-wrapped `run`, preserving fully synchronous tests
  * @property {() => string} hostname
  * @property {(msg: string) => void} log
  * @property {(msg: string) => void} warn
@@ -40,8 +45,8 @@
  *   against the config pins; null when no pins are configured
  */
 
-import { spawnSync } from "node:child_process";
-import { appendFileSync, readFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 
 import {
@@ -50,6 +55,7 @@ import {
   findAttestComment,
   goMajorMinorFromVersion,
   legStatus,
+  markSkips,
   renderComment,
   shouldAttest,
   summarizeResults,
@@ -97,6 +103,60 @@ export function realDeps() {
       } catch {
         return null;
       }
+    },
+    writeFile(path, content) {
+      writeFileSync(path, content);
+    },
+    // Async leg executor for concurrent lanes. Differences from the sync
+    // `run` are deliberate: stdin is "ignore" because two concurrent children
+    // cannot share one terminal (a prompting leg should EOF-fail fast, not
+    // hang); output is decoded with setEncoding so a UTF-8 sequence straddling
+    // a chunk boundary cannot corrupt the failure tail; buffers are bounded
+    // 256 KB rolling windows since only tail() output is ever rendered; and
+    // the "error" event settles too — Node does not guarantee "close" after a
+    // failed spawn (ENOENT cwd, EMFILE), and without it a lane awaits forever.
+    runLeg(leg) {
+      return new Promise((resolve) => {
+        const started = Date.now();
+        let settled = false;
+        const child = spawn(leg.command, {
+          shell: true,
+          cwd: leg.cwd,
+          env: { ...process.env, ...leg.env },
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        child.stdout.setEncoding("utf8");
+        child.stderr.setEncoding("utf8");
+        const CAP = 256 * 1024;
+        let stdout = "";
+        let stderr = "";
+        const append = (buf, d) => {
+          const next = buf + d;
+          return next.length > CAP ? next.slice(-CAP) : next;
+        };
+        const settle = (code) => {
+          if (settled) return;
+          settled = true;
+          resolve({
+            name: leg.name,
+            mode: leg.mode,
+            passed: code === 0,
+            durationS: Math.round((Date.now() - started) / 1000),
+            tail: tail(`${stdout}\n${stderr}`),
+          });
+        };
+        child.stdout.on("data", (d) => {
+          stdout = append(stdout, d);
+        });
+        child.stderr.on("data", (d) => {
+          stderr = append(stderr, d);
+        });
+        child.on("error", (err) => {
+          stderr = append(stderr, `\nspawn failed: ${err.message}\n`);
+          settle(-1);
+        });
+        child.on("close", settle);
+      });
     },
     hostname() {
       return os.hostname();
@@ -344,8 +404,12 @@ export function checkPreconditions(deps, cfg, opts = {}) {
 }
 
 /**
- * Execute the matrix sequentially. Each leg runs to completion; output is
- * tailed at 10 lines so large logs don't bloat the result struct.
+ * Execute the matrix as concurrent lanes: legs sharing a `lane` run serially
+ * in matrix order; distinct lanes run in parallel; legs without a lane share
+ * one default lane, so a lane-less matrix is fully sequential. Results are
+ * preallocated by matrix index — the summary, comment table, and audit line
+ * keep config order regardless of completion order. Output is tailed at 10
+ * lines so large logs don't bloat the result struct.
  *
  * With `failFast`, a hard failure stops launching further legs; the remainder
  * are recorded as `{ notRun: true, passed: false }` — fail-closed for any
@@ -358,37 +422,70 @@ export function checkPreconditions(deps, cfg, opts = {}) {
  * @param {{ failFast?: boolean }} [opts]
  * @returns {LegResult[]}
  */
-export function runMatrix(deps, matrix, { failFast = false } = {}) {
-  /** @type {LegResult[]} */
-  const results = [];
+export async function runMatrix(deps, matrix, { failFast = false } = {}) {
+  /** @type {import("./local-attest-lib.mjs").LegResult[]} */
+  const results = new Array(matrix.length);
   let aborted = false;
-  for (const leg of matrix) {
-    if (aborted) {
-      results.push({
+  // Stubs without an async executor fall back to the sync run, promise-wrapped
+  // — a lane-less matrix then behaves byte-for-byte like the sequential runner.
+  const runLeg =
+    deps.runLeg ??
+    (async (leg) => {
+      const started = Date.now();
+      const r = deps.run(leg.command, { cwd: leg.cwd, env: leg.env });
+      return {
         name: leg.name,
         mode: leg.mode,
-        passed: false,
-        notRun: true,
-        durationS: 0,
-        tail: "",
-      });
-      deps.log(`--- ${leg.name}: NOT RUN (fail-fast)`);
-      continue;
+        passed: r.status === 0,
+        durationS: Math.round((Date.now() - started) / 1000),
+        tail: tail(`${r.stdout || ""}\n${r.stderr || ""}`),
+      };
+    });
+
+  const lanes = [...new Set(matrix.map((l) => l.lane ?? ""))];
+  const runLane = async (lane) => {
+    for (let i = 0; i < matrix.length; i += 1) {
+      const leg = matrix[i];
+      if ((leg.lane ?? "") !== lane) continue;
+      // Skipped before aborted: a diff-skipped leg stays honestly "skipped"
+      // even after a fail-fast trip — it was never going to run.
+      if (leg.skipped) {
+        results[i] = {
+          name: leg.name,
+          mode: leg.mode,
+          passed: true,
+          skipped: true,
+          durationS: 0,
+          tail: "",
+        };
+        deps.log(`--- ${leg.name}: SKIPPED (diff-scoped; the matching CI job skips too)`);
+        continue;
+      }
+      if (aborted) {
+        results[i] = {
+          name: leg.name,
+          mode: leg.mode,
+          passed: false,
+          notRun: true,
+          durationS: 0,
+          tail: "",
+        };
+        deps.log(`--- ${leg.name}: NOT RUN (fail-fast)`);
+        continue;
+      }
+      deps.log(`\n=== ${leg.name} (${leg.mode}) ===`);
+      const r = await runLeg(leg);
+      results[i] = r;
+      deps.log(`--- ${leg.name}: ${r.passed ? "PASS" : "FAIL"} (${r.durationS}s)`);
+      if (!r.passed) deps.log(r.tail);
+      if (failFast && !r.passed && leg.mode === "hard") {
+        aborted = true;
+        deps.log(`fail-fast: ${leg.name} failed \u2014 remaining legs will not run.`);
+      }
     }
-    deps.log(`\n=== ${leg.name} (${leg.mode}) ===`);
-    const started = Date.now();
-    const r = deps.run(leg.command, { cwd: leg.cwd, env: leg.env });
-    const durationS = Math.round((Date.now() - started) / 1000);
-    const passed = r.status === 0;
-    const output = tail(`${r.stdout || ""}\n${r.stderr || ""}`);
-    results.push({ name: leg.name, mode: leg.mode, passed, durationS, tail: output });
-    deps.log(`--- ${leg.name}: ${passed ? "PASS" : "FAIL"} (${durationS}s)`);
-    if (!passed) deps.log(output);
-    if (failFast && !passed && leg.mode === "hard") {
-      aborted = true;
-      deps.log(`fail-fast: ${leg.name} failed — remaining legs will not run.`);
-    }
-  }
+  };
+
+  await Promise.all(lanes.map(runLane));
   return results;
 }
 
@@ -471,10 +568,52 @@ export function appendAuditLog(deps, { auditLogPath, ...entryInput }) {
   }
 }
 
+/**
+ * Snapshot the config's restoreFiles through deps.readFile. A null entry means
+ * the file was absent — restore will not create it.
+ *
+ * @param {Deps} deps
+ * @param {string[]} paths
+ * @returns {Map<string, string|null>}
+ */
+export function snapshotRestoreFiles(deps, paths) {
+  const snap = new Map();
+  for (const rel of paths) {
+    snap.set(rel, deps.readFile ? deps.readFile(rel) : null);
+  }
+  return snap;
+}
+
+/**
+ * Put the snapshot back, byte for byte, through deps.writeFile. Restores only
+ * files a leg actually changed, never creates an absent file, and never
+ * touches anything outside the snapshot. Runs in execute's finally BEFORE the
+ * post-matrix head recheck — otherwise the recheck aborts every run on the
+ * matrix's own writes.
+ *
+ * @param {Deps} deps
+ * @param {Map<string, string|null>} snap
+ * @returns {string[]} the paths actually restored
+ */
+export function restoreRestoreFiles(deps, snap) {
+  const restored = [];
+  for (const [rel, before] of snap) {
+    if (before === null) continue;
+    const now = deps.readFile ? deps.readFile(rel) : null;
+    if (now === null || now === before) continue;
+    if (deps.writeFile) {
+      deps.writeFile(rel, before);
+      restored.push(rel);
+    }
+  }
+  return restored;
+}
+
 const SUMMARY_LABELS = {
   pass: "PASS",
   fail: "FAIL",
   "advisory-fail": "fail (advisory)",
+  skipped: "SKIPPED (diff-scoped)",
   "not-run": "NOT RUN (fail-fast)",
 };
 
@@ -513,7 +652,7 @@ function printSummary(deps, results) {
  *           only?: string[], from?: string|null, failFast?: boolean }} flags
  * @returns {{ ok: boolean, body: string, results: LegResult[], pre: Preconditions|null, exitCode: number }}
  */
-export function execute(deps, cfg, flags) {
+export async function execute(deps, cfg, flags) {
   const only = flags.only ?? [];
   const from = flags.from ?? null;
   const failFast = flags.failFast === true;
@@ -535,7 +674,7 @@ export function execute(deps, cfg, flags) {
       `Diagnostic run: ${matrix.length} of ${cfg.matrix.length} leg(s) — attestation disabled.`,
     );
 
-    const results = runMatrix(deps, matrix, { failFast });
+    const results = await runMatrix(deps, matrix, { failFast });
     printSummary(deps, results);
     const { advisoryFails } = summarizeResults(results);
     appendAuditLog(deps, {
@@ -565,7 +704,54 @@ export function execute(deps, cfg, flags) {
   const pre = checkPreconditions(deps, cfg, { prOverride: flags.prOverride });
   deps.log(`Attesting PR #${pre.pr} (${pre.repo}) at ${pre.headSha.slice(0, 8)}.`);
 
-  const results = runMatrix(deps, cfg.matrix, { failFast });
+  // Diff rules: one paginated Files API call drives every when/skipWhenDiffOnly
+  // decision (the paginated endpoint, not `gh pr view --json files`, which caps
+  // at 100 files and would silently mis-classify a large PR). Fail-open: an
+  // unreadable list runs everything — running too much is safe, an attested PR
+  // skipping too much is not.
+  let matrix = cfg.matrix;
+  const usesDiffRules = cfg.matrix.some((l) => l.when || l.skipWhenDiffOnly);
+  if (usesDiffRules) {
+    let changedFiles = null;
+    try {
+      changedFiles = capture(
+        deps,
+        `gh api repos/${pre.repo}/pulls/${pre.pr}/files --paginate --jq '.[].filename'`,
+      )
+        .split("\n")
+        .filter(Boolean);
+    } catch {
+      deps.warn("WARNING: could not read the PR file list \u2014 running every leg to be safe.");
+    }
+    matrix = markSkips(cfg.matrix, changedFiles);
+    const skippedNames = matrix.filter((l) => l.skipped).map((l) => l.name);
+    if (skippedNames.length > 0) {
+      deps.log(`Diff rules skip ${skippedNames.length} leg(s): ${skippedNames.join(", ")}`);
+    }
+  }
+
+  // PR body injection: fetched once, empty on error (the consuming leg treats
+  // an empty body as a non-PR context). Env passing, never shell interpolation.
+  if (matrix.some((l) => l.passPrBody)) {
+    let prBody = "";
+    try {
+      prBody = capture(deps, `gh pr view ${pre.pr} --json body --jq .body`);
+    } catch {
+      // Empty is safe; the leg's consumer must tolerate a missing body.
+    }
+    matrix = matrix.map((l) => (l.passPrBody ? { ...l, env: { ...l.env, PR_BODY: prBody } } : l));
+  }
+
+  const snapshot = snapshotRestoreFiles(deps, cfg.restoreFiles ?? []);
+  let results;
+  try {
+    results = await runMatrix(deps, matrix, { failFast });
+  } finally {
+    const restored = restoreRestoreFiles(deps, snapshot);
+    if (restored.length > 0) {
+      deps.log(`Restored ${restored.length} seeded file(s): ${restored.join(", ")}`);
+    }
+  }
   const { hardFails, advisoryFails } = summarizeResults(results);
   printSummary(deps, results);
 

--- a/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
@@ -145,9 +145,11 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
    the first hard failure stops launching further legs in every lane; the
    rest are recorded `not run`, never as passes.
 3. **Attestation bar.** Posting is gated on a run-record predicate: every leg
-   executed, zero hard fails, not a diagnostic subset. A run that fails the
-   bar aborts — no comment, no label, no push — and still writes its audit
-   line (`result: "hard-fail"`).
+   accounted for — executed or diff-skipped — at least one leg actually
+   executed (an all-skipped run has verified nothing and refuses to attest;
+   CI's own path filters already skip the same jobs), zero hard fails, not a
+   diagnostic subset. A run that fails the bar aborts — no comment, no label,
+   no push — and still writes its audit line (`result: "hard-fail"`).
 4. **Re-check HEAD.** First, `restoreFiles` snapshots taken before the matrix
    are restored byte-exact (a leg that seeds fixture stubs over tracked files
    would otherwise fail this recheck on its own writes, every run). Then: the

--- a/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/SKILL.md
@@ -2,7 +2,7 @@
 id: local-attest
 name: local-attest
 type: skill
-version: 1.1.0
+version: 1.2.0
 domain: [devex, observability]
 platform: [github-actions]
 task: [testing, runtime-ops]
@@ -30,9 +30,9 @@ a hidden marker comment to the open PR so the remote `Test` / `Preview` jobs
 read the marker and skip themselves for that exact commit.
 
 > **This skill is side-effectful and slow.** It runs every leg of your CI
-> matrix sequentially — minutes to tens of minutes, whatever the configured
-> matrix costs — posts a PR comment, applies a label, and pushes the current
-> branch. Invoke only when you've decided to attest a specific PR. For the
+> matrix — serially within a lane, lanes in parallel; minutes to tens of
+> minutes, whatever the configured matrix costs — posts a PR comment, applies
+> a label, and pushes the current branch. Invoke only when you've decided to attest a specific PR. For the
 > fix-retry loop, use the diagnostic modes below instead: they run subsets,
 > tolerate a dirty tree, and are structurally unable to attest.
 
@@ -135,16 +135,23 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
    `author_association` on the repo (OWNER / MEMBER / COLLABORATOR, etc.) is
    not in the config's `trustedAssociations` list — the attestation will post
    but CI will ignore it.
-2. **Run matrix.** Each leg from the config runs sequentially. Hard legs must
-   pass to attest; advisory legs are reported but never block. Stdout + stderr
-   are tailed at 10 lines per leg so the result table stays readable. With
-   `--fail-fast`, the first hard failure stops launching further legs; the
+2. **Run matrix.** Legs sharing a `lane` run serially in matrix order;
+   distinct lanes run concurrently; a config without lanes runs fully
+   sequentially. Diff rules (`when.changedPaths`, `skipWhenDiffOnly`) mark
+   legs skipped against the PR's changed files — skipped legs still appear in
+   every table, and the comment headline says so rather than claiming a full
+   run. Hard legs must pass to attest; advisory legs are reported but never
+   block. Stdout + stderr are tailed at 10 lines per leg. With `--fail-fast`,
+   the first hard failure stops launching further legs in every lane; the
    rest are recorded `not run`, never as passes.
 3. **Attestation bar.** Posting is gated on a run-record predicate: every leg
    executed, zero hard fails, not a diagnostic subset. A run that fails the
    bar aborts — no comment, no label, no push — and still writes its audit
    line (`result: "hard-fail"`).
-4. **Re-check HEAD.** The matrix takes minutes — long enough for another agent
+4. **Re-check HEAD.** First, `restoreFiles` snapshots taken before the matrix
+   are restored byte-exact (a leg that seeds fixture stubs over tracked files
+   would otherwise fail this recheck on its own writes, every run). Then: the
+   matrix takes minutes — long enough for another agent
    session, another worktree, or you in a second terminal to commit onto the
    same branch. Step 1's check is stale by now, so HEAD and the worktree are
    re-asserted against what was actually tested. If either moved, everything

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
@@ -61,10 +61,21 @@ reorders anything — skipped legs are marked, not removed. Diff globs use
 `**` (crosses directories), `*` and `?` (single segment). All four fields are
 plain data, so they work identically in `.mjs` and `.json` configs.
 
-Fail-open rule: when the PR's changed-file list cannot be read (API failure,
-detached context), `when`/`skipWhenDiffOnly` skip nothing and every leg runs.
-Running too much is safe; an attested PR that skipped too much has disabled
-CI on unverified code.
+Fail-open rule: when the PR's changed-file list cannot be read, looks
+truncated (the Files API caps at 3000 files — the tool cross-checks the
+parsed list against the PR's declared `changedFiles` count), or is empty,
+`when`/`skipWhenDiffOnly` skip nothing and every leg runs. Running too much
+is safe; an attested PR that skipped too much has disabled CI on unverified
+code. An all-skipped run refuses to attest for the same reason.
+
+**The superset burden is yours.** Nothing verifies these globs against
+`.github/workflows/**`. A `when` glob narrower than the mirrored CI job's
+`paths:` filter skips the leg locally while the attestation switches that job
+off remotely — unverified code merges with CI disabled. Keep every diff-rule
+glob at least as broad as the CI filter it mirrors, and re-check the pair
+whenever either side changes. The dialect is deliberately small (`**`, `*`,
+`?`); CI syntax like `{a,b}` or `!` is rejected at validation rather than
+silently matching nothing.
 
 The matrix is the only required field; everything else has sensible defaults.
 
@@ -78,7 +89,7 @@ Every run whose matrix executes appends exactly one JSONL line to
 `auditLogPath`, tagged `result: attested | hard-fail | head-moved | push-fail
 | post-fail | dry-run | diagnostic`, with per-leg
 `{name, mode, status, durationS}` (`status ∈ pass | fail | advisory-fail |
-not-run`), the invocation `flags`, the certified `toolchain` versions when
+skipped | not-run`), the invocation `flags`, the certified `toolchain` versions when
 pins are configured, and — for diagnostic runs — a `dirty` marker, because a
 dirty tree's `sha` does not identify the tree that ran.
 Lines written by versions before `result` existed were only ever written

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
@@ -20,7 +20,11 @@ type Config = {
       | "advisory"; // "advisory" legs report but never block
     command: string; // shell command (runs under `bash -c`)
     cwd?: string; // working dir relative to project root
-    env?: Record<string, string>; // extra env vars for this leg only
+    env?: Record<string, string>; // extra env vars for this leg only (values must be strings)
+    lane?: string; // legs sharing a lane run serially in matrix order; distinct lanes run concurrently
+    when?: { changedPaths: string[] }; // run only when SOME changed PR file matches a glob (CI path filter, mirrored)
+    skipWhenDiffOnly?: string[]; // skip when EVERY changed PR file matches a glob (docs-only classify, mirrored)
+    passPrBody?: boolean; // inject the PR body as env.PR_BODY for this leg
   }>;
 
   label?: string; // PR label to apply on attest (default: "ci/local-verified")
@@ -39,8 +43,28 @@ type Config = {
     node?: string; // exact major pin ("22"); range syntax (">=22", "^22") is rejected
     goMod?: string; // relative path (no "..") to a go.mod; its go directive major.minor must match `go version`
   };
+
+  // Tracked files a leg is known to overwrite (e2e fixture seeders). They are
+  // snapshotted before the matrix and restored byte-exact afterwards, BEFORE
+  // the post-matrix head recheck — without this, the recheck aborts every run
+  // on the matrix's own writes. Relative paths, no "..".
+  restoreFiles?: string[];
 };
 ```
+
+### Lanes: the authoring contract
+
+Concurrent lanes share one worktree. Two rules keep that safe: **legs that
+mutate the tree, and every leg that reads what they mutate, must share one
+lane, ordered readers-first in the matrix**; and glob-gated skipping never
+reorders anything — skipped legs are marked, not removed. Diff globs use
+`**` (crosses directories), `*` and `?` (single segment). All four fields are
+plain data, so they work identically in `.mjs` and `.json` configs.
+
+Fail-open rule: when the PR's changed-file list cannot be read (API failure,
+detached context), `when`/`skipWhenDiffOnly` skip nothing and every leg runs.
+Running too much is safe; an attested PR that skipped too much has disabled
+CI on unverified code.
 
 The matrix is the only required field; everything else has sensible defaults.
 
@@ -138,6 +162,9 @@ export default {
 - Leg `name`s must be unique within the matrix.
 - `auditLogPath` must not contain `..` segments (path-traversal guard).
 - `trustedAssociations` must be a non-empty array of strings.
+- `env` values must be strings; `lane` non-empty; `when` exactly
+  `{ changedPaths: [globs] }` (non-empty); `skipWhenDiffOnly` a non-empty glob
+  array; `passPrBody` boolean; `restoreFiles` relative paths without `..`.
 - Unknown top-level keys are ignored. Defaults are merged from
   `plugins/dotbabel/src/local-attest-config.mjs:DEFAULTS`.
 

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/operator-guide.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/operator-guide.md
@@ -75,7 +75,14 @@ run in which nothing failed completed the full matrix and attests normally.
 `--only <leg>` / `--from <leg>` are diagnostic modes for the fix-retry loop:
 subsets under relaxed preconditions (dirty tree fine, no PR needed) that never
 post, label, or push, and exit 1 on any selected-leg failure, advisory
-included.
+included. `restoreFiles` snapshots and restores in diagnostic runs too.
+
+Config-side execution controls (see [config.md](config.md)): `lane` groups
+legs into concurrent lanes; `when.changedPaths` and `skipWhenDiffOnly` mark
+legs skipped against the PR's changed files (skipped legs still appear in
+every table with status `skipped`, and an all-skipped run refuses to attest);
+`passPrBody` injects the PR body as `env.PR_BODY`; `restoreFiles` snapshots
+tracked files a leg overwrites and restores them before the head recheck.
 
 ## Trust model
 
@@ -140,8 +147,9 @@ the diff manually whenever either side changes.
 
 ### Long-running matrices
 
-Attestation runs the matrix sequentially and costs whatever the configured
-legs cost — minutes for a lint-and-unit matrix, tens of minutes with heavy
+Attestation runs legs serially within a lane and lanes concurrently (a
+config without `lane` fields is fully sequential), and costs whatever the
+configured legs cost — minutes for a lint-and-unit matrix, tens of minutes with heavy
 e2e and multiple language runtimes. That's the deliberate price of skipping
 the remote run; use `--only`/`--from`/`--fail-fast` for iteration and save
 full runs for attestation.
@@ -173,7 +181,8 @@ for **every run whose matrix executes** — failures included — tagged with a
 ```
 
 `result` is one of `attested | hard-fail | head-moved | push-fail | post-fail
-| dry-run | diagnostic`. Lines written by versions before `result` existed
+| dry-run | diagnostic`; per-leg `status` is one of `pass | fail |
+advisory-fail | skipped | not-run`. Lines written by versions before `result` existed
 were only ever written after a successful post, so a missing `result` implies
 `attested`. Diagnostic lines add `dirty: true|false`, because a dirty tree's
 `sha` does not identify the tree that ran.
@@ -183,3 +192,13 @@ were only ever written after a successful post, so a missing `result` implies
 the `--dry-run` this guide recommends for validating a new config, so an
 untracked log makes the very next attest abort on its own output. The
 contract is single-line JSONL so any log shipper handles it natively.
+
+### Drift now has two axes
+
+The classic drift is matrix membership: a CI job with no local leg is
+enforced nowhere once a PR attests. Diff rules add a second axis: a local
+`when`/`skipWhenDiffOnly` glob narrower than the mirrored job's `paths:`
+filter skips the leg locally while the attestation disables the job remotely.
+Nothing cross-checks the globs against `.github/workflows/**` — the config
+author owns that mirror, and each diff-gated leg should cite the workflow
+filter it mirrors in a comment so the pair is reviewable together.

--- a/plugins/dotbabel/tests/local-attest-config.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-config.test.mjs
@@ -259,6 +259,16 @@ describe("validateConfig", () => {
     expect(() => validateConfig({ ...base(), restoreFiles: ["../x"] })).toThrow(/'\.\.'/);
   });
 
+  it("rejects CI glob syntax this dialect would silently misread", () => {
+    const leg = (extra) => ({ matrix: [{ name: "a", mode: "hard", command: "true", ...extra }] });
+    for (const bad of ["src/**/*.{ts,tsx}", "!docs/**", "src/[abc].js"]) {
+      expect(() => validateConfig(leg({ when: { changedPaths: [bad] } }))).toThrow(
+        /does not support/,
+      );
+      expect(() => validateConfig(leg({ skipWhenDiffOnly: [bad] }))).toThrow(/does not support/);
+    }
+  });
+
   it("rejects non-string env values — they flow straight into the child environment", () => {
     expect(() =>
       validateConfig({ matrix: [{ name: "a", mode: "hard", command: "true", env: { X: 1 } }] }),

--- a/plugins/dotbabel/tests/local-attest-config.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-config.test.mjs
@@ -217,6 +217,54 @@ describe("validateConfig", () => {
     });
   });
 
+  it("accepts lane, when, skipWhenDiffOnly, passPrBody per leg and restoreFiles top-level", () => {
+    const cfg = validateConfig({
+      matrix: [
+        {
+          name: "a",
+          mode: "hard",
+          command: "true",
+          lane: "go",
+          when: { changedPaths: ["api/**"] },
+          skipWhenDiffOnly: ["docs/**"],
+          passPrBody: true,
+        },
+      ],
+      restoreFiles: ["src/a.js"],
+    });
+    expect(cfg.matrix[0]).toMatchObject({
+      lane: "go",
+      when: { changedPaths: ["api/**"] },
+      skipWhenDiffOnly: ["docs/**"],
+      passPrBody: true,
+    });
+    expect(cfg.restoreFiles).toEqual(["src/a.js"]);
+  });
+
+  it("defaults restoreFiles to an empty array", () => {
+    expect(validateConfig(base()).restoreFiles).toEqual([]);
+  });
+
+  it("rejects malformed lane/when/skipWhenDiffOnly/passPrBody/restoreFiles", () => {
+    const leg = (extra) => ({ matrix: [{ name: "a", mode: "hard", command: "true", ...extra }] });
+    expect(() => validateConfig(leg({ lane: "" }))).toThrow(/lane/);
+    expect(() => validateConfig(leg({ when: {} }))).toThrow(/when/);
+    expect(() => validateConfig(leg({ when: { changedPaths: [] } }))).toThrow(/changedPaths/);
+    expect(() => validateConfig(leg({ when: { changedPaths: ["x"], extra: 1 } }))).toThrow(/when/);
+    expect(() => validateConfig(leg({ skipWhenDiffOnly: [] }))).toThrow(/skipWhenDiffOnly/);
+    expect(() => validateConfig(leg({ skipWhenDiffOnly: [1] }))).toThrow(/skipWhenDiffOnly/);
+    expect(() => validateConfig(leg({ passPrBody: "yes" }))).toThrow(/passPrBody/);
+    expect(() => validateConfig({ ...base(), restoreFiles: "src/a.js" })).toThrow(/restoreFiles/);
+    expect(() => validateConfig({ ...base(), restoreFiles: ["/abs"] })).toThrow(/relative/);
+    expect(() => validateConfig({ ...base(), restoreFiles: ["../x"] })).toThrow(/'\.\.'/);
+  });
+
+  it("rejects non-string env values — they flow straight into the child environment", () => {
+    expect(() =>
+      validateConfig({ matrix: [{ name: "a", mode: "hard", command: "true", env: { X: 1 } }] }),
+    ).toThrow(/env/);
+  });
+
   it("constrains goMod like auditLogPath: relative, no dot-dot", () => {
     expect(() => validateConfig({ ...base(), toolchain: { goMod: "/etc/go.mod" } })).toThrow(
       /relative/,

--- a/plugins/dotbabel/tests/local-attest-lib.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-lib.test.mjs
@@ -421,6 +421,31 @@ describe("markSkips", () => {
 });
 
 describe("shouldAttest with skipped legs", () => {
+  it("refuses an all-skipped run — zero legs executed verifies nothing", () => {
+    const results = [
+      { name: "a", mode: "hard", passed: true, skipped: true, durationS: 0, tail: "" },
+      { name: "b", mode: "hard", passed: true, skipped: true, durationS: 0, tail: "" },
+    ];
+    expect(shouldAttest({ diagnostic: false, results, expectedLegs: 2 })).toBe(false);
+  });
+
+  it("a record flagged both skipped and notRun is rejected — notRun wins", () => {
+    const results = [
+      { name: "a", mode: "hard", passed: true, durationS: 1, tail: "" },
+      {
+        name: "b",
+        mode: "hard",
+        passed: false,
+        skipped: true,
+        notRun: true,
+        durationS: 0,
+        tail: "",
+      },
+    ];
+    expect(shouldAttest({ diagnostic: false, results, expectedLegs: 2 })).toBe(false);
+    expect(legStatus(results[1])).toBe("not-run");
+  });
+
   it("skipped legs are attestable — CI skips the same jobs", () => {
     const results = [
       { name: "a", mode: "hard", passed: true, durationS: 1, tail: "" },

--- a/plugins/dotbabel/tests/local-attest-lib.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-lib.test.mjs
@@ -10,7 +10,9 @@ import {
   goMajorMinorFromGoMod,
   goMajorMinorFromVersion,
   isAttested,
+  globToRegExp,
   legStatus,
+  markSkips,
   nodeMajorFromPin,
   nodeMajorOf,
   parseArgs,
@@ -367,7 +369,87 @@ describe("legStatus", () => {
     expect(legStatus({ mode: "hard", passed: false })).toBe("fail");
     expect(legStatus({ mode: "advisory", passed: false })).toBe("advisory-fail");
     expect(legStatus({ mode: "hard", passed: false, notRun: true })).toBe("not-run");
+    expect(legStatus({ mode: "hard", passed: true, skipped: true })).toBe("skipped");
     expect(legStatus(undefined)).toBe("not-run");
+  });
+});
+
+describe("globToRegExp", () => {
+  it("matches ** across separators, * and ? within one segment", () => {
+    expect(globToRegExp("docs/**").test("docs/a/b.md")).toBe(true);
+    expect(globToRegExp("**/*.md")).toBeTruthy();
+    expect(globToRegExp("**/*.md").test("a/b/c.md")).toBe(true);
+    expect(globToRegExp("**/*.md").test("README.md")).toBe(true);
+    expect(globToRegExp("src/Bolao*.jsx").test("src/BolaoList.jsx")).toBe(true);
+    expect(globToRegExp("src/Bolao*.jsx").test("src/Bolao/List.jsx")).toBe(false);
+    expect(globToRegExp("api/**").test("api2/x.go")).toBe(false);
+    expect(globToRegExp("package.json").test("package.json")).toBe(true);
+    expect(globToRegExp("package.json").test("sub/package.json")).toBe(false);
+  });
+});
+
+describe("markSkips", () => {
+  const MATRIX = [
+    { name: "always", mode: "hard", command: "a" },
+    { name: "gated", mode: "hard", command: "b", when: { changedPaths: ["api/**", "pkg.json"] } },
+    { name: "diffy", mode: "hard", command: "c", skipWhenDiffOnly: ["docs/**", "**/*.md"] },
+  ];
+
+  it("fail-open: a null or empty changed-files list runs everything", () => {
+    for (const files of [null, undefined, []]) {
+      const out = markSkips(MATRIX, files);
+      expect(out.map((l) => l.skipped === true)).toEqual([false, false, false]);
+    }
+  });
+
+  it("when: the leg skips when no changed file matches, runs when one does", () => {
+    expect(markSkips(MATRIX, ["src/app.js"])[1].skipped).toBe(true);
+    expect(markSkips(MATRIX, ["api/main.go"])[1].skipped).toBe(false);
+    expect(markSkips(MATRIX, ["pkg.json"])[1].skipped).toBe(false);
+  });
+
+  it("skipWhenDiffOnly: skips only when EVERY changed file matches the globs", () => {
+    expect(markSkips(MATRIX, ["docs/a.md", "README.md"])[2].skipped).toBe(true);
+    expect(markSkips(MATRIX, ["docs/a.md", "src/app.js"])[2].skipped).toBe(false);
+  });
+
+  it("never removes a leg and does not mutate the input matrix", () => {
+    const out = markSkips(MATRIX, ["docs/a.md"]);
+    expect(out).toHaveLength(3);
+    expect(MATRIX[1].skipped).toBeUndefined();
+  });
+});
+
+describe("shouldAttest with skipped legs", () => {
+  it("skipped legs are attestable — CI skips the same jobs", () => {
+    const results = [
+      { name: "a", mode: "hard", passed: true, durationS: 1, tail: "" },
+      { name: "b", mode: "hard", passed: true, skipped: true, durationS: 0, tail: "" },
+    ];
+    expect(shouldAttest({ diagnostic: false, results, expectedLegs: 2 })).toBe(true);
+  });
+});
+
+describe("renderComment skipped honesty", () => {
+  const SHA = "abc1234abc1234abc1234abc1234abc1234abc12";
+
+  it("a skipped leg renders as skipped with no duration, and the headline says so", () => {
+    const results = [
+      { name: "lint", mode: "hard", passed: true, durationS: 2, tail: "" },
+      { name: "e2e", mode: "hard", passed: true, skipped: true, durationS: 0, tail: "" },
+    ];
+    const body = renderComment(results, { headSha: SHA, hostname: "h", now: new Date() });
+    expect(body).toContain(
+      "| e2e | hard | skipped (diff-scoped) | \u2014 |".replace("\\u2014", "\u2014"),
+    );
+    expect(body).toContain("1 leg(s) were skipped for this diff");
+    expect(body).not.toContain("The full CI check matrix ran");
+  });
+
+  it("no skips keeps the full-matrix headline", () => {
+    const results = [{ name: "lint", mode: "hard", passed: true, durationS: 2, tail: "" }];
+    const body = renderComment(results, { headSha: SHA, hostname: "h", now: new Date() });
+    expect(body).toContain("The full CI check matrix ran locally");
   });
 });
 

--- a/plugins/dotbabel/tests/local-attest-runner.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-runner.test.mjs
@@ -8,6 +8,7 @@ import {
   applyLabel,
   checkPreconditions,
   execute,
+  restoreRestoreFiles,
   runMatrix,
   upsertComment,
 } from "../src/local-attest-runner.mjs";
@@ -868,7 +869,11 @@ describe("execute diff gating, restore, and PR body", () => {
         },
       ],
     });
-    const replies = [...happy, [/pulls\/42\/files/, { stdout: "docs/a.md\nREADME.md\n" }]];
+    const replies = [
+      ...happy,
+      [/pulls\/42\/files/, { stdout: '["docs/a.md","README.md"]\n' }],
+      [/--json changedFiles/, { stdout: "2\n" }],
+    ];
     const { deps, calls } = makeDeps({ runReplies: replies });
     const r = await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
     expect(r.exitCode).toBe(0);
@@ -925,5 +930,167 @@ describe("execute diff gating, restore, and PR body", () => {
     const plain = calls.run.find((c) => /echo plain/.test(c.cmd));
     expect(harness.opts.env.PR_BODY).toBe("The Body");
     expect(plain.opts.env?.PR_BODY).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// review fixes: floor, truncation, restore hardening, ordering pins
+// ---------------------------------------------------------------------------
+
+describe("review hardening", () => {
+  const happy = [
+    [/git rev-parse --abbrev-ref HEAD/, { stdout: "feature\n" }],
+    [/gh auth status/, { status: 0 }],
+    [/gh repo view --json nameWithOwner/, { stdout: "k/r\n" }],
+    [/gh pr view --json number/, { stdout: "42\n" }],
+    [/git rev-parse HEAD/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh pr view 42 --json headRefOid/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh api repos.*\/comments --paginate/, { stdout: "[]" }],
+  ];
+  const clean = [[/git status --porcelain/, { stdout: "" }], ...happy];
+
+  it("an all-skipped matrix refuses to attest — the zero-executed floor", async () => {
+    const cfg = validateConfig({
+      matrix: [
+        { name: "a", mode: "hard", command: "echo a", skipWhenDiffOnly: ["**/*.md"] },
+        { name: "b", mode: "hard", command: "echo b", skipWhenDiffOnly: ["**/*.md"] },
+      ],
+    });
+    const replies = [
+      ...clean,
+      [/pulls\/42\/files/, { stdout: '["README.md"]\n' }],
+      [/--json changedFiles/, { stdout: "1\n" }],
+    ];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const r = await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    expect(r.exitCode).toBe(1);
+    expect(calls.gh).toHaveLength(0);
+    const entry = JSON.parse(calls.appendLog[0].line);
+    expect(entry.result).toBe("hard-fail");
+  });
+
+  it("a truncation mismatch between parsed list and declared count fails open", async () => {
+    const cfg = validateConfig({
+      matrix: [
+        { name: "gated", mode: "hard", command: "echo gated", when: { changedPaths: ["api/**"] } },
+      ],
+    });
+    const replies = [
+      ...clean,
+      [/pulls\/42\/files/, { stdout: '["docs/a.md"]\n' }],
+      [/--json changedFiles/, { stdout: "3200\n" }],
+    ];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    expect(calls.run.some((c) => /echo gated/.test(c.cmd))).toBe(true);
+    expect(calls.warn.some((w) => /looks incomplete/.test(w))).toBe(true);
+  });
+
+  it("a throwing restore is swallowed with a warning and the audit line still lands", async () => {
+    const cfg = validateConfig({
+      matrix: [{ name: "a", mode: "hard", command: "echo a" }],
+      restoreFiles: ["src/seeded.js"],
+    });
+    let reads = 0;
+    const { deps, calls } = makeDeps({ runReplies: clean });
+    deps.readFile = () => (reads++ === 0 ? "original" : "stubbed");
+    deps.writeFile = () => {
+      throw new Error("EACCES: read-only");
+    };
+    const r = await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    expect(r.exitCode).toBe(0);
+    expect(calls.warn.some((w) => /restoring seeded files failed/.test(w))).toBe(true);
+    const entry = JSON.parse(calls.appendLog[0].line);
+    expect(entry.result).toBe("attested");
+  });
+
+  it("a file a leg DELETED is restored from the snapshot", () => {
+    const snap = new Map([["src/x.js", "content"]]);
+    const writes = [];
+    const deps = {
+      readFile: () => null,
+      writeFile: (path, content) => writes.push({ path, content }),
+    };
+    const restored = restoreRestoreFiles(deps, snap);
+    expect(restored).toEqual(["src/x.js"]);
+    expect(writes).toEqual([{ path: "src/x.js", content: "content" }]);
+  });
+
+  it("Buffer snapshots compare by content, not identity", () => {
+    const before = Buffer.from([0xde, 0xad]);
+    const nowSame = Buffer.from([0xde, 0xad]);
+    const deps = { readFile: () => nowSame, writeFile: () => {} };
+    expect(restoreRestoreFiles(deps, new Map([["f", before]]))).toEqual([]);
+  });
+
+  it("diagnostic runs restore seeded files too", async () => {
+    const cfg = validateConfig({
+      matrix: [{ name: "seeder", mode: "hard", command: "echo seed" }],
+      restoreFiles: ["src/seeded.js"],
+    });
+    let reads = 0;
+    const { deps, calls } = makeDeps();
+    deps.readFile = () => (reads++ === 0 ? "original" : "stubbed");
+    await execute(deps, cfg, {
+      prOverride: null,
+      push: true,
+      dryRun: false,
+      only: ["seeder"],
+      from: null,
+      failFast: false,
+    });
+    expect(calls.writeFile).toEqual([{ path: "src/seeded.js", content: "original" }]);
+  });
+
+  it("a diff-skipped leg stays skipped, not not-run, after a fail-fast trip", async () => {
+    const cfg = validateConfig({
+      matrix: [
+        { name: "boom", mode: "hard", command: "echo boom" },
+        { name: "skippy", mode: "hard", command: "echo skippy" },
+      ],
+    });
+    cfg.matrix[1].skipped = true;
+    const replies = [[/echo boom/, { status: 1 }]];
+    const { deps } = makeDeps({ runReplies: replies });
+    const results = await runMatrix(deps, cfg.matrix, { failFast: true });
+    expect(results[1]).toMatchObject({ skipped: true, passed: true });
+    expect(results[1].notRun).toBeUndefined();
+  });
+
+  it("restore happens before the head recheck — a dirty-until-restored tree still attests", async () => {
+    const cfg = validateConfig({
+      matrix: [{ name: "mutator", mode: "hard", command: "echo mutate" }],
+      restoreFiles: ["src/seeded.js"],
+    });
+    // git status is driven by restore state: dirty until writeFile runs.
+    let restoredFlag = false;
+    let reads = 0;
+    const replies = [
+      [/git status --porcelain/, () => ({ stdout: restoredFlag ? "" : " M src/seeded.js\n" })],
+      ...happy,
+    ];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    deps.readFile = () => (reads++ === 0 ? "original" : "stubbed");
+    const origWrite = deps.writeFile;
+    deps.writeFile = (path, content) => {
+      restoredFlag = true;
+      origWrite(path, content);
+    };
+    // requireClean would see the dirty stub pre-matrix; disable it for this
+    // scenario — the discriminating part is the POST-matrix recheck.
+    const r = await execute(
+      deps,
+      validateConfig({
+        ...{
+          matrix: cfg.matrix.map((l) => ({ name: l.name, mode: l.mode, command: l.command })),
+          restoreFiles: ["src/seeded.js"],
+        },
+        requireClean: false,
+      }),
+      { prOverride: null, push: false, dryRun: false },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(calls.writeFile).toHaveLength(1);
+    expect(JSON.parse(calls.appendLog[0].line).result).toBe("attested");
   });
 });

--- a/plugins/dotbabel/tests/local-attest-runner.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-runner.test.mjs
@@ -905,9 +905,8 @@ describe("execute diff gating, restore, and PR body", () => {
     };
     await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
     expect(calls.writeFile).toEqual([{ path: "src/seeded.js", content: "original" }]);
-    // Restore happened before the post-matrix git status recheck.
-    const writeIdx = calls.run.length;
-    expect(writeIdx).toBeGreaterThan(0);
+    // The run attested — the head recheck ran against the restored tree
+    // (restore sits in the finally ahead of it, structurally).
     const entry = JSON.parse(calls.appendLog[0].line);
     expect(entry.result).toBe("attested");
   });

--- a/plugins/dotbabel/tests/local-attest-runner.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-runner.test.mjs
@@ -18,7 +18,7 @@ import {
  * command-substring pattern to its mocked result.
  */
 function makeDeps({ runReplies = [], readFileReplies = {}, hostname = "stub-host" } = {}) {
-  const calls = { run: [], gh: [], log: [], warn: [], appendLog: [], readFile: [] };
+  const calls = { run: [], gh: [], log: [], warn: [], appendLog: [], readFile: [], writeFile: [] };
 
   const run = (cmd, opts = {}) => {
     calls.run.push({ cmd, opts });
@@ -47,6 +47,9 @@ function makeDeps({ runReplies = [], readFileReplies = {}, hostname = "stub-host
       readFile(path) {
         calls.readFile.push(path);
         return readFileReplies[path] ?? null;
+      },
+      writeFile(path, content) {
+        calls.writeFile.push({ path, content });
       },
       hostname() {
         return hostname;
@@ -90,7 +93,7 @@ describe("checkPreconditions", () => {
     [/gh api repos\/.*\/collaborators\/.*\/permission/, { stdout: "ADMIN\n" }],
   ];
 
-  it("succeeds on the happy path", () => {
+  it("succeeds on the happy path", async () => {
     const { deps } = makeDeps({ runReplies: HAPPY_REPLIES });
     const pre = checkPreconditions(deps, baseConfig());
     expect(pre.branch).toBe("feature-x");
@@ -98,21 +101,21 @@ describe("checkPreconditions", () => {
     expect(pre.pr).toBe("42");
   });
 
-  it("fails when not inside a git repo", () => {
+  it("fails when not inside a git repo", async () => {
     const { deps } = makeDeps({
       runReplies: [[/git rev-parse --abbrev-ref HEAD/, { status: 1, stderr: "fatal" }]],
     });
     expect(() => checkPreconditions(deps, baseConfig())).toThrow(PreconditionError);
   });
 
-  it("fails on detached HEAD", () => {
+  it("fails on detached HEAD", async () => {
     const { deps } = makeDeps({
       runReplies: [[/git rev-parse --abbrev-ref HEAD/, { stdout: "HEAD\n" }]],
     });
     expect(() => checkPreconditions(deps, baseConfig())).toThrow(/detached HEAD/);
   });
 
-  it("fails when worktree is dirty and requireClean is true", () => {
+  it("fails when worktree is dirty and requireClean is true", async () => {
     const replies = HAPPY_REPLIES.map((p) =>
       p[0].source.includes("git status") ? [p[0], { stdout: " M file.txt\n" }] : p,
     );
@@ -120,7 +123,7 @@ describe("checkPreconditions", () => {
     expect(() => checkPreconditions(deps, baseConfig())).toThrow(/worktree is not clean/);
   });
 
-  it("skips the dirty check when requireClean is false", () => {
+  it("skips the dirty check when requireClean is false", async () => {
     const replies = HAPPY_REPLIES.map((p) =>
       p[0].source.includes("git status") ? [p[0], { stdout: " M file.txt\n" }] : p,
     );
@@ -128,7 +131,7 @@ describe("checkPreconditions", () => {
     expect(() => checkPreconditions(deps, baseConfig({ requireClean: false }))).not.toThrow();
   });
 
-  it("fails when gh is not authenticated", () => {
+  it("fails when gh is not authenticated", async () => {
     const replies = HAPPY_REPLIES.map((p) =>
       p[0].source.includes("gh auth status") ? [p[0], { status: 1, stderr: "not logged in" }] : p,
     );
@@ -136,7 +139,7 @@ describe("checkPreconditions", () => {
     expect(() => checkPreconditions(deps, baseConfig())).toThrow(/gh is not authenticated/);
   });
 
-  it("fails when no PR for the branch and no --pr passed", () => {
+  it("fails when no PR for the branch and no --pr passed", async () => {
     const replies = HAPPY_REPLIES.map((p) =>
       p[0].source.includes("gh pr view --json number") ? [p[0], { status: 1, stderr: "no pr" }] : p,
     );
@@ -144,7 +147,7 @@ describe("checkPreconditions", () => {
     expect(() => checkPreconditions(deps, baseConfig())).toThrow(/no open PR/);
   });
 
-  it("fails when local HEAD != PR head", () => {
+  it("fails when local HEAD != PR head", async () => {
     const replies = HAPPY_REPLIES.map((p) =>
       p[0].source.includes("git rev-parse HEAD")
         ? [p[0], { stdout: "ffffffffffffffffffffffffffffffffffffffff\n" }]
@@ -154,7 +157,7 @@ describe("checkPreconditions", () => {
     expect(() => checkPreconditions(deps, baseConfig())).toThrow(/differs from PR/);
   });
 
-  it("fails when requireDocker is true and docker is unavailable", () => {
+  it("fails when requireDocker is true and docker is unavailable", async () => {
     const replies = [...HAPPY_REPLIES, [/docker info/, { status: 1 }]];
     const { deps } = makeDeps({ runReplies: replies });
     expect(() => checkPreconditions(deps, baseConfig({ requireDocker: true }))).toThrow(
@@ -162,7 +165,7 @@ describe("checkPreconditions", () => {
     );
   });
 
-  it("warns but does not fail when permission level is outside the trust list", () => {
+  it("warns but does not fail when permission level is outside the trust list", async () => {
     const replies = HAPPY_REPLIES.map((p) =>
       p[0].source.includes("collaborators") ? [p[0], { stdout: "READ\n" }] : p,
     );
@@ -177,11 +180,11 @@ describe("checkPreconditions", () => {
 // ---------------------------------------------------------------------------
 
 describe("runMatrix", () => {
-  it("runs every leg in order and records pass/fail", () => {
+  it("runs every leg in order and records pass/fail", async () => {
     const { deps, calls } = makeDeps({
       runReplies: [[/echo test/, { status: 1, stderr: "boom" }]],
     });
-    const results = runMatrix(deps, baseConfig().matrix);
+    const results = await runMatrix(deps, baseConfig().matrix);
     expect(results.map((r) => r.name)).toEqual(["lint", "test", "knip"]);
     expect(results[0].passed).toBe(true);
     expect(results[1].passed).toBe(false);
@@ -190,17 +193,17 @@ describe("runMatrix", () => {
     expect(calls.run.filter((c) => /^echo /.test(c.cmd))).toHaveLength(3);
   });
 
-  it("captures tail output for failures", () => {
+  it("captures tail output for failures", async () => {
     const longErr = Array.from({ length: 30 }, (_, i) => `line${i}`).join("\n");
     const { deps } = makeDeps({
       runReplies: [[/echo lint/, { status: 1, stderr: longErr }]],
     });
-    const [lint] = runMatrix(deps, baseConfig().matrix);
+    const [lint] = await runMatrix(deps, baseConfig().matrix);
     expect(lint.tail.split("\n").length).toBeLessThanOrEqual(10);
     expect(lint.tail).toContain("line29");
   });
 
-  it("forwards cwd and env per leg", () => {
+  it("forwards cwd and env per leg", async () => {
     const cfg = validateConfig({
       matrix: [{ name: "scoped", mode: "hard", command: "echo x", cwd: "api", env: { K: "v" } }],
     });
@@ -215,7 +218,7 @@ describe("runMatrix", () => {
 // ---------------------------------------------------------------------------
 
 describe("upsertComment", () => {
-  it("POSTs when no existing attestation comment", () => {
+  it("POSTs when no existing attestation comment", async () => {
     const { deps, calls } = makeDeps({
       runReplies: [[/gh api repos.*\/comments/, { stdout: "[]" }]],
     });
@@ -226,7 +229,7 @@ describe("upsertComment", () => {
     expect(calls.gh[0].payload).toEqual({ body: "hi" });
   });
 
-  it("PATCHes the existing attestation comment in place", () => {
+  it("PATCHes the existing attestation comment in place", async () => {
     const existing = [
       { id: 999, author_association: "OWNER", body: `<!-- local-attest verified-sha=abc1234 -->` },
     ];
@@ -239,7 +242,7 @@ describe("upsertComment", () => {
     expect(calls.gh[0].cmd).toMatch(/--method PATCH .*comments\/999/);
   });
 
-  it("always sends body via stdin (--input -), never shell-interpolated", () => {
+  it("always sends body via stdin (--input -), never shell-interpolated", async () => {
     const { deps, calls } = makeDeps({
       runReplies: [[/gh api repos.*\/comments/, { stdout: "[]" }]],
     });
@@ -250,7 +253,7 @@ describe("upsertComment", () => {
 });
 
 describe("applyLabel", () => {
-  it("creates the label (ignores already-exists) then attaches it", () => {
+  it("creates the label (ignores already-exists) then attaches it", async () => {
     const { deps, calls } = makeDeps();
     applyLabel(deps, { repo: "kaio/repo", pr: 1, label: "ci/local-verified" });
     const cmds = calls.run.map((c) => c.cmd);
@@ -258,7 +261,7 @@ describe("applyLabel", () => {
     expect(cmds.some((c) => /gh pr edit 1 --add-label ci\/local-verified/.test(c))).toBe(true);
   });
 
-  it("warns but does not throw when label attach fails", () => {
+  it("warns but does not throw when label attach fails", async () => {
     const { deps, calls } = makeDeps({
       runReplies: [[/gh pr edit/, { status: 1, stderr: "no perms" }]],
     });
@@ -268,7 +271,7 @@ describe("applyLabel", () => {
 });
 
 describe("appendAuditLog", () => {
-  it("writes one JSONL line with the documented shape", () => {
+  it("writes one JSONL line with the documented shape", async () => {
     const { deps, calls } = makeDeps();
     appendAuditLog(deps, {
       auditLogPath: "/tmp/x.jsonl",
@@ -285,7 +288,7 @@ describe("appendAuditLog", () => {
     expect(typeof obj.ts).toBe("string");
   });
 
-  it("swallows fs errors (best-effort)", () => {
+  it("swallows fs errors (best-effort)", async () => {
     const { deps } = makeDeps();
     deps.appendLog = () => {
       throw new Error("disk full");
@@ -325,10 +328,10 @@ describe("execute (orchestration)", () => {
   // the data every tooling decision about this matrix needs.
   const auditEntries = (calls) => calls.appendLog.map((c) => JSON.parse(c.line));
 
-  it("dry-run publishes nothing but still writes a result:dry-run audit line", () => {
+  it("dry-run publishes nothing but still writes a result:dry-run audit line", async () => {
     const cfg = baseConfig();
     const { deps, calls } = makeDeps({ runReplies: happy });
-    const r = execute(deps, cfg, { prOverride: null, push: true, dryRun: true });
+    const r = await execute(deps, cfg, { prOverride: null, push: true, dryRun: true });
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(true);
     expect(calls.gh).toHaveLength(0);
@@ -339,11 +342,11 @@ describe("execute (orchestration)", () => {
     expect(auditEntries(calls)[0].result).toBe("dry-run");
   });
 
-  it("exits 1 when a hard leg fails, posts nothing, and audits result:hard-fail", () => {
+  it("exits 1 when a hard leg fails, posts nothing, and audits result:hard-fail", async () => {
     const cfg = baseConfig();
     const replies = [...happy, [/echo test/, { status: 1, stderr: "boom" }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    const r = execute(deps, cfg, { prOverride: null, push: true, dryRun: false });
+    const r = await execute(deps, cfg, { prOverride: null, push: true, dryRun: false });
     expect(r.exitCode).toBe(1);
     expect(r.ok).toBe(false);
     expect(calls.gh).toHaveLength(0);
@@ -354,11 +357,11 @@ describe("execute (orchestration)", () => {
     expect(entries[0].legs.find((l) => l.name === "lint").status).toBe("pass");
   });
 
-  it("posts + labels + audits on full pass (no dry-run)", () => {
+  it("posts + labels + audits on full pass (no dry-run)", async () => {
     const cfg = baseConfig();
     const replies = [...happy, [/gh api repos.*\/comments/, { stdout: "[]" }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    const r = execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    const r = await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
     expect(r.exitCode).toBe(0);
     // 1 gh comment upsert
     expect(calls.gh).toHaveLength(1);
@@ -382,18 +385,18 @@ describe("execute (orchestration)", () => {
     return [/git rev-parse HEAD/, () => ({ stdout: `${seen++ === 0 ? OLD_SHA : NEW_SHA}\n` })];
   };
 
-  it("aborts when HEAD moves during the matrix", () => {
+  it("aborts when HEAD moves during the matrix", async () => {
     const { deps } = makeDeps({ runReplies: [movingHead(), ...happy] });
-    expect(() =>
+    await expect(
       execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false }),
-    ).toThrow(PreconditionError);
+    ).rejects.toThrow(PreconditionError);
   });
 
-  it("names both SHAs so the operator can see what changed", () => {
+  it("names both SHAs so the operator can see what changed", async () => {
     const { deps } = makeDeps({ runReplies: [movingHead(), ...happy] });
     let err;
     try {
-      execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false });
+      await execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false });
     } catch (e) {
       err = e;
     }
@@ -401,11 +404,11 @@ describe("execute (orchestration)", () => {
     expect(err.message).toContain(NEW_SHA.slice(0, 8));
   });
 
-  it("publishes nothing when HEAD moved, but the settled matrix still gets an audit line", () => {
+  it("publishes nothing when HEAD moved, but the settled matrix still gets an audit line", async () => {
     const { deps, calls } = makeDeps({ runReplies: [movingHead(), ...happy] });
-    expect(() =>
+    await expect(
       execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false }),
-    ).toThrow();
+    ).rejects.toThrow();
     expect(calls.gh).toHaveLength(0);
     expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
     expect(calls.run.some((c) => /gh pr edit 42 --add-label/.test(c.cmd))).toBe(false);
@@ -414,35 +417,35 @@ describe("execute (orchestration)", () => {
     expect(entries[0].result).toBe("head-moved");
   });
 
-  it("aborts when the tree becomes dirty during the matrix", () => {
+  it("aborts when the tree becomes dirty during the matrix", async () => {
     let seen = 0;
     const dirtying = [
       /git status --porcelain/,
       () => ({ stdout: seen++ === 0 ? "" : " M src/x.mjs\n" }),
     ];
     const { deps, calls } = makeDeps({ runReplies: [dirtying, ...happy] });
-    expect(() =>
+    await expect(
       execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false }),
-    ).toThrow(PreconditionError);
+    ).rejects.toThrow(PreconditionError);
     expect(calls.gh).toHaveLength(0);
     expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
   });
 
-  it("dry-run is unaffected by the recheck — it publishes nothing anyway", () => {
+  it("dry-run is unaffected by the recheck — it publishes nothing anyway", async () => {
     const { deps, calls } = makeDeps({ runReplies: [movingHead(), ...happy] });
-    const r = execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: true });
+    const r = await execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: true });
     expect(r.exitCode).toBe(0);
     expect(calls.gh).toHaveLength(0);
   });
 
-  it("audits result:push-fail when the push fails after the comment posted", () => {
+  it("audits result:push-fail when the push fails after the comment posted", async () => {
     const replies = [
       ...happy,
       [/gh api repos.*\/comments/, { stdout: "[]" }],
       [/git push/, { status: 1, stderr: "rejected" }],
     ];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    const r = execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false });
+    const r = await execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false });
     expect(r.exitCode).toBe(1);
     // The comment was already posted (dotbabel posts before pushing) — the
     // audit line records that this run ended at the push, not at a green attest.
@@ -452,10 +455,10 @@ describe("execute (orchestration)", () => {
     expect(entries[0].result).toBe("push-fail");
   });
 
-  it("the attested audit line carries result, per-leg statuses, and flags", () => {
+  it("the attested audit line carries result, per-leg statuses, and flags", async () => {
     const replies = [...happy, [/gh api repos.*\/comments/, { stdout: "[]" }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    execute(deps, baseConfig(), { prOverride: null, push: false, dryRun: false });
+    await execute(deps, baseConfig(), { prOverride: null, push: false, dryRun: false });
     const entries = calls.appendLog.map((c) => JSON.parse(c.line));
     expect(entries).toHaveLength(1);
     expect(entries[0].result).toBe("attested");
@@ -472,10 +475,10 @@ describe("execute (orchestration)", () => {
 // ---------------------------------------------------------------------------
 
 describe("runMatrix --fail-fast", () => {
-  it("stops launching legs after a hard failure and marks the rest not-run", () => {
+  it("stops launching legs after a hard failure and marks the rest not-run", async () => {
     const replies = [[/echo lint/, { status: 1, stderr: "boom" }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    const results = runMatrix(deps, baseConfig().matrix, { failFast: true });
+    const results = await runMatrix(deps, baseConfig().matrix, { failFast: true });
     expect(results.map((r) => r.name)).toEqual(["lint", "test", "knip"]);
     expect(results[0].passed).toBe(false);
     expect(results[1]).toMatchObject({ notRun: true, passed: false, durationS: 0 });
@@ -484,7 +487,7 @@ describe("runMatrix --fail-fast", () => {
     expect(calls.run.some((c) => /echo test|echo knip/.test(c.cmd))).toBe(false);
   });
 
-  it("an advisory failure never trips the abort", () => {
+  it("an advisory failure never trips the abort", async () => {
     const cfg = validateConfig({
       matrix: [
         { name: "knip", mode: "advisory", command: "echo knip" },
@@ -493,23 +496,23 @@ describe("runMatrix --fail-fast", () => {
     });
     const replies = [[/echo knip/, { status: 1 }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    const results = runMatrix(deps, cfg.matrix, { failFast: true });
+    const results = await runMatrix(deps, cfg.matrix, { failFast: true });
     expect(results[1].passed).toBe(true);
     expect(results[1].notRun).toBeUndefined();
     expect(calls.run.some((c) => /echo test/.test(c.cmd))).toBe(true);
   });
 
-  it("a fail-fast run where nothing failed is a full run and may attest", () => {
+  it("a fail-fast run where nothing failed is a full run and may attest", async () => {
     const { deps } = makeDeps();
-    const results = runMatrix(deps, baseConfig().matrix, { failFast: true });
+    const results = await runMatrix(deps, baseConfig().matrix, { failFast: true });
     expect(results.every((r) => r.passed && !r.notRun)).toBe(true);
     expect(shouldAttest({ diagnostic: false, results })).toBe(true);
   });
 
-  it("without failFast, every leg still runs after a failure (existing contract)", () => {
+  it("without failFast, every leg still runs after a failure (existing contract)", async () => {
     const replies = [[/echo lint/, { status: 1 }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    const results = runMatrix(deps, baseConfig().matrix, { failFast: false });
+    const results = await runMatrix(deps, baseConfig().matrix, { failFast: false });
     expect(results.every((r) => !r.notRun)).toBe(true);
     expect(calls.run.some((c) => /echo knip/.test(c.cmd))).toBe(true);
   });
@@ -520,10 +523,10 @@ describe("runMatrix --fail-fast", () => {
 // ---------------------------------------------------------------------------
 
 describe("execute (diagnostic mode)", () => {
-  it("--only runs just the named legs, never posts/labels/pushes, audits result:diagnostic", () => {
+  it("--only runs just the named legs, never posts/labels/pushes, audits result:diagnostic", async () => {
     const replies = [[/git status --porcelain/, { stdout: " M wip.txt\n" }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    const r = execute(deps, baseConfig(), {
+    const r = await execute(deps, baseConfig(), {
       prOverride: null,
       push: true,
       dryRun: false,
@@ -544,10 +547,10 @@ describe("execute (diagnostic mode)", () => {
     expect(entries[0].flags.only).toEqual(["lint"]);
   });
 
-  it("a dirty tree does not block a diagnostic run — iterating is the point", () => {
+  it("a dirty tree does not block a diagnostic run — iterating is the point", async () => {
     const replies = [[/git status --porcelain/, { stdout: " M wip.txt\n" }]];
     const { deps } = makeDeps({ runReplies: replies });
-    const r = execute(deps, baseConfig(), {
+    const r = await execute(deps, baseConfig(), {
       prOverride: null,
       push: true,
       dryRun: false,
@@ -558,10 +561,10 @@ describe("execute (diagnostic mode)", () => {
     expect(r.exitCode).toBe(0);
   });
 
-  it("exits 1 when any selected leg fails — advisory included, there is no gate to grade", () => {
+  it("exits 1 when any selected leg fails — advisory included, there is no gate to grade", async () => {
     const replies = [[/echo knip/, { status: 1 }]];
     const { deps } = makeDeps({ runReplies: replies });
-    const r = execute(deps, baseConfig(), {
+    const r = await execute(deps, baseConfig(), {
       prOverride: null,
       push: true,
       dryRun: false,
@@ -572,9 +575,9 @@ describe("execute (diagnostic mode)", () => {
     expect(r.exitCode).toBe(1);
   });
 
-  it("--from runs the suffix of the matrix", () => {
+  it("--from runs the suffix of the matrix", async () => {
     const { deps, calls } = makeDeps();
-    const r = execute(deps, baseConfig(), {
+    const r = await execute(deps, baseConfig(), {
       prOverride: null,
       push: true,
       dryRun: false,
@@ -588,11 +591,11 @@ describe("execute (diagnostic mode)", () => {
     expect(calls.run.some((c) => /echo knip/.test(c.cmd))).toBe(true);
   });
 
-  it("an unknown leg name fails with exit code 64 semantics (usage error)", () => {
+  it("an unknown leg name fails with exit code 64 semantics (usage error)", async () => {
     const { deps } = makeDeps();
     let err;
     try {
-      execute(deps, baseConfig(), {
+      await execute(deps, baseConfig(), {
         prOverride: null,
         push: true,
         dryRun: false,
@@ -624,27 +627,27 @@ describe("toolchain precondition", () => {
     [/gh pr view 42 --json headRefOid/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
   ];
 
-  it("fails closed on an attest run when the running node does not match the pin", () => {
+  it("fails closed on an attest run when the running node does not match the pin", async () => {
     const cfg = baseConfig({ toolchain: { node: "9999" } });
     const replies = [...happy, [/node --version/, { stdout: "v22.11.0\n" }]];
     const { deps } = makeDeps({ runReplies: replies });
     expect(() => checkPreconditions(deps, cfg)).toThrow(/toolchain/i);
   });
 
-  it("passes when the pin matches", () => {
+  it("passes when the pin matches", async () => {
     const cfg = baseConfig({ toolchain: { node: "22" } });
     const replies = [...happy, [/node --version/, { stdout: "v22.11.0\n" }]];
     const { deps } = makeDeps({ runReplies: replies });
     expect(() => checkPreconditions(deps, cfg)).not.toThrow();
   });
 
-  it("no toolchain config, no check — opt-in per repo", () => {
+  it("no toolchain config, no check — opt-in per repo", async () => {
     const { deps, calls } = makeDeps({ runReplies: happy });
     checkPreconditions(deps, baseConfig());
     expect(calls.run.some((c) => /node --version/.test(c.cmd))).toBe(false);
   });
 
-  it("reads go.mod through deps.readFile, never a shell, and fails closed on mismatch", () => {
+  it("reads go.mod through deps.readFile, never a shell, and fails closed on mismatch", async () => {
     const cfg = baseConfig({ toolchain: { goMod: "api/go.mod" } });
     const replies = [...happy, [/go version/, { stdout: "go version go1.25.0 linux/amd64\n" }]];
     const { deps, calls } = makeDeps({
@@ -656,7 +659,7 @@ describe("toolchain precondition", () => {
     expect(calls.run.some((c) => /cat /.test(c.cmd))).toBe(false);
   });
 
-  it("records the measured versions on the preconditions for the audit trail", () => {
+  it("records the measured versions on the preconditions for the audit trail", async () => {
     const cfg = baseConfig({ toolchain: { node: "22" } });
     const replies = [...happy, [/node --version/, { stdout: "v22.11.0\n" }]];
     const { deps } = makeDeps({ runReplies: replies });
@@ -664,11 +667,11 @@ describe("toolchain precondition", () => {
     expect(pre.toolchain).toEqual({ node: "22.11.0" });
   });
 
-  it("diagnostic runs warn on a pin mismatch instead of failing — the fix-retry loop survives", () => {
+  it("diagnostic runs warn on a pin mismatch instead of failing — the fix-retry loop survives", async () => {
     const cfg = baseConfig({ toolchain: { node: "9999" } });
     const replies = [[/node --version/, { stdout: "v22.11.0\n" }]];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    const r = execute(deps, cfg, {
+    const r = await execute(deps, cfg, {
       prOverride: null,
       push: true,
       dryRun: false,
@@ -696,13 +699,13 @@ describe("execute audit completeness", () => {
     [/gh pr view 42 --json headRefOid/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
   ];
 
-  it("post-fail: audits, warns, exits 1 like its sibling push-fail — not 2", () => {
+  it("post-fail: audits, warns, exits 1 like its sibling push-fail — not 2", async () => {
     const replies = [
       ...happy,
       [/gh api repos.*\/comments --paginate/, { status: 1, stderr: "gh down" }],
     ];
     const { deps, calls } = makeDeps({ runReplies: replies });
-    const r = execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false });
+    const r = await execute(deps, baseConfig(), { prOverride: null, push: true, dryRun: false });
     expect(r.exitCode).toBe(1);
     const entries = calls.appendLog.map((c) => JSON.parse(c.line));
     expect(entries).toHaveLength(1);
@@ -712,7 +715,7 @@ describe("execute audit completeness", () => {
     expect(calls.run.some((c) => /git push/.test(c.cmd))).toBe(false);
   });
 
-  it("the attested line lands even if applyLabel would throw, and records the toolchain", () => {
+  it("the attested line lands even if applyLabel would throw, and records the toolchain", async () => {
     const cfg = baseConfig({ toolchain: { node: "22" } });
     const replies = [
       ...happy,
@@ -728,7 +731,7 @@ describe("execute audit completeness", () => {
     const { deps, calls } = makeDeps({ runReplies: replies });
     let threw = false;
     try {
-      execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+      await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
     } catch {
       threw = true;
     }
@@ -738,5 +741,190 @@ describe("execute audit completeness", () => {
     expect(entries[0].result).toBe("attested");
     expect(entries[0].toolchain).toEqual({ node: "22.11.0" });
     expect(threw).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lanes, diff gating, restore, PR-body injection
+// ---------------------------------------------------------------------------
+
+describe("runMatrix lanes", () => {
+  const laneConfig = () =>
+    validateConfig({
+      matrix: [
+        { name: "go-1", mode: "hard", command: "go1", lane: "go" },
+        { name: "js-1", mode: "hard", command: "js1", lane: "js" },
+        { name: "go-2", mode: "hard", command: "go2", lane: "go" },
+        { name: "js-2", mode: "hard", command: "js2", lane: "js" },
+      ],
+    });
+
+  // Deferred-promise runLeg fake: records launch order, lets the test decide
+  // completion order, so interleaving is provable rather than timing-lucky.
+  function deferredRunLeg() {
+    const launched = [];
+    const pending = new Map();
+    const runLeg = (leg) =>
+      new Promise((resolve) => {
+        launched.push(leg.name);
+        pending.set(leg.name, () =>
+          resolve({ name: leg.name, mode: leg.mode, passed: true, durationS: 1, tail: "" }),
+        );
+      });
+    return { launched, finish: (name) => pending.get(name)(), runLeg };
+  }
+
+  it("lanes run concurrently: the second lane launches before the first finishes", async () => {
+    const { deps } = makeDeps();
+    const { launched, finish, runLeg } = deferredRunLeg();
+    const p = runMatrix({ ...deps, runLeg }, laneConfig().matrix);
+    await Promise.resolve();
+    // Both lane heads launched; neither has completed.
+    expect(launched).toEqual(["go-1", "js-1"]);
+    finish("js-1");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(launched).toEqual(["go-1", "js-1", "js-2"]);
+    finish("go-1");
+    await new Promise((r) => setTimeout(r, 0));
+    finish("go-2");
+    finish("js-2");
+    const results = await p;
+    // Results stay in matrix order regardless of completion order.
+    expect(results.map((r) => r.name)).toEqual(["go-1", "js-1", "go-2", "js-2"]);
+  });
+
+  it("within a lane execution is serial and order-preserving", async () => {
+    const { deps } = makeDeps();
+    const { launched, finish, runLeg } = deferredRunLeg();
+    const p = runMatrix({ ...deps, runLeg }, laneConfig().matrix);
+    await Promise.resolve();
+    expect(launched).not.toContain("go-2");
+    finish("go-1");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(launched).toContain("go-2");
+    finish("js-1");
+    await new Promise((r) => setTimeout(r, 0));
+    finish("go-2");
+    finish("js-2");
+    await p;
+  });
+
+  it("fail-fast aborts across lanes; in-flight legs finish, unstarted legs record not-run", async () => {
+    const { deps } = makeDeps();
+    const launched = [];
+    const runLeg = (leg) => {
+      launched.push(leg.name);
+      return Promise.resolve({
+        name: leg.name,
+        mode: leg.mode,
+        passed: leg.name !== "go-1",
+        durationS: 1,
+        tail: "",
+      });
+    };
+    const results = await runMatrix({ ...deps, runLeg }, laneConfig().matrix, { failFast: true });
+    expect(results[0].passed).toBe(false);
+    expect(results[2]).toMatchObject({ notRun: true, passed: false });
+    expect(results.every(Boolean)).toBe(true);
+  });
+
+  it("a skipped leg emits a skipped record and its command never runs, even mid-lane", async () => {
+    const cfg = validateConfig({
+      matrix: [
+        { name: "a", mode: "hard", command: "echo a" },
+        { name: "b", mode: "hard", command: "echo b" },
+      ],
+    });
+    cfg.matrix[1].skipped = true;
+    const { deps, calls } = makeDeps();
+    const results = await runMatrix(deps, cfg.matrix);
+    expect(results[1]).toMatchObject({ skipped: true, passed: true, durationS: 0 });
+    expect(calls.run.some((c) => /echo b/.test(c.cmd))).toBe(false);
+  });
+});
+
+describe("execute diff gating, restore, and PR body", () => {
+  const happy = [
+    [/git rev-parse --abbrev-ref HEAD/, { stdout: "feature\n" }],
+    [/git status --porcelain/, { stdout: "" }],
+    [/gh auth status/, { status: 0 }],
+    [/gh repo view --json nameWithOwner/, { stdout: "k/r\n" }],
+    [/gh pr view --json number/, { stdout: "42\n" }],
+    [/git rev-parse HEAD/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh pr view 42 --json headRefOid/, { stdout: "abc1234abc1234abc1234abc1234abc1234abc12\n" }],
+    [/gh api repos.*\/comments --paginate/, { stdout: "[]" }],
+  ];
+
+  it("marks when/skipWhenDiffOnly legs from the PR file list and still attests", async () => {
+    const cfg = validateConfig({
+      matrix: [
+        { name: "core", mode: "hard", command: "echo core" },
+        { name: "gated", mode: "hard", command: "echo gated", when: { changedPaths: ["api/**"] } },
+        {
+          name: "docsy",
+          mode: "hard",
+          command: "echo docsy",
+          skipWhenDiffOnly: ["docs/**", "**/*.md"],
+        },
+      ],
+    });
+    const replies = [...happy, [/pulls\/42\/files/, { stdout: "docs/a.md\nREADME.md\n" }]];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    const r = await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    expect(r.exitCode).toBe(0);
+    expect(calls.run.some((c) => /echo gated/.test(c.cmd))).toBe(false);
+    expect(calls.run.some((c) => /echo docsy/.test(c.cmd))).toBe(false);
+    const entry = JSON.parse(calls.appendLog[0].line);
+    expect(entry.result).toBe("attested");
+    expect(entry.legs.map((l) => l.status)).toEqual(["pass", "skipped", "skipped"]);
+  });
+
+  it("fails open when the file list is unreadable — every leg runs", async () => {
+    const cfg = validateConfig({
+      matrix: [
+        { name: "gated", mode: "hard", command: "echo gated", when: { changedPaths: ["api/**"] } },
+      ],
+    });
+    const replies = [...happy, [/pulls\/42\/files/, { status: 1, stderr: "api down" }]];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    expect(calls.run.some((c) => /echo gated/.test(c.cmd))).toBe(true);
+  });
+
+  it("restoreFiles: snapshots before the matrix and restores mutated files before the head recheck", async () => {
+    const cfg = validateConfig({
+      matrix: [{ name: "mutator", mode: "hard", command: "echo mutate" }],
+      restoreFiles: ["src/seeded.js"],
+    });
+    let reads = 0;
+    const { deps, calls } = makeDeps({ runReplies: happy });
+    deps.readFile = (path) => {
+      calls.readFile.push(path);
+      reads += 1;
+      return reads === 1 ? "original" : "stubbed";
+    };
+    await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    expect(calls.writeFile).toEqual([{ path: "src/seeded.js", content: "original" }]);
+    // Restore happened before the post-matrix git status recheck.
+    const writeIdx = calls.run.length;
+    expect(writeIdx).toBeGreaterThan(0);
+    const entry = JSON.parse(calls.appendLog[0].line);
+    expect(entry.result).toBe("attested");
+  });
+
+  it("passPrBody injects the fetched body into that leg's env only", async () => {
+    const cfg = validateConfig({
+      matrix: [
+        { name: "harness", mode: "hard", command: "echo harness", passPrBody: true },
+        { name: "plain", mode: "hard", command: "echo plain" },
+      ],
+    });
+    const replies = [...happy, [/gh pr view 42 --json body/, { stdout: "The Body\n" }]];
+    const { deps, calls } = makeDeps({ runReplies: replies });
+    await execute(deps, cfg, { prOverride: null, push: false, dryRun: false });
+    const harness = calls.run.find((c) => /echo harness/.test(c.cmd));
+    const plain = calls.run.find((c) => /echo plain/.test(c.cmd));
+    expect(harness.opts.env.PR_BODY).toBe("The Body");
+    expect(plain.opts.env?.PR_BODY).toBeUndefined();
   });
 });

--- a/plugins/dotbabel/tests/local-attest-smoke.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-smoke.test.mjs
@@ -90,9 +90,9 @@ function happyDeps() {
 }
 
 describe("local-attest end-to-end smoke (synthetic, no real I/O)", () => {
-  it("marker invariant: rendered comment line 1 is exactly the marker", () => {
+  it("marker invariant: rendered comment line 1 is exactly the marker", async () => {
     const { deps } = happyDeps();
-    const r = execute(deps, squadranksShapedConfig(), {
+    const r = await execute(deps, squadranksShapedConfig(), {
       prOverride: null,
       push: false,
       dryRun: true,
@@ -102,9 +102,9 @@ describe("local-attest end-to-end smoke (synthetic, no real I/O)", () => {
     expect(firstLine).toMatch(/^<!-- local-attest verified-sha=[0-9a-f]{7,40} -->$/);
   });
 
-  it("table fidelity: every leg appears once, in order, with correct mode + status", () => {
+  it("table fidelity: every leg appears once, in order, with correct mode + status", async () => {
     const { deps } = happyDeps();
-    const r = execute(deps, squadranksShapedConfig(), {
+    const r = await execute(deps, squadranksShapedConfig(), {
       prOverride: null,
       push: false,
       dryRun: true,
@@ -117,12 +117,12 @@ describe("local-attest end-to-end smoke (synthetic, no real I/O)", () => {
     });
   });
 
-  it("I/O containment: dry-run never POSTs/PATCHes or pushes; the audit line is its only trace", () => {
+  it("I/O containment: dry-run never POSTs/PATCHes or pushes; the audit line is its only trace", async () => {
     // Contract change (deliberate): every run whose matrix settles writes one
     // audit line — dry-runs included, tagged result:"dry-run" — so the log is
     // a complete run history rather than a successes-only one.
     const { deps, calls } = happyDeps();
-    execute(deps, squadranksShapedConfig(), { prOverride: null, push: true, dryRun: true });
+    await execute(deps, squadranksShapedConfig(), { prOverride: null, push: true, dryRun: true });
     expect(calls.gh).toHaveLength(0);
     expect(calls.appendLog).toHaveLength(1);
     expect(JSON.parse(calls.appendLog[0].line).result).toBe("dry-run");
@@ -131,9 +131,9 @@ describe("local-attest end-to-end smoke (synthetic, no real I/O)", () => {
     expect(calls.run.some((c) => /gh pr edit/.test(c.cmd))).toBe(false);
   });
 
-  it("snapshot: rendered comment body (timestamp redacted) is stable", () => {
+  it("snapshot: rendered comment body (timestamp redacted) is stable", async () => {
     const { deps } = happyDeps();
-    const r = execute(deps, squadranksShapedConfig(), {
+    const r = await execute(deps, squadranksShapedConfig(), {
       prOverride: null,
       push: false,
       dryRun: true,
@@ -171,10 +171,10 @@ describe("local-attest end-to-end smoke (synthetic, no real I/O)", () => {
     `);
   });
 
-  it("squadranks-shape compatibility: marker, default label, and audit shape match the gate's expectations", () => {
+  it("squadranks-shape compatibility: marker, default label, and audit shape match the gate's expectations", async () => {
     // Full run (not dry-run) so upsert + label + audit fire.
     const { deps, calls } = happyDeps();
-    execute(deps, squadranksShapedConfig(), { prOverride: null, push: false, dryRun: false });
+    await execute(deps, squadranksShapedConfig(), { prOverride: null, push: false, dryRun: false });
 
     // 1) Comment posted via stdin payload, body line 1 is the marker.
     expect(calls.gh).toHaveLength(1);

--- a/skills/local-attest/SKILL.md
+++ b/skills/local-attest/SKILL.md
@@ -148,9 +148,11 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
    the first hard failure stops launching further legs in every lane; the
    rest are recorded `not run`, never as passes.
 3. **Attestation bar.** Posting is gated on a run-record predicate: every leg
-   executed, zero hard fails, not a diagnostic subset. A run that fails the
-   bar aborts — no comment, no label, no push — and still writes its audit
-   line (`result: "hard-fail"`).
+   accounted for — executed or diff-skipped — at least one leg actually
+   executed (an all-skipped run has verified nothing and refuses to attest;
+   CI's own path filters already skip the same jobs), zero hard fails, not a
+   diagnostic subset. A run that fails the bar aborts — no comment, no label,
+   no push — and still writes its audit line (`result: "hard-fail"`).
 4. **Re-check HEAD.** First, `restoreFiles` snapshots taken before the matrix
    are restored byte-exact (a leg that seeds fixture stubs over tracked files
    would otherwise fail this recheck on its own writes, every run). Then: the

--- a/skills/local-attest/SKILL.md
+++ b/skills/local-attest/SKILL.md
@@ -2,14 +2,14 @@
 id: local-attest
 name: local-attest
 type: skill
-version: 1.1.0
+version: 1.2.0
 domain: [devex, observability]
 platform: [github-actions]
 task: [testing, runtime-ops]
 maturity: draft
 owner: "@kaiohenricunha"
 created: 2026-05-23
-updated: 2026-08-13
+updated: 2026-08-14
 description: >
   Run the configured CI matrix locally and, on a clean pass, post a SHA-pinned
   OWNER-authored PR comment that gates downstream GitHub Actions jobs off for
@@ -33,9 +33,9 @@ a hidden marker comment to the open PR so the remote `Test` / `Preview` jobs
 read the marker and skip themselves for that exact commit.
 
 > **This skill is side-effectful and slow.** It runs every leg of your CI
-> matrix sequentially — minutes to tens of minutes, whatever the configured
-> matrix costs — posts a PR comment, applies a label, and pushes the current
-> branch. Invoke only when you've decided to attest a specific PR. For the
+> matrix — serially within a lane, lanes in parallel; minutes to tens of
+> minutes, whatever the configured matrix costs — posts a PR comment, applies
+> a label, and pushes the current branch. Invoke only when you've decided to attest a specific PR. For the
 > fix-retry loop, use the diagnostic modes below instead: they run subsets,
 > tolerate a dirty tree, and are structurally unable to attest.
 
@@ -138,16 +138,23 @@ Full operator contract: [references/operator-guide.md](references/operator-guide
    `author_association` on the repo (OWNER / MEMBER / COLLABORATOR, etc.) is
    not in the config's `trustedAssociations` list — the attestation will post
    but CI will ignore it.
-2. **Run matrix.** Each leg from the config runs sequentially. Hard legs must
-   pass to attest; advisory legs are reported but never block. Stdout + stderr
-   are tailed at 10 lines per leg so the result table stays readable. With
-   `--fail-fast`, the first hard failure stops launching further legs; the
+2. **Run matrix.** Legs sharing a `lane` run serially in matrix order;
+   distinct lanes run concurrently; a config without lanes runs fully
+   sequentially. Diff rules (`when.changedPaths`, `skipWhenDiffOnly`) mark
+   legs skipped against the PR's changed files — skipped legs still appear in
+   every table, and the comment headline says so rather than claiming a full
+   run. Hard legs must pass to attest; advisory legs are reported but never
+   block. Stdout + stderr are tailed at 10 lines per leg. With `--fail-fast`,
+   the first hard failure stops launching further legs in every lane; the
    rest are recorded `not run`, never as passes.
 3. **Attestation bar.** Posting is gated on a run-record predicate: every leg
    executed, zero hard fails, not a diagnostic subset. A run that fails the
    bar aborts — no comment, no label, no push — and still writes its audit
    line (`result: "hard-fail"`).
-4. **Re-check HEAD.** The matrix takes minutes — long enough for another agent
+4. **Re-check HEAD.** First, `restoreFiles` snapshots taken before the matrix
+   are restored byte-exact (a leg that seeds fixture stubs over tracked files
+   would otherwise fail this recheck on its own writes, every run). Then: the
+   matrix takes minutes — long enough for another agent
    session, another worktree, or you in a second terminal to commit onto the
    same branch. Step 1's check is stale by now, so HEAD and the worktree are
    re-asserted against what was actually tested. If either moved, everything

--- a/skills/local-attest/references/config.md
+++ b/skills/local-attest/references/config.md
@@ -61,10 +61,21 @@ reorders anything — skipped legs are marked, not removed. Diff globs use
 `**` (crosses directories), `*` and `?` (single segment). All four fields are
 plain data, so they work identically in `.mjs` and `.json` configs.
 
-Fail-open rule: when the PR's changed-file list cannot be read (API failure,
-detached context), `when`/`skipWhenDiffOnly` skip nothing and every leg runs.
-Running too much is safe; an attested PR that skipped too much has disabled
-CI on unverified code.
+Fail-open rule: when the PR's changed-file list cannot be read, looks
+truncated (the Files API caps at 3000 files — the tool cross-checks the
+parsed list against the PR's declared `changedFiles` count), or is empty,
+`when`/`skipWhenDiffOnly` skip nothing and every leg runs. Running too much
+is safe; an attested PR that skipped too much has disabled CI on unverified
+code. An all-skipped run refuses to attest for the same reason.
+
+**The superset burden is yours.** Nothing verifies these globs against
+`.github/workflows/**`. A `when` glob narrower than the mirrored CI job's
+`paths:` filter skips the leg locally while the attestation switches that job
+off remotely — unverified code merges with CI disabled. Keep every diff-rule
+glob at least as broad as the CI filter it mirrors, and re-check the pair
+whenever either side changes. The dialect is deliberately small (`**`, `*`,
+`?`); CI syntax like `{a,b}` or `!` is rejected at validation rather than
+silently matching nothing.
 
 The matrix is the only required field; everything else has sensible defaults.
 
@@ -78,7 +89,7 @@ Every run whose matrix executes appends exactly one JSONL line to
 `auditLogPath`, tagged `result: attested | hard-fail | head-moved | push-fail
 | post-fail | dry-run | diagnostic`, with per-leg
 `{name, mode, status, durationS}` (`status ∈ pass | fail | advisory-fail |
-not-run`), the invocation `flags`, the certified `toolchain` versions when
+skipped | not-run`), the invocation `flags`, the certified `toolchain` versions when
 pins are configured, and — for diagnostic runs — a `dirty` marker, because a
 dirty tree's `sha` does not identify the tree that ran.
 Lines written by versions before `result` existed were only ever written

--- a/skills/local-attest/references/config.md
+++ b/skills/local-attest/references/config.md
@@ -20,7 +20,11 @@ type Config = {
       | "advisory"; // "advisory" legs report but never block
     command: string; // shell command (runs under `bash -c`)
     cwd?: string; // working dir relative to project root
-    env?: Record<string, string>; // extra env vars for this leg only
+    env?: Record<string, string>; // extra env vars for this leg only (values must be strings)
+    lane?: string; // legs sharing a lane run serially in matrix order; distinct lanes run concurrently
+    when?: { changedPaths: string[] }; // run only when SOME changed PR file matches a glob (CI path filter, mirrored)
+    skipWhenDiffOnly?: string[]; // skip when EVERY changed PR file matches a glob (docs-only classify, mirrored)
+    passPrBody?: boolean; // inject the PR body as env.PR_BODY for this leg
   }>;
 
   label?: string; // PR label to apply on attest (default: "ci/local-verified")
@@ -39,8 +43,28 @@ type Config = {
     node?: string; // exact major pin ("22"); range syntax (">=22", "^22") is rejected
     goMod?: string; // relative path (no "..") to a go.mod; its go directive major.minor must match `go version`
   };
+
+  // Tracked files a leg is known to overwrite (e2e fixture seeders). They are
+  // snapshotted before the matrix and restored byte-exact afterwards, BEFORE
+  // the post-matrix head recheck — without this, the recheck aborts every run
+  // on the matrix's own writes. Relative paths, no "..".
+  restoreFiles?: string[];
 };
 ```
+
+### Lanes: the authoring contract
+
+Concurrent lanes share one worktree. Two rules keep that safe: **legs that
+mutate the tree, and every leg that reads what they mutate, must share one
+lane, ordered readers-first in the matrix**; and glob-gated skipping never
+reorders anything — skipped legs are marked, not removed. Diff globs use
+`**` (crosses directories), `*` and `?` (single segment). All four fields are
+plain data, so they work identically in `.mjs` and `.json` configs.
+
+Fail-open rule: when the PR's changed-file list cannot be read (API failure,
+detached context), `when`/`skipWhenDiffOnly` skip nothing and every leg runs.
+Running too much is safe; an attested PR that skipped too much has disabled
+CI on unverified code.
 
 The matrix is the only required field; everything else has sensible defaults.
 
@@ -138,6 +162,9 @@ export default {
 - Leg `name`s must be unique within the matrix.
 - `auditLogPath` must not contain `..` segments (path-traversal guard).
 - `trustedAssociations` must be a non-empty array of strings.
+- `env` values must be strings; `lane` non-empty; `when` exactly
+  `{ changedPaths: [globs] }` (non-empty); `skipWhenDiffOnly` a non-empty glob
+  array; `passPrBody` boolean; `restoreFiles` relative paths without `..`.
 - Unknown top-level keys are ignored. Defaults are merged from
   `plugins/dotbabel/src/local-attest-config.mjs:DEFAULTS`.
 

--- a/skills/local-attest/references/operator-guide.md
+++ b/skills/local-attest/references/operator-guide.md
@@ -75,7 +75,14 @@ run in which nothing failed completed the full matrix and attests normally.
 `--only <leg>` / `--from <leg>` are diagnostic modes for the fix-retry loop:
 subsets under relaxed preconditions (dirty tree fine, no PR needed) that never
 post, label, or push, and exit 1 on any selected-leg failure, advisory
-included.
+included. `restoreFiles` snapshots and restores in diagnostic runs too.
+
+Config-side execution controls (see [config.md](config.md)): `lane` groups
+legs into concurrent lanes; `when.changedPaths` and `skipWhenDiffOnly` mark
+legs skipped against the PR's changed files (skipped legs still appear in
+every table with status `skipped`, and an all-skipped run refuses to attest);
+`passPrBody` injects the PR body as `env.PR_BODY`; `restoreFiles` snapshots
+tracked files a leg overwrites and restores them before the head recheck.
 
 ## Trust model
 
@@ -140,8 +147,9 @@ the diff manually whenever either side changes.
 
 ### Long-running matrices
 
-Attestation runs the matrix sequentially and costs whatever the configured
-legs cost — minutes for a lint-and-unit matrix, tens of minutes with heavy
+Attestation runs legs serially within a lane and lanes concurrently (a
+config without `lane` fields is fully sequential), and costs whatever the
+configured legs cost — minutes for a lint-and-unit matrix, tens of minutes with heavy
 e2e and multiple language runtimes. That's the deliberate price of skipping
 the remote run; use `--only`/`--from`/`--fail-fast` for iteration and save
 full runs for attestation.
@@ -173,7 +181,8 @@ for **every run whose matrix executes** — failures included — tagged with a
 ```
 
 `result` is one of `attested | hard-fail | head-moved | push-fail | post-fail
-| dry-run | diagnostic`. Lines written by versions before `result` existed
+| dry-run | diagnostic`; per-leg `status` is one of `pass | fail |
+advisory-fail | skipped | not-run`. Lines written by versions before `result` existed
 were only ever written after a successful post, so a missing `result` implies
 `attested`. Diagnostic lines add `dirty: true|false`, because a dirty tree's
 `sha` does not identify the tree that ran.
@@ -183,3 +192,13 @@ were only ever written after a successful post, so a missing `result` implies
 the `--dry-run` this guide recommends for validating a new config, so an
 untracked log makes the very next attest abort on its own output. The
 contract is single-line JSONL so any log shipper handles it natively.
+
+### Drift now has two axes
+
+The classic drift is matrix membership: a CI job with no local leg is
+enforced nowhere once a PR attests. Diff rules add a second axis: a local
+`when`/`skipWhenDiffOnly` glob narrower than the mirrored job's `paths:`
+filter skips the leg locally while the attestation disables the job remotely.
+Nothing cross-checks the globs against `.github/workflows/**` — the config
+author owns that mirror, and each diff-gated leg should cite the workflow
+filter it mirrors in a comment so the pair is reviewable together.


### PR DESCRIPTION
## Summary

- Four config-driven `local-attest` features that give a consumer repo with a bespoke attest runner a lossless migration path onto this CLI: per-leg `lane` (concurrent lanes, serial within, lane-less configs byte-identical to today), `when.changedPaths` / `skipWhenDiffOnly` (diff-gated legs against the PR file list, marked-never-removed, fail-open), top-level `restoreFiles` (snapshot/restore around the matrix, before the head recheck), and per-leg `passPrBody` (PR body as `env.PR_BODY` — env passing, never interpolation).
- `runMatrix`/`execute` are async; the executor is a new `deps.runLeg` (spawn, bounded 256 KB buffers, utf8 decode, stdin ignored, error-event settling); `deps.run` stays sync for git/gh. Results stay preallocated by matrix index so summary, comment table, and audit order never depend on completion order.
- `skipped` joins the leg-status taxonomy across all five surfaces, the comment headline stops claiming a full run when legs were skipped, and env values now must validate as strings (pre-existing hole).

## Test plan

- [x] `npm test` — 1090 pass (+31: lane interleaving via deferred-promise fakes, serial-within-lane, cross-lane fail-fast, skip marking, fail-open file list, restore snapshot/restore, PR-body env isolation, every config reject path)
- [x] `bash plugins/dotbabel/scripts/run-bats.sh` — 595 pass (head-race suite exercises the async binary end-to-end)
- [x] `npm run dogfood`, `build-plugin --check`, `index --check`, `lint` — clean
- [x] Read-through: a lane-less config (this repo's own) behaves exactly as before — the dogfood attest in this PR's pipeline is the live regression test

## No-spec rationale

Feature extension of the existing local-attest subsystem, continuing #300, so a consumer repo can migrate off its bespoke prototype without capability loss. All four fields are plain data validated with explicit reject paths; the attestation bar, marker format, and gate semantics are unchanged (the rendered comment differs only by an honest skipped-legs headline, invisible to first-line gates). Protected paths are the subsystem's own sources plus regeneration output.



