### PR TITLE
fix(tests): drop fs.globSync — Node 20 leg red on main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -278,9 +278,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -298,9 +295,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -318,9 +312,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -338,9 +329,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -358,9 +346,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -378,9 +363,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1445,9 +1427,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1469,9 +1448,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1493,9 +1469,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1517,9 +1490,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2313,9 +2283,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/plugins/dotbabel/tests/bin-symlink.test.mjs
+++ b/plugins/dotbabel/tests/bin-symlink.test.mjs
@@ -8,7 +8,14 @@
 // the same loud behavior a direct invocation produces.
 
 import { spawnSync } from "node:child_process";
-import { globSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -51,6 +58,17 @@ const PROBES = [
 
 const shimDir = mkdtempSync(path.join(tmpdir(), "dotbabel-bin-shim-"));
 afterAll(() => rmSync(shimDir, { recursive: true, force: true }));
+
+// Every .mjs file under dir, recursively (Node 20-compatible glob substitute).
+function mjsFilesUnder(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...mjsFilesUnder(full));
+    else if (entry.name.endsWith(".mjs")) out.push(full);
+  }
+  return out;
+}
 
 describe.each(PROBES)("$bin invoked through a .bin-style symlink", ({ bin, args, expects }) => {
   it("still runs main() instead of a silent exit 0", () => {
@@ -96,10 +114,13 @@ describe("no file reintroduces the symlink-blind guard", () => {
     // (or deploy-ops' inlined realpath comparison), neither of which needs
     // this expression — so any new occurrence is a regression, most likely
     // copy-pasted from a pre-fix file.
+    // Recursive readdir, not fs.globSync: engines say node >=20 and CI runs
+    // a Node 20 leg, but globSync only exists from Node 22. Sweeping every
+    // .mjs under these roots is also strictly broader than the old globs.
     const files = [
-      ...globSync(path.join(BIN_DIR, "*.mjs")),
-      ...globSync(path.join(REPO_ROOT, "skills/*/scripts/*.mjs")),
-      ...globSync(path.join(REPO_ROOT, "plugins/dotbabel/templates/**/scripts/*.mjs")),
+      ...mjsFilesUnder(BIN_DIR),
+      ...mjsFilesUnder(path.join(REPO_ROOT, "skills")),
+      ...mjsFilesUnder(path.join(REPO_ROOT, "plugins/dotbabel/templates")),
     ];
     expect(files.length).toBeGreaterThan(20);
     const offenders = files.filter((f) =>


### PR DESCRIPTION
## Summary

- Fix the red Node 20 CI leg on main: the #302 source-sweep test used `fs.globSync`, which only exists from Node 22, while `engines` declares `>=20` and `test.yml` runs a Node 20 matrix leg. The first marker-free push to main (`5bfbc61`) exposed it — local runs are all Node 22, and the two prior pushes carried CI-suppression markers. Replaced with a recursive `readdirSync` walker that sweeps strictly more files than the old globs (every `.mjs` under `bin/`, `skills/`, and `templates/`).
- Ride-along: `npm audit fix` for GHSA-2v37-7h3g-55p8 (`nanoid <3.3.18`, high severity, dev-dependency chain) — lockfile-only.

## Test plan

- [x] `npx vitest run plugins/dotbabel/tests/bin-symlink.test.mjs` under **Node v20.20.2** — 8/8 pass (this exact file was the Node 20 failure)
- [x] `npx vitest run` under Node 22 — 1117 tests pass
- [x] `npm audit` — 0 vulnerabilities across all deps
- [x] `npm run lint` — clean

## Spec ID

dotbabel-core
