### PR TITLE
fix(bin): resolve argv[1] symlinks in the run-direct guard

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T22:17:23.892Z",
+  "generatedAt": "2026-08-13T22:52:09.250Z",
   "skills": [
     {
       "name": "agents-search",

--- a/plugins/dotbabel/bin/dotbabel-handoff.mjs
+++ b/plugins/dotbabel/bin/dotbabel-handoff.mjs
@@ -94,7 +94,7 @@ export { _HandoffError as HandoffError };
 import { env as legacyEnv } from "../src/lib/legacy-compat.mjs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { invokedDirectly } from "../src/lib/invoked-direct.mjs";
+import { invokedDirectly, misfiredAs } from "../src/lib/invoked-direct.mjs";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createInterface } from "node:readline";
@@ -1004,8 +1004,7 @@ async function main() {
     const force = Boolean(argv.flags["force-collision"]);
     const dryRun = Boolean(argv.flags["dry-run"]);
     try {
-      const stateFilePath =
-        argv.flags["state-file"] != null ? String(argv.flags["state-file"]) : null;
+      const stateFilePath = argv.flags["state-file"] != null ? String(argv.flags["state-file"]) : null;
       let stateBlock = null;
       if (stateFilePath) {
         try {
@@ -1154,9 +1153,14 @@ async function main() {
   );
 }
 
-// Only execute the CLI when invoked directly; stay import-safe for unit tests.
+// Only execute main() when this file is the entry script. (Importers still
+// pay the module-scope argv parse above — this guard only withholds main().)
+// When argv[1] names this bin but the guard still missed, fail loudly rather
+// than exit 0 as if the command ran.
 if (invokedDirectly(import.meta.url)) {
   main().catch((err) => fail(2, err.message));
+} else if (misfiredAs("dotbabel-handoff")) {
+  fail(EXIT_CODES.ENV, "run-direct guard did not fire; refusing to exit 0 without running.");
 }
 
 export {

--- a/plugins/dotbabel/bin/dotbabel-handoff.mjs
+++ b/plugins/dotbabel/bin/dotbabel-handoff.mjs
@@ -93,7 +93,8 @@ import {
 export { _HandoffError as HandoffError };
 import { env as legacyEnv } from "../src/lib/legacy-compat.mjs";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { invokedDirectly } from "../src/lib/invoked-direct.mjs";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createInterface } from "node:readline";
@@ -1003,7 +1004,8 @@ async function main() {
     const force = Boolean(argv.flags["force-collision"]);
     const dryRun = Boolean(argv.flags["dry-run"]);
     try {
-      const stateFilePath = argv.flags["state-file"] != null ? String(argv.flags["state-file"]) : null;
+      const stateFilePath =
+        argv.flags["state-file"] != null ? String(argv.flags["state-file"]) : null;
       let stateBlock = null;
       if (stateFilePath) {
         try {
@@ -1153,7 +1155,7 @@ async function main() {
 }
 
 // Only execute the CLI when invoked directly; stay import-safe for unit tests.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (invokedDirectly(import.meta.url)) {
   main().catch((err) => fail(2, err.message));
 }
 

--- a/plugins/dotbabel/bin/dotbabel-local-attest.mjs
+++ b/plugins/dotbabel/bin/dotbabel-local-attest.mjs
@@ -36,7 +36,8 @@
  *   64  bad CLI invocation (unknown flag, malformed --pr)
  */
 
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { invokedDirectly } from "../src/lib/invoked-direct.mjs";
 
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
 import { parseArgs } from "../src/local-attest-lib.mjs";
@@ -142,7 +143,7 @@ async function main() {
 }
 
 // Run only when invoked as a CLI, not when imported by tests.
-const invokedDirect = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const invokedDirect = invokedDirectly(import.meta.url);
 if (invokedDirect) {
   main().catch((err) => fail(2, err.message));
 }

--- a/plugins/dotbabel/bin/dotbabel-local-attest.mjs
+++ b/plugins/dotbabel/bin/dotbabel-local-attest.mjs
@@ -36,8 +36,7 @@
  *   64  bad CLI invocation (unknown flag, malformed --pr)
  */
 
-import { fileURLToPath } from "node:url";
-import { invokedDirectly } from "../src/lib/invoked-direct.mjs";
+import { invokedDirectly, misfiredAs } from "../src/lib/invoked-direct.mjs";
 
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
 import { parseArgs } from "../src/local-attest-lib.mjs";
@@ -142,10 +141,14 @@ async function main() {
   }
 }
 
-// Run only when invoked as a CLI, not when imported by tests.
+// Run only when invoked as a CLI, not when imported by tests. When argv[1]
+// names this bin but the guard still missed, exit 0 would read as a PASS to
+// gate tooling — fail loudly instead.
 const invokedDirect = invokedDirectly(import.meta.url);
 if (invokedDirect) {
   main().catch((err) => fail(2, err.message));
+} else if (misfiredAs("dotbabel-local-attest")) {
+  fail(EXIT_CODES.ENV, "run-direct guard did not fire; refusing to exit 0 without running.");
 }
 
 // Re-exports for unit tests that want to drive the binary's `main` without spawning.

--- a/plugins/dotbabel/bin/dotbabel-pr-stack.mjs
+++ b/plugins/dotbabel/bin/dotbabel-pr-stack.mjs
@@ -31,7 +31,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { invokedDirectly } from "../src/lib/invoked-direct.mjs";
+import { invokedDirectly, misfiredAs } from "../src/lib/invoked-direct.mjs";
 
 import { parse } from "../src/lib/argv.mjs";
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
@@ -159,8 +159,7 @@ function assertRev(rev) {
 function requireNumber(raw, flag) {
   if (raw === undefined) return fail(EXIT_CODES.USAGE, `${flag} is required`);
   const n = Number(raw);
-  if (!Number.isInteger(n) || n <= 0)
-    return fail(EXIT_CODES.USAGE, `${flag} must be a positive integer`);
+  if (!Number.isInteger(n) || n <= 0) return fail(EXIT_CODES.USAGE, `${flag} must be a positive integer`);
   return n;
 }
 
@@ -248,9 +247,7 @@ function fetchPrs(limit) {
  * @returns {string[]}
  */
 function renderPlan(plan) {
-  const lines = [
-    `stack on ${plan.trunk}: ${plan.counts.total} PR(s), merge order ${plan.order.join(" → ") || "—"}`,
-  ];
+  const lines = [`stack on ${plan.trunk}: ${plan.counts.total} PR(s), merge order ${plan.order.join(" → ") || "—"}`];
   for (const entry of plan.actionable) {
     lines.push(`  ✓ #${entry.number} ${entry.head} — ${entry.action}: ${entry.reason}`);
   }
@@ -344,18 +341,14 @@ async function main() {
     } catch (err) {
       return fail(EXIT_CODES.VALIDATION, err.message);
     }
-    for (const warning of transition.warnings)
-      process.stderr.write(`${TOOL}: warning: ${warning}\n`);
+    for (const warning of transition.warnings) process.stderr.write(`${TOOL}: warning: ${warning}\n`);
 
     return emit({
       subcommand: sub,
       ok: true,
       trunk: flags.trunk,
       result: transition,
-      lines: [
-        `#${transition.number}: ${transition.reason}`,
-        ...transition.steps.map((s) => `  ${s.cmd}`),
-      ],
+      lines: [`#${transition.number}: ${transition.reason}`, ...transition.steps.map((s) => `  ${s.cmd}`)],
       json,
     });
   }
@@ -389,10 +382,7 @@ async function main() {
       ok: result.ok,
       result,
       problems: result.reasons,
-      lines: [
-        `gate skip-ci: ${result.ok ? "PASS" : "FAIL"}`,
-        ...result.reasons.map((r) => `  ✗ ${r.message}`),
-      ],
+      lines: [`gate skip-ci: ${result.ok ? "PASS" : "FAIL"}`, ...result.reasons.map((r) => `  ✗ ${r.message}`)],
       json,
     });
   }
@@ -413,10 +403,7 @@ async function main() {
       ok: result.ok,
       result,
       problems: result.reasons,
-      lines: [
-        `gate local-attest: ${result.ok ? "PASS" : "FAIL"}`,
-        ...result.reasons.map((r) => `  ✗ ${r.message}`),
-      ],
+      lines: [`gate local-attest: ${result.ok ? "PASS" : "FAIL"}`, ...result.reasons.map((r) => `  ✗ ${r.message}`)],
       json,
     });
   }
@@ -438,10 +425,7 @@ async function main() {
       ok: summary.ok,
       result,
       problems: result.reasons,
-      lines: [
-        `gate merge: ${result.ok ? "PASS" : "FAIL"}`,
-        ...result.reasons.map((r) => `  ✗ ${r.message}`),
-      ],
+      lines: [`gate merge: ${result.ok ? "PASS" : "FAIL"}`, ...result.reasons.map((r) => `  ✗ ${r.message}`)],
       json,
     });
   }
@@ -449,10 +433,14 @@ async function main() {
   return fail(EXIT_CODES.USAGE, `--gate must be one of: local-attest, merge, skip-ci`);
 }
 
-// Run only when invoked as a CLI, not when imported by tests.
+// Run only when invoked as a CLI, not when imported by tests. When argv[1]
+// names this bin but the guard still missed, exit 0 would read as a gate
+// PASS — fail loudly instead.
 const invokedDirect = invokedDirectly(import.meta.url);
 if (invokedDirect) {
   main().catch((err) => fail(EXIT_CODES.ENV, err.message));
+} else if (misfiredAs("dotbabel-pr-stack")) {
+  fail(EXIT_CODES.ENV, "run-direct guard did not fire; refusing to exit 0 without running.");
 }
 
 // Re-exports for unit tests that want to drive the binary without spawning.

--- a/plugins/dotbabel/bin/dotbabel-pr-stack.mjs
+++ b/plugins/dotbabel/bin/dotbabel-pr-stack.mjs
@@ -31,7 +31,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { pathToFileURL } from "node:url";
+import { invokedDirectly } from "../src/lib/invoked-direct.mjs";
 
 import { parse } from "../src/lib/argv.mjs";
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
@@ -159,7 +159,8 @@ function assertRev(rev) {
 function requireNumber(raw, flag) {
   if (raw === undefined) return fail(EXIT_CODES.USAGE, `${flag} is required`);
   const n = Number(raw);
-  if (!Number.isInteger(n) || n <= 0) return fail(EXIT_CODES.USAGE, `${flag} must be a positive integer`);
+  if (!Number.isInteger(n) || n <= 0)
+    return fail(EXIT_CODES.USAGE, `${flag} must be a positive integer`);
   return n;
 }
 
@@ -247,7 +248,9 @@ function fetchPrs(limit) {
  * @returns {string[]}
  */
 function renderPlan(plan) {
-  const lines = [`stack on ${plan.trunk}: ${plan.counts.total} PR(s), merge order ${plan.order.join(" → ") || "—"}`];
+  const lines = [
+    `stack on ${plan.trunk}: ${plan.counts.total} PR(s), merge order ${plan.order.join(" → ") || "—"}`,
+  ];
   for (const entry of plan.actionable) {
     lines.push(`  ✓ #${entry.number} ${entry.head} — ${entry.action}: ${entry.reason}`);
   }
@@ -341,14 +344,18 @@ async function main() {
     } catch (err) {
       return fail(EXIT_CODES.VALIDATION, err.message);
     }
-    for (const warning of transition.warnings) process.stderr.write(`${TOOL}: warning: ${warning}\n`);
+    for (const warning of transition.warnings)
+      process.stderr.write(`${TOOL}: warning: ${warning}\n`);
 
     return emit({
       subcommand: sub,
       ok: true,
       trunk: flags.trunk,
       result: transition,
-      lines: [`#${transition.number}: ${transition.reason}`, ...transition.steps.map((s) => `  ${s.cmd}`)],
+      lines: [
+        `#${transition.number}: ${transition.reason}`,
+        ...transition.steps.map((s) => `  ${s.cmd}`),
+      ],
       json,
     });
   }
@@ -382,7 +389,10 @@ async function main() {
       ok: result.ok,
       result,
       problems: result.reasons,
-      lines: [`gate skip-ci: ${result.ok ? "PASS" : "FAIL"}`, ...result.reasons.map((r) => `  ✗ ${r.message}`)],
+      lines: [
+        `gate skip-ci: ${result.ok ? "PASS" : "FAIL"}`,
+        ...result.reasons.map((r) => `  ✗ ${r.message}`),
+      ],
       json,
     });
   }
@@ -403,7 +413,10 @@ async function main() {
       ok: result.ok,
       result,
       problems: result.reasons,
-      lines: [`gate local-attest: ${result.ok ? "PASS" : "FAIL"}`, ...result.reasons.map((r) => `  ✗ ${r.message}`)],
+      lines: [
+        `gate local-attest: ${result.ok ? "PASS" : "FAIL"}`,
+        ...result.reasons.map((r) => `  ✗ ${r.message}`),
+      ],
       json,
     });
   }
@@ -425,7 +438,10 @@ async function main() {
       ok: summary.ok,
       result,
       problems: result.reasons,
-      lines: [`gate merge: ${result.ok ? "PASS" : "FAIL"}`, ...result.reasons.map((r) => `  ✗ ${r.message}`)],
+      lines: [
+        `gate merge: ${result.ok ? "PASS" : "FAIL"}`,
+        ...result.reasons.map((r) => `  ✗ ${r.message}`),
+      ],
       json,
     });
   }
