### PR TITLE
fix(release): stop squash merges from suppressing release-please

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,181 +1,181 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-13T22:52:09.250Z",
+  "generatedAt": "2026-08-14T14:26:24.705Z",
   "skills": [
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "audit-and-fix",
       "path": ".claude/skills/audit-and-fix/SKILL.md",
       "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:ba954a78351a0988ccd7ab00574bde2f6aa0d4dab0b5a32fb755f14957411358",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:7c1625de68e13e15ab0beb179e4cf6f9a3d2a80ec294a04cbb46e430cb0ab425",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "code-simplifier",
       "path": ".claude/skills/code-simplifier/SKILL.md",
       "checksum": "sha256:e24c64485f950d93815f492de5673aaa3ff65abb0df91fb41e41a40b68017cff",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "create-assessment",
       "path": ".claude/skills/create-assessment/SKILL.md",
       "checksum": "sha256:7d364824b0ce34d5703a3db91956b4607182b52be79bc5fdec9583c73ef6f73c",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "create-audit",
       "path": ".claude/skills/create-audit/SKILL.md",
       "checksum": "sha256:c65ff762a76e721fd0169cee087c582198c628a7a79b518792b168b2b6001cd4",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "create-experiment",
       "path": ".claude/skills/create-experiment/SKILL.md",
       "checksum": "sha256:424f23db1e1ba2cfc32c215bc4ae8f8dd8f710274161884252ac1fcfb28dcd3c",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "create-inspection",
       "path": ".claude/skills/create-inspection/SKILL.md",
       "checksum": "sha256:d8febaf15dd98a5d72fe97f8f41fd7d0a83ed98f0a11ab7ecedeedeaec544e85",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:ef78a49da882582f409c0c166d74112c6d37af437592e05bf6cd218bb8c34476",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "deploy-status",
       "path": ".claude/skills/deploy-status/SKILL.md",
       "checksum": "sha256:9119370d74077eae376afa72b28fff9cfd7617fd11b310590ddd6eb6c3d9258f",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/skills/detect-flaky/SKILL.md",
       "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/skills/fix-with-evidence/SKILL.md",
       "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "flyctl",
       "path": ".claude/skills/flyctl/SKILL.md",
       "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:39763f741bbff9bd6f9b72908ed3ea8de1870e2d5017b3ddab9015e0db4ff108",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "git",
       "path": ".claude/skills/git/SKILL.md",
       "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "ground-first",
       "path": ".claude/skills/ground-first/SKILL.md",
       "checksum": "sha256:0a8a9c125bc3fd0a3fe5cacb4f8cf6ff5971895ea1b703037a8712d3b5e15dd6",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
       "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:e3f0404dbd80ebdfce9df79df0a9bf501574abafcb7cd5a656c2afd4519428fb",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
       "checksum": "sha256:688dc4b8e9c926627c6eab50c6bb836bad6787a4355ba588bbbb22792171d269",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
-      "checksum": "sha256:a008eb234eebabeebda81dca533b62421455a1e7126ef207444a809f39aa32b1",
+      "checksum": "sha256:90bad56b3ba6c4cf6c5f2e1123ae5b297e0daa84b7034ead6de5bfd77173420e",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "plan-grader",
       "path": ".claude/skills/plan-grader/SKILL.md",
       "checksum": "sha256:50ba919efa0b4235e182a7d5b1ff2308481086a3ddddbf9166b0560370c3af27",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "post-pr-review",
@@ -184,7 +184,7 @@
       "dependencies": [
         "review-pr"
       ],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "pr-conductor",
@@ -198,28 +198,28 @@
         "local-attest",
         "merge-pr"
       ],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:5b648d63608231c077c3a5bd54f5c3b7a598443782a8d8ab7f223e62c5d4d37a",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "project-sync",
       "path": ".claude/skills/project-sync/SKILL.md",
       "checksum": "sha256:8243e74bcf280574a2b04ac0ee3c19590a7dc273560a4ec83f74cc8a56fbd858",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:6620a3862749142cf450245e9c6fc6c398530208848f64e2c34132e138f6f5ef",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "release-conductor",
@@ -228,28 +228,28 @@
       "dependencies": [
         "deploy-status"
       ],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "reproduce-bug",
       "path": ".claude/skills/reproduce-bug/SKILL.md",
       "checksum": "sha256:e73ae70e76b0c4a0ba43dc42d01596b2df1e97ffa7813a9fab45012711408b51",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "review-pr",
       "path": ".claude/skills/review-pr/SKILL.md",
       "checksum": "sha256:ad8f9312d61e5913f3e36a51b05b43230d1e8f6993c3ff0944dad35539904eed",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "review-prs",
       "path": ".claude/skills/review-prs/SKILL.md",
       "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "rollback-prod",
@@ -258,49 +258,49 @@
       "dependencies": [
         "deploy-status"
       ],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "security-review",
       "path": ".claude/skills/security-review/SKILL.md",
       "checksum": "sha256:c8447582929b315402af24e304acd4addaa9be7120e895ca25d4c897ba84cfda",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:9ec1c67a434bf90512a2dcb5a68c4bb3bffd65c1bee967fa370164ec6ea84002",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:9e9c0d8b36ef44fb7f4f604aa706c2f380787c38c0282987c24436ec7bd53b85",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:fc7f266342f1686a5ca394398f048742b5f249144f45354d5f8c2520e359a2bb",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:13320e86060cb9a74d9ee98aecbbb9eff43c6100b47f09debe15f7049f6c050c",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2f66c14a71e88734d8a734bf1ce6f220f74ce28a9e302635e4e225edc1f9300e",
       "dependencies": [],
