### PR TITLE
feat(local-attest): --init drafts a matrix from .github/workflows

### DIFF
--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-14T14:34:33.617Z",
+  "generatedAt": "2026-08-14T20:08:23.098Z",
   "skills": [
     {
       "name": "agents-search",

--- a/README.md
+++ b/README.md
@@ -6,16 +6,39 @@
 
 > Maintained by [@kaiohenricunha](https://github.com/kaiohenricunha) · [Changelog](./CHANGELOG.md) · [Security](./SECURITY.md)
 
-An opinionated, model-agnostic governance toolkit for Claude Code, Codex,
-Gemini CLI, Copilot CLI, and other agentic CLIs. Ships a curated library of
-skills, slash commands, and cloud/IaC specialists plus a global rule floor
-that hardens every agent session — and an optional spec-driven-development
-governance CLI on top, for repos that want PR-time gates.
+**Stop paying for CI you already ran locally.**
+
+You run the test suite on your machine, push, and then wait ten minutes while
+GitHub-hosted runners run exactly the same commands again — and bill you for
+it. `dotbabel local-attest` runs your CI matrix locally and, on a clean pass,
+posts a SHA-pinned comment that makes your workflows skip themselves for that
+commit. One repo using it cut ~27 minutes of runner time per push to zero.
+
+```bash
+npx dotbabel-local-attest --init      # draft a matrix from .github/workflows
+npx dotbabel-local-attest --dry-run   # run it locally, post nothing
+npx dotbabel-local-attest             # run it, attest, push
+```
+
+It is deliberately hard to fool. The attestation is pinned to the exact head
+SHA, so the next push invalidates it; only repo-owner comments are trusted;
+the run refuses to attest if any leg was skipped, never launched, or hard
+failed; every run — including every failure — appends a line to an audit log;
+and toolchain pins fail the run closed when your local Node or Go differs from
+CI's. The tradeoffs, including the ones that should stop you adopting it, are
+in [the operator guide](./skills/local-attest/references/operator-guide.md).
+
+**That is the wedge. The rest of the toolkit is optional.** dotbabel is also an
+opinionated, model-agnostic library of skills, slash commands, and cloud/IaC
+specialists for Claude Code, Codex, Gemini CLI, and Copilot CLI, plus a global
+rule floor and spec-governance gates. Take the CLI, take the library, or take
+both.
 
 **Who is this for?**
 
 | I am…            | I want…                                                                          | Start here                                       |
 | ---------------- | -------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **CI payer**     | To stop re-running verified checks on paid runners                               | [Cut your CI bill](#cut-your-ci-bill)            |
 | **Dotfile user** | The toolkit — skills, commands, and CLAUDE.md in every Claude session            | [Clone & bootstrap](#clone--bootstrap)           |
 | **Consumer**     | The CLI in my repo — bootstrap, doctor, drift detection, optional spec-gov gates | [Install the CLI](#install-the-cli)              |
 | **Library user** | Node API in my own tooling                                                       | [docs/api-reference.md](./docs/api-reference.md) |
@@ -27,10 +50,47 @@ governance CLI on top, for repos that want PR-time gates.
 
 | What you want                                                                | How                                                                                |
 | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Skip remote CI for commits you verified locally                              | **[Cut your CI bill](#cut-your-ci-bill)** — `npx dotbabel-local-attest --init`     |
 | Skills & commands library wired into `~/.claude/`                            | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required           |
 | Governance CLI for your own repos (bootstrap + doctor + optional spec gates) | **[Install the CLI](#install-the-cli)** — see install section (Node ≥ 20 required) |
 
-Both paths are independent. You can use one or both.
+All three paths are independent. You can use one, two, or all of them.
+
+---
+
+## Cut your CI bill
+
+`local-attest` needs one file: a matrix of the checks CI runs. `--init` drafts
+it from your existing workflows, so adoption is a command rather than an
+afternoon:
+
+```bash
+npx dotbabel-local-attest --init
+```
+
+It reads `.github/workflows/*.yml`, turns every `run:` step in a
+pull-request-triggered job into a leg, groups legs into one lane per job (lanes
+run concurrently, legs within a lane run in order), mirrors any `paths:` filter
+as a `when.changedPaths` rule, and copies `setup-node` / `setup-go` versions
+into toolchain pins. Anything it cannot translate — a marketplace action, a
+service container, a job-level `if:` — becomes a `TODO:` comment inside the
+generated file rather than a silent omission.
+
+**The draft is a starting point, not a gate.** Read it against your workflows
+before you attest anything: a green attestation switches remote CI off, so a
+check missing from the matrix is enforced nowhere. Then:
+
+```bash
+npx dotbabel-local-attest --dry-run   # run the matrix, print the comment, post nothing
+npx dotbabel-local-attest             # run it, post the attestation, push
+```
+
+Wire the gate into a workflow by skipping when a trusted attestation matches
+the head SHA. The full contract — comment format, trust model, audit log, and
+the branch-protection caveat — is in
+[`skills/local-attest/references/operator-guide.md`](./skills/local-attest/references/operator-guide.md);
+the config schema is in
+[`skills/local-attest/references/config.md`](./skills/local-attest/references/config.md).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dotbabel/dotbabel",
   "version": "2.17.1",
-  "description": "An opinionated, model-agnostic governance toolkit for Claude Code, Codex, Gemini, and other agentic CLIs: skills, slash commands, cloud/IaC specialists, and an optional spec-governance CLI.",
+  "description": "Skip remote CI for commits you verified locally: run your GitHub Actions matrix on your machine and post a SHA-pinned attestation that makes the workflows skip themselves. Plus a model-agnostic toolkit of skills, slash commands, and governance gates for Claude Code, Codex, Gemini, and Copilot CLI.",
   "type": "module",
   "main": "plugins/dotbabel/src/index.mjs",
   "exports": {
@@ -81,6 +81,12 @@
     "url": "https://github.com/kaiohenricunha/dotbabel/issues"
   },
   "keywords": [
+    "ci-cd",
+    "github-actions",
+    "ci-optimization",
+    "ci-cost",
+    "local-ci",
+    "developer-tools",
     "claude-code",
     "codex",
     "gemini",
@@ -88,13 +94,9 @@
     "agent-toolkit",
     "skills",
     "slash-commands",
-    "cloud-specialists",
     "dotbabel",
-    "sdd",
-    "spec-driven",
-    "validator",
-    "linter",
     "governance",
+    "spec-driven",
     "cli"
   ],
   "license": "MIT",

--- a/plugins/dotbabel/bin/dotbabel-local-attest.mjs
+++ b/plugins/dotbabel/bin/dotbabel-local-attest.mjs
@@ -36,7 +36,15 @@
  *   64  bad CLI invocation (unknown flag, malformed --pr)
  */
 
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { invokedDirectly, misfiredAs } from "../src/lib/invoked-direct.mjs";
+import {
+  matrixFromWorkflows,
+  renderConfig,
+  toolchainFromWorkflows,
+} from "../src/local-attest-init.mjs";
 
 import { EXIT_CODES } from "../src/lib/exit-codes.mjs";
 import { parseArgs } from "../src/local-attest-lib.mjs";
@@ -45,11 +53,16 @@ import { PreconditionError, execute, realDeps } from "../src/local-attest-runner
 
 const HELP = `dotbabel-local-attest [--pr <N>] [--no-push] [--dry-run] [--fail-fast]
                       [--only <leg>] [--from <leg>] [--config <path>]
+                      [--init [--force]]
 
 Run the configured CI matrix locally and, on a clean pass, post an attestation
 comment to the open PR so the remote pipeline skips itself for this commit.
 
 Options:
+  --init             Draft a .local-attest config from .github/workflows and
+                     exit. Runs no legs and posts nothing. The draft is a
+                     starting point for review, never a finished gate.
+  --force            Let --init overwrite an existing config file.
   --pr <N>           Target PR number (defaults to the open PR for the branch)
   --no-push          Do not run \`git push\` after attesting
   --dry-run          Print the comment that would be posted; post nothing
@@ -81,6 +94,63 @@ function fail(code, msg) {
   process.exit(code);
 }
 
+/**
+ * `--init`: draft a config from the repo's workflows and write it.
+ *
+ * Refuses to clobber an existing config without --force — that file is a
+ * gate, and silently replacing a reviewed matrix with a draft is the worst
+ * thing this command could do.
+ *
+ * @param {ReturnType<typeof parseArgs>} argv
+ * @returns {Promise<number>} exit code
+ */
+async function runInit(argv) {
+  const dir = resolve(process.cwd(), ".github/workflows");
+  if (!existsSync(dir)) {
+    fail(EXIT_CODES.ENV, `no .github/workflows directory in ${process.cwd()} — nothing to read.`);
+  }
+  const names = readdirSync(dir).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+  if (names.length === 0) {
+    fail(EXIT_CODES.ENV, "no workflow files in .github/workflows.");
+  }
+
+  const target = resolve(process.cwd(), argv.config ?? ".local-attest.config.mjs");
+  if (existsSync(target) && !argv.force) {
+    fail(
+      EXIT_CODES.VALIDATION,
+      `${target} already exists. Pass --force to overwrite it, but read it first:\n` +
+        "  a reviewed matrix replaced by a draft is a gate you no longer control.",
+    );
+  }
+
+  const files = names.map((n) => ({
+    path: `.github/workflows/${n}`,
+    text: readFileSync(resolve(dir, n), "utf8"),
+  }));
+  const draft = matrixFromWorkflows(files);
+  const toolchain = toolchainFromWorkflows(files);
+
+  if (draft.legs.length === 0) {
+    fail(
+      EXIT_CODES.VALIDATION,
+      "no pull_request-triggered `run:` steps found — nothing to draft.\n" +
+        draft.warnings.map((w) => `  - ${w}`).join("\n"),
+    );
+  }
+
+  writeFileSync(target, renderConfig({ ...draft, toolchain }), "utf8");
+
+  process.stdout.write(
+    `Drafted ${target}\n` +
+      `  ${draft.legs.length} leg(s) from ${files.length} workflow file(s)\n` +
+      `  ${draft.warnings.length} TODO(s) written into the file\n\n` +
+      "This is a DRAFT, not a gate. Attesting switches remote CI off, so a leg\n" +
+      "missing here is enforced nowhere. Review it against your workflows, then:\n" +
+      "  dotbabel local-attest --dry-run    # run the matrix, post nothing\n",
+  );
+  return EXIT_CODES.OK;
+}
+
 async function main() {
   const rawArgs = process.argv.slice(2);
   if (rawArgs.includes("--version") || rawArgs.includes("-V")) {
@@ -102,6 +172,10 @@ async function main() {
   if (argv.help) {
     process.stdout.write(HELP + "\n");
     process.exit(EXIT_CODES.OK);
+  }
+
+  if (argv.init) {
+    process.exit(await runInit(argv));
   }
 
   /** @type {import("../src/local-attest-config.mjs").Config} */

--- a/plugins/dotbabel/src/local-attest-init.mjs
+++ b/plugins/dotbabel/src/local-attest-init.mjs
@@ -1,0 +1,332 @@
+/**
+ * local-attest-init — draft a `.local-attest.config.mjs` from a repo's
+ * GitHub Actions workflows.
+ *
+ * Hand-writing the matrix is the single biggest cost of adopting
+ * local-attest, and it is mechanical work: the legs are the `run:` steps CI
+ * already executes. This module reads the workflows and drafts the config.
+ *
+ * SAFETY: the output is a DRAFT for a human to review, never a finished gate.
+ * An attestation switches remote CI off, so a matrix that quietly omits a job
+ * certifies work nobody did. Everything here is therefore biased toward
+ * over-reporting: constructs that cannot be translated become warnings the
+ * renderer writes into the file as TODO comments, every leg carries a
+ * provenance comment naming the workflow, job, and step it mirrors, and the
+ * file opens with a review banner. Nothing in this module ever runs a leg or
+ * posts anything.
+ *
+ * Pure functions only — all file I/O lives in the bin, matching pr-stack.
+ *
+ * @typedef {object} WorkflowFile
+ * @property {string} path  repo-relative path, used in provenance and warnings
+ * @property {string} text  raw YAML
+ *
+ * @typedef {object} DraftLeg
+ * @property {string} name
+ * @property {"hard"|"advisory"} mode
+ * @property {string} command
+ * @property {string} [cwd]
+ * @property {string} lane
+ * @property {{ changedPaths: string[] }} [when]
+ * @property {string} source  provenance, rendered as a comment
+ */
+
+import yaml from "js-yaml";
+
+/** Steps whose `uses:` is pure CI plumbing with no local equivalent. */
+const PLUMBING = /^actions\/(checkout|setup-|cache|upload-|download-)/;
+
+/**
+ * Workflows that ship something rather than check something. They often do
+ * trigger on pull_request (preview environments), so their steps are drafted
+ * like any other — but running a deploy locally to satisfy a gate is almost
+ * never what the author wants, and these workflows tend to dominate the leg
+ * count. Flagged for pruning, never dropped: guessing wrong here would remove
+ * a real check.
+ */
+const SHIPPING = /(deploy|preview|release|publish|cleanup)/i;
+
+/**
+ * Job-level keys that change what CI actually runs and have no config
+ * equivalent, so a draft that ignored them would overstate its coverage.
+ */
+const UNTRANSLATABLE = [
+  ["strategy", "strategy.matrix runs this job several times; the draft keeps one leg"],
+  ["if", "if: condition gates this job in CI; mirror it with when.changedPaths or drop the leg"],
+  ["services", "services containers are provisioned by CI; the leg must provision them locally"],
+  ["container", "container: runs this job in an image; the leg runs on the host instead"],
+  ["environment", "environment: may inject secrets the local leg will not have"],
+];
+
+/**
+ * Parse one workflow, tolerating malformed YAML.
+ *
+ * @param {WorkflowFile} file
+ * @returns {{ doc: Record<string, unknown>|null, error: string|null }}
+ */
+function parseWorkflow(file) {
+  try {
+    const doc = yaml.load(file.text);
+    if (!doc || typeof doc !== "object") return { doc: null, error: "not a YAML mapping" };
+    return { doc: /** @type {Record<string, unknown>} */ (doc), error: null };
+  } catch (err) {
+    return { doc: null, error: err.message.split("\n")[0] };
+  }
+}
+
+/**
+ * The `on:` block, normalised. YAML parses a bare `on` as the boolean true,
+ * so both spellings have to be probed.
+ *
+ * @param {Record<string, unknown>} doc
+ * @returns {Record<string, unknown>|string[]|null}
+ */
+function triggers(doc) {
+  const raw = doc.on ?? doc[true];
+  if (!raw) return null;
+  return /** @type {Record<string, unknown>|string[]} */ (raw);
+}
+
+/**
+ * True when the workflow runs on pull_request. A workflow that does not is
+ * not part of the PR gate, so attesting says nothing about it.
+ *
+ * @param {Record<string, unknown>} doc
+ * @returns {boolean}
+ */
+function runsOnPullRequest(doc) {
+  const on = triggers(doc);
+  if (!on) return false;
+  if (Array.isArray(on)) return on.includes("pull_request");
+  if (typeof on === "string") return on === "pull_request";
+  return Object.prototype.hasOwnProperty.call(on, "pull_request");
+}
+
+/**
+ * The `pull_request.paths` filter, if the workflow declares one. Mirroring it
+ * as `when.changedPaths` keeps the local leg scoped exactly like the CI job.
+ *
+ * @param {Record<string, unknown>} doc
+ * @returns {string[]|null}
+ */
+function pullRequestPaths(doc) {
+  const on = triggers(doc);
+  if (!on || Array.isArray(on) || typeof on === "string") return null;
+  const pr = /** @type {Record<string, unknown>} */ (on).pull_request;
+  if (!pr || typeof pr !== "object") return null;
+  const paths = /** @type {Record<string, unknown>} */ (pr).paths;
+  if (!Array.isArray(paths) || paths.length === 0) return null;
+  return paths.map(String);
+}
+
+/**
+ * Read toolchain pins out of setup-node / setup-go steps.
+ *
+ * `node` must be an exact major for the schema, so "22.x" and "22.11.0" are
+ * reduced to "22"; a non-numeric spec (e.g. "lts/*") is dropped rather than
+ * guessed, because a wrong pin fails every attest run closed.
+ *
+ * @param {WorkflowFile[]} fileList
+ * @returns {{node?: string, goMod?: string}|null}
+ */
+export function toolchainFromWorkflows(fileList) {
+  /** @type {{node?: string, goMod?: string}} */
+  const out = {};
+  for (const file of fileList) {
+    const { doc } = parseWorkflow(file);
+    if (!doc || !runsOnPullRequest(doc)) continue;
+    for (const job of Object.values(doc.jobs ?? {})) {
+      for (const step of job?.steps ?? []) {
+        const uses = typeof step?.uses === "string" ? step.uses : "";
+        const w = step?.with ?? {};
+        if (uses.startsWith("actions/setup-node") && !out.node) {
+          const major = String(w["node-version"] ?? "").match(/^(\d+)/);
+          if (major) out.node = major[1];
+        }
+        if (uses.startsWith("actions/setup-go") && !out.goMod) {
+          const file2 = w["go-version-file"];
+          if (typeof file2 === "string" && file2) out.goMod = file2;
+        }
+      }
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * Draft a matrix from the workflows that gate pull requests.
+ *
+ * One leg per `run:` step: a step is the smallest unit whose failure CI
+ * reports independently, and collapsing a job's steps into one leg would hide
+ * which one broke. Legs are laned by job so independent jobs run
+ * concurrently, matching how CI schedules them.
+ *
+ * @param {WorkflowFile[]} fileList
+ * @returns {{ legs: DraftLeg[], warnings: string[] }}
+ */
+export function matrixFromWorkflows(fileList) {
+  /** @type {DraftLeg[]} */
+  const legs = [];
+  /** @type {string[]} */
+  const warnings = [];
+
+  for (const file of fileList) {
+    const { doc, error } = parseWorkflow(file);
+    if (error || !doc) {
+      warnings.push(`${file.path}: could not parse (${error ?? "empty"}) — skipped entirely`);
+      continue;
+    }
+    if (!runsOnPullRequest(doc)) {
+      warnings.push(`${file.path}: no pull_request trigger — skipped (it does not gate a PR)`);
+      continue;
+    }
+
+    const paths = pullRequestPaths(doc);
+    const jobs = /** @type {Record<string, any>} */ (doc.jobs ?? {});
+    const legsBefore = legs.length;
+
+    for (const [jobId, job] of Object.entries(jobs)) {
+      if (!job || typeof job !== "object") continue;
+
+      for (const [key, message] of UNTRANSLATABLE) {
+        if (job[key] !== undefined) warnings.push(`${file.path} job "${jobId}": ${message}`);
+      }
+      if (job.needs !== undefined) {
+        const needs = Array.isArray(job.needs) ? job.needs.join(", ") : String(job.needs);
+        warnings.push(
+          `${file.path} job "${jobId}": needs [${needs}] — lanes run concurrently, so order ` +
+            `across jobs is not preserved; merge dependent jobs into one lane if it matters`,
+        );
+      }
+
+      const jobCwd = job.defaults?.run?.["working-directory"];
+      const steps = Array.isArray(job.steps) ? job.steps : [];
+
+      for (const step of steps) {
+        if (!step || typeof step !== "object") continue;
+        if (typeof step.uses === "string") {
+          if (!PLUMBING.test(step.uses)) {
+            warnings.push(
+              `${file.path} job "${jobId}": step uses ${step.uses} — no local equivalent, ` +
+                `no leg drafted; add one by hand if it gates anything`,
+            );
+          }
+          continue;
+        }
+        if (typeof step.run !== "string" || step.run.trim() === "") continue;
+
+        const label = typeof step.name === "string" && step.name ? step.name : step.run.trim();
+        const cwd = step["working-directory"] ?? jobCwd;
+        /** @type {DraftLeg} */
+        const leg = {
+          name: `${jobId}: ${label}`.slice(0, 80),
+          mode:
+            step["continue-on-error"] === true || job["continue-on-error"] === true
+              ? "advisory"
+              : "hard",
+          command: step.run.trim(),
+          lane: jobId,
+          source: `${file.path} job "${jobId}" step "${label}"`,
+        };
+        if (typeof cwd === "string" && cwd) leg.cwd = cwd;
+        if (paths) leg.when = { changedPaths: paths };
+        if (step.env && typeof step.env === "object") {
+          const stringly = Object.entries(step.env).every(([, v]) => typeof v === "string");
+          if (stringly) leg.env = /** @type {Record<string,string>} */ (step.env);
+          else
+            warnings.push(
+              `${file.path} job "${jobId}" step "${label}": env has non-string values — dropped`,
+            );
+        }
+        legs.push(leg);
+      }
+    }
+
+    const drafted = legs.length - legsBefore;
+    if (drafted > 0 && SHIPPING.test(file.path)) {
+      warnings.push(
+        `${file.path}: drafted ${drafted} leg(s), but this workflow looks like it ships ` +
+          `rather than checks — deploy steps rarely belong in an attestation matrix. ` +
+          `Prune the ones that do not verify anything.`,
+      );
+    }
+  }
+
+  const seen = new Set();
+  for (const leg of legs) {
+    let name = leg.name;
+    for (let i = 2; seen.has(name); i++) name = `${leg.name} (${i})`;
+    leg.name = name;
+    seen.add(name);
+  }
+
+  return { legs, warnings };
+}
+
+/**
+ * Render a draft config as `.local-attest.config.mjs` source.
+ *
+ * Warnings become TODO comments in the file itself rather than terminal
+ * output: the file outlives the terminal, and an unreviewed warning is
+ * exactly how a matrix ends up certifying a job it never ran.
+ *
+ * @param {{ legs: DraftLeg[], warnings: string[], toolchain: {node?: string, goMod?: string}|null }} draft
+ * @returns {string}
+ */
+export function renderConfig({ legs, warnings, toolchain }) {
+  const q = (s) => JSON.stringify(s);
+  const out = [];
+
+  out.push("// .local-attest.config.mjs — DRAFTED by `dotbabel local-attest --init`.");
+  out.push("//");
+  out.push("// !! REVIEW THIS FILE BEFORE YOU ATTEST ANYTHING !!");
+  out.push("//");
+  out.push("// A green attestation switches remote CI OFF for that commit, so this");
+  out.push("// matrix becomes the only gate. A leg that is missing here is enforced");
+  out.push("// nowhere. The generator can only see `run:` steps — it cannot see what");
+  out.push("// a marketplace action does, what a service container provides, or what");
+  out.push("// a job-level `if:` decides. Walk your workflows and this file side by");
+  out.push("// side once, fix every TODO below, then delete this banner.");
+  out.push("");
+
+  if (warnings.length > 0) {
+    out.push(`// ${warnings.length} thing(s) the generator could not translate:`);
+    for (const w of warnings) out.push(`// TODO: ${w}`);
+    out.push("");
+  }
+
+  out.push("export default {");
+  out.push("  matrix: [");
+  for (const leg of legs) {
+    out.push(`    // ${leg.source}`);
+    out.push("    {");
+    out.push(`      name: ${q(leg.name)},`);
+    out.push(`      mode: ${q(leg.mode)},`);
+    out.push(`      lane: ${q(leg.lane)},`);
+    out.push(`      command: ${q(leg.command)},`);
+    if (leg.cwd) out.push(`      cwd: ${q(leg.cwd)},`);
+    if (leg.env) out.push(`      env: ${JSON.stringify(leg.env)},`);
+    if (leg.when)
+      out.push(`      when: { changedPaths: ${JSON.stringify(leg.when.changedPaths)} },`);
+    out.push("    },");
+  }
+  out.push("  ],");
+  out.push("");
+  if (toolchain) {
+    out.push("  // Pins read from setup-node / setup-go. An attest run fails closed");
+    out.push("  // when the local toolchain does not match.");
+    out.push(`  toolchain: ${JSON.stringify(toolchain)},`);
+  } else {
+    out.push("  // TODO: no toolchain pin found. Without one, a local run on a different");
+    out.push("  // runtime than CI can attest a result CI would not reproduce.");
+    out.push('  // toolchain: { node: "22", goMod: "api/go.mod" },');
+  }
+  out.push("");
+  out.push("  // TODO: does any leg overwrite a tracked file (e2e seeders do)? List those");
+  out.push("  // paths here or every run aborts on its own writes.");
+  out.push("  restoreFiles: [],");
+  out.push("};");
+  out.push("");
+
+  return out.join("\n");
+}

--- a/plugins/dotbabel/src/local-attest-lib.mjs
+++ b/plugins/dotbabel/src/local-attest-lib.mjs
@@ -35,6 +35,8 @@
  * @property {string[]} only
  * @property {string|null} from
  * @property {boolean} failFast
+ * @property {boolean} init   draft a config from .github/workflows and exit; runs no legs
+ * @property {boolean} force  allow --init to overwrite an existing config
  */
 
 export const ATTEST_MARKER_PREFIX = "<!-- local-attest verified-sha=";
@@ -128,6 +130,8 @@ export function parseArgs(argv, die) {
     only: [],
     from: null,
     failFast: false,
+    init: false,
+    force: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -153,6 +157,10 @@ export function parseArgs(argv, die) {
       if (!v) return exit(64, "--from requires a leg name");
       if (args.from !== null) return exit(64, "--from given more than once");
       args.from = v;
+    } else if (a === "--init") {
+      args.init = true;
+    } else if (a === "--force") {
+      args.force = true;
     } else if (a === "--fail-fast") {
       args.failFast = true;
     } else if (a === "--help" || a === "-h") {

--- a/plugins/dotbabel/tests/local-attest-init.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-init.test.mjs
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  matrixFromWorkflows,
+  renderConfig,
+  toolchainFromWorkflows,
+} from "../src/local-attest-init.mjs";
+
+const TEST_YML = `
+name: test
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true
+      - name: Unit tests
+        run: npm run test:coverage
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: api/go.mod
+      - name: Go tests
+        run: go test -race -count=1 ./...
+`;
+
+const BOLAO_YML = `
+name: e2e
+on:
+  pull_request:
+    paths:
+      - "api/**"
+      - "src/Bolao*.jsx"
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/run-e2e.sh
+`;
+
+const files = (...pairs) => pairs.map(([path, text]) => ({ path, text }));
+
+describe("matrixFromWorkflows", () => {
+  const result = () => matrixFromWorkflows(files([".github/workflows/test.yml", TEST_YML]));
+
+  it("emits one leg per run step, named from the job and step", () => {
+    const names = result().legs.map((l) => l.name);
+    expect(names).toEqual([
+      "frontend: npm ci",
+      "frontend: Lint",
+      "frontend: Unit tests",
+      "backend: Go tests",
+    ]);
+  });
+
+  it("carries the command verbatim — a paraphrased command attests the wrong thing", () => {
+    expect(result().legs[3].command).toBe("go test -race -count=1 ./...");
+  });
+
+  it("maps continue-on-error to an advisory leg, everything else hard", () => {
+    const byName = Object.fromEntries(result().legs.map((l) => [l.name, l.mode]));
+    expect(byName["frontend: Lint"]).toBe("advisory");
+    expect(byName["frontend: Unit tests"]).toBe("hard");
+  });
+
+  it("propagates the job's working-directory as cwd", () => {
+    expect(result().legs[3].cwd).toBe("api");
+    expect(result().legs[0].cwd).toBeUndefined();
+  });
+
+  it("skips `uses:` steps — actions have no local equivalent", () => {
+    expect(result().legs.every((l) => l.command && !l.command.includes("actions/"))).toBe(true);
+  });
+
+  it("assigns lanes per job so independent jobs run concurrently", () => {
+    const lanes = new Set(result().legs.map((l) => l.lane));
+    expect(lanes).toEqual(new Set(["frontend", "backend"]));
+  });
+
+  it("records provenance for every leg — the reviewer must see what it mirrors", () => {
+    expect(result().legs[1].source).toBe('.github/workflows/test.yml job "frontend" step "Lint"');
+  });
+
+  it("mirrors a workflow-level paths filter onto its legs as when.changedPaths", () => {
+    const r = matrixFromWorkflows(files([".github/workflows/e2e.yml", BOLAO_YML]));
+    expect(r.legs[0].when).toEqual({ changedPaths: ["api/**", "src/Bolao*.jsx"] });
+  });
+
+  it("warns on constructs it cannot translate rather than silently dropping them", () => {
+    const withMatrix = `
+name: t
+on: [pull_request]
+jobs:
+  build:
+    strategy:
+      matrix:
+        node: [20, 22]
+    if: github.actor != 'dependabot[bot]'
+    services:
+      pg:
+        image: postgres:16
+    steps:
+      - run: npm test
+`;
+    const r = matrixFromWorkflows(files([".github/workflows/t.yml", withMatrix]));
+    const joined = r.warnings.join("\n");
+    expect(joined).toMatch(/strategy\.matrix/);
+    expect(joined).toMatch(/if:/);
+    expect(joined).toMatch(/services/);
+    expect(r.legs).toHaveLength(1);
+  });
+
+  it("ignores workflows with no pull_request trigger — they gate nothing on a PR", () => {
+    const cron = `
+name: nightly
+on:
+  schedule:
+    - cron: '0 3 * * *'
+jobs:
+  j:
+    steps:
+      - run: npm run nightly
+`;
+    const r = matrixFromWorkflows(files([".github/workflows/nightly.yml", cron]));
+    expect(r.legs).toEqual([]);
+    expect(r.warnings.join("\n")).toMatch(/nightly\.yml/);
+  });
+
+  it("survives unparseable YAML with a warning instead of throwing", () => {
+    const r = matrixFromWorkflows(files([".github/workflows/bad.yml", "jobs: [unclosed"]));
+    expect(r.legs).toEqual([]);
+    expect(r.warnings.join("\n")).toMatch(/bad\.yml/);
+  });
+
+  it("keeps multi-line run blocks as one command", () => {
+    const multi = `
+name: t
+on: [pull_request]
+jobs:
+  j:
+    steps:
+      - name: Chain
+        run: |
+          npm ci
+          npm test
+`;
+    const r = matrixFromWorkflows(files([".github/workflows/t.yml", multi]));
+    expect(r.legs[0].command).toBe("npm ci\nnpm test");
+  });
+});
+
+describe("toolchainFromWorkflows", () => {
+  it("reads an exact node pin and a go-version-file", () => {
+    expect(toolchainFromWorkflows(files([".github/workflows/test.yml", TEST_YML]))).toEqual({
+      node: "22",
+      goMod: "api/go.mod",
+    });
+  });
+
+  it("drops a floating node range — the schema only accepts an exact major", () => {
+    const floating = TEST_YML.replace("node-version: '22'", "node-version: '22.x'");
+    const t = toolchainFromWorkflows(files([".github/workflows/test.yml", floating]));
+    expect(t.node).toBe("22");
+  });
+
+  it("returns null when nothing is pinned", () => {
+    const bare = "name: t\non: [pull_request]\njobs:\n  j:\n    steps:\n      - run: make\n";
+    expect(toolchainFromWorkflows(files([".github/workflows/t.yml", bare]))).toBeNull();
+  });
+});
+
+describe("renderConfig", () => {
+  const rendered = () => {
+    const r = matrixFromWorkflows(files([".github/workflows/test.yml", TEST_YML]));
+    return renderConfig({ ...r, toolchain: { node: "22", goMod: "api/go.mod" } });
+  };
+
+  it("emits a config the validator accepts", async () => {
+    const { validateConfig } = await import("../src/local-attest-config.mjs");
+    // Strip the export wrapper and eval the object literal the same way a
+    // dynamic import would, so the test proves the emitted file is loadable.
+    const mod = await import(
+      `data:text/javascript,${encodeURIComponent(rendered().replace(/^#!.*\n/, ""))}`
+    );
+    expect(() => validateConfig(mod.default)).not.toThrow();
+  });
+
+  it("carries provenance comments, not just data", () => {
+    expect(rendered()).toContain('job "frontend" step "Lint"');
+  });
+
+  it("leads with a review banner — a generated matrix is a draft, never a gate", () => {
+    expect(rendered()).toMatch(/REVIEW THIS FILE/);
+  });
+
+  it("renders warnings as TODO comments inside the file, where they cannot be missed", () => {
+    const out = renderConfig({
+      legs: [{ name: "a", mode: "hard", command: "true", lane: "j", source: "x" }],
+      warnings: ["t.yml job build: strategy.matrix is not translated"],
+      toolchain: null,
+    });
+    expect(out).toMatch(/TODO.*strategy\.matrix/);
+  });
+});

--- a/plugins/dotbabel/tests/local-attest-lib.test.mjs
+++ b/plugins/dotbabel/tests/local-attest-lib.test.mjs
@@ -135,7 +135,15 @@ describe("parseArgs", () => {
       only: [],
       from: null,
       failFast: false,
+      init: false,
+      force: false,
     });
+  });
+
+  it("parses --init and --force; both default off so a bare run never scaffolds", () => {
+    expect(parseArgs(["--init"]).init).toBe(true);
+    expect(parseArgs(["--init", "--force"]).force).toBe(true);
+    expect(parseArgs(["--dry-run"]).init).toBe(false);
   });
 
   it("parses --pr <N>", () => {


### PR DESCRIPTION
## Summary

- **`--init` drafts a `.local-attest` config from `.github/workflows`.** Hand-writing the matrix was the single biggest adoption cost, and it is mechanical work: the legs are the `run:` steps CI already runs. One leg per run step, one lane per job (matching how CI schedules them), `paths:` filters mirrored as `when.changedPaths`, `setup-node`/`setup-go` versions lifted into toolchain pins.
- **Safety is the design constraint, not a feature.** An attestation switches remote CI off, so a matrix that quietly omits a check is enforced nowhere. Everything over-reports: untranslatable constructs (marketplace actions, service containers, job-level `if:`, `strategy.matrix`, `needs` ordering) become `TODO:` comments *inside the generated file*; every leg carries a provenance comment naming its workflow, job, and step; the file opens with a review banner; deploy-shaped workflows are flagged for pruning rather than dropped; and `--init` refuses to clobber an existing config without `--force`.
- **Repositions the front door around the wedge.** The README now opens with the CI-cost problem and a three-command path instead of "governance toolkit", and npm keywords lead with problem-shaped terms (`ci-cd`, `github-actions`, `ci-optimization`) rather than internal taxonomy. `package.json` version untouched.

## Test plan

- [x] `npx vitest run` — 1137 pass (19 new: parsing, provenance, advisory mapping, lane assignment, paths mirroring, toolchain extraction and range-narrowing, warning emission for each untranslatable construct, malformed YAML, non-PR workflows, multi-line run blocks, and a render test that dynamic-imports the emitted file and feeds it to the real `validateConfig`)
- [x] `bash plugins/dotbabel/scripts/run-bats.sh` — 595 pass
- [x] `npm run lint` / `npm run dogfood` / `build-plugin --check` / `index --check` — clean
- [x] Dogfooded on this repo: 37 legs from 9 workflows, 10 TODOs
- [x] Validated against a real consumer repo with a hand-written config as ground truth: 10/15 commands reproduced verbatim; all 5 misses are marketplace actions with no local equivalent, each surfaced as a TODO

## Spec ID

dotbabel-core
