### PR TITLE
fix(release): regen the plugin manifest after the version bump

### DIFF
--- a/.github/workflows/release-please-post-bump.yml
+++ b/.github/workflows/release-please-post-bump.yml
@@ -1,13 +1,19 @@
 name: release-please-post-bump
 
 # Runs after release-please bumps package.json on a release branch.
-# Regenerates the two artefacts that dogfood CI checks in --check mode:
+# Regenerates the three artefacts that dogfood CI checks in --check mode:
 #   1. index/artifacts.json + index/by-type.json + index/by-facet.json
 #      (version field in the envelope comes from package.json)
 #   2. docs/*.md  _Last updated: vX.Y.Z_ stamps
+#   3. plugins/dotbabel/.claude-plugin/plugin.json (version stamped from
+#      package.json by build-plugin). Missing this one turned main red on the
+#      2.18.1 release: package.json said 2.18.1, the plugin manifest still
+#      said 2.18.0, and both `build-plugin --check` and the plugin-manifest
+#      bats gate failed. Anything that derives from the version belongs here.
 #
-# No-loop guarantee: the post-bump commit touches only index/ + docs/, not
-# package.json, so the paths filter never re-fires on the commit itself.
+# No-loop guarantee: the post-bump commit touches only index/, docs/, and the
+# plugin manifest — never package.json — so the paths filter never re-fires on
+# the commit itself.
 #
 # PAT required: GITHUB_TOKEN pushes suppress the pull_request (synchronize)
 # event on the open release PR — without the PAT, dogfood CI never re-runs
@@ -51,14 +57,17 @@ jobs:
       - name: stamp doc versions
         run: node scripts/stamp-doc-versions.mjs
 
+      - name: regen plugin manifest
+        run: node scripts/build-plugin.mjs
+
       - name: commit if anything changed
         run: |
-          git diff --quiet index/ docs/ && {
-            echo "Nothing changed — index and stamps already current."
+          git diff --quiet index/ docs/ plugins/dotbabel/ && {
+            echo "Nothing changed — index, stamps and plugin manifest already current."
             exit 0
           }
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add index/ docs/
-          git commit -m "chore: refresh index envelope + doc stamps for $(node -p "require('./package.json').version")"
+          git add index/ docs/ plugins/dotbabel/
+          git commit -m "chore: refresh index envelope + doc stamps + plugin manifest for $(node -p "require('./package.json').version")"
           git push

--- a/plugins/dotbabel/.claude-plugin/plugin.json
+++ b/plugins/dotbabel/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dotbabel",
   "displayName": "dotbabel",
   "description": "Make an AI coding agent show its work. A verification layer for agentic development: skills that force an agent to ground every claim in real source, reproduce a bug before fixing it, and cite file:line — plus gates that check the result. Includes local CI attestation, spec-governance checks, and one rule floor fanned out to Claude Code, Codex, Gemini, and Copilot CLI.",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "author": {
     "name": "Kaio Cunha",
     "url": "https://github.com/kaiohenricunha"


### PR DESCRIPTION
## Summary

- **Fixes red `main` at `ecf0780`.** #311 made `build-plugin` stamp `plugin.json`'s `version` from `package.json`, but release-please's bump touches only `package.json` — so the 2.18.1 release landed with the package at 2.18.1 and the plugin manifest still at 2.18.0, failing both `build-plugin --check` (the `dogfood` job) and the `plugin-manifest` bats gate. Regression is mine, from the plugin-installability PR.
- **Fixes the recurrence at the right layer.** `release-please-post-bump.yml` already exists to regenerate version-derived artefacts on the release branch (index envelope, doc stamps); the plugin manifest simply was never registered there. Adds a `build-plugin` step and widens the commit scope to `plugins/dotbabel/`, with a comment recording why. The workflow's no-loop guarantee is preserved — the post-bump commit still never touches `package.json`, so the `paths:` filter cannot re-fire on itself.
- Regenerates `plugin.json` to 2.18.1 so `main` is green immediately rather than waiting for the next release.

## Test plan

- [x] `npx bats plugins/dotbabel/tests/bats/plugin-manifest.bats` — 6/6 (was failing test 5, the version-tracks-package pin)
- [x] `npm run build-plugin -- --check` — fresh (was `plugin.json is stale`)
- [x] `npm run dogfood` — clean
- [x] `claude plugin validate ./plugins/dotbabel` — passes, zero warnings
- [x] `npx vitest run` — 1139 pass; `run-bats.sh` — 601 pass
- [x] `actionlint` on the edited workflow — clean
- [ ] Post-merge: `main` CI green, and the next release PR carries a matching plugin manifest without manual intervention

## Spec ID

dotbabel-core