-      "lastValidated": "2026-08-13"
+      "lastValidated": "2026-08-14"
     }
   ]
 }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  # Manual escape hatch: a squash body that inherits a CI-suppression marker
+  # from its intermediate commits suppresses this push workflow too (GitHub
+  # matches the marker anywhere in the message), leaving pending releasable
+  # commits with no trigger — branch protection forbids empty pushes to main.
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/commands/merge-pr.md
+++ b/commands/merge-pr.md
@@ -91,11 +91,23 @@ Arguments: `$ARGUMENTS` — the PR number (e.g. `125`). If missing, ask the user
    - The exact merge command you will run
      Wait for the user to say "merge" (or equivalent).
 
-9. **Merge.**
+9. **Merge — with an explicit, marker-free squash body.**
+   The default squash body concatenates the branch's commit messages. Every
+   intermediate commit carries `[skip ci]` (the conductor requires it), GitHub
+   honors the marker **anywhere** in the final message, and release-please is
+   a push-triggered workflow — so a default-body squash merge silently
+   suppresses the release for its own commits. Build the body from the PR
+   description and strip any CI-suppression markers it happens to quote:
+
    ```bash
-   gh pr merge <N> --squash --delete-branch
+   gh pr view <N> --json body -q .body \
+     | sed -e 's/\[skip ci\]//g' -e 's/\[ci skip\]//g' -e 's/skip-checks: *true//g' \
+     > /tmp/merge-pr-<N>-body.md
+   gh pr merge <N> --squash --delete-branch --body-file /tmp/merge-pr-<N>-body.md
    ```
+
    Then clean up the worktree:
+
    ```bash
    cd -
    git worktree remove /tmp/merge-pr-<N>
@@ -104,6 +116,7 @@ Arguments: `$ARGUMENTS` — the PR number (e.g. `125`). If missing, ask the user
 ## Rules
 
 - Never skip the full test suite, even if CI is green — CI config drift is real.
+- Never let a squash merge carry a `[skip ci]` / `[ci skip]` / `skip-checks:` marker into main's history — it suppresses push-triggered workflows (release-please included) for the merge itself. Step 9's `--body-file` flow exists for exactly this.
 - Never claim a failure is "pre-existing" without the `git stash` proof.
 - Never merge without explicit user confirmation. CI green alone is not authorization.
 - Never force-push; never merge into `main`/`master` with failing local tests.

--- a/plugins/dotbabel/templates/claude/commands/merge-pr.md
+++ b/plugins/dotbabel/templates/claude/commands/merge-pr.md
@@ -88,11 +88,23 @@ Arguments: `$ARGUMENTS` — the PR number (e.g. `125`). If missing, ask the user
    - The exact merge command you will run
      Wait for the user to say "merge" (or equivalent).
 
-9. **Merge.**
+9. **Merge — with an explicit, marker-free squash body.**
+   The default squash body concatenates the branch's commit messages. Every
+   intermediate commit carries `[skip ci]` (the conductor requires it), GitHub
+   honors the marker **anywhere** in the final message, and release-please is
+   a push-triggered workflow — so a default-body squash merge silently
+   suppresses the release for its own commits. Build the body from the PR
+   description and strip any CI-suppression markers it happens to quote:
+
    ```bash
-   gh pr merge <N> --squash --delete-branch
+   gh pr view <N> --json body -q .body \
+     | sed -e 's/\[skip ci\]//g' -e 's/\[ci skip\]//g' -e 's/skip-checks: *true//g' \
+     > /tmp/merge-pr-<N>-body.md
+   gh pr merge <N> --squash --delete-branch --body-file /tmp/merge-pr-<N>-body.md
    ```
+
    Then clean up the worktree:
+
    ```bash
    cd -
    git worktree remove /tmp/merge-pr-<N>
@@ -101,6 +113,7 @@ Arguments: `$ARGUMENTS` — the PR number (e.g. `125`). If missing, ask the user
 ## Rules
 
 - Never skip the full test suite, even if CI is green — CI config drift is real.
+- Never let a squash merge carry a `[skip ci]` / `[ci skip]` / `skip-checks:` marker into main's history — it suppresses push-triggered workflows (release-please included) for the merge itself. Step 9's `--body-file` flow exists for exactly this.
 - Never claim a failure is "pre-existing" without the `git stash` proof.
 - Never merge without explicit user confirmation. CI green alone is not authorization.
 - Never force-push; never merge into `main`/`master` with failing local tests.


### PR DESCRIPTION
## Summary

- Fix the release pipeline suppression discovered after #301/#302: their squash bodies inherited the intermediate commits' `[skip ci]` markers, GitHub honors the marker anywhere in the final message, and release-please is push-triggered — so neither merge proposed 2.17.0, and branch protection (PRs only) left no way to nudge main.
- `commands/merge-pr.md` step 9 now merges with an explicit squash body built from the PR description, with any quoted CI-suppression markers stripped — the default concatenated-commit-messages body is exactly the trap. New Rules bullet codifies it.
- `.github/workflows/release-please.yml` gains `workflow_dispatch:` as the manual escape hatch for main history that already carries the marker (needed once, immediately after this merges, to release the pending #301 + #302).

## Test plan

- [x] `npx vitest run` — 1117 tests pass
- [x] `npm run lint` / `npm run dogfood` / `dotbabel-index --check` — clean
- [x] `npm run build-plugin` — template fan-out of merge-pr.md regenerated
- [ ] Post-merge: merge THIS PR with the new step-9 body flow (its own body is marker-free prose, so the push fires release-please), or run `gh workflow run release-please.yml` — either way the 2.17.0 release PR appears

## Spec ID

dotbabel-core