@@ -434,7 +450,7 @@ async function main() {
 }
 
 // Run only when invoked as a CLI, not when imported by tests.
-const invokedDirect = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const invokedDirect = invokedDirectly(import.meta.url);
 if (invokedDirect) {
   main().catch((err) => fail(EXIT_CODES.ENV, err.message));
 }

--- a/plugins/dotbabel/src/lib/invoked-direct.mjs
+++ b/plugins/dotbabel/src/lib/invoked-direct.mjs
@@ -1,0 +1,27 @@
+import { realpathSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+/**
+ * True when the module at `importMetaUrl` is the script Node was asked to run,
+ * as opposed to being imported by a test or another module.
+ *
+ * The comparison must resolve `process.argv[1]` through symlinks: npm installs
+ * package bins as `node_modules/.bin` symlinks, and Node realpath-resolves the
+ * ESM entry module (so `import.meta.url` points at the real file) while
+ * leaving `argv[1]` as the symlink path. A verbatim comparison therefore
+ * concludes an `npx`-invoked bin was merely imported, and the process exits 0
+ * having done nothing.
+ *
+ * @param {string} importMetaUrl - the caller's `import.meta.url`
+ * @returns {boolean}
+ */
+export function invokedDirectly(importMetaUrl) {
+  if (!process.argv[1]) return false;
+  try {
+    return importMetaUrl === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    // argv[1] can name a path that no longer exists (embedded runners,
+    // deleted cwd). Not resolvable means not this module.
+    return false;
+  }
+}

--- a/plugins/dotbabel/src/lib/invoked-direct.mjs
+++ b/plugins/dotbabel/src/lib/invoked-direct.mjs
@@ -1,27 +1,53 @@
 import { realpathSync } from "node:fs";
-import { pathToFileURL } from "node:url";
+import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * True when the module at `importMetaUrl` is the script Node was asked to run,
  * as opposed to being imported by a test or another module.
  *
- * The comparison must resolve `process.argv[1]` through symlinks: npm installs
- * package bins as `node_modules/.bin` symlinks, and Node realpath-resolves the
- * ESM entry module (so `import.meta.url` points at the real file) while
- * leaving `argv[1]` as the symlink path. A verbatim comparison therefore
- * concludes an `npx`-invoked bin was merely imported, and the process exits 0
- * having done nothing.
+ * Two comparisons, cheapest first. The verbatim one is pure string math and
+ * never throws. The realpath one resolves BOTH sides, which is what makes it
+ * correct in either symlink mode: npm installs bins as `node_modules/.bin`
+ * symlinks, and by default Node realpath-resolves the ESM entry (so
+ * `import.meta.url` points at the real file) while leaving `argv[1]` as the
+ * symlink — a verbatim-only comparison concludes an `npx`-invoked bin was
+ * merely imported, and the process exits 0 having done nothing. Under
+ * `--preserve-symlinks-main` the asymmetry flips (the entry URL keeps the
+ * symlink), and resolving both sides collapses either shape to the same real
+ * file. Ordering matters too: the syscalls are a widening step, never
+ * load-bearing, so a filesystem error cannot veto a match the pure
+ * comparison already made.
  *
  * @param {string} importMetaUrl - the caller's `import.meta.url`
  * @returns {boolean}
  */
 export function invokedDirectly(importMetaUrl) {
-  if (!process.argv[1]) return false;
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(importMetaUrl);
+  if (self === entry) return true;
   try {
-    return importMetaUrl === pathToFileURL(realpathSync(process.argv[1])).href;
+    return realpathSync(self) === realpathSync(entry);
   } catch {
     // argv[1] can name a path that no longer exists (embedded runners,
-    // deleted cwd). Not resolvable means not this module.
+    // deleted cwd). Unresolvable and not a literal match means not direct.
     return false;
   }
+}
+
+/**
+ * Tripwire for the `invokedDirectly` miss case: true when `argv[1]` plainly
+ * names this bin (with or without the `.mjs` suffix) yet the guard did not
+ * match. For gate tooling, falling through to `exit 0` without running
+ * `main()` is indistinguishable from a PASS, so a caller that sees this
+ * should fail loudly instead. Never true on the import-for-tests path —
+ * a test runner's `argv[1]` is the runner, not the bin.
+ *
+ * @param {string} binName - the bin's canonical name, e.g. "dotbabel-pr-stack"
+ * @returns {boolean}
+ */
+export function misfiredAs(binName) {
+  const entry = process.argv[1];
+  return Boolean(entry) && basename(entry).replace(/\.mjs$/, "") === binName;
 }

--- a/plugins/dotbabel/src/local-attest-runner.mjs
+++ b/plugins/dotbabel/src/local-attest-runner.mjs
@@ -49,6 +49,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
+import { dirname } from "node:path";
 
 import {
   buildAuditEntry,
@@ -227,7 +228,11 @@ function gatherToolchain(deps, cfg) {
     if (inputs.nodeVersion) seen.node = inputs.nodeVersion;
   }
   if (pin.goMod !== undefined) {
-    const rv = deps.run("go version", { capture: true });
+    // Probe from the pinned module's directory, not the repo root: with
+    // GOTOOLCHAIN=auto the go command answers with the toolchain the module
+    // will actually use — the same one the Go legs get via leg.cwd. From the
+    // root, an auto-downloaded newer toolchain reads as a false mismatch.
+    const rv = deps.run("go version", { capture: true, cwd: dirname(pin.goMod) });
     inputs.goVersionOutput = rv.status === 0 ? rv.stdout : "";
     const parsed = goMajorMinorFromVersion(inputs.goVersionOutput);
     if (parsed) seen.go = parsed;

--- a/plugins/dotbabel/templates/claude/skills/deploy-status/scripts/deploy-ops.mjs
+++ b/plugins/dotbabel/templates/claude/skills/deploy-status/scripts/deploy-ops.mjs
@@ -8,9 +8,9 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 const EXIT = {
   OK: 0,
@@ -991,7 +991,26 @@ export async function main(argv = process.argv.slice(2)) {
   return EXIT.USAGE;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Run-direct guard, symlink-safe. bootstrap.sh symlinks this skill into
+// ~/.claude/skills/, and SKILL.md prefers that path — Node realpath-resolves
+// the entry module while argv[1] keeps the symlink, so a verbatim comparison
+// concludes the script was imported and exits 0 without running, which
+// callers read as "every target in sync". Compare realpaths on both sides.
+// (Inlined rather than shared: scaffolded copies of this file have no
+// plugins/dotbabel/src to import a helper from.)
+let runDirect = false;
+if (process.argv[1]) {
+  const self = fileURLToPath(import.meta.url);
+  runDirect = self === process.argv[1];
+  if (!runDirect) {
+    try {
+      runDirect = realpathSync(self) === realpathSync(process.argv[1]);
+    } catch {
+      runDirect = false;
+    }
+  }
+}
+if (runDirect) {
   main().then((code) => {
     process.exitCode = code;
   });

--- a/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
+++ b/plugins/dotbabel/templates/claude/skills/local-attest/references/config.md
@@ -41,7 +41,7 @@ type Config = {
   // versions count as mismatches.
   toolchain?: {
     node?: string; // exact major pin ("22"); range syntax (">=22", "^22") is rejected
-    goMod?: string; // relative path (no "..") to a go.mod; its go directive major.minor must match `go version`
+    goMod?: string; // relative path (no "..") to a go.mod; its go directive major.minor must match `go version` probed from that module directory (so GOTOOLCHAIN=auto counts)
   };
 
   // Tracked files a leg is known to overwrite (e2e fixture seeders). They are

--- a/plugins/dotbabel/tests/bin-symlink.test.mjs
+++ b/plugins/dotbabel/tests/bin-symlink.test.mjs
@@ -1,0 +1,31 @@
+// npm installs package bins as node_modules/.bin symlinks. Node realpath-
+// resolves the ESM entry module (so import.meta.url points at the real file)
+// but leaves process.argv[1] as the symlink path, so a run-direct guard that
+// compares the two verbatim concludes the bin was imported, not executed —
+// and the bin silently exits 0 having done nothing. These tests invoke each
+// guarded bin through a symlink, exactly like `npx <bin>` does, and expect
+// the same loud usage error a direct invocation produces.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+
+const BIN_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../bin");
+
+const GUARDED_BINS = ["dotbabel-local-attest", "dotbabel-pr-stack", "dotbabel-handoff"];
+
+const shimDir = mkdtempSync(path.join(tmpdir(), "dotbabel-bin-shim-"));
+afterAll(() => rmSync(shimDir, { recursive: true, force: true }));
+
+describe.each(GUARDED_BINS)("%s invoked through a .bin-style symlink", (bin) => {
+  it("still runs main() — a bogus flag dies loudly instead of a silent exit 0", () => {
+    const shim = path.join(shimDir, bin);
+    symlinkSync(path.join(BIN_DIR, `${bin}.mjs`), shim);
+    const r = spawnSync(process.execPath, [shim, "--bogus-flag"], { encoding: "utf8" });
+    expect(r.status).toBe(64);
+    expect(r.stderr).toMatch(/[Uu]nknown (argument|option)/);
+  });
+});

--- a/plugins/dotbabel/tests/bin-symlink.test.mjs
+++ b/plugins/dotbabel/tests/bin-symlink.test.mjs
@@ -1,31 +1,110 @@
-// npm installs package bins as node_modules/.bin symlinks. Node realpath-
-// resolves the ESM entry module (so import.meta.url points at the real file)
-// but leaves process.argv[1] as the symlink path, so a run-direct guard that
-// compares the two verbatim concludes the bin was imported, not executed —
-// and the bin silently exits 0 having done nothing. These tests invoke each
-// guarded bin through a symlink, exactly like `npx <bin>` does, and expect
-// the same loud usage error a direct invocation produces.
+// npm installs package bins as node_modules/.bin symlinks, and bootstrap.sh
+// symlinks skills into ~/.claude/skills/. Node realpath-resolves the ESM
+// entry module (so import.meta.url points at the real file) but leaves
+// process.argv[1] as the symlink path, so a run-direct guard that compares
+// the two verbatim concludes the script was imported, not executed — and the
+// process silently exits 0 having done nothing. These tests invoke each
+// guarded script through a symlink, exactly like `npx <bin>` does, and expect
+// the same loud behavior a direct invocation produces.
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { globSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterAll, describe, expect, it } from "vitest";
 
 const BIN_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../bin");
+const REPO_ROOT = path.resolve(BIN_DIR, "../../..");
 
-const GUARDED_BINS = ["dotbabel-local-attest", "dotbabel-pr-stack", "dotbabel-handoff"];
+// Per-bin probe that only main() can satisfy. dotbabel-handoff parses argv at
+// module top level, so a bogus flag exits 64 before the guard is ever
+// consulted — a probe that must reach main() is the only non-vacuous one.
+const PROBES = [
+  {
+    bin: "dotbabel-local-attest",
+    args: ["--bogus-flag"],
+    expects: (r) => {
+      expect(r.status).toBe(64);
+      expect(r.stderr).toMatch(/unknown argument/);
+    },
+  },
+  {
+    bin: "dotbabel-pr-stack",
+    args: ["--bogus-flag"],
+    expects: (r) => {
+      expect(r.status).toBe(64);
+      expect(r.stderr).toMatch(/Unknown option/);
+    },
+  },
+  {
+    bin: "dotbabel-handoff",
+    args: [],
+    expects: (r) => {
+      // No-arg handoff prints usage from main() and exits 0; pre-fix the
+      // guard miss produced the same exit 0 but with EMPTY stdout.
+      expect(r.status).toBe(0);
+      expect(r.stdout).not.toBe("");
+    },
+  },
+];
 
 const shimDir = mkdtempSync(path.join(tmpdir(), "dotbabel-bin-shim-"));
 afterAll(() => rmSync(shimDir, { recursive: true, force: true }));
 
-describe.each(GUARDED_BINS)("%s invoked through a .bin-style symlink", (bin) => {
-  it("still runs main() — a bogus flag dies loudly instead of a silent exit 0", () => {
+describe.each(PROBES)("$bin invoked through a .bin-style symlink", ({ bin, args, expects }) => {
+  it("still runs main() instead of a silent exit 0", () => {
     const shim = path.join(shimDir, bin);
     symlinkSync(path.join(BIN_DIR, `${bin}.mjs`), shim);
-    const r = spawnSync(process.execPath, [shim, "--bogus-flag"], { encoding: "utf8" });
-    expect(r.status).toBe(64);
-    expect(r.stderr).toMatch(/[Uu]nknown (argument|option)/);
+    expects(spawnSync(process.execPath, [shim, ...args], { encoding: "utf8" }));
+  });
+
+  it("a residual guard miss trips the misfire tripwire instead of exiting 0", () => {
+    // A wrapper file NAMED like the bin that merely imports it: argv[1]
+    // basename matches, but the bin module is not the entry, so the guard
+    // is (correctly) false — and for a bin name that must never mean a
+    // silent success.
+    const wrapperDir = mkdtempSync(path.join(shimDir, "wrap-"));
+    const wrapper = path.join(wrapperDir, `${bin}.mjs`);
+    writeFileSync(
+      wrapper,
+      `import ${JSON.stringify(pathToFileURL(path.join(BIN_DIR, `${bin}.mjs`)).href)};\n`,
+    );
+    const r = spawnSync(process.execPath, [wrapper, ...args], { encoding: "utf8" });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/guard did not fire/);
+  });
+});
+
+describe("deploy-ops.mjs through a bootstrap-style symlink", () => {
+  it("still runs main() — a no-args run dies loudly instead of a silent exit 0", () => {
+    // In this repo, target resolution rejects before the usage branch, so the
+    // exact code varies (2 here, 64 where targets exist) — the discriminator
+    // against the pre-fix bug is exit 0 with NOTHING on either stream.
+    const shim = path.join(shimDir, "deploy-ops.mjs");
+    symlinkSync(path.join(REPO_ROOT, "skills/deploy-status/scripts/deploy-ops.mjs"), shim);
+    const r = spawnSync(process.execPath, [shim], { encoding: "utf8" });
+    expect(r.status).not.toBe(0);
+    expect(r.stdout + r.stderr).not.toBe("");
+  });
+});
+
+describe("no file reintroduces the symlink-blind guard", () => {
+  it("pathToFileURL(process.argv[1]) never appears in a runnable script", () => {
+    // The broken idiom compares the realpath-resolved entry URL against the
+    // raw argv[1] URL. Every current guard goes through invokedDirectly()
+    // (or deploy-ops' inlined realpath comparison), neither of which needs
+    // this expression — so any new occurrence is a regression, most likely
+    // copy-pasted from a pre-fix file.
+    const files = [
+      ...globSync(path.join(BIN_DIR, "*.mjs")),
+      ...globSync(path.join(REPO_ROOT, "skills/*/scripts/*.mjs")),
+      ...globSync(path.join(REPO_ROOT, "plugins/dotbabel/templates/**/scripts/*.mjs")),
+    ];
+    expect(files.length).toBeGreaterThan(20);
+    const offenders = files.filter((f) =>
+      /pathToFileURL\(\s*process\.argv\[1\]\s*\)/.test(readFileSync(f, "utf8")),
+    );
+    expect(offenders).toEqual([]);
   });
 });

--- a/plugins/dotbabel/tests/invoked-direct.test.mjs
+++ b/plugins/dotbabel/tests/invoked-direct.test.mjs
@@ -1,0 +1,67 @@
+// Direct unit tests for the run-direct guard helper — the subprocess tests in
+// bin-symlink.test.mjs prove the wiring, these pin the helper's contract,
+// including the two `false` branches a happy-path spawn never reaches.
+
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+
+import { invokedDirectly, misfiredAs } from "../src/lib/invoked-direct.mjs";
+
+const SELF_URL = import.meta.url;
+const SELF_PATH = fileURLToPath(SELF_URL);
+
+const tmp = mkdtempSync(path.join(tmpdir(), "invoked-direct-"));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+const originalArgv1 = process.argv[1];
+afterEach(() => {
+  process.argv[1] = originalArgv1;
+});
+
+describe("invokedDirectly", () => {
+  it("true on a verbatim path match — no filesystem access needed", () => {
+    process.argv[1] = SELF_PATH;
+    expect(invokedDirectly(SELF_URL)).toBe(true);
+  });
+
+  it("true when argv[1] is a symlink to the module — the npx/.bin shape", () => {
+    const link = path.join(tmp, "shim.mjs");
+    symlinkSync(SELF_PATH, link);
+    process.argv[1] = link;
+    expect(invokedDirectly(SELF_URL)).toBe(true);
+  });
+
+  it("false with no argv[1] at all (embedded runners)", () => {
+    process.argv[1] = undefined;
+    expect(invokedDirectly(SELF_URL)).toBe(false);
+  });
+
+  it("false when argv[1] does not resolve — a missing path is not this module", () => {
+    process.argv[1] = path.join(tmp, "deleted-mid-run.mjs");
+    expect(invokedDirectly(SELF_URL)).toBe(false);
+  });
+
+  it("false when argv[1] is a different real file — the import-by-a-runner shape", () => {
+    process.argv[1] = fileURLToPath(new URL("./bin-symlink.test.mjs", SELF_URL));
+    expect(invokedDirectly(SELF_URL)).toBe(false);
+  });
+});
+
+describe("misfiredAs", () => {
+  it("true when argv[1] basename names the bin, with or without .mjs", () => {
+    process.argv[1] = "/anywhere/dotbabel-pr-stack.mjs";
+    expect(misfiredAs("dotbabel-pr-stack")).toBe(true);
+    process.argv[1] = "/anywhere/dotbabel-pr-stack";
+    expect(misfiredAs("dotbabel-pr-stack")).toBe(true);
+  });
+
+  it("false for other names and for a missing argv[1]", () => {
+    process.argv[1] = "/anywhere/vitest.mjs";
+    expect(misfiredAs("dotbabel-pr-stack")).toBe(false);
+    process.argv[1] = undefined;
+    expect(misfiredAs("dotbabel-pr-stack")).toBe(false);
+  });
+});

--- a/plugins/dotbabel/tests/local-attest-runner.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-runner.test.mjs
@@ -660,6 +660,21 @@ describe("toolchain precondition", () => {
     expect(calls.run.some((c) => /cat /.test(c.cmd))).toBe(false);
   });
 
+  it("probes go version from the goMod module dir so GOTOOLCHAIN=auto answers for the pin", async () => {
+    // With GOTOOLCHAIN=auto the go command delegates to the module's pinned
+    // toolchain only when run inside the module. Probing from the repo root
+    // reports the PATH binary and flags a machine Go itself considers sound.
+    const cfg = baseConfig({ toolchain: { goMod: "api/go.mod" } });
+    const replies = [...happy, [/go version/, { stdout: "go version go1.26.5 linux/amd64\n" }]];
+    const { deps, calls } = makeDeps({
+      runReplies: replies,
+      readFileReplies: { "api/go.mod": "module x\n\ngo 1.26.5\n" },
+    });
+    expect(() => checkPreconditions(deps, cfg)).not.toThrow();
+    const probe = calls.run.find((c) => /go version/.test(c.cmd));
+    expect(probe.opts.cwd).toBe("api");
+  });
+
   it("records the measured versions on the preconditions for the audit trail", async () => {
     const cfg = baseConfig({ toolchain: { node: "22" } });
     const replies = [...happy, [/node --version/, { stdout: "v22.11.0\n" }]];

--- a/skills/deploy-status/scripts/deploy-ops.mjs
+++ b/skills/deploy-status/scripts/deploy-ops.mjs
@@ -8,9 +8,9 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 const EXIT = {
   OK: 0,
@@ -991,7 +991,26 @@ export async function main(argv = process.argv.slice(2)) {
   return EXIT.USAGE;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Run-direct guard, symlink-safe. bootstrap.sh symlinks this skill into
+// ~/.claude/skills/, and SKILL.md prefers that path — Node realpath-resolves
+// the entry module while argv[1] keeps the symlink, so a verbatim comparison
+// concludes the script was imported and exits 0 without running, which
+// callers read as "every target in sync". Compare realpaths on both sides.
+// (Inlined rather than shared: scaffolded copies of this file have no
+// plugins/dotbabel/src to import a helper from.)
+let runDirect = false;
+if (process.argv[1]) {
+  const self = fileURLToPath(import.meta.url);
+  runDirect = self === process.argv[1];
+  if (!runDirect) {
+    try {
+      runDirect = realpathSync(self) === realpathSync(process.argv[1]);
+    } catch {
+      runDirect = false;
+    }
+  }
+}
+if (runDirect) {
   main().then((code) => {
     process.exitCode = code;
   });

--- a/skills/local-attest/references/config.md
+++ b/skills/local-attest/references/config.md
@@ -41,7 +41,7 @@ type Config = {
   // versions count as mismatches.
   toolchain?: {
     node?: string; // exact major pin ("22"); range syntax (">=22", "^22") is rejected
-    goMod?: string; // relative path (no "..") to a go.mod; its go directive major.minor must match `go version`
+    goMod?: string; // relative path (no "..") to a go.mod; its go directive major.minor must match `go version` probed from that module directory (so GOTOOLCHAIN=auto counts)
   };
 
   // Tracked files a leg is known to overwrite (e2e fixture seeders). They are


### PR DESCRIPTION
## Summary

- Fix the run-direct guard in `dotbabel-local-attest`, `dotbabel-pr-stack`, and `dotbabel-handoff`: `npx <bin>` (any `node_modules/.bin` symlink invocation) silently exited 0 without running `main()`, because Node realpath-resolves the ESM entry (`import.meta.url`) but leaves `process.argv[1]` as the symlink path, so the verbatim URL comparison concluded the bin was imported rather than executed.
- The three bins now share `invokedDirectly()` (`src/lib/invoked-direct.mjs`), which realpath-resolves `argv[1]` before comparing and treats an unresolvable path as not-direct.
- Found while dogfooding the consumer migration: a downstream repo's `npx dotbabel-local-attest` no-opped with exit 0 — the exact invocation the skill documentation prescribes. It never surfaced upstream because this repo's own tests and skills invoke `node plugins/dotbabel/bin/<bin>.mjs` directly.

## Test plan

- [x] `npx vitest run plugins/dotbabel/tests/bin-symlink.test.mjs` — red before the fix (status 0, no output through a symlink), green after (8/8 in the final shape: per-bin main()-reaching probes, misfire tripwires, and the deploy-ops bootstrap-symlink case, all through a `.bin`-style symlink)
- [x] `npx vitest run` — 1117 tests pass (13 added by the review round: per-bin probes, tripwires, deploy-ops symlink, source sweep, helper units)
- [x] `bash plugins/dotbabel/scripts/run-bats.sh` — 595 tests pass
- [x] `npm run lint` — clean, JSDoc coverage includes the new export
- [x] `npm run dogfood` — all validators pass
- [x] `npm run build-plugin -- --check` — templates fresh

## Spec ID

dotbabel-core

