### PR TITLE
docs(merge-pr): clean the squash subject too — single-commit PRs inherit it

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-14T14:26:24.705Z",
+  "generatedAt": "2026-08-14T14:34:33.617Z",
   "skills": [
     {
       "name": "agents-search",
@@ -166,7 +166,7 @@
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
-      "checksum": "sha256:90bad56b3ba6c4cf6c5f2e1123ae5b297e0daa84b7034ead6de5bfd77173420e",
+      "checksum": "sha256:b5a86222bec1f7561672fb67010527a076e3439f74e7f8c9b71932a1b8923200",
       "dependencies": [],
       "lastValidated": "2026-08-14"
     },

--- a/commands/merge-pr.md
+++ b/commands/merge-pr.md
@@ -91,19 +91,31 @@ Arguments: `$ARGUMENTS` — the PR number (e.g. `125`). If missing, ask the user
    - The exact merge command you will run
      Wait for the user to say "merge" (or equivalent).
 
-9. **Merge — with an explicit, marker-free squash body.**
-   The default squash body concatenates the branch's commit messages. Every
-   intermediate commit carries `[skip ci]` (the conductor requires it), GitHub
-   honors the marker **anywhere** in the final message, and release-please is
-   a push-triggered workflow — so a default-body squash merge silently
-   suppresses the release for its own commits. Build the body from the PR
-   description and strip any CI-suppression markers it happens to quote:
+9. **Merge — with an explicit, marker-free squash subject AND body.**
+   The default squash body concatenates the branch's commit messages, and —
+   the sneakier half — on a **single-commit PR** the default squash _subject_
+   is that commit's subject line, not the PR title. Every intermediate commit
+   carries `[skip ci]` (the conductor requires it), GitHub honors the marker
+   **anywhere** in the final message including line 1, and release-please is
+   a push-triggered workflow — so a default merge silently suppresses the
+   release for its own commits. Pass both halves explicitly, built from the
+   PR title and description with any CI-suppression markers stripped:
 
    ```bash
-   gh pr view <N> --json body -q .body \
-     | sed -e 's/\[skip ci\]//g' -e 's/\[ci skip\]//g' -e 's/skip-checks: *true//g' \
-     > /tmp/merge-pr-<N>-body.md
-   gh pr merge <N> --squash --delete-branch --body-file /tmp/merge-pr-<N>-body.md
+   STRIP='s/\[skip ci\]//g; s/\[ci skip\]//g; s/skip-checks: *true//g'
+   SUBJ="$(gh pr view <N> --json title -q .title | sed "$STRIP") (#<N>)"
+   gh pr view <N> --json body -q .body | sed "$STRIP" > /tmp/merge-pr-<N>-body.md
+   gh pr merge <N> --squash --delete-branch \
+     --subject "$SUBJ" --body-file /tmp/merge-pr-<N>-body.md
+   ```
+
+   Afterwards, verify the merge commit is marker-free — this exact flow has
+   been beaten three ways (body, then subject) and the check is one line:
+
+   ```bash
+   git log --format=%B -1 <merge-sha> | grep -nE '\[skip ci\]|\[ci skip\]|skip-checks' \
+     && echo "SUPPRESSED — run: gh workflow run release-please.yml --ref main" \
+     || echo "clean"
    ```
 
    Then clean up the worktree:
@@ -116,7 +128,7 @@ Arguments: `$ARGUMENTS` — the PR number (e.g. `125`). If missing, ask the user
 ## Rules
 
 - Never skip the full test suite, even if CI is green — CI config drift is real.
-- Never let a squash merge carry a `[skip ci]` / `[ci skip]` / `skip-checks:` marker into main's history — it suppresses push-triggered workflows (release-please included) for the merge itself. Step 9's `--body-file` flow exists for exactly this.
+- Never let a squash merge carry a `[skip ci]` / `[ci skip]` / `skip-checks:` marker into main's history — it suppresses push-triggered workflows (release-please included) for the merge itself. Step 9's explicit `--subject`/`--body-file` flow exists for exactly this; the single-commit-PR default subject is the trap that bites after the body is fixed.
 - Never claim a failure is "pre-existing" without the `git stash` proof.
 - Never merge without explicit user confirmation. CI green alone is not authorization.
 - Never force-push; never merge into `main`/`master` with failing local tests.

--- a/plugins/dotbabel/templates/claude/commands/merge-pr.md
+++ b/plugins/dotbabel/templates/claude/commands/merge-pr.md
@@ -88,19 +88,31 @@ Arguments: `$ARGUMENTS` — the PR number (e.g. `125`). If missing, ask the user
    - The exact merge command you will run
      Wait for the user to say "merge" (or equivalent).
 
-9. **Merge — with an explicit, marker-free squash body.**
-   The default squash body concatenates the branch's commit messages. Every
-   intermediate commit carries `[skip ci]` (the conductor requires it), GitHub
-   honors the marker **anywhere** in the final message, and release-please is
-   a push-triggered workflow — so a default-body squash merge silently
-   suppresses the release for its own commits. Build the body from the PR
-   description and strip any CI-suppression markers it happens to quote:
+9. **Merge — with an explicit, marker-free squash subject AND body.**
+   The default squash body concatenates the branch's commit messages, and —
+   the sneakier half — on a **single-commit PR** the default squash _subject_
+   is that commit's subject line, not the PR title. Every intermediate commit
+   carries `[skip ci]` (the conductor requires it), GitHub honors the marker
+   **anywhere** in the final message including line 1, and release-please is
+   a push-triggered workflow — so a default merge silently suppresses the
+   release for its own commits. Pass both halves explicitly, built from the
+   PR title and description with any CI-suppression markers stripped:
 
    ```bash
-   gh pr view <N> --json body -q .body \
-     | sed -e 's/\[skip ci\]//g' -e 's/\[ci skip\]//g' -e 's/skip-checks: *true//g' \
-     > /tmp/merge-pr-<N>-body.md
-   gh pr merge <N> --squash --delete-branch --body-file /tmp/merge-pr-<N>-body.md
+   STRIP='s/\[skip ci\]//g; s/\[ci skip\]//g; s/skip-checks: *true//g'
+   SUBJ="$(gh pr view <N> --json title -q .title | sed "$STRIP") (#<N>)"
+   gh pr view <N> --json body -q .body | sed "$STRIP" > /tmp/merge-pr-<N>-body.md
+   gh pr merge <N> --squash --delete-branch \
+     --subject "$SUBJ" --body-file /tmp/merge-pr-<N>-body.md
+   ```
+
+   Afterwards, verify the merge commit is marker-free — this exact flow has
+   been beaten three ways (body, then subject) and the check is one line:
+
+   ```bash
+   git log --format=%B -1 <merge-sha> | grep -nE '\[skip ci\]|\[ci skip\]|skip-checks' \
+     && echo "SUPPRESSED — run: gh workflow run release-please.yml --ref main" \
+     || echo "clean"
    ```
 
    Then clean up the worktree:
@@ -113,7 +125,7 @@ Arguments: `$ARGUMENTS` — the PR number (e.g. `125`). If missing, ask the user
 ## Rules
 
 - Never skip the full test suite, even if CI is green — CI config drift is real.
-- Never let a squash merge carry a `[skip ci]` / `[ci skip]` / `skip-checks:` marker into main's history — it suppresses push-triggered workflows (release-please included) for the merge itself. Step 9's `--body-file` flow exists for exactly this.
+- Never let a squash merge carry a `[skip ci]` / `[ci skip]` / `skip-checks:` marker into main's history — it suppresses push-triggered workflows (release-please included) for the merge itself. Step 9's explicit `--subject`/`--body-file` flow exists for exactly this; the single-commit-PR default subject is the trap that bites after the body is fixed.
 - Never claim a failure is "pre-existing" without the `git stash` proof.
 - Never merge without explicit user confirmation. CI green alone is not authorization.
 - Never force-push; never merge into `main`/`master` with failing local tests.


### PR DESCRIPTION
## Summary

- Close the second half of the squash-suppression trap: #303 cleaned the squash **body**, then was immediately defeated by its own merge — on a single-commit PR, GitHub's default squash **subject** is the commit's subject line (not the PR title), so `[skip ci]` landed on line 1 of `8a1f64a` and suppressed release-please a third time (recovered via the just-merged `workflow_dispatch` hatch; 2.17.0 release PR #304 is open).
- `commands/merge-pr.md` step 9 now passes `--subject` built from the PR title alongside `--body-file`, both piped through the same marker-stripping sed, and adds a one-line post-merge verification that the merge commit is marker-free (with the dispatch command as the printed remedy).

## Test plan

- [x] `npm run dogfood` / `npm run lint` — clean; template fan-out regenerated by build-plugin
- [x] `dotbabel pr-stack gate --gate skip-ci` — PASS on the branch commit
- [ ] Post-merge: `git log --format=%B -1 <merge-sha>` carries no suppression marker and release-please runs for the push

## Spec ID

dotbabel-core
