### PR TITLE
docs: lead with verification discipline, not CI cost

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "dotbabel",
-  "description": "Kaio Cunha's Claude Code plugins: local CI attestation, engineering skills, and governance gates.",
+  "description": "Kaio Cunha's Claude Code plugins: verification discipline for agentic development, local CI attestation, and governance gates.",
   "owner": {
     "name": "Kaio Cunha",
     "url": "https://github.com/kaiohenricunha"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "dotbabel",
-      "description": "Skip remote CI for commits you verified locally: run your GitHub Actions matrix on your machine and post a SHA-pinned attestation that makes the workflows skip themselves. Ships with a library of engineering skills and specialist subagents, spec-governance gates, and cross-CLI instruction sync.",
+      "description": "Make an AI coding agent show its work. A verification layer for agentic development: skills that force an agent to ground every claim in real source, reproduce a bug before fixing it, and cite file:line \u2014 plus gates that check the result. Includes local CI attestation, spec-governance checks, and one rule floor fanned out to Claude Code, Codex, Gemini, and Copilot CLI.",
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/kaiohenricunha/dotbabel.git",

--- a/.claude/skills-manifest.json
+++ b/.claude/skills-manifest.json
@@ -1,181 +1,181 @@
 {
   "version": 1,
-  "generatedAt": "2026-08-14T23:02:56.931Z",
+  "generatedAt": "2026-08-15T00:20:32.075Z",
   "skills": [
     {
       "name": "agents-search",
       "path": ".claude/skills/agents-search/SKILL.md",
       "checksum": "sha256:ed2f98dc0344f7c57f19b92c0f08a1bf02e517435175bc690b51fee2a78136b3",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "audit-and-fix",
       "path": ".claude/skills/audit-and-fix/SKILL.md",
       "checksum": "sha256:ac8ee5735fa846a54da111bebcf2c9ef550d48d3cfcc7da75c070c527a29991a",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "aws-specialist",
       "path": ".claude/skills/aws-specialist/SKILL.md",
       "checksum": "sha256:ba954a78351a0988ccd7ab00574bde2f6aa0d4dab0b5a32fb755f14957411358",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "azure-specialist",
       "path": ".claude/skills/azure-specialist/SKILL.md",
       "checksum": "sha256:7c1625de68e13e15ab0beb179e4cf6f9a3d2a80ec294a04cbb46e430cb0ab425",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "changelog",
       "path": ".claude/commands/changelog.md",
       "checksum": "sha256:8f60bfe166c378b81bd9ba0ed0538053d472da8fdd29dfc146657dac4eb3dfe4",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "code-simplifier",
       "path": ".claude/skills/code-simplifier/SKILL.md",
       "checksum": "sha256:e24c64485f950d93815f492de5673aaa3ff65abb0df91fb41e41a40b68017cff",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "create-assessment",
       "path": ".claude/skills/create-assessment/SKILL.md",
       "checksum": "sha256:7d364824b0ce34d5703a3db91956b4607182b52be79bc5fdec9583c73ef6f73c",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "create-audit",
       "path": ".claude/skills/create-audit/SKILL.md",
       "checksum": "sha256:c65ff762a76e721fd0169cee087c582198c628a7a79b518792b168b2b6001cd4",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "create-experiment",
       "path": ".claude/skills/create-experiment/SKILL.md",
       "checksum": "sha256:424f23db1e1ba2cfc32c215bc4ae8f8dd8f710274161884252ac1fcfb28dcd3c",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "create-inspection",
       "path": ".claude/skills/create-inspection/SKILL.md",
       "checksum": "sha256:d8febaf15dd98a5d72fe97f8f41fd7d0a83ed98f0a11ab7ecedeedeaec544e85",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "crossplane-specialist",
       "path": ".claude/skills/crossplane-specialist/SKILL.md",
       "checksum": "sha256:ef78a49da882582f409c0c166d74112c6d37af437592e05bf6cd218bb8c34476",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "dependabot-sweep",
       "path": ".claude/commands/dependabot-sweep.md",
       "checksum": "sha256:5142a4d1788d379a65a1e828a04ebf490ed3536596542773c9ffc4d3697017bd",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "deploy-status",
       "path": ".claude/skills/deploy-status/SKILL.md",
       "checksum": "sha256:9119370d74077eae376afa72b28fff9cfd7617fd11b310590ddd6eb6c3d9258f",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "detect-flaky",
       "path": ".claude/skills/detect-flaky/SKILL.md",
       "checksum": "sha256:088b6790ca5a2a3e17c333a1325e9a0789fd7887071b18df92378e4a3ae88edc",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "fix-with-evidence",
       "path": ".claude/skills/fix-with-evidence/SKILL.md",
       "checksum": "sha256:c75cd2f1f6268140dda2da98b634940bebac03a0c01781e17628f8cf502e3c49",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "flyctl",
       "path": ".claude/skills/flyctl/SKILL.md",
       "checksum": "sha256:6a22f1494f62720df786919d8c563d20ecdf0f48c25b04f748c67535bef32318",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "gcp-specialist",
       "path": ".claude/skills/gcp-specialist/SKILL.md",
       "checksum": "sha256:39763f741bbff9bd6f9b72908ed3ea8de1870e2d5017b3ddab9015e0db4ff108",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "git",
       "path": ".claude/skills/git/SKILL.md",
       "checksum": "sha256:c9632f1e4565f2c51167da4a95e841edc924dbfabf1bd0f3529c1c73a19d55e4",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "ground-first",
       "path": ".claude/skills/ground-first/SKILL.md",
       "checksum": "sha256:0a8a9c125bc3fd0a3fe5cacb4f8cf6ff5971895ea1b703037a8712d3b5e15dd6",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "handoff",
       "path": ".claude/skills/handoff/SKILL.md",
       "checksum": "sha256:dcb590aeb5859f004465fd94c4f9d4c591cb2eed2c184e0f0957f2e7edba003b",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "kubernetes-specialist",
       "path": ".claude/skills/kubernetes-specialist/SKILL.md",
       "checksum": "sha256:e3f0404dbd80ebdfce9df79df0a9bf501574abafcb7cd5a656c2afd4519428fb",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "local-attest",
       "path": ".claude/skills/local-attest/SKILL.md",
       "checksum": "sha256:688dc4b8e9c926627c6eab50c6bb836bad6787a4355ba588bbbb22792171d269",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "markdown",
       "path": ".claude/commands/markdown.md",
       "checksum": "sha256:65340c8b4b440f905e60e8c1c3d474273e27d404bc1728a73fdab21aef31a3ee",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "merge-pr",
       "path": ".claude/commands/merge-pr.md",
       "checksum": "sha256:b5a86222bec1f7561672fb67010527a076e3439f74e7f8c9b71932a1b8923200",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "plan-grader",
       "path": ".claude/skills/plan-grader/SKILL.md",
       "checksum": "sha256:50ba919efa0b4235e182a7d5b1ff2308481086a3ddddbf9166b0560370c3af27",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "post-pr-review",
@@ -184,7 +184,7 @@
       "dependencies": [
         "review-pr"
       ],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "pr-conductor",
@@ -198,28 +198,28 @@
         "local-attest",
         "merge-pr"
       ],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "pre-pr",
       "path": ".claude/commands/pre-pr.md",
       "checksum": "sha256:5b648d63608231c077c3a5bd54f5c3b7a598443782a8d8ab7f223e62c5d4d37a",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "project-sync",
       "path": ".claude/skills/project-sync/SKILL.md",
       "checksum": "sha256:8243e74bcf280574a2b04ac0ee3c19590a7dc273560a4ec83f74cc8a56fbd858",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "pulumi-specialist",
       "path": ".claude/skills/pulumi-specialist/SKILL.md",
       "checksum": "sha256:6620a3862749142cf450245e9c6fc6c398530208848f64e2c34132e138f6f5ef",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "release-conductor",
@@ -228,28 +228,28 @@
       "dependencies": [
         "deploy-status"
       ],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "reproduce-bug",
       "path": ".claude/skills/reproduce-bug/SKILL.md",
       "checksum": "sha256:e73ae70e76b0c4a0ba43dc42d01596b2df1e97ffa7813a9fab45012711408b51",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "review-pr",
       "path": ".claude/skills/review-pr/SKILL.md",
       "checksum": "sha256:ad8f9312d61e5913f3e36a51b05b43230d1e8f6993c3ff0944dad35539904eed",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "review-prs",
       "path": ".claude/skills/review-prs/SKILL.md",
       "checksum": "sha256:6f7c8b4fa94084265a5fae3237225e7ba4b3e225678955ed5f0f1c14c3193733",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "rollback-prod",
@@ -258,49 +258,49 @@
       "dependencies": [
         "deploy-status"
       ],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "security-review",
       "path": ".claude/skills/security-review/SKILL.md",
       "checksum": "sha256:c8447582929b315402af24e304acd4addaa9be7120e895ca25d4c897ba84cfda",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "spec",
       "path": ".claude/skills/spec/SKILL.md",
       "checksum": "sha256:9ec1c67a434bf90512a2dcb5a68c4bb3bffd65c1bee967fa370164ec6ea84002",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "terraform-specialist",
       "path": ".claude/skills/terraform-specialist/SKILL.md",
       "checksum": "sha256:9e9c0d8b36ef44fb7f4f604aa706c2f380787c38c0282987c24436ec7bd53b85",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "terragrunt-specialist",
       "path": ".claude/skills/terragrunt-specialist/SKILL.md",
       "checksum": "sha256:fc7f266342f1686a5ca394398f048742b5f249144f45354d5f8c2520e359a2bb",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "validate-spec",
       "path": ".claude/skills/validate-spec/SKILL.md",
       "checksum": "sha256:13320e86060cb9a74d9ee98aecbbb9eff43c6100b47f09debe15f7049f6c050c",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     },
     {
       "name": "veracity-audit",
       "path": ".claude/skills/veracity-audit/SKILL.md",
       "checksum": "sha256:2f66c14a71e88734d8a734bf1ce6f220f74ce28a9e302635e4e225edc1f9300e",
       "dependencies": [],
-      "lastValidated": "2026-08-14"
+      "lastValidated": "2026-08-15"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -6,43 +6,48 @@
 
 > Maintained by [@kaiohenricunha](https://github.com/kaiohenricunha) · [Changelog](./CHANGELOG.md) · [Security](./SECURITY.md)
 
-**Stop paying for CI you already ran locally.**
+**Make an AI coding agent show its work.**
 
-You run the test suite on your machine, push, and then wait ten minutes while
-GitHub-hosted runners run exactly the same commands again — and bill you for
-it. `dotbabel local-attest` runs your CI matrix locally and, on a clean pass,
-posts a SHA-pinned comment that makes your workflows skip themselves for that
-commit. One repo using it cut ~27 minutes of runner time per push to zero.
+Agents produce plausible output fast. The expensive failures come from the
+plausible-but-unverified kind: a fix for a bug nobody reproduced, an analysis
+citing a file that was never opened, a "done" that no test covers. dotbabel is
+the verification layer — a library of skills that force an agent to ground
+every claim, plus gates that check the result before it merges.
 
-```bash
-npx dotbabel-local-attest --init      # draft a matrix from .github/workflows
-npx dotbabel-local-attest --dry-run   # run it locally, post nothing
-npx dotbabel-local-attest             # run it, attest, push
-```
+The skills encode the discipline. `/ground-first` refuses to propose an edit
+until the relevant source has actually been read. `/fix-with-evidence` demands
+a failing reproduction before a fix and a passing run after it.
+`/veracity-audit` and `/plan-grader` grade work against what the code really
+says. `/security-review`, `/detect-flaky`, and `/validate-spec` gate the
+output. Cloud and IaC specialists (`aws`, `gcp`, `azure`, `kubernetes`,
+`terraform`, `crossplane`) bring the same evidence-first posture to
+infrastructure work.
 
-It is deliberately hard to fool. The attestation is pinned to the exact head
-SHA, so the next push invalidates it; only repo-owner comments are trusted;
-the run refuses to attest if any leg was skipped, never launched, or hard
-failed; every run — including every failure — appends a line to an audit log;
-and toolchain pins fail the run closed when your local Node or Go differs from
-CI's. The tradeoffs, including the ones that should stop you adopting it, are
-in [the operator guide](./skills/local-attest/references/operator-guide.md).
+**How serious is that verification? Serious enough to replace your CI gate.**
+`dotbabel local-attest` runs your GitHub Actions matrix on your machine and,
+on a clean pass, posts a SHA-pinned attestation that makes the remote
+workflows skip themselves for that commit — one repo cut ~27 minutes of runner
+time per push to zero. It is deliberately hard to fool: pinned to the exact
+head SHA so the next push invalidates it, owner-authored comments only, a
+refusal to attest when any leg was skipped or never launched, an audit log
+that records failures as well as passes, and toolchain pins that fail the run
+closed when your local Node or Go differs from CI's. That is the standard the
+rest of the toolkit is built to.
 
-**That is the wedge. The rest of the toolkit is optional.** dotbabel is also an
-opinionated, model-agnostic library of skills, slash commands, and cloud/IaC
-specialists for Claude Code, Codex, Gemini CLI, and Copilot CLI, plus a global
-rule floor and spec-governance gates. Take the CLI, take the library, or take
-both.
+It also runs everywhere you work: one rule floor, fanned out to Claude Code,
+Codex, Gemini CLI, and Copilot CLI, with drift detection so the copies cannot
+silently disagree.
 
 **Who is this for?**
 
-| I am…            | I want…                                                                          | Start here                                       |
-| ---------------- | -------------------------------------------------------------------------------- | ------------------------------------------------ |
-| **CI payer**     | To stop re-running verified checks on paid runners                               | [Cut your CI bill](#cut-your-ci-bill)            |
-| **Dotfile user** | The toolkit — skills, commands, and CLAUDE.md in every Claude session            | [Clone & bootstrap](#clone--bootstrap)           |
-| **Consumer**     | The CLI in my repo — bootstrap, doctor, drift detection, optional spec-gov gates | [Install the CLI](#install-the-cli)              |
-| **Library user** | Node API in my own tooling                                                       | [docs/api-reference.md](./docs/api-reference.md) |
-| **Contributor**  | Dev workflow, local gates                                                        | [CONTRIBUTING.md](./CONTRIBUTING.md)             |
+| I am…            | I want…                                                                          | Start here                                              |
+| ---------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| **Agent user**   | Skills that make Claude ground, verify, and cite its work                        | [Install as a plugin](#install-as-a-claude-code-plugin) |
+| **Dotfile user** | The toolkit — skills, commands, and CLAUDE.md in every Claude session            | [Clone & bootstrap](#clone--bootstrap)                  |
+| **CI payer**     | To stop re-running checks I already verified locally                             | [Local attestation](#local-attestation)                 |
+| **Consumer**     | The CLI in my repo — bootstrap, doctor, drift detection, optional spec-gov gates | [Install the CLI](#install-the-cli)                     |
+| **Library user** | Node API in my own tooling                                                       | [docs/api-reference.md](./docs/api-reference.md)        |
+| **Contributor**  | Dev workflow, local gates                                                        | [CONTRIBUTING.md](./CONTRIBUTING.md)                    |
 
 ---
 
@@ -50,20 +55,20 @@ both.
 
 | What you want                                                                | How                                                                                |
 | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Skip remote CI for commits you verified locally                              | **[Cut your CI bill](#cut-your-ci-bill)** — `npx dotbabel-local-attest --init`     |
 | Skills & subagents inside Claude Code, no clone                              | **[Install as a plugin](#install-as-a-claude-code-plugin)** — two slash commands   |
 | Skills & commands library wired into `~/.claude/`                            | **[Clone & bootstrap](#clone--bootstrap)** — 30 seconds, no npm required           |
+| Skip remote CI for commits you verified locally                              | **[Local attestation](#local-attestation)** — `npx dotbabel-local-attest --init`   |
 | Governance CLI for your own repos (bootstrap + doctor + optional spec gates) | **[Install the CLI](#install-the-cli)** — see install section (Node ≥ 20 required) |
 
-All three paths are independent. You can use one, two, or all of them.
+All four paths are independent. You can use one, some, or all of them.
 
 ---
 
-## Cut your CI bill
+## Local attestation
 
-`local-attest` needs one file: a matrix of the checks CI runs. `--init` drafts
-it from your existing workflows, so adoption is a command rather than an
-afternoon:
+Verification you can substitute for the remote run. `local-attest` needs one
+file: a matrix of the checks CI runs. `--init` drafts it from your existing
+workflows, so adoption is a command rather than an afternoon:
 
 ```bash
 npx dotbabel-local-attest --init

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,12 +2,15 @@
 
 _Last updated: v2.18.0_
 
+dotbabel is a verification layer for agentic development: skills that make an
+agent ground its claims in real source, and gates that check the result.
+
 **Two paths — pick yours:**
 
-| I want…                                                                 | Path                                                                           |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Skills & commands in every Claude Code session                          | **[Dotfile bootstrap](./dotfile-quickstart.md)** — 30 seconds, no npm required |
-| Governance CLI for my own repo (bootstrap, doctor, optional spec gates) | **This page** — 10 minutes, Node ≥ 20 required                                 |
+| I want…                                                                | Path                                                                           |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Skills & commands in every Claude Code session                         | **[Dotfile bootstrap](./dotfile-quickstart.md)** — 30 seconds, no npm required |
+| The CLI in my own repo (verification gates, local attestation, doctor) | **This page** — 10 minutes, Node ≥ 20 required                                 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dotbabel/dotbabel",
   "version": "2.18.0",
-  "description": "Skip remote CI for commits you verified locally: run your GitHub Actions matrix on your machine and post a SHA-pinned attestation that makes the workflows skip themselves. Plus a model-agnostic toolkit of skills, slash commands, and governance gates for Claude Code, Codex, Gemini, and Copilot CLI.",
+  "description": "Make an AI coding agent show its work. A verification layer for agentic development: skills that force an agent to ground every claim in real source, reproduce a bug before fixing it, and cite file:line — plus gates that check the result. Includes local CI attestation, spec-governance checks, and one rule floor fanned out to Claude Code, Codex, Gemini, and Copilot CLI.",
   "type": "module",
   "main": "plugins/dotbabel/src/index.mjs",
   "exports": {

--- a/plugins/dotbabel/.claude-plugin/plugin.json
+++ b/plugins/dotbabel/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dotbabel",
   "displayName": "dotbabel",
-  "description": "Skip remote CI for commits you verified locally: run your GitHub Actions matrix on your machine and post a SHA-pinned attestation that makes the workflows skip themselves. Ships with a library of engineering skills and specialist subagents, spec-governance gates, and cross-CLI instruction sync.",
+  "description": "Make an AI coding agent show its work. A verification layer for agentic development: skills that force an agent to ground every claim in real source, reproduce a bug before fixing it, and cite file:line — plus gates that check the result. Includes local CI attestation, spec-governance checks, and one rule floor fanned out to Claude Code, Codex, Gemini, and Copilot CLI.",
   "version": "2.18.0",
   "author": {
     "name": "Kaio Cunha",

--- a/plugins/dotbabel/README.md
+++ b/plugins/dotbabel/README.md
@@ -1,9 +1,14 @@
 # `@dotbabel/dotbabel`
 
-Portable Claude Code plugin + zero-dependency npm package for
-spec-driven-development governance. Installs seven CLI bins, a Node API
-barrel, a destructive-git PreToolUse hook, and a gold-standard shell
-settings validator.
+**Make an AI coding agent show its work.** A verification layer for agentic
+development: skills that force an agent to ground every claim in real source,
+reproduce a bug before fixing it, and cite `file:line` — plus the gates that
+check the result before it merges.
+
+This is the portable Claude Code plugin and zero-dependency npm package. It
+installs the CLI bins (including `dotbabel-local-attest`, which runs your CI
+matrix locally and attests it), a Node API barrel, a destructive-git
+PreToolUse hook, and a shell settings validator.
 
 This README is the npm tarball's entry point. **The full docs set lives at
 <https://github.com/kaiohenricunha/dotbabel/tree/main/docs>.**


### PR DESCRIPTION
## Summary

- **Repositions the project around verification discipline rather than CI cost.** The skip-CI pitch had two problems: `local-attest` is 1 skill of 36, so leading with it misrepresented a library whose center of gravity is `ground-first`, `fix-with-evidence`, `veracity-audit`, `plan-grader`, `security-review`, and `validate-spec` — making an agent's work checkable. And a tool whose failure mode is "you attested something you never actually verified" should not headline with an invitation to do less work; that framing selects for the users most likely to misuse it.
- **`local-attest` is kept as the proof, not the product.** The 27-minutes-to-zero figure now appears as evidence that the verification is rigorous enough to substitute for a CI gate, which is a claim about standards rather than savings. The `Cut your CI bill` section becomes `Local attestation`, with both nav tables repointed.
- **One description, everywhere it's read**: `package.json`, `plugins/dotbabel/.claude-plugin/plugin.json` (marketplace-visible), `.claude-plugin/marketplace.json`, plus the plugin README and quickstart headers. CI keywords stay in npm keywords and repo topics, where they cost nothing and still route search traffic. `package.json` version untouched.

## Test plan

- [x] `npx vitest run` — 1139 pass
- [x] `bash plugins/dotbabel/scripts/run-bats.sh` — 601 pass
- [x] `claude plugin validate ./plugins/dotbabel` — passes, zero warnings (the description change is marketplace-visible)
- [x] `npm run lint` / `npm run dogfood` / `build-plugin --check` / `index --check` — clean
- [x] Grepped for dangling `#cut-your-ci-bill` anchors after the section rename — none

## Spec ID

dotbabel-core
